### PR TITLE
synq: fix Zed extension email, version, and bump script

### DIFF
--- a/integrations/zed/Cargo.toml
+++ b/integrations/zed/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "syntaqlite-zed"
-version = "0.0.1"
+version = "0.2.12"
 edition = "2024"
 
 [lib]

--- a/integrations/zed/extension.toml
+++ b/integrations/zed/extension.toml
@@ -3,9 +3,9 @@
 
 id = "syntaqlite"
 name = "Syntaqlite"
-version = "0.0.1"
+version = "0.2.12"
 schema_version = 1
-authors = ["Lalit Maganti <lalit@syntaqlite.dev>"]
+authors = ["Lalit Maganti <lalitmaganti@gmail.com>"]
 description = "SQL language support powered by syntaqlite — tokenizer, parser, formatter and validator built on SQLite's own grammar."
 repository = "https://github.com/LalitMaganti/syntaqlite"
 

--- a/tools/bump-version
+++ b/tools/bump-version
@@ -22,11 +22,13 @@ CARGO_TOMLS = [
     "syntaqlite-buildtools/Cargo.toml",
     "tests/benches/Cargo.toml",
     "tests/comparison/parser/Cargo.toml",
+    "integrations/zed/Cargo.toml",
 ]
 
 # Files with `version = "X.Y.Z"` (pyproject.toml style).
 OTHER_MANIFESTS = [
     "python/pyproject.toml",
+    "integrations/zed/extension.toml",
 ]
 
 # Files with `"version": "X.Y.Z"` (package.json style).


### PR DESCRIPTION
## Motivation

The Zed extension was shipped with the wrong author email and version 0.0.1 instead of matching the repo's current version. It was also missing from the version bump script, so future releases would leave it behind.

## Changes

- Fix author email in `extension.toml` to `lalitmaganti@gmail.com`
- Update version in both `extension.toml` and `Cargo.toml` to `0.2.12`
- Add both Zed manifest files to `tools/bump-version`