### PR TITLE
synq: fix broken C API docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ pip install syntaqlite
 npm install syntaqlite
 ```
 
-**C** — the parser, tokenizer, formatter, and validator all have C APIs. See the [C API docs](https://docs.syntaqlite.com/reference/c-api/).
+**C** — the parser, tokenizer, formatter, and validator all have C APIs. See the [C API docs](https://docs.syntaqlite.com/main/reference/c-api/).
 
 ## Architecture ([docs](https://docs.syntaqlite.com/main/contributing/architecture/))
 


### PR DESCRIPTION
## Motivation

The C API docs link in the README was pointing to `/reference/c-api/` instead of `/main/reference/c-api/`, resulting in a broken link.

## Changes

Add the missing `/main/` prefix to match all other doc links in the README.