### PR TITLE
synq: fix Node.js 20 deprecation and macOS deployment target warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,7 +231,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -244,6 +244,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_BEFORE_ALL_LINUX: bash {package}/dev/cibw_before_all.sh
           CIBW_BEFORE_ALL_MACOS: bash {package}/dev/cibw_before_all.sh
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=11.0
           CIBW_BEFORE_ALL_WINDOWS: powershell -File {package}/dev/cibw_before_all_windows.ps1
 
       - name: Upload wheels

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Motivation

CI emits warnings on every python-wheels build:
- `actions/setup-python@v5` targets Node.js 20, which GitHub Actions has deprecated
- cibuildwheel bumps `MACOSX_DEPLOYMENT_TARGET` from 10.12 to 11.0 on arm64 (4 warnings per build)

## Changes

- Upgrade `actions/setup-python` from v5 to v6 in `release.yml` and `test-install.yml`
- Set `CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=11.0` so cibuildwheel doesn't need to bump it