### PR TITLE
synq: fix collapsible groups in version selector

### DIFF
--- a/web/docs/static/style.css
+++ b/web/docs/static/style.css
@@ -353,9 +353,9 @@ header nav ul a:hover { color: var(--c-fg); }
   user-select: none;
   border-top: 1px solid var(--c-border);
   margin-top: var(--sp-xs);
+  text-decoration: none;
 }
 
-.version-switcher__group-label:first-child { border-top: none; margin-top: 0; }
 .version-switcher__group-label:hover { color: var(--c-fg); background: var(--c-bg); }
 
 .version-switcher__group-label svg {

--- a/web/docs/templates/base.html
+++ b/web/docs/templates/base.html
@@ -141,21 +141,16 @@
           groupOrder.forEach(function(key) {
             var items = groups[key];
             var hasActive = items.some(function(v) { return v.version === current; });
-            // Group label navigates to the latest (first) in the group
-            var lbl = document.createElement('a');
-            lbl.href = '/' + items[0].version + pagePath;
+            var lbl = document.createElement('div');
             lbl.className = 'version-switcher__group-label' + (hasActive ? ' expanded' : '');
             lbl.innerHTML = key + '.x ' + chevron;
-            // Chevron toggles expansion without navigating
-            var toggle = lbl.querySelector('svg');
-            toggle.addEventListener('click', function(e) {
-              e.preventDefault();
+            var grp = document.createElement('div');
+            grp.className = 'version-switcher__group' + (hasActive ? ' expanded' : '');
+            lbl.addEventListener('click', function(e) {
               e.stopPropagation();
               lbl.classList.toggle('expanded');
               grp.classList.toggle('expanded');
             });
-            var grp = document.createElement('div');
-            grp.className = 'version-switcher__group' + (hasActive ? ' expanded' : '');
             items.forEach(function(v) {
               var a = document.createElement('a');
               a.href = '/' + v.version + pagePath;


### PR DESCRIPTION
## Motivation

The version selector's collapsible groups don't actually collapse/expand when clicked. The group labels are `<a>` tags that navigate to a URL — only clicking the tiny SVG chevron icon toggles the group, which is nearly impossible to hit reliably.

## Changes

- Change group labels from `<a>` to `<div>` elements so they act purely as toggle controls
- Move the click handler from the SVG chevron to the entire group label
- Remove stale `:first-child` CSS rule that never matched (groups always follow top-level entries)
- Individual version links inside each group remain as `<a>` tags for navigation