### PR TITLE
synq: add per-statement C API for diagnostics, lineage, and defined relations

### DIFF
--- a/python/csrc/_syntaqlite.c
+++ b/python/csrc/_syntaqlite.c
@@ -558,6 +558,169 @@ syntaqlite_py_validate(PyObject *self, PyObject *args, PyObject *kwargs)
         Py_DECREF(Py_None);
     }
 
+    /* Per-statement data */
+    {
+        uint32_t stmt_count = syntaqlite_validator_statement_count(v);
+        PyObject *stmt_list = PyList_New(0);
+        if (!stmt_list) {
+            Py_DECREF(result);
+            syntaqlite_validator_destroy(v);
+            return NULL;
+        }
+        for (uint32_t si = 0; si < stmt_count; si++) {
+            PyObject *stmt_dict = PyDict_New();
+            if (!stmt_dict) {
+                Py_DECREF(stmt_list);
+                Py_DECREF(result);
+                syntaqlite_validator_destroy(v);
+                return NULL;
+            }
+
+            /* Per-statement diagnostics */
+            uint32_t sd_count = syntaqlite_validator_statement_diagnostic_count(v, si);
+            PyObject *sd_list = PyList_New(0);
+            if (sd_list) {
+                const SyntaqliteDiagnostic *sd = syntaqlite_validator_statement_diagnostics(v, si);
+                for (uint32_t i = 0; i < sd_count; i++) {
+                    PyObject *d = PyDict_New();
+                    if (!d) break;
+                    const char *sev_str;
+                    switch (sd[i].severity) {
+                        case SYNTAQLITE_SEVERITY_ERROR:   sev_str = "error"; break;
+                        case SYNTAQLITE_SEVERITY_WARNING: sev_str = "warning"; break;
+                        case SYNTAQLITE_SEVERITY_INFO:    sev_str = "info"; break;
+                        case SYNTAQLITE_SEVERITY_HINT:    sev_str = "hint"; break;
+                        default:                          sev_str = "unknown"; break;
+                    }
+                    PyObject *sev = PyUnicode_FromString(sev_str);
+                    PyObject *msg = PyUnicode_FromString(sd[i].message ? sd[i].message : "");
+                    PyObject *start = PyLong_FromUnsignedLong(sd[i].start_offset);
+                    PyObject *end = PyLong_FromUnsignedLong(sd[i].end_offset);
+                    if (sev) { PyDict_SetItemString(d, "severity", sev); Py_DECREF(sev); }
+                    if (msg) { PyDict_SetItemString(d, "message", msg); Py_DECREF(msg); }
+                    if (start) { PyDict_SetItemString(d, "start_offset", start); Py_DECREF(start); }
+                    if (end) { PyDict_SetItemString(d, "end_offset", end); Py_DECREF(end); }
+                    PyList_Append(sd_list, d);
+                    Py_DECREF(d);
+                }
+                PyDict_SetItemString(stmt_dict, "diagnostics", sd_list);
+                Py_DECREF(sd_list);
+            }
+
+            /* Per-statement lineage */
+            uint32_t sc_count = syntaqlite_validator_statement_column_lineage_count(v, si);
+            if (sc_count > 0) {
+                const SyntaqliteColumnLineage *sc = syntaqlite_validator_statement_column_lineage(v, si);
+                PyObject *lin = PyDict_New();
+                if (lin) {
+                    PyObject *col_list = PyList_New(0);
+                    if (col_list) {
+                        for (uint32_t i = 0; i < sc_count; i++) {
+                            PyObject *c = PyDict_New();
+                            if (!c) break;
+                            PyObject *name = PyUnicode_FromString(sc[i].name ? sc[i].name : "");
+                            PyObject *idx = PyLong_FromUnsignedLong(sc[i].index);
+                            if (name) { PyDict_SetItemString(c, "name", name); Py_DECREF(name); }
+                            if (idx) { PyDict_SetItemString(c, "index", idx); Py_DECREF(idx); }
+                            if (sc[i].origin.table) {
+                                PyObject *origin = PyDict_New();
+                                if (origin) {
+                                    PyObject *tbl = PyUnicode_FromString(sc[i].origin.table);
+                                    PyObject *col_name = PyUnicode_FromString(sc[i].origin.column);
+                                    if (tbl) { PyDict_SetItemString(origin, "table", tbl); Py_DECREF(tbl); }
+                                    if (col_name) { PyDict_SetItemString(origin, "column", col_name); Py_DECREF(col_name); }
+                                    PyDict_SetItemString(c, "origin", origin);
+                                    Py_DECREF(origin);
+                                }
+                            } else {
+                                Py_INCREF(Py_None);
+                                PyDict_SetItemString(c, "origin", Py_None);
+                                Py_DECREF(Py_None);
+                            }
+                            PyList_Append(col_list, c);
+                            Py_DECREF(c);
+                        }
+                        PyDict_SetItemString(lin, "columns", col_list);
+                        Py_DECREF(col_list);
+                    }
+
+                    /* Per-statement relations */
+                    uint32_t sr_count = syntaqlite_validator_statement_relation_count(v, si);
+                    PyObject *rel_list = PyList_New(0);
+                    if (rel_list) {
+                        const SyntaqliteRelationAccess *sr = syntaqlite_validator_statement_relations(v, si);
+                        for (uint32_t i = 0; i < sr_count; i++) {
+                            PyObject *r = PyDict_New();
+                            if (r) {
+                                PyObject *rname = PyUnicode_FromString(sr[i].name ? sr[i].name : "");
+                                PyObject *rkind = PyUnicode_FromString(
+                                    sr[i].kind == SYNTAQLITE_RELATION_VIEW ? "view" : "table");
+                                if (rname) { PyDict_SetItemString(r, "name", rname); Py_DECREF(rname); }
+                                if (rkind) { PyDict_SetItemString(r, "kind", rkind); Py_DECREF(rkind); }
+                                PyList_Append(rel_list, r);
+                                Py_DECREF(r);
+                            }
+                        }
+                        PyDict_SetItemString(lin, "relations", rel_list);
+                        Py_DECREF(rel_list);
+                    }
+
+                    /* Per-statement tables */
+                    uint32_t st_count = syntaqlite_validator_statement_table_count(v, si);
+                    PyObject *tbl_list = PyList_New(0);
+                    if (tbl_list) {
+                        const SyntaqliteTableAccess *st = syntaqlite_validator_statement_tables(v, si);
+                        for (uint32_t i = 0; i < st_count; i++) {
+                            PyObject *tname = PyUnicode_FromString(st[i].name ? st[i].name : "");
+                            if (tname) { PyList_Append(tbl_list, tname); Py_DECREF(tname); }
+                        }
+                        PyDict_SetItemString(lin, "tables", tbl_list);
+                        Py_DECREF(tbl_list);
+                    }
+
+                    PyObject *complete = Py_True;  /* per-stmt lineage always present if we got here */
+                    Py_INCREF(complete);
+                    PyDict_SetItemString(lin, "complete", complete);
+                    Py_DECREF(complete);
+
+                    PyDict_SetItemString(stmt_dict, "lineage", lin);
+                    Py_DECREF(lin);
+                }
+            } else {
+                Py_INCREF(Py_None);
+                PyDict_SetItemString(stmt_dict, "lineage", Py_None);
+                Py_DECREF(Py_None);
+            }
+
+            /* Per-statement defined relations */
+            uint32_t dr_count = syntaqlite_validator_statement_defined_relation_count(v, si);
+            PyObject *dr_list = PyList_New(0);
+            if (dr_list) {
+                const SyntaqliteDefinedRelation *drs = syntaqlite_validator_statement_defined_relations(v, si);
+                for (uint32_t i = 0; i < dr_count; i++) {
+                    PyObject *dr = PyDict_New();
+                    if (dr) {
+                        PyObject *drname = PyUnicode_FromString(drs[i].name ? drs[i].name : "");
+                        PyObject *is_view = drs[i].is_view ? Py_True : Py_False;
+                        Py_INCREF(is_view);
+                        if (drname) { PyDict_SetItemString(dr, "name", drname); Py_DECREF(drname); }
+                        PyDict_SetItemString(dr, "is_view", is_view);
+                        Py_DECREF(is_view);
+                        PyList_Append(dr_list, dr);
+                        Py_DECREF(dr);
+                    }
+                }
+                PyDict_SetItemString(stmt_dict, "defined_relations", dr_list);
+                Py_DECREF(dr_list);
+            }
+
+            PyList_Append(stmt_list, stmt_dict);
+            Py_DECREF(stmt_dict);
+        }
+        PyDict_SetItemString(result, "statements", stmt_list);
+        Py_DECREF(stmt_list);
+    }
+
     syntaqlite_validator_destroy(v);
     return result;
 }

--- a/python/syntaqlite/__init__.py
+++ b/python/syntaqlite/__init__.py
@@ -212,20 +212,60 @@ class View:
         return f"View({self.name!r})"
 
 
-class ValidationResult:
-    """Result of validate() — diagnostics and optional lineage."""
+class DefinedRelation:
+    """A relation defined by a DDL statement (CREATE TABLE / CREATE VIEW)."""
 
-    __slots__ = ("diagnostics", "lineage")
+    __slots__ = ("name", "is_view")
+
+    def __init__(self, d: dict):
+        self.name: str = d["name"]
+        self.is_view: bool = d["is_view"]
+
+    def __repr__(self):
+        kind = "view" if self.is_view else "table"
+        return f"DefinedRelation({self.name!r}, {kind})"
+
+
+class Statement:
+    """Per-statement analysis result."""
+
+    __slots__ = ("diagnostics", "lineage", "defined_relations")
 
     def __init__(self, d: dict):
         self.diagnostics: list[Diagnostic] = [Diagnostic(x) for x in d["diagnostics"]]
         lin = d["lineage"]
         self.lineage: Lineage | None = Lineage(lin) if lin else None
+        self.defined_relations: list[DefinedRelation] = [
+            DefinedRelation(x) for x in d.get("defined_relations", [])
+        ]
 
     def __repr__(self):
         parts = [f"{len(self.diagnostics)} diagnostics"]
         if self.lineage:
             parts.append(str(self.lineage))
+        if self.defined_relations:
+            parts.append(f"{len(self.defined_relations)} defined relations")
+        return f"Statement({', '.join(parts)})"
+
+
+class ValidationResult:
+    """Result of validate() — diagnostics, optional lineage, and per-statement data."""
+
+    __slots__ = ("diagnostics", "lineage", "statements")
+
+    def __init__(self, d: dict):
+        self.diagnostics: list[Diagnostic] = [Diagnostic(x) for x in d["diagnostics"]]
+        lin = d["lineage"]
+        self.lineage: Lineage | None = Lineage(lin) if lin else None
+        self.statements: list[Statement] = [
+            Statement(s) for s in d.get("statements", [])
+        ]
+
+    def __repr__(self):
+        parts = [f"{len(self.diagnostics)} diagnostics"]
+        if self.lineage:
+            parts.append(str(self.lineage))
+        parts.append(f"{len(self.statements)} statements")
         return f"ValidationResult({', '.join(parts)})"
 
 

--- a/syntaqlite/include/syntaqlite/validation.h
+++ b/syntaqlite/include/syntaqlite/validation.h
@@ -240,54 +240,54 @@ SYNTAQLITE_API const SyntaqliteTableAccess* syntaqlite_validator_tables(
 
 // Number of statements produced by the last analyze() call.
 SYNTAQLITE_API uint32_t syntaqlite_validator_statement_count(
-    const SyntaqliteValidator* v);
+    SyntaqliteValidator* v);
 
 // Number of diagnostics for statement at index `idx`.
 // Returns 0 if idx is out of bounds.
 SYNTAQLITE_API uint32_t syntaqlite_validator_statement_diagnostic_count(
-    const SyntaqliteValidator* v, uint32_t idx);
+    SyntaqliteValidator* v, uint32_t idx);
 
 // Pointer to diagnostics for statement `idx`. NULL when count is 0 or
 // idx is out of bounds.
 SYNTAQLITE_API const SyntaqliteDiagnostic*
 syntaqlite_validator_statement_diagnostics(
-    const SyntaqliteValidator* v, uint32_t idx);
+    SyntaqliteValidator* v, uint32_t idx);
 
 // Number of result columns with lineage for statement `idx`.
 SYNTAQLITE_API uint32_t syntaqlite_validator_statement_column_lineage_count(
-    const SyntaqliteValidator* v, uint32_t idx);
+    SyntaqliteValidator* v, uint32_t idx);
 
 // Column lineage array for statement `idx`. NULL when count is 0.
 SYNTAQLITE_API const SyntaqliteColumnLineage*
 syntaqlite_validator_statement_column_lineage(
-    const SyntaqliteValidator* v, uint32_t idx);
+    SyntaqliteValidator* v, uint32_t idx);
 
 // Number of relations referenced in FROM for statement `idx`.
 SYNTAQLITE_API uint32_t syntaqlite_validator_statement_relation_count(
-    const SyntaqliteValidator* v, uint32_t idx);
+    SyntaqliteValidator* v, uint32_t idx);
 
 // Relation access array for statement `idx`. NULL when count is 0.
 SYNTAQLITE_API const SyntaqliteRelationAccess*
 syntaqlite_validator_statement_relations(
-    const SyntaqliteValidator* v, uint32_t idx);
+    SyntaqliteValidator* v, uint32_t idx);
 
 // Number of physical tables accessed for statement `idx`.
 SYNTAQLITE_API uint32_t syntaqlite_validator_statement_table_count(
-    const SyntaqliteValidator* v, uint32_t idx);
+    SyntaqliteValidator* v, uint32_t idx);
 
 // Physical table access array for statement `idx`. NULL when count is 0.
 SYNTAQLITE_API const SyntaqliteTableAccess*
 syntaqlite_validator_statement_tables(
-    const SyntaqliteValidator* v, uint32_t idx);
+    SyntaqliteValidator* v, uint32_t idx);
 
 // Number of relations defined by DDL in statement `idx`.
 SYNTAQLITE_API uint32_t syntaqlite_validator_statement_defined_relation_count(
-    const SyntaqliteValidator* v, uint32_t idx);
+    SyntaqliteValidator* v, uint32_t idx);
 
 // Defined relations for statement `idx`. NULL when count is 0.
 SYNTAQLITE_API const SyntaqliteDefinedRelation*
 syntaqlite_validator_statement_defined_relations(
-    const SyntaqliteValidator* v, uint32_t idx);
+    SyntaqliteValidator* v, uint32_t idx);
 
 // Free a string returned by a syntaqlite_* function that documents
 // ownership transfer. No-op if s is NULL.

--- a/syntaqlite/include/syntaqlite/validation.h
+++ b/syntaqlite/include/syntaqlite/validation.h
@@ -91,6 +91,12 @@ typedef struct {
   const char* name;
 } SyntaqliteTableAccess;
 
+// A relation defined by a DDL statement (CREATE TABLE, CREATE VIEW).
+typedef struct {
+  const char* name;
+  uint32_t is_view;   // 0 = table, 1 = view
+} SyntaqliteDefinedRelation;
+
 // Analysis mode — controls whether DDL persists across analyze() calls.
 typedef enum {
   // Statements are being analyzed (e.g. editing a SQL file).
@@ -227,6 +233,61 @@ SYNTAQLITE_API uint32_t syntaqlite_validator_table_count(
 // Returns NULL when table_count is 0.
 SYNTAQLITE_API const SyntaqliteTableAccess* syntaqlite_validator_tables(
     const SyntaqliteValidator* v);
+
+// ---------------------------------------------------------------------------
+// Per-statement access (valid until next analyze() or destroy())
+// ---------------------------------------------------------------------------
+
+// Number of statements produced by the last analyze() call.
+SYNTAQLITE_API uint32_t syntaqlite_validator_statement_count(
+    const SyntaqliteValidator* v);
+
+// Number of diagnostics for statement at index `idx`.
+// Returns 0 if idx is out of bounds.
+SYNTAQLITE_API uint32_t syntaqlite_validator_statement_diagnostic_count(
+    const SyntaqliteValidator* v, uint32_t idx);
+
+// Pointer to diagnostics for statement `idx`. NULL when count is 0 or
+// idx is out of bounds.
+SYNTAQLITE_API const SyntaqliteDiagnostic*
+syntaqlite_validator_statement_diagnostics(
+    const SyntaqliteValidator* v, uint32_t idx);
+
+// Number of result columns with lineage for statement `idx`.
+SYNTAQLITE_API uint32_t syntaqlite_validator_statement_column_lineage_count(
+    const SyntaqliteValidator* v, uint32_t idx);
+
+// Column lineage array for statement `idx`. NULL when count is 0.
+SYNTAQLITE_API const SyntaqliteColumnLineage*
+syntaqlite_validator_statement_column_lineage(
+    const SyntaqliteValidator* v, uint32_t idx);
+
+// Number of relations referenced in FROM for statement `idx`.
+SYNTAQLITE_API uint32_t syntaqlite_validator_statement_relation_count(
+    const SyntaqliteValidator* v, uint32_t idx);
+
+// Relation access array for statement `idx`. NULL when count is 0.
+SYNTAQLITE_API const SyntaqliteRelationAccess*
+syntaqlite_validator_statement_relations(
+    const SyntaqliteValidator* v, uint32_t idx);
+
+// Number of physical tables accessed for statement `idx`.
+SYNTAQLITE_API uint32_t syntaqlite_validator_statement_table_count(
+    const SyntaqliteValidator* v, uint32_t idx);
+
+// Physical table access array for statement `idx`. NULL when count is 0.
+SYNTAQLITE_API const SyntaqliteTableAccess*
+syntaqlite_validator_statement_tables(
+    const SyntaqliteValidator* v, uint32_t idx);
+
+// Number of relations defined by DDL in statement `idx`.
+SYNTAQLITE_API uint32_t syntaqlite_validator_statement_defined_relation_count(
+    const SyntaqliteValidator* v, uint32_t idx);
+
+// Defined relations for statement `idx`. NULL when count is 0.
+SYNTAQLITE_API const SyntaqliteDefinedRelation*
+syntaqlite_validator_statement_defined_relations(
+    const SyntaqliteValidator* v, uint32_t idx);
 
 // Free a string returned by a syntaqlite_* function that documents
 // ownership transfer. No-op if s is NULL.

--- a/syntaqlite/src/semantic/ffi.rs
+++ b/syntaqlite/src/semantic/ffi.rs
@@ -72,16 +72,16 @@ pub struct SyntaqliteDefinedRelation {
     pub is_view: u32,
 }
 
-/// Per-statement C-compatible data, populated after each `analyze()` call.
-struct PerStatementC {
-    diagnostics: Vec<SyntaqliteDiagnostic>,
-    messages: Vec<CString>,
-    column_lineage: Vec<SyntaqliteColumnLineage>,
-    relations: Vec<SyntaqliteRelationAccess>,
-    tables: Vec<SyntaqliteTableAccess>,
-    defined_relations: Vec<SyntaqliteDefinedRelation>,
-    /// All CStrings for lineage/relation/defined_relation names.
-    strings: Vec<CString>,
+/// Lazily-cached C-compatible data for a single statement.
+/// Each field is populated on first access by the corresponding accessor
+/// function and remains valid until the next `analyze()` call.
+#[derive(Default)]
+struct PerStatementCache {
+    diagnostics: Option<(Vec<SyntaqliteDiagnostic>, Vec<CString>)>,
+    column_lineage: Option<(Vec<SyntaqliteColumnLineage>, Vec<CString>)>,
+    relations: Option<(Vec<SyntaqliteRelationAccess>, Vec<CString>)>,
+    tables: Option<(Vec<SyntaqliteTableAccess>, Vec<CString>)>,
+    defined_relations: Option<(Vec<SyntaqliteDefinedRelation>, Vec<CString>)>,
 }
 
 /// Opaque validator handle exposed to C.
@@ -114,8 +114,10 @@ struct ValidatorState {
     c_tables: Vec<SyntaqliteTableAccess>,
     /// Rendered lineage strings, kept alive for the C pointers.
     lineage_strings: Vec<CString>,
-    /// Per-statement C data from the most recent `analyze()` call.
-    per_statement: Vec<PerStatementC>,
+    /// The model from the most recent `analyze()` call.
+    last_model: Option<SemanticModel>,
+    /// Lazily-cached per-statement C data.
+    per_statement_cache: Vec<PerStatementCache>,
 }
 
 /// Opaque C handle — the pointer target of `SyntaqliteValidator*`.
@@ -292,7 +294,8 @@ fn create_validator(dialect: AnyDialect) -> *mut SyntaqliteValidator {
         c_relations: Vec::new(),
         c_tables: Vec::new(),
         lineage_strings: Vec::new(),
-        per_statement: Vec::new(),
+        last_model: None,
+        per_statement_cache: Vec::new(),
     });
     Box::into_raw(state).cast::<SyntaqliteValidator>()
 }
@@ -413,7 +416,12 @@ pub unsafe extern "C" fn syntaqlite_validator_analyze(
     }
 
     populate_lineage(state, &model);
-    populate_per_statement(state, &model);
+
+    // Store model and reset per-statement cache for lazy access.
+    let stmt_count = model.statements().len();
+    state.per_statement_cache.clear();
+    state.per_statement_cache.resize_with(stmt_count, PerStatementCache::default);
+    state.last_model = Some(model);
 
     state.c_diagnostics.len() as u32
 }
@@ -777,275 +785,256 @@ pub unsafe extern "C" fn syntaqlite_validator_tables(
     }
 }
 
-// ── Per-statement data population ─────────────────────────────────────────
+// ── Per-statement lazy accessors ──────────────────────────────────────────
+//
+// Each accessor lazily populates its cache in PerStatementCache on first
+// call, reading from last_model.statements()[idx]. The cache (and model)
+// are cleared on the next analyze() call.
 
-fn populate_per_statement(state: &mut ValidatorState, model: &SemanticModel) {
-    state.per_statement.clear();
+use super::model::StatementModel;
 
-    for stmt in model.statements() {
-        let mut ps = PerStatementC {
-            diagnostics: Vec::new(),
-            messages: Vec::new(),
-            column_lineage: Vec::new(),
-            relations: Vec::new(),
-            tables: Vec::new(),
-            defined_relations: Vec::new(),
-            strings: Vec::new(),
-        };
-
-        // Diagnostics: two-pass (strings first, then C structs).
+/// Build C diagnostics from a `StatementModel`, caching into the slot.
+fn ensure_diagnostics<'a>(cache: &'a mut PerStatementCache, stmt: &StatementModel)
+    -> &'a (Vec<SyntaqliteDiagnostic>, Vec<CString>)
+{
+    cache.diagnostics.get_or_insert_with(|| {
+        let mut msgs = Vec::new();
+        let mut diags = Vec::new();
         for d in stmt.diagnostics() {
-            ps.messages
-                .push(CString::new(d.message().to_string()).unwrap_or_default());
+            msgs.push(CString::new(d.message().to_string()).unwrap_or_default());
         }
-        for (d, msg) in stmt.diagnostics().iter().zip(ps.messages.iter()) {
-            ps.diagnostics.push(SyntaqliteDiagnostic {
+        for (d, msg) in stmt.diagnostics().iter().zip(msgs.iter()) {
+            diags.push(SyntaqliteDiagnostic {
                 severity: severity_to_c(d.severity()),
                 message: msg.as_ptr(),
                 start_offset: d.start_offset() as u32,
                 end_offset: d.end_offset() as u32,
             });
         }
+        (diags, msgs)
+    })
+}
 
-        // Lineage: column lineage, relations, tables.
+/// Build C column lineage from a `StatementModel`.
+fn ensure_column_lineage<'a>(cache: &'a mut PerStatementCache, stmt: &StatementModel)
+    -> &'a (Vec<SyntaqliteColumnLineage>, Vec<CString>)
+{
+    cache.column_lineage.get_or_insert_with(|| {
+        let mut strings = Vec::new();
+        let mut cols = Vec::new();
         if let Some(lineage) = stmt.lineage() {
-            let cols = lineage.into_inner();
-            // First pass: push all strings.
-            for col in cols {
-                ps.strings
-                    .push(CString::new(col.name.as_str()).unwrap_or_default());
+            // First pass: all strings.
+            for col in lineage.into_inner() {
+                strings.push(CString::new(col.name.as_str()).unwrap_or_default());
                 if let Some(ref origin) = col.origin {
-                    ps.strings
-                        .push(CString::new(origin.table.as_str()).unwrap_or_default());
-                    ps.strings
-                        .push(CString::new(origin.column.as_str()).unwrap_or_default());
+                    strings.push(CString::new(origin.table.as_str()).unwrap_or_default());
+                    strings.push(CString::new(origin.column.as_str()).unwrap_or_default());
                 }
             }
             // Second pass: build C structs.
-            let mut str_idx = 0;
+            let mut si = 0;
             for col in stmt.lineage().unwrap().into_inner() {
-                let name_ptr = ps.strings[str_idx].as_ptr();
-                str_idx += 1;
+                let name_ptr = strings[si].as_ptr();
+                si += 1;
                 let origin = if col.origin.is_some() {
-                    let table_ptr = ps.strings[str_idx].as_ptr();
-                    str_idx += 1;
-                    let column_ptr = ps.strings[str_idx].as_ptr();
-                    str_idx += 1;
-                    SyntaqliteColumnOrigin {
-                        table: table_ptr,
-                        column: column_ptr,
-                    }
+                    let tp = strings[si].as_ptr(); si += 1;
+                    let cp = strings[si].as_ptr(); si += 1;
+                    SyntaqliteColumnOrigin { table: tp, column: cp }
                 } else {
-                    SyntaqliteColumnOrigin {
-                        table: std::ptr::null(),
-                        column: std::ptr::null(),
-                    }
+                    SyntaqliteColumnOrigin { table: std::ptr::null(), column: std::ptr::null() }
                 };
-                ps.column_lineage.push(SyntaqliteColumnLineage {
-                    name: name_ptr,
-                    index: col.index,
-                    origin,
-                });
+                cols.push(SyntaqliteColumnLineage { name: name_ptr, index: col.index, origin });
             }
         }
-
-        // Relations accessed.
-        if let Some(rels) = stmt.relations_accessed() {
-            let base = ps.strings.len();
-            for r in rels.into_inner() {
-                ps.strings
-                    .push(CString::new(r.name.as_str()).unwrap_or_default());
-            }
-            for (i, r) in stmt
-                .relations_accessed()
-                .unwrap()
-                .into_inner()
-                .iter()
-                .enumerate()
-            {
-                ps.relations.push(SyntaqliteRelationAccess {
-                    name: ps.strings[base + i].as_ptr(),
-                    kind: match r.kind {
-                        RelationKind::Table => 0,
-                        RelationKind::View => 1,
-                    },
-                });
-            }
-        }
-
-        // Tables accessed.
-        if let Some(tbls) = stmt.tables_accessed() {
-            let base = ps.strings.len();
-            for t in tbls.into_inner() {
-                ps.strings
-                    .push(CString::new(t.name.as_str()).unwrap_or_default());
-            }
-            let count = stmt.tables_accessed().unwrap().into_inner().len();
-            for i in 0..count {
-                ps.tables.push(SyntaqliteTableAccess {
-                    name: ps.strings[base + i].as_ptr(),
-                });
-            }
-        }
-
-        // Defined relations.
-        {
-            let base = ps.strings.len();
-            for dr in stmt.defined_relations() {
-                ps.strings
-                    .push(CString::new(dr.name.as_str()).unwrap_or_default());
-            }
-            for (i, dr) in stmt.defined_relations().iter().enumerate() {
-                ps.defined_relations.push(SyntaqliteDefinedRelation {
-                    name: ps.strings[base + i].as_ptr(),
-                    is_view: u32::from(dr.is_view),
-                });
-            }
-        }
-
-        state.per_statement.push(ps);
-    }
+        (cols, strings)
+    })
 }
 
-// ── Per-statement accessors ───────────────────────────────────────────────
+/// Build C relation access from a `StatementModel`.
+fn ensure_relations<'a>(cache: &'a mut PerStatementCache, stmt: &StatementModel)
+    -> &'a (Vec<SyntaqliteRelationAccess>, Vec<CString>)
+{
+    cache.relations.get_or_insert_with(|| {
+        let mut strings = Vec::new();
+        let mut rels = Vec::new();
+        if let Some(result) = stmt.relations_accessed() {
+            for r in result.into_inner() {
+                strings.push(CString::new(r.name.as_str()).unwrap_or_default());
+            }
+            for (i, r) in stmt.relations_accessed().unwrap().into_inner().iter().enumerate() {
+                rels.push(SyntaqliteRelationAccess {
+                    name: strings[i].as_ptr(),
+                    kind: match r.kind { RelationKind::Table => 0, RelationKind::View => 1 },
+                });
+            }
+        }
+        (rels, strings)
+    })
+}
+
+/// Build C table access from a `StatementModel`.
+fn ensure_tables<'a>(cache: &'a mut PerStatementCache, stmt: &StatementModel)
+    -> &'a (Vec<SyntaqliteTableAccess>, Vec<CString>)
+{
+    cache.tables.get_or_insert_with(|| {
+        let mut strings = Vec::new();
+        let mut tbls = Vec::new();
+        if let Some(result) = stmt.tables_accessed() {
+            for t in result.into_inner() {
+                strings.push(CString::new(t.name.as_str()).unwrap_or_default());
+            }
+            for i in 0..strings.len() {
+                tbls.push(SyntaqliteTableAccess { name: strings[i].as_ptr() });
+            }
+        }
+        (tbls, strings)
+    })
+}
+
+/// Build C defined relations from a `StatementModel`.
+fn ensure_defined_relations<'a>(cache: &'a mut PerStatementCache, stmt: &StatementModel)
+    -> &'a (Vec<SyntaqliteDefinedRelation>, Vec<CString>)
+{
+    cache.defined_relations.get_or_insert_with(|| {
+        let mut strings = Vec::new();
+        let mut defs = Vec::new();
+        for dr in stmt.defined_relations() {
+            strings.push(CString::new(dr.name.as_str()).unwrap_or_default());
+        }
+        for (i, dr) in stmt.defined_relations().iter().enumerate() {
+            defs.push(SyntaqliteDefinedRelation {
+                name: strings[i].as_ptr(),
+                is_view: u32::from(dr.is_view),
+            });
+        }
+        (defs, strings)
+    })
+}
+
+/// Look up the statement + cache for a given index, or return `None` if
+/// out of bounds or no model is available.
+///
+/// # Safety
+/// `v` must be a valid pointer from `syntaqlite_validator_create_*`.
+unsafe fn stmt_cache<'a>(
+    v: *mut SyntaqliteValidator,
+    idx: u32,
+) -> Option<(&'a StatementModel, &'a mut PerStatementCache)> {
+    let state = unsafe { &mut *v }.state_mut();
+    let i = idx as usize;
+    let model = state.last_model.as_ref()?;
+    let stmt = model.statements().get(i)?;
+    let cache = &mut state.per_statement_cache[i];
+    // Reborrow stmt with a longer lifetime — model lives in state and won't
+    // move while we hold &mut state.
+    let stmt: &StatementModel = unsafe { &*(stmt as *const StatementModel) };
+    Some((stmt, cache))
+}
+
+/// Return (ptr, count) for a lazily-cached vec, or (null, 0) on miss.
+fn cached_slice<T>(v: &[T]) -> (*const T, u32) {
+    if v.is_empty() {
+        (std::ptr::null(), 0)
+    } else {
+        (v.as_ptr(), v.len() as u32)
+    }
+}
 
 #[unsafe(no_mangle)]
 #[expect(clippy::cast_possible_truncation)]
 pub unsafe extern "C" fn syntaqlite_validator_statement_count(
-    v: *const SyntaqliteValidator,
+    v: *mut SyntaqliteValidator,
 ) -> u32 {
-    let v = unsafe { &*v };
-    v.state().per_statement.len() as u32
+    let state = unsafe { &mut *v }.state_mut();
+    state
+        .last_model
+        .as_ref()
+        .map_or(0, |m| m.statements().len() as u32)
 }
 
 #[unsafe(no_mangle)]
 #[expect(clippy::cast_possible_truncation)]
 pub unsafe extern "C" fn syntaqlite_validator_statement_diagnostic_count(
-    v: *const SyntaqliteValidator,
-    idx: u32,
+    v: *mut SyntaqliteValidator, idx: u32,
 ) -> u32 {
-    let v = unsafe { &*v };
-    v.state()
-        .per_statement
-        .get(idx as usize)
-        .map_or(0, |ps| ps.diagnostics.len() as u32)
+    let Some((s, c)) = (unsafe { stmt_cache(v, idx) }) else { return 0 };
+    cached_slice(&ensure_diagnostics(c, s).0).1
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn syntaqlite_validator_statement_diagnostics(
-    v: *const SyntaqliteValidator,
-    idx: u32,
+    v: *mut SyntaqliteValidator, idx: u32,
 ) -> *const SyntaqliteDiagnostic {
-    let v = unsafe { &*v };
-    v.state()
-        .per_statement
-        .get(idx as usize)
-        .filter(|ps| !ps.diagnostics.is_empty())
-        .map_or(std::ptr::null(), |ps| ps.diagnostics.as_ptr())
+    let Some((s, c)) = (unsafe { stmt_cache(v, idx) }) else { return std::ptr::null() };
+    cached_slice(&ensure_diagnostics(c, s).0).0
 }
 
 #[unsafe(no_mangle)]
 #[expect(clippy::cast_possible_truncation)]
 pub unsafe extern "C" fn syntaqlite_validator_statement_column_lineage_count(
-    v: *const SyntaqliteValidator,
-    idx: u32,
+    v: *mut SyntaqliteValidator, idx: u32,
 ) -> u32 {
-    let v = unsafe { &*v };
-    v.state()
-        .per_statement
-        .get(idx as usize)
-        .map_or(0, |ps| ps.column_lineage.len() as u32)
+    let Some((s, c)) = (unsafe { stmt_cache(v, idx) }) else { return 0 };
+    cached_slice(&ensure_column_lineage(c, s).0).1
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn syntaqlite_validator_statement_column_lineage(
-    v: *const SyntaqliteValidator,
-    idx: u32,
+    v: *mut SyntaqliteValidator, idx: u32,
 ) -> *const SyntaqliteColumnLineage {
-    let v = unsafe { &*v };
-    v.state()
-        .per_statement
-        .get(idx as usize)
-        .filter(|ps| !ps.column_lineage.is_empty())
-        .map_or(std::ptr::null(), |ps| ps.column_lineage.as_ptr())
+    let Some((s, c)) = (unsafe { stmt_cache(v, idx) }) else { return std::ptr::null() };
+    cached_slice(&ensure_column_lineage(c, s).0).0
 }
 
 #[unsafe(no_mangle)]
 #[expect(clippy::cast_possible_truncation)]
 pub unsafe extern "C" fn syntaqlite_validator_statement_relation_count(
-    v: *const SyntaqliteValidator,
-    idx: u32,
+    v: *mut SyntaqliteValidator, idx: u32,
 ) -> u32 {
-    let v = unsafe { &*v };
-    v.state()
-        .per_statement
-        .get(idx as usize)
-        .map_or(0, |ps| ps.relations.len() as u32)
+    let Some((s, c)) = (unsafe { stmt_cache(v, idx) }) else { return 0 };
+    cached_slice(&ensure_relations(c, s).0).1
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn syntaqlite_validator_statement_relations(
-    v: *const SyntaqliteValidator,
-    idx: u32,
+    v: *mut SyntaqliteValidator, idx: u32,
 ) -> *const SyntaqliteRelationAccess {
-    let v = unsafe { &*v };
-    v.state()
-        .per_statement
-        .get(idx as usize)
-        .filter(|ps| !ps.relations.is_empty())
-        .map_or(std::ptr::null(), |ps| ps.relations.as_ptr())
+    let Some((s, c)) = (unsafe { stmt_cache(v, idx) }) else { return std::ptr::null() };
+    cached_slice(&ensure_relations(c, s).0).0
 }
 
 #[unsafe(no_mangle)]
 #[expect(clippy::cast_possible_truncation)]
 pub unsafe extern "C" fn syntaqlite_validator_statement_table_count(
-    v: *const SyntaqliteValidator,
-    idx: u32,
+    v: *mut SyntaqliteValidator, idx: u32,
 ) -> u32 {
-    let v = unsafe { &*v };
-    v.state()
-        .per_statement
-        .get(idx as usize)
-        .map_or(0, |ps| ps.tables.len() as u32)
+    let Some((s, c)) = (unsafe { stmt_cache(v, idx) }) else { return 0 };
+    cached_slice(&ensure_tables(c, s).0).1
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn syntaqlite_validator_statement_tables(
-    v: *const SyntaqliteValidator,
-    idx: u32,
+    v: *mut SyntaqliteValidator, idx: u32,
 ) -> *const SyntaqliteTableAccess {
-    let v = unsafe { &*v };
-    v.state()
-        .per_statement
-        .get(idx as usize)
-        .filter(|ps| !ps.tables.is_empty())
-        .map_or(std::ptr::null(), |ps| ps.tables.as_ptr())
+    let Some((s, c)) = (unsafe { stmt_cache(v, idx) }) else { return std::ptr::null() };
+    cached_slice(&ensure_tables(c, s).0).0
 }
 
 #[unsafe(no_mangle)]
 #[expect(clippy::cast_possible_truncation)]
 pub unsafe extern "C" fn syntaqlite_validator_statement_defined_relation_count(
-    v: *const SyntaqliteValidator,
-    idx: u32,
+    v: *mut SyntaqliteValidator, idx: u32,
 ) -> u32 {
-    let v = unsafe { &*v };
-    v.state()
-        .per_statement
-        .get(idx as usize)
-        .map_or(0, |ps| ps.defined_relations.len() as u32)
+    let Some((s, c)) = (unsafe { stmt_cache(v, idx) }) else { return 0 };
+    cached_slice(&ensure_defined_relations(c, s).0).1
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn syntaqlite_validator_statement_defined_relations(
-    v: *const SyntaqliteValidator,
-    idx: u32,
+    v: *mut SyntaqliteValidator, idx: u32,
 ) -> *const SyntaqliteDefinedRelation {
-    let v = unsafe { &*v };
-    v.state()
-        .per_statement
-        .get(idx as usize)
-        .filter(|ps| !ps.defined_relations.is_empty())
-        .map_or(std::ptr::null(), |ps| ps.defined_relations.as_ptr())
+    let Some((s, c)) = (unsafe { stmt_cache(v, idx) }) else { return std::ptr::null() };
+    cached_slice(&ensure_defined_relations(c, s).0).0
 }
 
 /// Free a string returned by `syntaqlite_string_*` functions.

--- a/syntaqlite/src/semantic/ffi.rs
+++ b/syntaqlite/src/semantic/ffi.rs
@@ -65,6 +65,25 @@ pub struct SyntaqliteTableAccess {
     pub name: *const c_char,
 }
 
+/// A relation defined by a DDL statement.
+#[repr(C)]
+pub struct SyntaqliteDefinedRelation {
+    pub name: *const c_char,
+    pub is_view: u32,
+}
+
+/// Per-statement C-compatible data, populated after each `analyze()` call.
+struct PerStatementC {
+    diagnostics: Vec<SyntaqliteDiagnostic>,
+    messages: Vec<CString>,
+    column_lineage: Vec<SyntaqliteColumnLineage>,
+    relations: Vec<SyntaqliteRelationAccess>,
+    tables: Vec<SyntaqliteTableAccess>,
+    defined_relations: Vec<SyntaqliteDefinedRelation>,
+    /// All CStrings for lineage/relation/defined_relation names.
+    strings: Vec<CString>,
+}
+
 /// Opaque validator handle exposed to C.
 ///
 /// Owns a `SemanticAnalyzer`, a user `Catalog` (for persistent schema), and
@@ -95,6 +114,8 @@ struct ValidatorState {
     c_tables: Vec<SyntaqliteTableAccess>,
     /// Rendered lineage strings, kept alive for the C pointers.
     lineage_strings: Vec<CString>,
+    /// Per-statement C data from the most recent `analyze()` call.
+    per_statement: Vec<PerStatementC>,
 }
 
 /// Opaque C handle — the pointer target of `SyntaqliteValidator*`.
@@ -271,6 +292,7 @@ fn create_validator(dialect: AnyDialect) -> *mut SyntaqliteValidator {
         c_relations: Vec::new(),
         c_tables: Vec::new(),
         lineage_strings: Vec::new(),
+        per_statement: Vec::new(),
     });
     Box::into_raw(state).cast::<SyntaqliteValidator>()
 }
@@ -391,6 +413,7 @@ pub unsafe extern "C" fn syntaqlite_validator_analyze(
     }
 
     populate_lineage(state, &model);
+    populate_per_statement(state, &model);
 
     state.c_diagnostics.len() as u32
 }
@@ -752,6 +775,277 @@ pub unsafe extern "C" fn syntaqlite_validator_tables(
     } else {
         state.c_tables.as_ptr()
     }
+}
+
+// ── Per-statement data population ─────────────────────────────────────────
+
+fn populate_per_statement(state: &mut ValidatorState, model: &SemanticModel) {
+    state.per_statement.clear();
+
+    for stmt in model.statements() {
+        let mut ps = PerStatementC {
+            diagnostics: Vec::new(),
+            messages: Vec::new(),
+            column_lineage: Vec::new(),
+            relations: Vec::new(),
+            tables: Vec::new(),
+            defined_relations: Vec::new(),
+            strings: Vec::new(),
+        };
+
+        // Diagnostics: two-pass (strings first, then C structs).
+        for d in stmt.diagnostics() {
+            ps.messages
+                .push(CString::new(d.message().to_string()).unwrap_or_default());
+        }
+        for (d, msg) in stmt.diagnostics().iter().zip(ps.messages.iter()) {
+            ps.diagnostics.push(SyntaqliteDiagnostic {
+                severity: severity_to_c(d.severity()),
+                message: msg.as_ptr(),
+                start_offset: d.start_offset() as u32,
+                end_offset: d.end_offset() as u32,
+            });
+        }
+
+        // Lineage: column lineage, relations, tables.
+        if let Some(lineage) = stmt.lineage() {
+            let cols = lineage.into_inner();
+            // First pass: push all strings.
+            for col in cols {
+                ps.strings
+                    .push(CString::new(col.name.as_str()).unwrap_or_default());
+                if let Some(ref origin) = col.origin {
+                    ps.strings
+                        .push(CString::new(origin.table.as_str()).unwrap_or_default());
+                    ps.strings
+                        .push(CString::new(origin.column.as_str()).unwrap_or_default());
+                }
+            }
+            // Second pass: build C structs.
+            let mut str_idx = 0;
+            for col in stmt.lineage().unwrap().into_inner() {
+                let name_ptr = ps.strings[str_idx].as_ptr();
+                str_idx += 1;
+                let origin = if col.origin.is_some() {
+                    let table_ptr = ps.strings[str_idx].as_ptr();
+                    str_idx += 1;
+                    let column_ptr = ps.strings[str_idx].as_ptr();
+                    str_idx += 1;
+                    SyntaqliteColumnOrigin {
+                        table: table_ptr,
+                        column: column_ptr,
+                    }
+                } else {
+                    SyntaqliteColumnOrigin {
+                        table: std::ptr::null(),
+                        column: std::ptr::null(),
+                    }
+                };
+                ps.column_lineage.push(SyntaqliteColumnLineage {
+                    name: name_ptr,
+                    index: col.index,
+                    origin,
+                });
+            }
+        }
+
+        // Relations accessed.
+        if let Some(rels) = stmt.relations_accessed() {
+            let base = ps.strings.len();
+            for r in rels.into_inner() {
+                ps.strings
+                    .push(CString::new(r.name.as_str()).unwrap_or_default());
+            }
+            for (i, r) in stmt
+                .relations_accessed()
+                .unwrap()
+                .into_inner()
+                .iter()
+                .enumerate()
+            {
+                ps.relations.push(SyntaqliteRelationAccess {
+                    name: ps.strings[base + i].as_ptr(),
+                    kind: match r.kind {
+                        RelationKind::Table => 0,
+                        RelationKind::View => 1,
+                    },
+                });
+            }
+        }
+
+        // Tables accessed.
+        if let Some(tbls) = stmt.tables_accessed() {
+            let base = ps.strings.len();
+            for t in tbls.into_inner() {
+                ps.strings
+                    .push(CString::new(t.name.as_str()).unwrap_or_default());
+            }
+            let count = stmt.tables_accessed().unwrap().into_inner().len();
+            for i in 0..count {
+                ps.tables.push(SyntaqliteTableAccess {
+                    name: ps.strings[base + i].as_ptr(),
+                });
+            }
+        }
+
+        // Defined relations.
+        {
+            let base = ps.strings.len();
+            for dr in stmt.defined_relations() {
+                ps.strings
+                    .push(CString::new(dr.name.as_str()).unwrap_or_default());
+            }
+            for (i, dr) in stmt.defined_relations().iter().enumerate() {
+                ps.defined_relations.push(SyntaqliteDefinedRelation {
+                    name: ps.strings[base + i].as_ptr(),
+                    is_view: u32::from(dr.is_view),
+                });
+            }
+        }
+
+        state.per_statement.push(ps);
+    }
+}
+
+// ── Per-statement accessors ───────────────────────────────────────────────
+
+#[unsafe(no_mangle)]
+#[expect(clippy::cast_possible_truncation)]
+pub unsafe extern "C" fn syntaqlite_validator_statement_count(
+    v: *const SyntaqliteValidator,
+) -> u32 {
+    let v = unsafe { &*v };
+    v.state().per_statement.len() as u32
+}
+
+#[unsafe(no_mangle)]
+#[expect(clippy::cast_possible_truncation)]
+pub unsafe extern "C" fn syntaqlite_validator_statement_diagnostic_count(
+    v: *const SyntaqliteValidator,
+    idx: u32,
+) -> u32 {
+    let v = unsafe { &*v };
+    v.state()
+        .per_statement
+        .get(idx as usize)
+        .map_or(0, |ps| ps.diagnostics.len() as u32)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn syntaqlite_validator_statement_diagnostics(
+    v: *const SyntaqliteValidator,
+    idx: u32,
+) -> *const SyntaqliteDiagnostic {
+    let v = unsafe { &*v };
+    v.state()
+        .per_statement
+        .get(idx as usize)
+        .filter(|ps| !ps.diagnostics.is_empty())
+        .map_or(std::ptr::null(), |ps| ps.diagnostics.as_ptr())
+}
+
+#[unsafe(no_mangle)]
+#[expect(clippy::cast_possible_truncation)]
+pub unsafe extern "C" fn syntaqlite_validator_statement_column_lineage_count(
+    v: *const SyntaqliteValidator,
+    idx: u32,
+) -> u32 {
+    let v = unsafe { &*v };
+    v.state()
+        .per_statement
+        .get(idx as usize)
+        .map_or(0, |ps| ps.column_lineage.len() as u32)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn syntaqlite_validator_statement_column_lineage(
+    v: *const SyntaqliteValidator,
+    idx: u32,
+) -> *const SyntaqliteColumnLineage {
+    let v = unsafe { &*v };
+    v.state()
+        .per_statement
+        .get(idx as usize)
+        .filter(|ps| !ps.column_lineage.is_empty())
+        .map_or(std::ptr::null(), |ps| ps.column_lineage.as_ptr())
+}
+
+#[unsafe(no_mangle)]
+#[expect(clippy::cast_possible_truncation)]
+pub unsafe extern "C" fn syntaqlite_validator_statement_relation_count(
+    v: *const SyntaqliteValidator,
+    idx: u32,
+) -> u32 {
+    let v = unsafe { &*v };
+    v.state()
+        .per_statement
+        .get(idx as usize)
+        .map_or(0, |ps| ps.relations.len() as u32)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn syntaqlite_validator_statement_relations(
+    v: *const SyntaqliteValidator,
+    idx: u32,
+) -> *const SyntaqliteRelationAccess {
+    let v = unsafe { &*v };
+    v.state()
+        .per_statement
+        .get(idx as usize)
+        .filter(|ps| !ps.relations.is_empty())
+        .map_or(std::ptr::null(), |ps| ps.relations.as_ptr())
+}
+
+#[unsafe(no_mangle)]
+#[expect(clippy::cast_possible_truncation)]
+pub unsafe extern "C" fn syntaqlite_validator_statement_table_count(
+    v: *const SyntaqliteValidator,
+    idx: u32,
+) -> u32 {
+    let v = unsafe { &*v };
+    v.state()
+        .per_statement
+        .get(idx as usize)
+        .map_or(0, |ps| ps.tables.len() as u32)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn syntaqlite_validator_statement_tables(
+    v: *const SyntaqliteValidator,
+    idx: u32,
+) -> *const SyntaqliteTableAccess {
+    let v = unsafe { &*v };
+    v.state()
+        .per_statement
+        .get(idx as usize)
+        .filter(|ps| !ps.tables.is_empty())
+        .map_or(std::ptr::null(), |ps| ps.tables.as_ptr())
+}
+
+#[unsafe(no_mangle)]
+#[expect(clippy::cast_possible_truncation)]
+pub unsafe extern "C" fn syntaqlite_validator_statement_defined_relation_count(
+    v: *const SyntaqliteValidator,
+    idx: u32,
+) -> u32 {
+    let v = unsafe { &*v };
+    v.state()
+        .per_statement
+        .get(idx as usize)
+        .map_or(0, |ps| ps.defined_relations.len() as u32)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn syntaqlite_validator_statement_defined_relations(
+    v: *const SyntaqliteValidator,
+    idx: u32,
+) -> *const SyntaqliteDefinedRelation {
+    let v = unsafe { &*v };
+    v.state()
+        .per_statement
+        .get(idx as usize)
+        .filter(|ps| !ps.defined_relations.is_empty())
+        .map_or(std::ptr::null(), |ps| ps.defined_relations.as_ptr())
 }
 
 /// Free a string returned by `syntaqlite_string_*` functions.
@@ -1499,6 +1793,195 @@ mod tests {
             let n = analyze(v, "SELECT id FROM users");
             assert_eq!(n, 0, "valid DDL before error should still be registered");
 
+            syntaqlite_validator_destroy(v);
+        }
+    }
+
+    // ── Per-statement API ────────────────────────────────────────────────
+
+    unsafe fn c_str_val(ptr: *const c_char) -> String {
+        if ptr.is_null() {
+            String::new()
+        } else {
+            unsafe { CStr::from_ptr(ptr) }
+                .to_str()
+                .unwrap_or("")
+                .to_owned()
+        }
+    }
+
+    #[test]
+    fn statement_count_single() {
+        unsafe {
+            let v = syntaqlite_validator_create_sqlite();
+            analyze(v, "SELECT 1;");
+            assert_eq!(syntaqlite_validator_statement_count(v), 1);
+            syntaqlite_validator_destroy(v);
+        }
+    }
+
+    #[test]
+    fn statement_count_multiple() {
+        unsafe {
+            let v = syntaqlite_validator_create_sqlite();
+            analyze(v, "SELECT 1; SELECT 2; SELECT 3;");
+            assert_eq!(syntaqlite_validator_statement_count(v), 3);
+            syntaqlite_validator_destroy(v);
+        }
+    }
+
+    #[test]
+    fn statement_count_with_ddl() {
+        unsafe {
+            let v = syntaqlite_validator_create_sqlite();
+            analyze(v, "CREATE TABLE t (a INT); SELECT a FROM t;");
+            assert_eq!(syntaqlite_validator_statement_count(v), 2);
+            syntaqlite_validator_destroy(v);
+        }
+    }
+
+    #[test]
+    fn per_statement_diagnostics_only_on_bad_statement() {
+        unsafe {
+            let v = syntaqlite_validator_create_sqlite();
+            add_table(v, "users", &["id", "name"]);
+            analyze(v, "SELECT id FROM users; SELECT bogus FROM users;");
+            assert_eq!(syntaqlite_validator_statement_count(v), 2);
+            assert_eq!(syntaqlite_validator_statement_diagnostic_count(v, 0), 0);
+            assert_eq!(syntaqlite_validator_statement_diagnostic_count(v, 1), 1);
+
+            let diags = syntaqlite_validator_statement_diagnostics(v, 1);
+            assert!(!diags.is_null());
+            let msg = c_str_val((*diags).message);
+            assert!(msg.contains("bogus"), "expected 'bogus' in: {msg}");
+            syntaqlite_validator_destroy(v);
+        }
+    }
+
+    #[test]
+    fn per_statement_diagnostics_parse_error() {
+        unsafe {
+            let v = syntaqlite_validator_create_sqlite();
+            analyze(v, "SELECT FROM; SELECT 1;");
+            assert_eq!(syntaqlite_validator_statement_count(v), 2);
+            assert!(syntaqlite_validator_statement_diagnostic_count(v, 0) > 0);
+            assert_eq!(syntaqlite_validator_statement_diagnostic_count(v, 1), 0);
+            syntaqlite_validator_destroy(v);
+        }
+    }
+
+    #[test]
+    fn per_statement_lineage_select() {
+        unsafe {
+            let v = syntaqlite_validator_create_sqlite();
+            add_table(v, "t", &["a", "b"]);
+            analyze(v, "SELECT a, b FROM t;");
+            assert_eq!(syntaqlite_validator_statement_count(v), 1);
+            assert_eq!(syntaqlite_validator_statement_column_lineage_count(v, 0), 2);
+
+            let cols = syntaqlite_validator_statement_column_lineage(v, 0);
+            assert!(!cols.is_null());
+            assert_eq!(c_str_val((*cols).name), "a");
+            assert_eq!(c_str_val((*cols.add(1)).name), "b");
+            assert_eq!(c_str_val((*cols).origin.table), "t");
+            assert_eq!(c_str_val((*cols).origin.column), "a");
+            syntaqlite_validator_destroy(v);
+        }
+    }
+
+    #[test]
+    fn per_statement_lineage_ddl_has_none() {
+        unsafe {
+            let v = syntaqlite_validator_create_sqlite();
+            analyze(v, "CREATE TABLE t (a INT); SELECT 1;");
+            assert_eq!(syntaqlite_validator_statement_count(v), 2);
+            assert_eq!(syntaqlite_validator_statement_column_lineage_count(v, 0), 0);
+            assert_eq!(syntaqlite_validator_statement_column_lineage_count(v, 1), 1);
+            syntaqlite_validator_destroy(v);
+        }
+    }
+
+    #[test]
+    fn per_statement_relations_accessed() {
+        unsafe {
+            let v = syntaqlite_validator_create_sqlite();
+            add_table(v, "users", &["id"]);
+            add_table(v, "orders", &["id"]);
+            analyze(v, "SELECT id FROM users; SELECT id FROM orders;");
+            assert_eq!(syntaqlite_validator_statement_count(v), 2);
+
+            assert_eq!(syntaqlite_validator_statement_relation_count(v, 0), 1);
+            let rels0 = syntaqlite_validator_statement_relations(v, 0);
+            assert_eq!(c_str_val((*rels0).name), "users");
+
+            assert_eq!(syntaqlite_validator_statement_relation_count(v, 1), 1);
+            let rels1 = syntaqlite_validator_statement_relations(v, 1);
+            assert_eq!(c_str_val((*rels1).name), "orders");
+            syntaqlite_validator_destroy(v);
+        }
+    }
+
+    #[test]
+    fn per_statement_defined_relations_create_table() {
+        unsafe {
+            let v = syntaqlite_validator_create_sqlite();
+            analyze(v, "CREATE TABLE foo (a INT); SELECT 1;");
+            assert_eq!(syntaqlite_validator_statement_count(v), 2);
+            assert_eq!(syntaqlite_validator_statement_defined_relation_count(v, 0), 1);
+            let defs = syntaqlite_validator_statement_defined_relations(v, 0);
+            assert!(!defs.is_null());
+            assert_eq!(c_str_val((*defs).name), "foo");
+            assert_eq!((*defs).is_view, 0);
+            assert_eq!(syntaqlite_validator_statement_defined_relation_count(v, 1), 0);
+            syntaqlite_validator_destroy(v);
+        }
+    }
+
+    #[test]
+    fn per_statement_defined_relations_create_view() {
+        unsafe {
+            let v = syntaqlite_validator_create_sqlite();
+            analyze(v, "CREATE VIEW v AS SELECT 1; SELECT 1;");
+            assert_eq!(syntaqlite_validator_statement_count(v), 2);
+            assert_eq!(syntaqlite_validator_statement_defined_relation_count(v, 0), 1);
+            let defs = syntaqlite_validator_statement_defined_relations(v, 0);
+            assert_eq!(c_str_val((*defs).name), "v");
+            assert_eq!((*defs).is_view, 1);
+            syntaqlite_validator_destroy(v);
+        }
+    }
+
+    #[test]
+    fn out_of_bounds_returns_zero() {
+        unsafe {
+            let v = syntaqlite_validator_create_sqlite();
+            analyze(v, "SELECT 1;");
+            assert_eq!(syntaqlite_validator_statement_diagnostic_count(v, 99), 0);
+            assert!(syntaqlite_validator_statement_diagnostics(v, 99).is_null());
+            assert_eq!(syntaqlite_validator_statement_column_lineage_count(v, 99), 0);
+            assert!(syntaqlite_validator_statement_column_lineage(v, 99).is_null());
+            assert_eq!(syntaqlite_validator_statement_relation_count(v, 99), 0);
+            assert!(syntaqlite_validator_statement_relations(v, 99).is_null());
+            assert_eq!(syntaqlite_validator_statement_table_count(v, 99), 0);
+            assert!(syntaqlite_validator_statement_tables(v, 99).is_null());
+            assert_eq!(syntaqlite_validator_statement_defined_relation_count(v, 99), 0);
+            assert!(syntaqlite_validator_statement_defined_relations(v, 99).is_null());
+            syntaqlite_validator_destroy(v);
+        }
+    }
+
+    #[test]
+    fn aggregated_diagnostics_matches_per_statement_sum() {
+        unsafe {
+            let v = syntaqlite_validator_create_sqlite();
+            add_table(v, "t", &["a"]);
+            let total = analyze(v, "SELECT bogus FROM t; SELECT also_bad FROM t;");
+            let stmt_count = syntaqlite_validator_statement_count(v);
+            let mut per_stmt_total = 0u32;
+            for i in 0..stmt_count {
+                per_stmt_total += syntaqlite_validator_statement_diagnostic_count(v, i);
+            }
+            assert_eq!(total, per_stmt_total);
             syntaqlite_validator_destroy(v);
         }
     }


### PR DESCRIPTION
## Summary
- Add `syntaqlite_validator_statement_count()` and per-statement accessors for diagnostics, column lineage, relations, tables, and defined relations
- New `SyntaqliteDefinedRelation` type exposes DDL output (CREATE TABLE/VIEW) per statement
- All existing aggregated APIs unchanged; out-of-bounds indices return 0/NULL
- 13 new FFI unit tests

Addresses part of #21 (beef up C API testing).

Python API update deferred pending #19 (Python test infrastructure).

## Test plan
- [x] `cargo test -p syntaqlite --features "sqlite,validation" --lib -- semantic::ffi::tests` — 42 tests pass (13 new)
- [x] Full test suite: `cargo test -p syntaqlite --features "sqlite,fmt,validation"` — all pass