### PR TITLE
synq: reduce redundant CI work on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,40 +22,6 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  build-cli:
-    name: Build CLI
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Cache third_party
-        uses: actions/cache@v5
-        with:
-          path: third_party
-          key: third-party-${{ runner.os }}-${{ hashFiles('python/tools/install_build_deps.py') }}
-
-      - name: Install build dependencies
-        run: python3 tools/install-build-deps
-
-      - name: Cache Rust build artifacts
-        uses: actions/cache@v5
-        with:
-          path: target
-          key: cargo-cli-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-cli-${{ runner.os }}-
-
-      - name: Build CLI
-        run: tools/cargo build -p syntaqlite-cli
-
-      - name: Upload CLI binary
-        uses: actions/upload-artifact@v6
-        with:
-          name: syntaqlite-cli
-          path: target/debug/syntaqlite
-          retention-days: 1
-
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -77,15 +43,25 @@ jobs:
         uses: actions/cache@v5
         with:
           path: target
-          key: cargo-unit-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-unit-${{ runner.os }}-
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-${{ runner.os }}-
 
       - name: Run unit tests
         run: tools/run-unit-tests
 
+      - name: Build CLI
+        run: tools/cargo build -p syntaqlite-cli
+
+      - name: Upload CLI binary
+        uses: actions/upload-artifact@v6
+        with:
+          name: syntaqlite-cli
+          path: target/debug/syntaqlite
+          retention-days: 1
+
   integration-tests:
     name: Integration tests
-    needs: [build-cli]
+    needs: [unit-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -106,7 +82,7 @@ jobs:
 
   upstream-sqlite-validation:
     name: Upstream SQLite validation
-    needs: [build-cli]
+    needs: [unit-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 #
 # On version tag push: builds CLI binaries, Python wheels, C libraries,
 # amalgamation archives, and publishes to PyPI and GitHub Releases.
-# On pull_request: builds CLI binaries only (smoke test).
+# On pull_request: builds Python wheels only (smoke test).
 name: Release
 
 permissions:
@@ -29,6 +29,7 @@ jobs:
   #   - buildtools binary (for amalgamation, linux-x64 only)
   build:
     name: build (${{ matrix.name }})
+    if: ${{ !github.event.pull_request }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Motivation

On every PR, we were doing ~10 independent Rust compilations across ci.yml and release.yml:
- ci.yml had a standalone `build-cli` job that duplicated most of the compilation already done by `unit-tests`
- release.yml ran the full `build` job on PRs, compiling release binaries for all 6 platforms as a "smoke test"

## Changes

- **ci.yml**: Merge `build-cli` into `unit-tests` — after tests run, build the CLI binary (nearly free since deps are already compiled) and upload it as an artifact. Downstream jobs (`integration-tests`, `upstream-sqlite-validation`) now depend on `unit-tests`. Unified cache key since there's only one Rust compilation job.
- **release.yml**: Skip the `build` job entirely on PRs. Keep `build-python-wheels` on PRs since those catch Python-specific issues.