### PR TITLE
synq: clamp formatting TextEdit range to uinteger bounds

### DIFF
--- a/syntaqlite/src/lsp/server.rs
+++ b/syntaqlite/src/lsp/server.rs
@@ -479,7 +479,7 @@ impl LspServer {
         match host.format(uri, &config) {
             Ok(formatted) => {
                 let edit = TextEdit {
-                    range: Range::new(Position::new(0, 0), Position::new(u32::MAX, 0)),
+                    range: Range::new(Position::new(0, 0), Position::new(i32::MAX as u32, 0)),
                     new_text: formatted,
                 };
                 Response::new_ok(req.id, Some(vec![edit]))


### PR DESCRIPTION
## Motivation

The LSP spec defines `Position.line` as `uinteger` (0 to 2^31-1). The
formatting handler was using `u32::MAX` (2^32-1) as the end-of-document
sentinel, which exceeds the spec's upper bound. Fixes #66.

## Changes

- Replace `u32::MAX` with `i32::MAX as u32` in the formatting TextEdit range