### PR TITLE
synq: fix panic on macro expansion spans (#84)

### DIFF
--- a/syntaqlite-syntax/src/ast.rs
+++ b/syntaqlite-syntax/src/ast.rs
@@ -472,7 +472,7 @@ mod ffi {
         pub(crate) fn as_str(self, source: &str) -> &str {
             let start = self.offset as usize;
             let end = start + self.length as usize;
-            &source[start..end]
+            source.get(start..end).unwrap_or("")
         }
 
         /// Slice the span out of the correct buffer, accounting for macro
@@ -488,12 +488,15 @@ mod ffi {
         ) -> &'a str {
             let start = self.offset as usize;
             let end = start + self.length as usize;
-            if self.buf_idx == 0 {
-                &source[start..end]
+            let buf = if self.buf_idx == 0 {
+                source
             } else {
-                let buf = owned_bufs[(self.buf_idx - 1) as usize];
-                &buf[start..end]
-            }
+                match owned_bufs.get((self.buf_idx - 1) as usize) {
+                    Some(b) => b,
+                    None => return "",
+                }
+            };
+            buf.get(start..end).unwrap_or("")
         }
     }
 

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -873,4 +873,54 @@ mod tests {
             "macro region should cover full call, got: '{call_text}'"
         );
     }
+
+    #[test]
+    fn macro_expanded_extract_fields_does_not_panic() {
+        // Regression: synq_span() computes `tok.z - ctx->source` for ALL
+        // tokens, but during macro expansion tok.z points into the expansion
+        // buffer (a different allocation). This makes the offset garbage when
+        // buf_idx == 0 is not corrected. extract_fields then panics with
+        // "byte index N is out of bounds".
+        use crate::ParserConfig;
+        use crate::any::{AnyParser, ParseOutcome};
+
+        let dialect = crate::sqlite::dialect::dialect();
+        let parser = AnyParser::with_config(
+            dialect.into(),
+            &ParserConfig::default()
+                .with_collect_tokens(true)
+                .with_macro_fallback(true),
+        );
+        // Register a macro whose body is a valid expression that produces
+        // span fields (identifiers) in the expansion buffer.
+        {
+            let mut setup = parser.parse("SELECT 1;");
+            while let ParseOutcome::Ok(_) = setup.next() {}
+            setup.register_macro("my_expr", &["x"], "$x + 1");
+        }
+
+        // Parse a statement that invokes the macro in expression position.
+        // The macro body "$x + 1" expands with x=42, producing "42 + 1".
+        // The "1" token comes from the expansion buffer — its span offset
+        // must be relative to the expansion buffer, not ctx->source.
+        let mut session2 = parser.parse("SELECT my_expr!(42);");
+        match session2.next() {
+            ParseOutcome::Ok(stmt) => {
+                let erased = stmt.erase();
+                let root = erased.root_id();
+                // This is the call that panics if span offsets are wrong.
+                let result = erased.extract_fields(root);
+                assert!(result.is_some(), "root should have extractable fields");
+                // Also walk all children to exercise all spans.
+                for child in erased.child_node_ids(root) {
+                    let _ = erased.extract_fields(child);
+                }
+            }
+            ParseOutcome::Err(_) => {
+                // Parse error is acceptable — the macro may not produce
+                // valid SQL. But it must not panic.
+            }
+            ParseOutcome::Done => panic!("expected a statement"),
+        }
+    }
 }

--- a/tests/perfetto_validation_diff_tests/perfetto.py
+++ b/tests/perfetto_validation_diff_tests/perfetto.py
@@ -57,6 +57,22 @@ class PerfettoFunctionValidation(TestSuite):
         )
 
 
+class MacroExpansionSpanRegression(TestSuite):
+    def test_macro_expansion_does_not_crash(self):
+        """Regression: macro expansion produced spans with out-of-bounds
+        offsets that panicked in as_str / as_str_with_bufs.
+
+        TODO(#84): The macro invocation _d!(a) should produce a diagnostic
+        like "unknown column 'a'" pointing at the call site. Currently the
+        expanded span resolves to empty text so no diagnostic is emitted.
+        Fixing this requires rewriting the macro expansion span tracking.
+        """
+        return DiffTestBlueprint(
+            sql="CREATE PERFETTO MACRO _d(name ColumnName) RETURNS Expr AS $name;\nSELECT _d!(a);",
+            out="",
+        )
+
+
 class BaselineValidation(TestSuite):
     def test_plain_select_unknown_table(self):
         return DiffTestBlueprint(


### PR DESCRIPTION
## Motivation

Perfetto dialect macro expansion (`CREATE PERFETTO MACRO` + invocation) panics with "byte index N is out of bounds" in `as_str` / `as_str_with_bufs`. Minimal repro:

```sql
CREATE PERFETTO MACRO _d(name ColumnName) RETURNS Expr AS $name;
SELECT _d!(a);
```

This blocks the Python `perfetto-stdlib-graph` example from analyzing any stdlib file that uses macros (which is most of them).

Root cause: `synq_span()` computes offsets via `tok.z - ctx->source`, which produces garbage when `tok.z` points into a macro expansion buffer. A holistic rewrite of macro span tracking is needed (#84), but this PR fixes the immediate crash.

## Changes

- Make `CSourceSpan::as_str()` and `as_str_with_bufs()` return `""` on out-of-bounds instead of panicking (`source.get(start..end).unwrap_or("")`)
- Add Perfetto validation diff test for the crash regression (with TODO pointing to #84 for correct diagnostic output)
- Add `syntaqlite-syntax` unit test exercising `extract_fields` on macro-expanded statements