### PR TITLE
synq: add CI job to build Zed extension for wasm32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,18 @@ jobs:
       - name: Run upstream SQLite validation tests
         run: tools/run-integration-tests --suite upstream-sqlite --validate
 
+  zed-extension:
+    name: Zed extension build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Add wasm32-unknown-unknown target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Build Zed extension
+        run: cargo build --target wasm32-unknown-unknown --manifest-path integrations/zed/Cargo.toml
+
   amalgamation:
     name: Amalgamation build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

The Zed extension was added recently but has no CI coverage. Changes to the extension or its dependencies could break the wasm32 build without anyone noticing until a release.

## Changes

Adds a lightweight `zed-extension` CI job that:
- Adds the `wasm32-unknown-unknown` rustup target
- Builds the Zed extension crate for that target

No submodules or build deps needed — the extension only depends on `zed_extension_api`. Build takes ~2s.