### PR TITLE
Fix Windows Python extension build: use correct static lib name

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -16,13 +16,17 @@ from setuptools import Extension, setup
 ROOT = Path(__file__).resolve().parent.parent
 
 # Build the static library if needed.
-STATIC_LIB = ROOT / "target" / "release" / "libsyntaqlite.a"
+# Rust produces libsyntaqlite.a on Unix, syntaqlite.lib on Windows (MSVC).
+if sys.platform == "win32":
+    STATIC_LIB = ROOT / "target" / "release" / "syntaqlite.lib"
+else:
+    STATIC_LIB = ROOT / "target" / "release" / "libsyntaqlite.a"
 
 
 def _ensure_static_lib():
     if STATIC_LIB.exists():
         return
-    print("Building libsyntaqlite.a ...")
+    print(f"Building {STATIC_LIB.name} ...")
     subprocess.check_call(
         ["cargo", "build", "-p", "syntaqlite", "--release"],
         cwd=ROOT,
@@ -49,6 +53,9 @@ ext = Extension(
 # On macOS, link system frameworks needed by Rust stdlib.
 if sys.platform == "darwin":
     ext.extra_link_args = ["-framework", "Security", "-framework", "SystemConfiguration"]
+# On Windows, link system libraries needed by Rust stdlib.
+elif sys.platform == "win32":
+    ext.libraries = ["ws2_32", "userenv", "advapi32", "bcrypt", "ntdll"]
 
 setup(
     name="syntaqlite",


### PR DESCRIPTION
On Windows with MSVC, Rust produces `syntaqlite.lib` not `libsyntaqlite.a`.
Also add Windows system libraries needed by Rust stdlib for linking.

https://claude.ai/code/session_01RBkfTPmkJxyHuF5eXhzRuu