### PR TITLE
synq: add /latest/ docs alias pointing to newest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ error: syntax error near 'RETURNING'
 
 `RETURNING` was added in SQLite 3.35.0; Android 13 still ships SQLite 3.32.2.
 
-We've tested against ~396K statements from [SQLite's upstream test suite](https://sqlite.org/testing.html) with ~99.7% agreement on parse acceptance. See the [detailed comparison](https://docs.syntaqlite.com/main/reference/comparison/) for how syntaqlite stacks up against other tools.
+We've tested against ~396K statements from [SQLite's upstream test suite](https://sqlite.org/testing.html) with ~99.7% agreement on parse acceptance. See the [detailed comparison](https://docs.syntaqlite.com/latest/reference/comparison/) for how syntaqlite stacks up against other tools.
 
 ## What it does
 
-### Validate ([docs](https://docs.syntaqlite.com/main/concepts/validation/))
+### Validate ([docs](https://docs.syntaqlite.com/latest/concepts/validation/))
 
 Finds unknown tables, columns, and functions against your schema, the same errors `sqlite3_prepare` would catch but without needing a database. Unlike `sqlite3`, syntaqlite finds **all** errors in one pass:
 
@@ -69,7 +69,7 @@ warning: unknown function 'ROUDN'
    = help: did you mean 'round'?
 ```
 
-### Format ([docs](https://docs.syntaqlite.com/main/reference/cli/#fmt))
+### Format ([docs](https://docs.syntaqlite.com/latest/reference/cli/#fmt))
 
 Deterministic formatting with configurable line width, keyword casing, and indentation:
 
@@ -88,7 +88,7 @@ ORDER BY p.created_at DESC
 LIMIT 10;
 ```
 
-### Version and compile-flag aware ([docs](https://docs.syntaqlite.com/main/guides/version-pinning/))
+### Version and compile-flag aware ([docs](https://docs.syntaqlite.com/latest/guides/version-pinning/))
 
 Pin the parser to a specific SQLite version or enable [compile-time flags](https://www.sqlite.org/compile.html) to match your exact build:
 
@@ -147,21 +147,21 @@ semicolons = true
 
 The config file is discovered by walking up from the file being processed, same as `rustfmt.toml` or `ruff.toml`. CLI flags override config file values.
 
-### Editor integration ([docs](https://docs.syntaqlite.com/main/getting-started/vscode/))
+### Editor integration ([docs](https://docs.syntaqlite.com/latest/getting-started/vscode/))
 
 Full language server with no database connection required. Diagnostics, format on save, completions, and semantic highlighting.
 
 **VS Code** — install the [syntaqlite extension](https://marketplace.visualstudio.com/items?itemName=syntaqlite.syntaqlite) from the marketplace.
 
-**[Other editors](https://docs.syntaqlite.com/main/getting-started/other-editors/)** — point your LSP client at:
+**[Other editors](https://docs.syntaqlite.com/latest/getting-started/other-editors/)** — point your LSP client at:
 
 ```bash
 syntaqlite lsp
 ```
 
-**Claude Code** — `claude plugin install syntaqlite@lalitmaganti-plugins` ([docs](https://docs.syntaqlite.com/main/getting-started/claude-code/))
+**Claude Code** — `claude plugin install syntaqlite@lalitmaganti-plugins` ([docs](https://docs.syntaqlite.com/latest/getting-started/claude-code/))
 
-### Parse ([docs](https://docs.syntaqlite.com/main/guides/parsing/))
+### Parse ([docs](https://docs.syntaqlite.com/latest/guides/parsing/))
 
 Full abstract syntax tree with side tables for tokens, comments, and whitespace, for code generation, migration tooling, or static analysis.
 
@@ -173,7 +173,7 @@ syntaqlite parse -e "SELECT 1 + 2"
 
 Want to try syntaqlite without installing anything? The **[web playground](https://playground.syntaqlite.com)** runs entirely in your browser via WASM. Parse, format, and validate SQL instantly.
 
-## Install ([all methods](https://docs.syntaqlite.com/main/getting-started/cli/))
+## Install ([all methods](https://docs.syntaqlite.com/latest/getting-started/cli/))
 
 **Download and run (all platforms, no install)**
 
@@ -207,30 +207,30 @@ brew install LalitMaganti/tap/syntaqlite
 cargo install syntaqlite-cli
 ```
 
-## Use as a library ([docs](https://docs.syntaqlite.com/main/integrating/))
+## Use as a library ([docs](https://docs.syntaqlite.com/latest/integrating/))
 
-**Rust** ([API docs](https://docs.syntaqlite.com/main/integrating/rust-api/))
+**Rust** ([API docs](https://docs.syntaqlite.com/latest/integrating/rust-api/))
 
 ```toml
 [dependencies]
 syntaqlite = { version = "0.2.16", features = ["fmt"] }
 ```
 
-**Python** ([API docs](https://docs.syntaqlite.com/main/reference/python-api/))
+**Python** ([API docs](https://docs.syntaqlite.com/latest/reference/python-api/))
 
 ```bash
 pip install syntaqlite
 ```
 
-**JavaScript / WASM** ([API docs](https://docs.syntaqlite.com/main/reference/js-api/))
+**JavaScript / WASM** ([API docs](https://docs.syntaqlite.com/latest/reference/js-api/))
 
 ```bash
 npm install syntaqlite
 ```
 
-**C** — the parser, tokenizer, formatter, and validator all have C APIs. See the [C API docs](https://docs.syntaqlite.com/main/reference/c-api/).
+**C** — the parser, tokenizer, formatter, and validator all have C APIs. See the [C API docs](https://docs.syntaqlite.com/latest/reference/c-api/).
 
-## Architecture ([docs](https://docs.syntaqlite.com/main/contributing/architecture/))
+## Architecture ([docs](https://docs.syntaqlite.com/latest/contributing/architecture/))
 
 The parser and tokenizer are written in C, directly wrapping SQLite's own grammar. Everything else (formatter, validator, LSP) is written in Rust with C bindings available.
 
@@ -245,7 +245,7 @@ tools/cargo build
 
 ## Contributing
 
-See the [contributing guide](https://docs.syntaqlite.com/contributing/) for architecture overview and testing instructions.
+See the [contributing guide](https://docs.syntaqlite.com/latest/contributing/) for architecture overview and testing instructions.
 
 ## License
 

--- a/tools/build-versioned-docs
+++ b/tools/build-versioned-docs
@@ -60,12 +60,39 @@ for tag in $TAGS; do
   fi
 done
 
+# --- Build /latest/ as a copy of the latest release ---
+if [ -n "$LATEST" ]; then
+  LATEST_TAG="v$LATEST"
+  worktree_dir="$REPO_ROOT/.worktree-docs-latest"
+
+  echo "==> Building /latest/ (v$LATEST)"
+  git -C "$REPO_ROOT" worktree add --detach "$worktree_dir" "$LATEST_TAG" 2>/dev/null || {
+    echo "    WARN: could not create worktree for latest, copying v$LATEST instead"
+    cp -r "$OUT_DIR/v$LATEST" "$OUT_DIR/latest"
+    worktree_dir=""
+  }
+
+  if [ -n "$worktree_dir" ]; then
+    if (cd "$worktree_dir/web/docs" && "$ZOLA" build --base-url "/latest/" --output-dir "$OUT_DIR/latest") 2>&1; then
+      echo "    OK: /latest/"
+    else
+      echo "    WARN: zola build failed for /latest/, copying v$LATEST instead"
+      cp -r "$OUT_DIR/v$LATEST" "$OUT_DIR/latest"
+    fi
+    git -C "$REPO_ROOT" worktree remove --force "$worktree_dir" 2>/dev/null || true
+  fi
+fi
+
 # --- Generate versions.json ---
 echo "==> Generating versions.json"
 
-# main always first
+# main and latest always shown at top level
 versions='['
 versions+='{"version":"main","path":"/main/","label":"main"}'
+
+if [ -n "$LATEST" ]; then
+  versions+=",{\"version\":\"latest\",\"path\":\"/latest/\",\"label\":\"latest (v$LATEST)\"}"
+fi
 
 # Add tags in reverse order (newest first), mark latest
 for tag in $(echo "$TAGS" | tail -r 2>/dev/null || echo "$TAGS" | tac 2>/dev/null || true); do
@@ -87,9 +114,9 @@ for dir in "$OUT_DIR"/*/; do
   cp "$OUT_DIR/versions.json" "$dir"
 done
 
-# --- Root redirect: latest release if available, otherwise main ---
+# --- Root redirect: /latest/ if available, otherwise /main/ ---
 if [ -n "$LATEST" ]; then
-  REDIRECT_TARGET="/v$LATEST/"
+  REDIRECT_TARGET="/latest/"
 else
   REDIRECT_TARGET="/main/"
 fi

--- a/web/docs/templates/base.html
+++ b/web/docs/templates/base.html
@@ -100,7 +100,7 @@
       var menu = document.getElementById('version-menu');
       var label = document.getElementById('version-label');
       if (!btn || !menu || !label) return;
-      var match = window.location.pathname.match(/^\/(main|v[^/]+)(\/.*)?$/);
+      var match = window.location.pathname.match(/^\/(main|latest|v[^/]+)(\/.*)?$/);
       var current = match ? match[1] : 'main';
       var pagePath = match && match[2] ? match[2] : '/';
       label.textContent = current;
@@ -118,7 +118,7 @@
           var groups = {};
           var groupOrder = [];
           versions.forEach(function(v) {
-            if (v.version === 'main' || v.label.indexOf('(latest)') !== -1) {
+            if (v.version === 'main' || v.version === 'latest' || v.label.indexOf('(latest)') !== -1) {
               topLevel.push(v);
               return;
             }


### PR DESCRIPTION
## Motivation

README and external links pointed to `/main/`, which tracks HEAD and may show unreleased content. There was no stable URL that always resolves to the most recent release.

## Changes

- `tools/build-versioned-docs`: build the latest tagged release a second time under `/latest/`, include it in `versions.json`, and redirect the root URL to `/latest/` instead of `/v{x.y.z}/`
- `web/docs/templates/base.html`: version switcher recognizes `/latest/` in URLs and shows it as a top-level entry in the dropdown
- `README.md`: update all doc links from `/main/` to `/latest/` (also fixes the broken C API link that was missing a path prefix)