### PR TITLE
synq: fix versioned docs not discovering v-prefixed tags

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,9 +3,6 @@ name: Deploy Docs
 on:
   push:
     branches: [main]
-    paths:
-      - "web/docs/**"
-      - "tools/build-versioned-docs"
     tags: ['**[0-9]+.[0-9]+.[0-9]+*']
   workflow_dispatch:
 

--- a/tools/build-versioned-docs
+++ b/tools/build-versioned-docs
@@ -18,7 +18,7 @@ echo "==> Building main docs"
 (cd "$DOCS_DIR" && "$ZOLA" build --base-url "/main/" --output-dir "$OUT_DIR/main")
 
 # --- Discover release tags (semver-like) ---
-TAGS=$(git -C "$REPO_ROOT" tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | sort -V || true)
+TAGS=$(git -C "$REPO_ROOT" tag --list | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+' | sort -V || true)
 
 # --- Build docs for each release tag ---
 for tag in $TAGS; do
@@ -30,17 +30,19 @@ for tag in $TAGS; do
     continue
   fi
 
-  version_dir="$OUT_DIR/v$tag"
+  # Normalize: strip leading v if present, then always use v-prefix
+  ver="${tag#v}"
+  version_dir="$OUT_DIR/v$ver"
   worktree_dir="$REPO_ROOT/.worktree-docs-$tag"
 
-  echo "    Building v$tag"
+  echo "    Building v$ver"
   git -C "$REPO_ROOT" worktree add --detach "$worktree_dir" "$tag" 2>/dev/null || {
     echo "    SKIP: could not create worktree for $tag"
     continue
   }
 
-  if (cd "$worktree_dir/web/docs" && "$ZOLA" build --base-url "/v$tag/" --output-dir "$version_dir") 2>&1; then
-    echo "    OK: v$tag"
+  if (cd "$worktree_dir/web/docs" && "$ZOLA" build --base-url "/v$ver/" --output-dir "$version_dir") 2>&1; then
+    echo "    OK: v$ver"
   else
     echo "    WARN: zola build failed for tag $tag, skipping"
     rm -rf "$version_dir"
@@ -49,11 +51,12 @@ for tag in $TAGS; do
   git -C "$REPO_ROOT" worktree remove --force "$worktree_dir" 2>/dev/null || true
 done
 
-# --- Find latest release tag (last in sort -V order) that was actually built ---
+# --- Find latest release version (last in sort -V order) that was actually built ---
 LATEST=""
 for tag in $TAGS; do
-  if [ -d "$OUT_DIR/v$tag" ]; then
-    LATEST="$tag"
+  ver="${tag#v}"
+  if [ -d "$OUT_DIR/v$ver" ]; then
+    LATEST="$ver"
   fi
 done
 
@@ -66,11 +69,12 @@ versions+='{"version":"main","path":"/main/","label":"main"}'
 
 # Add tags in reverse order (newest first), mark latest
 for tag in $(echo "$TAGS" | tail -r 2>/dev/null || echo "$TAGS" | tac 2>/dev/null || true); do
-  if [ -d "$OUT_DIR/v$tag" ]; then
-    if [ "$tag" = "$LATEST" ]; then
-      versions+=",{\"version\":\"v$tag\",\"path\":\"/v$tag/\",\"label\":\"v$tag (latest)\"}"
+  ver="${tag#v}"
+  if [ -d "$OUT_DIR/v$ver" ]; then
+    if [ "$ver" = "$LATEST" ]; then
+      versions+=",{\"version\":\"v$ver\",\"path\":\"/v$ver/\",\"label\":\"v$ver (latest)\"}"
     else
-      versions+=",{\"version\":\"v$tag\",\"path\":\"/v$tag/\",\"label\":\"v$tag\"}"
+      versions+=",{\"version\":\"v$ver\",\"path\":\"/v$ver/\",\"label\":\"v$ver\"}"
     fi
   fi
 done

--- a/web/docs/templates/base.html
+++ b/web/docs/templates/base.html
@@ -100,8 +100,9 @@
       var menu = document.getElementById('version-menu');
       var label = document.getElementById('version-label');
       if (!btn || !menu || !label) return;
-      var match = window.location.pathname.match(/^\/(main|v[^/]+)\//);
+      var match = window.location.pathname.match(/^\/(main|v[^/]+)(\/.*)?$/);
       var current = match ? match[1] : 'main';
+      var pagePath = match && match[2] ? match[2] : '/';
       label.textContent = current;
       btn.addEventListener('click', function(e) {
         e.stopPropagation();
@@ -114,7 +115,7 @@
           menu.innerHTML = '';
           versions.forEach(function(v) {
             var a = document.createElement('a');
-            a.href = v.path;
+            a.href = '/' + v.version + pagePath;
             a.textContent = v.label;
             if (v.version === current) a.classList.add('active');
             menu.appendChild(a);


### PR DESCRIPTION
## Motivation

The version selector in the docs site only ever shows "main" — no release
versions appear despite 49 tags existing. This is because the build script's
tag discovery grep (`^[0-9]+\.`) requires tags to start with a digit, but all
release tags use `v`-prefixed format (`v0.2.14`, `v0.1.0`, etc.).

Additionally, the `paths` filter in `deploy-docs.yml` blocks the workflow from
running on tag pushes (tag push events have no file diff, so the paths filter
sees zero matches and skips the workflow).

## Changes

- Accept `v`-prefixed tags in the grep pattern (`^v?[0-9]+`)
- Normalize tag → version with `${tag#v}` to avoid double-v directory paths
  like `/vv0.2.14/`
- Remove `paths` filter from `deploy-docs.yml` so tag pushes trigger deploys
- Preserve current page path in the version switcher when switching versions