### PR TITLE
synq: switch to PR-based workflow

### DIFF
--- a/.agents/skills/cp/SKILL.md
+++ b/.agents/skills/cp/SKILL.md
@@ -1,56 +1,41 @@
 ---
 name: cp
-description: Commit all current changes and push to the remote. Use when the user asks to commit, push, save progress, or ship changes.
+description: Commit all current changes, push to a feature branch, and create a PR. Use when the user asks to commit, push, save progress, or ship changes.
 user_invocable: true
 ---
 
-# commit-and-push
+# commit-and-push (PR workflow)
 
-Commit all current changes and push to the remote. All pre-push checks must
-pass before committing.
+Commit all current changes, push to a feature branch, and open a pull request.
+All pre-push checks must pass before pushing.
 
 ## Instructions
 
-1. **Sync with origin/main**:
-   ```sh
-   git stash
-   git pull origin main
-   git stash pop
-   ```
-   If `git stash` complains that a file "needs merge" (unresolved conflict markers in the
-   working tree), reset first then re-stash:
-   ```sh
-   git reset HEAD
-   git stash
-   ```
-   If `stash pop` produces merge conflicts, resolve them before continuing.
-   If the stash was empty (`No local changes to save`), skip the `stash pop`.
-
-2. **Run pre-push checks with auto-fix** (quiet mode suppresses output on success):
+1. **Run pre-push checks with auto-fix** (quiet mode suppresses output on success):
    ```sh
    tools/pre-push --fix -q
    ```
    If this fails, fix the issues and re-run until it passes.
    Do NOT skip this step — it is the project's only gate against broken code.
 
-3. **Check for changes**:
+2. **Check for changes**:
    ```sh
    git status
    git diff --stat
    git log --oneline -5
    ```
 
-4. **Stage all changes** (including any fixes from step 2):
+3. **Stage all changes** (including any fixes from step 1):
    ```sh
    git add -A
    ```
 
-5. **Write a commit message** following the project convention:
+4. **Write a commit message** following the project convention:
    - Prefix with `synq: ` (lowercase)
    - Concise summary line describing the "why"
    - Add detail in the body for non-trivial changes
 
-6. **Commit using a HEREDOC**:
+5. **Commit using a HEREDOC**:
    ```sh
    git commit -m "$(cat <<'EOF'
    synq: <summary>
@@ -60,9 +45,34 @@ pass before committing.
    )"
    ```
 
-7. **Push to main**:
+6. **Create a feature branch if on main**:
+   If currently on `main`, create and switch to a descriptive branch:
    ```sh
-   git push origin HEAD:main
+   git checkout -b <branch-name>
+   ```
+   Branch naming: use lowercase kebab-case describing the change (e.g.,
+   `add-cte-column-validation`, `fix-fmt-trailing-comma`). No prefixes needed.
+
+7. **Push the branch**:
+   ```sh
+   git push -u origin HEAD
    ```
 
-8. **Report the commit hash** to the user.
+8. **Create a PR** using `gh pr create`:
+   ```sh
+   gh pr create --title "<title>" --body "$(cat <<'EOF'
+   ## Motivation
+
+   <Why this change is needed — what problem exists, what's missing, what broke>
+
+   ## Changes
+
+   <What this PR does to address the motivation>
+   EOF
+   )"
+   ```
+   - Keep the title under 70 characters, prefixed with `synq: `
+   - Motivation section: explain the problem/need driving this change
+   - Changes section: describe what you're doing about it
+
+9. **Report the PR URL** to the user.

--- a/.agents/skills/cpfast/SKILL.md
+++ b/.agents/skills/cpfast/SKILL.md
@@ -1,17 +1,16 @@
 ---
 name: cpfast
-description: "Quickly commit and push current changes, skipping pre-push checks. Use when you want a fast save without running the full presubmit. WARNING: if origin/main starts failing, use /cp instead."
+description: "Quickly commit and push current changes to a feature branch and create a PR, skipping pre-push checks. WARNING: if CI starts failing, use /cp instead."
 user_invocable: true
 ---
 
-# commit-and-push-fast
+# commit-and-push-fast (PR workflow)
 
-Commit all current changes and push to the remote, skipping pre-push checks and
-stash/sync steps for speed.
+Commit all current changes, push to a feature branch, and open a pull request.
+Skips pre-push checks for speed — CI will catch issues.
 
-> **Note**: This skips `tools/pre-push` and the stash/pull/pop sync. If CI on
-> `origin/main` starts failing after using this, run `/cp` instead — it runs the
-> full presubmit gate and syncs with main before pushing.
+> **Note**: This skips `tools/pre-push`. If CI starts failing after using this,
+> switch to `/cp` which runs the full presubmit gate.
 
 ## Instructions
 
@@ -42,9 +41,34 @@ stash/sync steps for speed.
    )"
    ```
 
-5. **Push to main**:
+5. **Create a feature branch if on main**:
+   If currently on `main`, create and switch to a descriptive branch:
    ```sh
-   git push origin HEAD:main
+   git checkout -b <branch-name>
+   ```
+   Branch naming: use lowercase kebab-case describing the change (e.g.,
+   `add-cte-column-validation`, `fix-fmt-trailing-comma`). No prefixes needed.
+
+6. **Push the branch**:
+   ```sh
+   git push -u origin HEAD
    ```
 
-6. **Report the commit hash** to the user.
+7. **Create a PR** using `gh pr create`:
+   ```sh
+   gh pr create --title "<title>" --body "$(cat <<'EOF'
+   ## Motivation
+
+   <Why this change is needed — what problem exists, what's missing, what broke>
+
+   ## Changes
+
+   <What this PR does to address the motivation>
+   EOF
+   )"
+   ```
+   - Keep the title under 70 characters, prefixed with `synq: `
+   - Motivation section: explain the problem/need driving this change
+   - Changes section: describe what you're doing about it
+
+8. **Report the PR URL** to the user.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Motivation
+
+<!-- Why is this change needed? What problem exists, what's missing, or what broke? -->
+
+## Changes
+
+<!-- What does this PR do to address the motivation? -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,18 @@ This allows projects like libSQL, rqlite, or custom embedded databases to use sy
 - Unsafe minimized: `DialectEnv` safe accessors wrap all raw pointer access; `Interpreter` has zero unsafe
 - AST dump is in C (`syntaqlite_dump_node`), not Rust — single source of truth for metadata
 
+## Git Workflow
+
+All changes go through pull requests — never push directly to `main`.
+
+1. **Branch**: Create a feature branch from `main` with a descriptive kebab-case name (e.g., `add-cte-column-validation`, `fix-fmt-trailing-comma`)
+2. **Commit**: Use the `synq: ` prefix (lowercase). Describe the "why", not the "what"
+3. **Push & PR**: Push the branch and open a PR via `gh pr create`. CI runs automatically on all PRs
+4. **Merge**: PRs merge to `main` after CI passes
+
+Use `/cp` to commit, run pre-push checks, push, and create a PR in one step.
+Use `/cpfast` for the same without pre-push checks (CI will catch issues).
+
 ## Key Directories
 
 - `syntaqlite-common/` - Shared primitives with no generated-file dependencies (e.g. fmt bytecode types). Safe for the bootstrap tool to depend on.


### PR DESCRIPTION
## Motivation

We've been pushing directly to main, which bypasses code review and makes it
harder to catch issues before they land. Moving to a PR-based workflow gives us
a review checkpoint and lets CI run before changes hit main.

## Changes

- Update `/cp` and `/cpfast` skills to create feature branches and open PRs
  (instead of `git push origin HEAD:main`)
- Add `.github/PULL_REQUEST_TEMPLATE.md` with Motivation/Changes sections
  to encourage giving context on every PR
- Add "Git Workflow" section to `AGENTS.md` documenting the branch/PR convention