### PR TITLE
synq: add macro registration, module resolver, and DDL lineage

### DIFF
--- a/syntaqlite/src/dialect/mod.rs
+++ b/syntaqlite/src/dialect/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use syntaqlite_syntax::util::SqliteVersion;
 
 // ── Semantic role types (re-exported from syntaqlite-common) ─────────────────
 
-pub(crate) use syntaqlite_common::roles::{FIELD_ABSENT, SemanticRole};
+pub(crate) use syntaqlite_common::roles::{FIELD_ABSENT, MacroDef, SemanticRole};
 #[cfg(test)]
 use syntaqlite_common::roles::{FieldIdx, FlagSpec};
 
@@ -238,6 +238,15 @@ impl AnyDialect {
     pub(crate) fn roles(&self) -> &'static [SemanticRole] {
         // SAFETY: template() is valid for the lifetime of self.
         unsafe { self.template().roles() }
+    }
+
+    /// The macro definition descriptors for this dialect.
+    ///
+    /// Each entry describes an AST node type that defines a template macro
+    /// (e.g. `CREATE PERFETTO MACRO`). Empty for dialects without macros.
+    pub(crate) fn macro_defs(&self) -> &'static [MacroDef] {
+        // SAFETY: template() is valid for the lifetime of self.
+        unsafe { self.template().macro_defs() }
     }
 
     /// Whether this dialect has formatter data.
@@ -487,6 +496,12 @@ pub(crate) trait CDialectTemplateExt {
     /// `self` must be a valid, fully-initialized `CDialectTemplate`.
     unsafe fn roles(&self) -> &'static [SemanticRole];
 
+    /// The macro definition descriptors for this dialect.
+    ///
+    /// # Safety
+    /// `self` must be a valid, fully-initialized `CDialectTemplate`.
+    unsafe fn macro_defs(&self) -> &'static [MacroDef];
+
     /// Whether this template has formatter data.
     fn has_fmt_data(&self) -> bool;
 
@@ -539,6 +554,17 @@ impl CDialectTemplateExt for ffi::CDialectTemplate {
 
     fn has_fmt_data(&self) -> bool {
         self.fmt_str_count > 0
+    }
+
+    unsafe fn macro_defs(&self) -> &'static [MacroDef] {
+        // SAFETY: macro_defs_data points to macro_defs_count valid MacroDef values
+        // in static storage.
+        unsafe {
+            std::slice::from_raw_parts(
+                self.macro_defs_data.cast::<MacroDef>(),
+                self.macro_defs_count as usize,
+            )
+        }
     }
 
     unsafe fn fmt_dispatch(&self, tag_idx: usize) -> Option<(&[u8], usize)> {

--- a/syntaqlite/src/semantic/analyzer.rs
+++ b/syntaqlite/src/semantic/analyzer.rs
@@ -12,7 +12,7 @@ use syntaqlite_syntax::any::{
 };
 
 use crate::dialect::AnyDialect;
-use crate::dialect::{FIELD_ABSENT, SemanticRole};
+use crate::dialect::{FIELD_ABSENT, MacroDef, SemanticRole};
 
 use super::catalog::{
     AritySpec, Catalog, CatalogLayer, ColumnResolution, FunctionCategory, FunctionCheckResult,
@@ -63,6 +63,10 @@ pub struct SemanticAnalyzer {
     catalog: Catalog,
     mode: AnalysisMode,
     macro_fallback: bool,
+    resolver: Option<Box<dyn super::ModuleResolver>>,
+    /// Modules already imported (by dotted path) — prevents cycles and
+    /// duplicate imports.
+    imported: HashSet<String>,
 }
 
 #[expect(dead_code)]
@@ -97,6 +101,8 @@ impl SemanticAnalyzer {
             dialect,
             mode: AnalysisMode::default(),
             macro_fallback: false,
+            resolver: None,
+            imported: HashSet::new(),
         }
     }
 
@@ -110,6 +116,18 @@ impl SemanticAnalyzer {
     /// Set the analysis mode on an existing analyzer.
     pub fn set_mode(&mut self, mode: AnalysisMode) {
         self.mode = mode;
+    }
+
+    /// Attach a module resolver for handling import statements (e.g.
+    /// `INCLUDE PERFETTO MODULE`).
+    ///
+    /// When the analyzer encounters an import, it calls the resolver to
+    /// obtain the module's SQL source, analyzes it recursively, and
+    /// accumulates the resulting DDL into the catalog.
+    #[must_use]
+    pub fn with_module_resolver(mut self, resolver: Box<dyn super::ModuleResolver>) -> Self {
+        self.resolver = Some(resolver);
+        self
     }
 
     /// Enable macro fallback: unregistered `name!(args)` calls parse as
@@ -301,14 +319,32 @@ impl SemanticAnalyzer {
             collect_tokens(stmt.tokens(), &mut tokens);
             collect_comments(stmt.comments(), &mut comments);
 
-            let erased = stmt.erase();
-            let stmt_model = self.analyze_statement(
-                &erased,
-                config,
-                &mut resolutions,
-                &mut definition_offsets,
-            );
+            // Process the statement and extract macro registration info.
+            // The erased statement borrows the session, so we must extract
+            // owned macro data before dropping it and calling register_macro.
+            let (stmt_model, macro_reg) = {
+                let erased = stmt.erase();
+                let model = self.analyze_statement(
+                    &erased,
+                    config,
+                    &mut resolutions,
+                    &mut definition_offsets,
+                );
+                let reg = extract_macro_registration(
+                    &erased,
+                    erased.root_id(),
+                    self.dialect.macro_defs(),
+                );
+                (model, reg)
+            };
             statements.push(stmt_model);
+
+            // Register any macro defined by this statement so subsequent
+            // `name!(args)` invocations are expanded inline by the parser.
+            if let Some((name, params, body)) = macro_reg {
+                let param_refs: Vec<&str> = params.iter().map(String::as_str).collect();
+                session.register_macro(&name, &param_refs, &body);
+            }
         }
 
         SemanticModel {
@@ -333,6 +369,9 @@ impl SemanticAnalyzer {
 
         self.catalog
             .accumulate_ddl(CatalogLayer::Document, erased, root_id, &self.dialect);
+
+        // Handle module imports: resolve and analyze imported source.
+        self.handle_import(erased, root_id, config, &mut diagnostics);
 
         // Record DDL definition offsets for go-to-definition (same-file).
         if let Some((table_name, off)) = ddl_name_offset(erased, root_id, &self.dialect) {
@@ -368,6 +407,65 @@ impl SemanticAnalyzer {
         StatementModel::new(stmt_source, diagnostics, lineage, defined_relations)
     }
 
+    /// If this statement is an import, resolve and analyze the imported module.
+    fn handle_import(
+        &mut self,
+        erased: &AnyParsedStatement<'_>,
+        root_id: AnyNodeId,
+        config: &ValidationConfig,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        // Check if resolver is available and root is an Import node.
+        if self.resolver.is_none() {
+            return;
+        }
+
+        let Some((tag, fields)) = erased.extract_fields(root_id) else {
+            return;
+        };
+        let idx = u32::from(tag) as usize;
+        let Some(&role) = self.dialect.roles().get(idx) else {
+            return;
+        };
+        let SemanticRole::Import { module } = role else {
+            return;
+        };
+
+        // Extract the module name text.
+        let module_name = match fields[module as usize] {
+            FieldValue::Span { text, .. } if !text.is_empty() => text.to_string(),
+            _ => return,
+        };
+
+        // Dedup / cycle detection.
+        if !self.imported.insert(module_name.clone()) {
+            return;
+        }
+
+        // Resolve the module source.
+        let Some(source) = self.resolver.as_ref().and_then(|r| r.resolve(&module_name)) else {
+            // Emit diagnostic for unresolvable module.
+            let (start, end) = match fields[module as usize] {
+                FieldValue::Span { text, .. } => {
+                    let offset = erased.source().find(text).unwrap_or(0);
+                    (offset, offset + text.len())
+                }
+                _ => (0, 0),
+            };
+            let message = DiagnosticMessage::UnknownModule {
+                name: module_name,
+            };
+            if let Some(severity) = config.checks().level_for(&message).to_severity() {
+                diagnostics.push(Diagnostic::new(start, end, message, severity, None));
+            }
+            return;
+        };
+
+        // Recursively analyze the imported module. DDL accumulates into the
+        // Document layer (visible to subsequent statements in the importing
+        // file).
+        let _ = self.analyze_inner(&source, config);
+    }
 }
 
 #[cfg(feature = "sqlite")]
@@ -796,6 +894,65 @@ fn ddl_name_offset(
 /// extract the macro name, parameter names, and body text as owned strings.
 ///
 /// `SQLite`'s implicit rowid aliases.
+/// Check if the root node of a statement defines a template macro and, if so,
+/// extract the macro name, parameter names, and body text as owned strings.
+///
+/// Returns `None` when the statement is not a macro definition or when any
+/// required field is missing.
+fn extract_macro_registration(
+    stmt: &AnyParsedStatement<'_>,
+    root: AnyNodeId,
+    macro_defs: &[MacroDef],
+) -> Option<(String, Vec<String>, String)> {
+    if macro_defs.is_empty() || root.is_null() {
+        return None;
+    }
+    let (tag, fields) = stmt.extract_fields(root)?;
+    let tag_u32 = u32::from(tag);
+
+    // Find the matching MacroDef entry for this node tag.
+    let def = macro_defs.iter().find(|d| d.node_tag() == tag_u32)?;
+
+    // Extract the macro name.
+    let name = match fields[def.name_field as usize] {
+        FieldValue::Span { text, .. } if !text.is_empty() => text.to_string(),
+        _ => return None,
+    };
+
+    // Extract the macro body.
+    let body = match fields[def.body_field as usize] {
+        FieldValue::Span { text, .. } if !text.is_empty() => text.to_string(),
+        _ => return None,
+    };
+
+    // Extract parameter names from the args list (if present).
+    let params = if def.args_field == FIELD_ABSENT {
+        Vec::new()
+    } else {
+        let args_id = match fields[def.args_field as usize] {
+            FieldValue::NodeId(id) if !id.is_null() => id,
+            _ => return Some((name, Vec::new(), body)),
+        };
+        let children = stmt.list_children(args_id)?;
+        let mut param_names = Vec::with_capacity(children.len());
+        for &child_id in children {
+            if child_id.is_null() {
+                continue;
+            }
+            let (_, child_fields) = stmt.extract_fields(child_id)?;
+            match child_fields[def.arg_name_field as usize] {
+                FieldValue::Span { text, .. } if !text.is_empty() => {
+                    param_names.push(text.to_string());
+                }
+                _ => return None,
+            }
+        }
+        param_names
+    };
+
+    Some((name, params, body))
+}
+
 fn is_rowid_alias(column: &str) -> bool {
     column.eq_ignore_ascii_case("rowid")
         || column.eq_ignore_ascii_case("oid")
@@ -3567,6 +3724,35 @@ mod tests {
         assert!(s.is_none());
     }
 
+    // ── Module import resolution ─────────────────────────────────────────────
+
+    struct MapResolver(HashMap<String, String>);
+
+    impl super::super::ModuleResolver for MapResolver {
+        fn resolve(&self, module_path: &str) -> Option<String> {
+            self.0.get(module_path).cloned()
+        }
+    }
+
+    #[test]
+    fn module_resolver_with_analyzer_does_not_panic() {
+        let resolver = MapResolver(HashMap::new());
+        let mut analyzer =
+            sqlite_analyzer().with_module_resolver(Box::new(resolver));
+        let catalog = sqlite_catalog();
+        let model = analyzer.analyze("SELECT 1", &catalog, &lenient());
+        assert!(!model.has_diagnostics());
+    }
+
+    #[test]
+    fn module_import_dedup_tracking() {
+        let resolver = MapResolver(HashMap::new());
+        let mut analyzer =
+            sqlite_analyzer().with_module_resolver(Box::new(resolver));
+        assert!(analyzer.imported.insert("test.module".to_string()));
+        assert!(!analyzer.imported.insert("test.module".to_string()));
+    }
+
     #[test]
     fn relation_names_enumerates_catalog() {
         let mut catalog = sqlite_catalog();
@@ -3909,6 +4095,50 @@ mod lineage_tests {
     }
 
     // ── Test 9b: DDL with inner SELECT computes lineage ─────────────────────
+
+    #[test]
+    fn lineage_create_table_as_select() {
+        let mut analyzer = sqlite_analyzer();
+        let mut catalog = sqlite_catalog();
+        catalog
+            .layer_mut(CatalogLayer::Database)
+            .insert_table("src", Some(vec!["a".into(), "b".into()]), false);
+
+        let model = analyzer.analyze(
+            "CREATE TABLE t AS SELECT a, b FROM src",
+            &catalog,
+            &lenient(),
+        );
+
+        let lineage = model.lineage().unwrap().into_inner();
+        assert_eq!(lineage.len(), 2);
+        assert_eq!(lineage[0].name, "a");
+        assert_eq!(lineage[0].origin.as_ref().unwrap().table, "src");
+        assert_eq!(lineage[1].name, "b");
+
+        let rels = model.statements().last().unwrap().relations_accessed().unwrap().into_inner();
+        assert_eq!(rels.len(), 1);
+        assert_eq!(rels[0].name, "src");
+    }
+
+    #[test]
+    fn lineage_create_view_as_select() {
+        let mut analyzer = sqlite_analyzer();
+        let mut catalog = sqlite_catalog();
+        catalog
+            .layer_mut(CatalogLayer::Database)
+            .insert_table("t", Some(vec!["x".into(), "y".into()]), false);
+
+        let model = analyzer.analyze(
+            "CREATE VIEW v AS SELECT x FROM t",
+            &catalog,
+            &lenient(),
+        );
+
+        let rels = model.statements().last().unwrap().relations_accessed().unwrap().into_inner();
+        assert_eq!(rels.len(), 1);
+        assert_eq!(rels[0].name, "t");
+    }
 
     // ── Test 10: CTE with expression — origin None ───────────────────────────
 

--- a/syntaqlite/src/semantic/lineage/resolver.rs
+++ b/syntaqlite/src/semantic/lineage/resolver.rs
@@ -90,6 +90,16 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
                 None
             }
             SemanticRole::Query { .. } => self.resolve_select(node_id),
+            SemanticRole::DefineTable { select, .. }
+            | SemanticRole::DefineView { select, .. }
+            | SemanticRole::DefineFunction { select, .. } => {
+                if select != crate::dialect::FIELD_ABSENT
+                    && let FieldValue::NodeId(select_id) = fields[select as usize]
+                {
+                    return self.resolve_node(select_id);
+                }
+                None
+            }
             SemanticRole::Transparent | SemanticRole::DmlScope => {
                 for child_id in self.stmt.child_node_ids(node_id) {
                     if let Some(result) = self.resolve_node(child_id) {

--- a/syntaqlite/src/semantic/mod.rs
+++ b/syntaqlite/src/semantic/mod.rs
@@ -78,6 +78,78 @@ pub use lineage::{
 #[cfg(feature = "validation")]
 pub use model::{DefinedRelation, SemanticModel, StatementModel};
 
+
+// ── Module resolution ────────────────────────────────────────────────────────
+
+/// Callback for resolving `INCLUDE PERFETTO MODULE` (or similar) import
+/// statements during semantic analysis.
+///
+/// Implement this trait to teach the [`SemanticAnalyzer`] how to locate
+/// module source text. The analyzer calls [`resolve`](Self::resolve) when
+/// it encounters an import statement; if the module is found, its DDL is
+/// analyzed and accumulated into the catalog so that subsequent statements
+/// can reference the imported definitions.
+///
+/// # Example
+///
+/// ```
+/// use syntaqlite::semantic::ModuleResolver;
+///
+/// struct InMemoryResolver {
+///     modules: std::collections::HashMap<String, String>,
+/// }
+///
+/// impl ModuleResolver for InMemoryResolver {
+///     fn resolve(&self, module_path: &str) -> Option<String> {
+///         self.modules.get(module_path).cloned()
+///     }
+/// }
+/// ```
+pub trait ModuleResolver {
+    /// Given a dotted module path (e.g. `"slices.flow"`), return the SQL
+    /// source text for that module.
+    ///
+    /// Return `None` if the module cannot be found — the analyzer will emit
+    /// an [`UnknownModule`](DiagnosticMessage::UnknownModule) diagnostic.
+    fn resolve(&self, module_path: &str) -> Option<String>;
+}
+
+/// A [`ModuleResolver`] that maps dotted module paths to files under a
+/// directory root.
+///
+/// The path `slices.flow` is resolved to `<root>/slices/flow.sql`.
+///
+/// # Example
+///
+/// ```no_run
+/// use syntaqlite::semantic::{DirectoryModuleResolver, ModuleResolver};
+/// use std::path::PathBuf;
+///
+/// let resolver = DirectoryModuleResolver::new(PathBuf::from("stdlib/"));
+/// assert_eq!(
+///     resolver.resolve("slices.flow").is_some(),
+///     std::path::Path::new("stdlib/slices/flow.sql").exists(),
+/// );
+/// ```
+pub struct DirectoryModuleResolver {
+    root: std::path::PathBuf,
+}
+
+impl DirectoryModuleResolver {
+    /// Create a resolver rooted at the given directory.
+    pub fn new(root: std::path::PathBuf) -> Self {
+        Self { root }
+    }
+}
+
+impl ModuleResolver for DirectoryModuleResolver {
+    fn resolve(&self, module_path: &str) -> Option<String> {
+        let rel = module_path.replace('.', std::path::MAIN_SEPARATOR_STR);
+        let path = self.root.join(rel).with_extension("sql");
+        std::fs::read_to_string(path).ok()
+    }
+}
+
 /// Whether statements are being analyzed (editing a file) or executed
 /// (running sequentially in a session).
 ///


### PR DESCRIPTION
## Summary
- `extract_macro_registration`: detect `CREATE MACRO` statements and register them with the parser so subsequent `name!(args)` calls expand inline
- `ModuleResolver` trait + `DirectoryModuleResolver` for resolving `INCLUDE MODULE` statements; imported DDL accumulates into the catalog
- `handle_import`: resolve imports with cycle detection, emit `UnknownModule` diagnostics
- Extend lineage resolver to follow SELECT bodies inside `CREATE TABLE/VIEW/FUNCTION` DDL
- Add `MacroDef` accessor to `AnyDialect` via `CDialectTemplateExt` trait

Stacked on #77.

## Test plan
- [x] `cargo check -p syntaqlite --features "sqlite,fmt,validation,dynload"`
- [x] `cargo test -p syntaqlite --features "sqlite,fmt,validation"` — 225 lib + 15 integration + 31 doctests pass