### PR TITLE
synq: use current templates when building /latest/ docs

### DIFF
--- a/tools/build-versioned-docs
+++ b/tools/build-versioned-docs
@@ -73,6 +73,10 @@ if [ -n "$LATEST" ]; then
   }
 
   if [ -n "$worktree_dir" ]; then
+    # Use current templates so the version switcher is up to date
+    rm -rf "$worktree_dir/web/docs/templates"
+    cp -r "$DOCS_DIR/templates" "$worktree_dir/web/docs/templates"
+
     if (cd "$worktree_dir/web/docs" && "$ZOLA" build --base-url "/latest/" --output-dir "$OUT_DIR/latest") 2>&1; then
       echo "    OK: /latest/"
     else


### PR DESCRIPTION
## Motivation

Follow-up to #59. The `/latest/` docs are built from the latest tag's worktree, so they had stale templates where the version switcher didn't recognize the `/latest/` URL. This caused:
1. The version label showing "main" instead of "latest"
2. The "latest (vx.y.z)" entry appearing in an "other.x" group

## Changes

Copy current HEAD templates into the tag worktree before building `/latest/`, so the version switcher JS is always up to date while the content stays pinned to the tagged release.