### PR TITLE
Fix "Other editors" link

### DIFF
--- a/web/docs/templates/index.html
+++ b/web/docs/templates/index.html
@@ -242,7 +242,7 @@ syntaqlite lsp</code></pre>
       <span class="entry-card__title">Command line</span>
       <span class="entry-card__desc">Install the CLI for formatting, validation, CI, and scripting.</span>
     </a>
-    <a href="{{ get_url(path='guides/other-editors') }}" class="entry-card">
+    <a href="{{ get_url(path='getting-started/other-editors') }}" class="entry-card">
       <span class="entry-card__title">Other editors</span>
       <span class="entry-card__desc">Neovim, Helix, or any editor with LSP support.</span>
     </a>


### PR DESCRIPTION
## Motivation

Link on https://docs.syntaqlite.com/main/ is broken.

## Changes

Fix the link.
