### PR TITLE
test: smoke test cibuildwheel migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,7 +229,7 @@ jobs:
           python-version: "3.12"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2
+        uses: pypa/cibuildwheel@v2.23
         with:
           package-dir: python/
           output-dir: wheelhouse/


### PR DESCRIPTION
## Summary
- Empty commit to trigger CI and verify cibuildwheel wheel builds work across all platforms
- Tests the migration from custom `build_wheel.py` to `pypa/cibuildwheel@v2`
- Will delete this branch after verifying

## What to check
- [ ] Linux x86_64 wheels build
- [ ] Linux aarch64 wheels build
- [ ] macOS arm64 wheels build
- [ ] macOS x86_64 wheels build
- [ ] Windows AMD64 + ARM64 wheels build
- [ ] Pyodide (WASM) wheel builds