### PR TITLE
synq: lay text-expansion model groundwork (plan steps 1-6)

### DIFF
--- a/dialects/perfetto/actions/perfetto.y
+++ b/dialects/perfetto/actions/perfetto.y
@@ -27,7 +27,7 @@ perfetto_arg_type(A) ::= ID(B) LP ID DOT ID RP(E). {
         .type = B.type,
         .token_idx = B.token_idx,
         .offset = B.offset,
-        .buf_idx = B.buf_idx,
+        .layer_id = B.layer_id,
     };
 }
 
@@ -124,7 +124,7 @@ perfetto_module_name(A) ::= perfetto_module_name(B) DOT ID|STAR|INTERSECT(C). {
         .type = B.type,
         .token_idx = B.token_idx,
         .offset = B.offset,
-        .buf_idx = B.buf_idx,
+        .layer_id = B.layer_id,
     };
 }
 
@@ -197,7 +197,7 @@ perfetto_macro_body(A) ::= perfetto_macro_body(B) ANY(C). {
         .type = B.type,
         .token_idx = B.token_idx,
         .offset = B.offset,
-        .buf_idx = B.buf_idx,
+        .layer_id = B.layer_id,
     };
 }
 

--- a/docs/text-expansion-model-plan.md
+++ b/docs/text-expansion-model-plan.md
@@ -1,0 +1,863 @@
+# Text / Expanded-Text Model Plan
+
+## Context
+
+Today the parser exposes a multi-buffer model for macro expansion: spans
+carry a `_buf_idx` that identifies which expansion buffer their offset lives
+in, and consumers call `resolve_span` to walk the parent chain up to source.
+This model has leaked across the public API in inconsistent ways:
+
+- `FieldValue::Span::text` refers to the *expansion-buffer* slice, not the
+  authored text — backwards from how most consumers think about "text".
+- `analyzer.rs::statement_source()` slices source using raw token offsets,
+  which is silently broken for any statement containing a macro call (token
+  offsets for expansion-buffer tokens aren't source positions).
+- The formatter's `try_macro_verbatim` has a bespoke scan over macro
+  regions to decide when to emit an un-expanded call site, rather than
+  using a shared primitive.
+- Issue #89 asks for a subtree-level equivalent of `statement_source`, but
+  there's no single concept of "the text of a subtree" that consumers can
+  rely on.
+- `expansion_traceback` is powerful but low-fidelity: it doesn't track
+  argument provenance, so an error at byte N inside a substituted argument
+  collapses to the whole `foo!(…)` call site rather than pointing at the
+  user's authored arg expression.
+
+The goal of this plan is to replace the ad-hoc multi-buffer surface with a
+coherent vocabulary and API, restore Perfetto-style traceback fidelity
+(argument-level), and make issue #89 fall out trivially as a side effect.
+
+## Core vocabulary
+
+Exactly two words, used consistently at every scope:
+
+- **`text`** = what the user authored. Always a slice of the input you
+  handed to `parser_reset`.
+- **`expanded_text`** = what the parser's tokenizer actually saw, after
+  all macro expansion. For statements with no macros, `expanded_text`
+  equals `text` byte-for-byte.
+
+These two words are the only names used in the public API. `source` is
+dropped from user-facing names (it remains fine as an internal
+implementation term where appropriate).
+
+### Duality, stated crisply
+
+|                     | Whole statement        | Span                        | Subtree                        |
+| ------------------- | ---------------------- | --------------------------- | ------------------------------ |
+| **Authored**        | `text()`               | `span_text(span)`           | `subtree_text(node)`           |
+| **Expanded**        | `expanded_text()`      | `span_expanded_text(span)`  | `subtree_expanded_text(node)`  |
+| **Range in text()** | —                      | `span_text_range(span)`     | (derivable)                    |
+
+Invariants:
+
+- `span_text(span)` is *always* a slice of `text()`.
+- `span_expanded_text(span)` is *content-equivalent* to the corresponding
+  slice of `expanded_text()`, but may live in a different backing buffer
+  (a private expansion layer). Users should treat it as an owned `&str`,
+  not as "a pointer into some known buffer".
+- For macro-free statements, all four collapse: `text() == expanded_text()`
+  and `span_text == span_expanded_text` for every element.
+
+## Architectural decision: lazy layer tree, no materialization
+
+After considering two alternatives — (a) eager materialization into a single
+flat `expanded_text` string at end of parse, and (b) a Perfetto-style
+preprocessor pass producing a pre-built tree of `SqlSource` nodes — we
+landed on a **lazy** model:
+
+- During parse, the parser maintains an in-memory tree of "expansion
+  layers" (the same multi-buffer structure we have today, with richer
+  per-layer metadata).
+- `parser_next` returns immediately after Lemon finishes — there is no
+  post-parse materialization pass.
+- Queries (`text`, `expanded_text`, `traceback`, subtree accessors) are
+  computed on demand from the layer tree, with caching for the expensive
+  ones (subtree extents, full expanded text splicer).
+
+### Why lazy?
+
+- **Zero baseline cost.** Parsers that don't ask about expanded text — the
+  common case for formatters on macro-free SQL, validators, autocompletion
+  — pay nothing for the machinery. No allocation, no walk.
+- **No temporary state to reason about.** The parse result is the final
+  state; there's no "materialized view" transition point that could go
+  stale or be forgotten.
+- **Minimally disruptive.** The existing `expand_and_feed` / tokenizer-swap
+  / recursive expansion pipeline stays intact. We add fields to the layer
+  struct, add an arg-segment recording step inside the existing parameter
+  substitution code, and layer new accessors on top.
+
+### Why *not* Perfetto preprocessor style?
+
+Perfetto's preprocessor is a separate pass that consumes tokens and produces
+a `SqlSource` tree via a frame stack of mutable `Rewriter` builders. The
+complexity is real: non-movable frames in a linked list, a custom Lemon
+grammar for recognizing macro syntax, `Rewriter::Build`'s 4-phase
+recomputation, `Node::Substr` as a tree-rewriting op, macro bodies stored as
+pre-built `SqlSource` at registration time. All of that exists because the
+preprocessor has no parser context and must construct a standalone
+`SqlSource` eagerly.
+
+We expand macros lazily during parse (the tokenizer hits a call and expands
+inline), so we already have the parser context Perfetto's preprocessor was
+rebuilding from scratch. We can borrow Perfetto's **conceptual model**
+(authored layer → rewrite tree → full fidelity traceback with arguments
+traced back to caller positions) without importing any of its machinery.
+
+### Why *not* eager materialization?
+
+An eager "build full expanded_text + per-node extents at end of parse"
+approach works, but it unconditionally allocates O(statement size) on every
+parse, even for the vast majority of parses that never query expanded text.
+Lazy gives us the same end-state queryability without the baseline cost.
+
+The eager design also committed us to a single flat offset space, which
+would have made every span carry a rewritten-sql offset rather than a
+layer-local one. That is cleaner conceptually but required us to rewrite
+every AST span during materialization — more code churn for no functional
+benefit once the public API is behind accessors.
+
+## Encapsulation: layers are internal
+
+A strict rule:
+
+> Layers are never exposed in the public API. `_layer_id` lives on spans
+> and tokens as an underscore-prefixed implementation detail field.
+> Consumers interact with spans only through parser accessors. There is
+> no `Layer` type, no `layers()` accessor, no `Frame` field pointing at
+> a layer.
+
+Everything user-visible goes through accessors that take opaque `Span`s and
+`NodeId`s and return `&str` slices or self-contained value types. A user who
+holds a `Span` can pass it to `span_text`, `span_expanded_text`,
+`span_text_range`, or `traceback` and nothing else. No peeking.
+
+## Data model
+
+### `SynqExpansionLayer` (internal)
+
+One per macro invocation, plus one for the root statement. Replaces the
+current `SynqMacroRegion` / `macro_expansions` split with a single unified
+structure.
+
+```c
+typedef struct SynqExpansionLayer {
+    // Tree structure
+    uint32_t parent_layer_id;           // UINT32_MAX for the root layer
+    uint32_t call_offset_in_parent;     // position of foo!(...) in parent's buf
+    uint32_t call_length_in_parent;     // length of foo!(...) in parent's buf
+
+    // The buffer this layer's tokens were tokenized from.
+    // - Root: pointer into user source, not owned.
+    // - Macro call: template body with $params substituted + any nested
+    //   macros further expanded inline, owned via p->mem.
+    const char* buf;
+    uint32_t buf_len;
+    uint8_t owns_buf;                   // 0 for root, 1 for expansions
+
+    // Parameter substitutions: one per $param that was substituted with
+    // caller argument text. Sorted by sub_offset, non-overlapping.
+    // Empty for the root layer.
+    SynqArgSegment* arg_segments;
+    uint32_t arg_segment_count;
+
+    // Macro template text and definition provenance for traceback
+    // rendering. All NULL / zero for the root layer.
+    const char* template_body;          // borrowed from macro registry
+    uint32_t template_body_len;
+    const char* name;                   // e.g. "Macro 'foo'" (owned)
+    uint32_t def_line;                  // macro definition line
+    uint32_t def_col;
+} SynqExpansionLayer;
+```
+
+### `SynqArgSegment`
+
+Records one parameter substitution within an expansion layer. The key piece
+of new metadata that enables argument-level traceback fidelity.
+
+```c
+typedef struct SynqArgSegment {
+    // Where the substituted arg text lives in this layer's buf.
+    uint32_t sub_offset;
+    uint32_t sub_length;
+
+    // Where the arg came from (in its origin layer's buf).
+    uint32_t origin_layer_id;
+    uint32_t origin_offset;
+    uint32_t origin_length;
+} SynqArgSegment;
+```
+
+When `synq_parser_expand_macro` substitutes `$1` with the bytes of the
+first argument, it copies arg text from the caller's buffer into the new
+layer's buf. At the moment of copy, all the information for a
+`SynqArgSegment` is available: record it.
+
+### Parser state
+
+```c
+struct SyntaqliteParser {
+    // ... existing lifecycle / tokenizer / grammar state ...
+
+    // The layer tree. layers.data[0] is the root, always present.
+    SYNQ_VEC(SynqExpansionLayer) layers;
+
+    // Side vector parallel to p->tokens, storing layer_id per token.
+    // Only needed if we keep the public SyntaqliteParserToken struct
+    // unchanged. See "Token layer_id" below.
+    SYNQ_VEC(uint8_t) token_layer_ids;
+
+    // Lazy caches (allocated on first query, freed on parser_next):
+    SynqSubtreeExtentCache* extent_cache;       // per-node text ranges
+    SynqExpandedTextCache* expanded_cache;      // spliced expanded strings
+};
+```
+
+### Public types
+
+```c
+// Public struct; _layer_id is an implementation-detail field.
+typedef struct SyntaqliteSourceSpan {
+    uint32_t offset;
+    uint16_t length;
+    uint8_t flags;
+    uint8_t _layer_id;   // Internal. Do not access.
+} SyntaqliteSourceSpan;
+
+// Byte range in text() (the user's authored input).
+typedef struct SyntaqliteTextRange {
+    uint32_t start;
+    uint32_t end;
+} SyntaqliteTextRange;
+
+// Self-contained traceback frame. No pointers back to layers.
+typedef struct SyntaqliteTracebackFrame {
+    const char* name;             // "File \"stdin\"" or "Macro 'foo'"
+    uint32_t line;
+    uint32_t col;
+    const char* snippet;          // the buffer to render the caret against
+    uint32_t snippet_len;
+    uint32_t offset_in_snippet;
+} SyntaqliteTracebackFrame;
+```
+
+### Token layer_id
+
+Tokens need to know which layer they came from so `span_expanded_text`
+equivalents can resolve their buffer. Two options:
+
+**(a) Add `uint8_t layer_id` (+ padding) to `SyntaqliteParserToken`.**
+Same discipline as spans — public struct, underscore-prefixed field,
+treated as internal. Grows tokens from 16 bytes to 20.
+
+**(b) Side vector `token_layer_ids` indexed parallel to `p->tokens`.**
+Public struct stays unchanged. Accessors need to go through the parser to
+map index → layer_id.
+
+**Decision: (a).** Consistent with how spans handle layer_id, no
+parallel-index correctness risk, the 4-byte growth per token is
+negligible. `SyntaqliteParserToken` becomes:
+
+```c
+typedef struct SyntaqliteParserToken {
+    uint32_t offset;
+    uint32_t length;
+    uint32_t type;
+    uint32_t flags;
+    uint8_t _layer_id;
+    uint8_t _pad[3];
+} SyntaqliteParserToken;
+```
+
+## Public API
+
+### C side
+
+```c
+// ── Whole-statement text ─────────────────────────────────────────────────
+
+// The user's authored input. Same as syntaqlite_parser_source() today,
+// renamed for vocabulary consistency.
+SYNTAQLITE_API const char*
+syntaqlite_parser_text(SyntaqliteParser* p, uint32_t* out_len);
+
+// The full post-expansion text. Lazily built on first call; cached. For
+// macro-free statements, aliases parser_text() (no allocation).
+SYNTAQLITE_API const char*
+syntaqlite_parser_expanded_text(SyntaqliteParser* p, uint32_t* out_len);
+
+// ── Span accessors ───────────────────────────────────────────────────────
+
+// Authored slice of text() corresponding to this span. For spans inside
+// a macro expansion, collapses to the outermost call site's range in
+// text(). Always a direct slice of text() — no allocation.
+SYNTAQLITE_API const char*
+syntaqlite_parser_span_text(SyntaqliteParser* p,
+                            const SyntaqliteSourceSpan* span,
+                            uint32_t* out_len);
+
+// What the parser's tokenizer saw for this span. For spans outside a
+// macro, equals span_text. For spans inside a macro, a slice of the
+// expansion layer's buffer. Always a direct slice — no allocation.
+SYNTAQLITE_API const char*
+syntaqlite_parser_span_expanded_text(SyntaqliteParser* p,
+                                     const SyntaqliteSourceSpan* span,
+                                     uint32_t* out_len);
+
+// Byte range of span_text in text(). Always a valid range in the user's
+// authored input.
+SYNTAQLITE_API SyntaqliteTextRange
+syntaqlite_parser_span_text_range(SyntaqliteParser* p,
+                                  const SyntaqliteSourceSpan* span);
+
+// ── Subtree accessors ────────────────────────────────────────────────────
+
+// Authored text covering the entire subtree rooted at node_id. Lazily
+// computes per-node extents on first call; cached for subsequent queries.
+SYNTAQLITE_API const char*
+syntaqlite_parser_subtree_text(SyntaqliteParser* p,
+                               uint32_t node_id,
+                               uint32_t* out_len);
+
+// Post-expansion text of the subtree. May require splicing across
+// layer buffers when the subtree spans macro boundaries. Lazily built
+// and cached.
+SYNTAQLITE_API const char*
+syntaqlite_parser_subtree_expanded_text(SyntaqliteParser* p,
+                                        uint32_t node_id,
+                                        uint32_t* out_len);
+
+// ── Traceback ────────────────────────────────────────────────────────────
+
+// Write up to max_frames traceback frames for the given span, ordered
+// outermost (root) to innermost (deepest macro expansion). Returns the
+// total number of frames available (caller can call with max_frames=0
+// to query the count).
+SYNTAQLITE_API uint32_t
+syntaqlite_parser_traceback(SyntaqliteParser* p,
+                            const SyntaqliteSourceSpan* span,
+                            SyntaqliteTracebackFrame* frames,
+                            uint32_t max_frames);
+```
+
+### Rust side
+
+Mirror of the C API, returning `&'a str` with the parser's per-statement
+lifetime.
+
+```rust
+impl<'a> AnyParsedStatement<'a> {
+    // Whole
+    pub fn text(&self) -> &'a str;
+    pub fn expanded_text(&self) -> &'a str;
+
+    // Span
+    pub fn span_text(&self, span: Span) -> &'a str;
+    pub fn span_expanded_text(&self, span: Span) -> &'a str;
+    pub fn span_text_range(&self, span: Span) -> TextRange;
+
+    // Subtree
+    pub fn subtree_text(&self, node: NodeId) -> &'a str;
+    pub fn subtree_expanded_text(&self, node: NodeId) -> &'a str;
+
+    // Traceback
+    pub fn traceback(&self, span: Span) -> impl Iterator<Item = Frame<'a>> + '_;
+}
+```
+
+### `FieldValue::Span` — final shape
+
+```rust
+#[derive(Clone, Copy, Debug)]
+pub enum FieldValue<'a> {
+    NodeId(AnyNodeId),
+    Span {
+        /// Authored text — slice of `text()`.
+        text: &'a str,
+        /// What the parser saw — slice of whichever layer buf
+        /// this field's span came from.
+        expanded_text: &'a str,
+        /// Byte range of `text` in `text()`.
+        text_range: TextRange,
+        /// Whether the identifier was quoted in source.
+        quoted: bool,
+    },
+    Bool(bool),
+    Flags(u8),
+    Enum(u32),
+}
+```
+
+Both `text` and `expanded_text` are populated in `extract_fields` by
+calling the parser's span accessors. No extra per-field storage.
+
+## Internal mechanics
+
+### `span_text(span)` — O(depth)
+
+Walk the span's layer parent chain:
+
+1. Start at `layer = layers[span._layer_id]`, `off = span.offset`,
+   `len = span.length`.
+2. While `layer.parent_layer_id != UINT32_MAX`:
+   a. Check if `[off, off+len)` falls inside any of `layer`'s parent's
+      arg segments (looking up from the child side: is this arg a copy
+      that came from our layer's buf into our parent's?). If the span
+      was tokenized inside an arg region of an ancestor layer, jump to
+      the arg's origin layer at the corresponding position.
+   b. Otherwise, collapse to the call site: `off = layer.call_offset_in_parent`,
+      `len = layer.call_length_in_parent`, `layer = layers[layer.parent_layer_id]`.
+3. At layer 0, `off` and `len` are a range in user source. Return
+   `source[off..off+len]`.
+
+Bounded by `SYNQ_MAX_MACRO_DEPTH` (16). Typical case is 1-2 iterations.
+
+### `span_expanded_text(span)` — O(1)
+
+`&layers[span._layer_id].buf[span.offset..span.offset + span.length]`.
+Trivial.
+
+### `span_text_range(span)` — O(depth)
+
+Same walk as `span_text`, but return the final `(off, off+len)` pair
+instead of slicing.
+
+### `subtree_text(node)` — O(subtree) first call, O(1) cached
+
+On first call for any node in the statement: do one traversal of the AST,
+populating a per-node extent array `[start, end) × node_count` with the
+text-range of each subtree (computed from its descendants' direct field
+spans via `span_text_range`). Cache on the parser.
+
+Subsequent calls: direct array lookup, slice `text()`.
+
+### `subtree_expanded_text(node)` — O(expanded size) first call, O(1) cached
+
+More intricate because the result may need to splice across layer buffers.
+On first call, walk the subtree:
+
+1. Find the subtree's "host layer" — the layer that contains its root
+   node's direct fields.
+2. Inside the host layer's buf, find the start/end of the subtree as
+   min/max of its direct field spans.
+3. If the subtree has no descendants in other layers (no nested macro
+   calls), return a direct slice of the host layer's buf.
+4. Otherwise, splice: walk child layers whose `call_offset_in_parent`
+   falls inside the subtree's range, recursively producing their expanded
+   text and substituting at the correct positions.
+
+Cache the result on the parser, indexed by node_id.
+
+### `expanded_text()` — O(total) first call, O(1) cached
+
+Same splicer as `subtree_expanded_text`, rooted at the statement's root
+node. Fast path for macro-free statements: alias `text()`, no allocation.
+
+### `traceback(span)` — O(depth)
+
+Start at `span._layer_id` and walk toward root, emitting one frame per
+layer. Drill through arg segments when the span's position falls inside
+one:
+
+```
+fn traceback(span):
+  layer_id = span._layer_id
+  off = span.offset
+  frames = []
+  loop:
+    layer = layers[layer_id]
+
+    # Is our current position inside an arg segment of this layer?
+    # If so, the "real" provenance at this level is the arg's origin
+    # layer, not the expansion layer itself. Redirect.
+    if arg_seg = find_arg_segment(layer, off):
+      off = arg_seg.origin_offset + (off - arg_seg.sub_offset)
+      layer_id = arg_seg.origin_layer_id
+      continue  # retry at the origin layer
+
+    # Emit a frame for this layer.
+    if layer.parent_layer_id == UINT32_MAX:
+      # Root — frame rendered against user source.
+      frames.push(Frame {
+        name: "File \"stdin\"" (or similar),
+        line/col computed from off in text(),
+        snippet: text(), offset_in_snippet: off,
+      })
+      break
+    else:
+      # Macro expansion — frame rendered against template body.
+      frames.push(Frame {
+        name: layer.name,  # e.g. "Macro 'foo'"
+        line/col: layer.def_line/def_col adjusted by off,
+        snippet: layer.template_body, offset_in_snippet: template_off,
+      })
+      # Walk up to parent at the call site.
+      off = layer.call_offset_in_parent
+      layer_id = layer.parent_layer_id
+
+  reverse(frames)  # outermost first
+  return frames
+```
+
+The frame rendered against a layer's `template_body` uses the template,
+not the layer's `buf` (which has $params already substituted). This gives
+the Perfetto-style behavior where a macro frame shows the original
+template with `$param` references visible.
+
+The arg-segment drill is the fidelity-adding mechanism: when a span was
+tokenized inside a substituted arg, its provenance chain follows the arg
+back to where the user typed it, not to the macro body's `$param`
+reference.
+
+## What disappears
+
+From today's codebase:
+
+- `SyntaqliteSourceSpan._buf_idx` field name (renamed to `_layer_id`).
+- `SynqMacroRegion` type (unified into `SynqExpansionLayer`).
+- `macro_regions` and `macro_expansions` parser vectors (unified into
+  `layers`).
+- `synq_span_needs_resolve` inline helper (no longer meaningful — all
+  accessors handle the layer walk internally).
+- `resolve_span`'s expansion-walking code path (simplified to a
+  straight call into `span_text` / `span_expanded_text` /
+  `span_text_range`; may be kept as a thin compat shim or removed
+  entirely).
+- `syntaqlite_parser_expansion_traceback` (replaced by the new
+  `syntaqlite_parser_traceback` with argument fidelity).
+- `try_macro_verbatim`'s bespoke scan in `fmt/formatter.rs` (replaced by
+  a call to `subtree_text` on the child node).
+- `analyzer.rs::statement_source()` helper (replaced by
+  `stmt.text()` — which is now correct for macros instead of silently
+  broken).
+- `FieldValue::Span::text` referring to the expansion-buffer slice (the
+  name is reassigned to mean authored slice, with a new `expanded_text`
+  field for the expansion-buffer slice).
+
+## Stacked implementation plan
+
+Each step compiles and passes tests green. Steps are ordered so that
+additive/rename work lands first, then behavior changes, then deletions.
+
+### Progress
+
+| Step | Status | Notes |
+| ---- | ------ | ----- |
+| 1. Rename `_buf_idx` → `_layer_id`                  | ✅ done | |
+| 2. Rename `SynqMacroRegion` → `SynqExpansionLayer`  | ✅ done | Public `syntaqlite_result_macros` preserved via lazy `public_macros_view`. |
+| 3. Add new layer metadata fields                    | ✅ done | `syntaqlite_parser_register_macro` gained `def_line`/`def_col` params; Rust wrappers currently pass `0, 0`. |
+| 4. Record `SynqArgSegment` during param substitution| ✅ done | `SynqMacroExpansion` carries arg segments until transferred onto the layer in `feed_macro_expansion`; `reset_stmt` / `destroy` free both expansion buffers and segment arrays. |
+| 5. Add `_layer_id` to `SyntaqliteParserToken`       | ✅ done | ABI change (16 → 20 bytes). Python bindings unaffected (they don't use the struct); Rust `CParserToken` mirror updated. |
+| 6. Add `span_text` / `span_expanded_text` / `span_text_range` | ✅ done | See "Notes on Step 6" below. |
+| 7. Add `traceback` with arg-segment drilling        | ⏳ deferred | |
+| 8. Lazy subtree extent cache + `subtree_text`       | ⏳ deferred | |
+| 9. Lazy expanded splicer + `subtree_expanded_text` / `expanded_text` | ⏳ deferred | |
+| 10. Migrate formatter's `try_macro_verbatim`        | ⏳ deferred | |
+| 11. Migrate analyzer's `statement_source`           | ⏳ deferred | |
+| 12. `FieldValue::Span` rename                       | ⏳ deferred | Step 6 Rust methods are `pub(crate)` and test-only; Step 12 promotes them and rewrites `extract_field_value`. |
+| 13. Delete old expansion traceback API              | ⏳ deferred | |
+| 14. Delete `resolve_span` and `SyntaqliteResolvedSpan` | ⏳ deferred | Currently still the live path for `FieldValue::Span` population. |
+| 15. Rename `syntaqlite_parser_source()` → `syntaqlite_parser_text()` | ⏳ deferred | |
+
+**Notes on Step 6 (session 1):**
+- The existing Rust `AnyParsedStatement::span_text` method (which returned
+  the expansion-buffer slice) was renamed to `span_expanded_text` as part
+  of this step — otherwise the new `span_text` (authored slice) would
+  silently change the semantics of every `self.stmt_result.span_text(...)`
+  call site in the generated `sqlite/ast.rs`. The codegen
+  (`syntaqlite-buildtools/src/dialect_codegen/rust_ast.rs`) was updated to
+  emit `span_expanded_text(...)` and generated files were regenerated.
+  Generated call sites preserve their original behavior after the rename.
+- All three new Rust methods are `pub(crate)` for now. Test callers live
+  in the same crate (`parser/session.rs` tests), and the eventual
+  Step 12 migration will promote them to `pub` when `FieldValue::Span`
+  consumes them directly.
+- Methods are annotated with `#[cfg_attr(not(test), expect(dead_code,
+  reason = "wired into FieldValue::Span in Step 12"))]` where the only
+  non-test caller is tests; this is removed in Step 12.
+
+**Red-green discipline:** Steps 1–5 are mechanical renames and internal
+plumbing with no user-visible surface, so there is nothing to fail a
+test against — they proceed as straight refactors, verified by existing
+tests staying green. Red-green begins at Step 6, where the first new
+public accessors are introduced: the unit tests for `span_text`,
+`span_expanded_text`, and `span_text_range` are written before the
+implementation and must fail on the pre-change tree.
+
+**Session log:**
+- **Session 1** landed Steps 1–6. New unit tests in
+  `syntaqlite-syntax/src/parser/session.rs`:
+  `span_text_macro_free_equals_authored_slice`,
+  `span_text_inside_macro_body_collapses_to_call_site`,
+  `span_text_inside_substituted_arg_drills_to_origin`. Full workspace
+  tests, integration suites (`ast`, `fmt`, `grammar`), and clippy
+  `-D warnings` all green at session end.
+
+### Step 1 — Rename `_buf_idx` to `_layer_id`
+
+Pure rename at the field level. Touches:
+- `include/syntaqlite/types.h` — `SyntaqliteSourceSpan._buf_idx` → `_layer_id`
+- `include/syntaqlite/dialect.h` — `SynqParseToken.buf_idx` → `layer_id`
+- `include/syntaqlite_dialect/ast_builder.h` — `SynqParseCtx.buf_idx` → `layer_id`
+- `csrc/parser*.c` — all references, including `synq_span`, `synq_span_dequote`
+- `src/parser/ffi.rs`, `src/ast.rs`, `src/parser/mod.rs` — Rust mirror
+
+No semantic change. Tests untouched.
+
+### Step 2 — Rename `SynqMacroRegion` → `SynqExpansionLayer`
+
+Internal rename. Unify `p->macro_expansions` and `p->macro_regions` into a
+single `p->layers` vector with the union of fields the two structs held.
+Update all internal call sites (`parser_macros.c`, `parser.c`,
+`parser_dump.c`). Public API unchanged.
+
+### Step 3 — Add new layer metadata fields
+
+Add to `SynqExpansionLayer`:
+- `template_body` / `template_body_len` (borrowed directly from the
+  macro registry entry's `body` field — no separate snapshot storage)
+- `name` (borrowed from the registry entry's `name` field)
+- `def_line` / `def_col` (from the macro registration site)
+- `arg_segments` / `arg_segment_count` (empty for now)
+
+Populate at `begin_macro_expansion` call sites. Extend the macro registry
+entry (`SynqMacroEntry`) to carry `def_line`/`def_col` (passed in at
+register time). Source of these values: the statement position where
+`CREATE PERFETTO MACRO` was parsed.
+
+**Decision on macro body provenance (resolves the open question
+below):** the `template_body` shown in traceback frames for a macro
+layer is sourced from the registry entry's existing `body` field — no
+new `def_text_snapshot` field is added. The registry already owns a
+copy of each macro's template; we point `template_body` at that copy
+and rely on the fact that a registered macro's body outlives any parse
+using it. This is the cheapest of the three options in the Open
+Question section and costs zero extra memory.
+
+### Step 4 — Record `SynqArgSegment` during param substitution
+
+Modify `synq_parser_expand_macro` to emit a `SynqArgSegment` each time
+it substitutes a `$param` with caller arg text. The segment records:
+- where the arg landed in the new layer's buf (`sub_offset`, `sub_length`)
+- where it came from (`origin_layer_id` = current layer, `origin_offset`,
+  `origin_length`)
+
+Attach the segment list to the new expansion layer.
+
+### Step 5 — Add `_layer_id` field to `SyntaqliteParserToken`
+
+Extend the public struct to carry layer_id. Populate at `synq_parser_record_and_feed`
+time using the current tokenizer layer. Update `SynqParseToken` shift-time
+propagation so tokens emitted from expansion buffers get the right layer_id.
+
+ABI change. Document in public API notes. In-tree consumers to update:
+- `python/csrc/_syntaqlite.c` (Python bindings)
+- any CLI/WASM code that reads `SyntaqliteParserToken` (audit)
+
+### Step 6 — Add `span_text` / `span_expanded_text` / `span_text_range`
+
+New C accessors. New Rust methods on `AnyParsedStatement`. Implemented
+via the layer walk described under "Internal mechanics". Unit-tested
+against simple nested macro cases.
+
+At this point, all the infrastructure is in place but nothing consumes it
+yet.
+
+### Step 7 — Add `traceback` with arg-segment drilling
+
+New C + Rust API. Replaces `expansion_traceback` semantically but is NOT
+wired up yet (the old API stays in parallel during migration).
+
+Unit tests exercising:
+- Traceback from a root-level span (single frame)
+- Traceback from inside a macro body (two frames)
+- Traceback from inside a substituted arg (three frames: root → macro → arg origin)
+- Traceback from nested macro inside an arg (root → outer → arg origin → inner)
+- Per Perfetto's "Fully expanded statement" header, the root frame
+  includes the expanded snippet when the statement contains any
+  expansion; deeper frames don't.
+
+### Step 8 — Lazy subtree extent cache + `subtree_text`
+
+Add the per-statement cache structure and the single-pass extent walker.
+Implement `subtree_text(node)`. Unit tests for macro-free and macro-laden
+subtrees.
+
+### Step 9 — Lazy expanded splicer + `subtree_expanded_text` / `expanded_text`
+
+Implement the splicer for subtree_expanded_text and expanded_text. Unit
+tests covering:
+- Macro-free subtree (fast path: direct slice, no splice)
+- Single-macro subtree
+- Nested macros with arg substitutions
+
+### Step 10 — Migrate formatter's `try_macro_verbatim`
+
+Replace the bespoke macro region scan with `ctx.reader.subtree_text(child_id)`.
+Diff-test the formatter to ensure zero behavioral change.
+
+### Step 11 — Migrate analyzer's `statement_source`
+
+Replace `analyzer.rs::statement_source()` with `stmt.text()` at its call
+site. This is a silent correctness fix for statements containing macros;
+unit-test it.
+
+### Step 12 — `FieldValue::Span` rename
+
+Replace the current two-field `Span { text, source }` with four-field
+`Span { text, expanded_text, text_range, quoted }`:
+- old `text` (expansion-buffer slice) → new `expanded_text`
+- old `source` (byte range) → new `text_range`
+- new `text` (authored slice) — populated from `span_text`
+
+Compile errors at every call site will pinpoint the rename. Update them
+all in one sweep.
+
+### Step 13 — Delete old expansion traceback API
+
+Remove `syntaqlite_parser_expansion_traceback` and its C struct. Confirm
+no callers remain (likely none after #87, but verify).
+
+### Step 14 — Delete `resolve_span` and `SyntaqliteResolvedSpan`
+
+By this point, all in-tree callers of `syntaqlite_parser_resolve_span`
+have been migrated to the new span accessors:
+- `FieldValue::Span` is populated directly from `span_text` /
+  `span_expanded_text` / `span_text_range` (Step 12).
+- The formatter uses `subtree_text` (Step 10).
+- The validator uses `stmt.text()` (Step 11).
+
+Remove the C function and the `SyntaqliteResolvedSpan` struct entirely.
+No thin shim is retained — a hard delete, verified by a final grep for
+`resolve_span` turning up zero matches.
+
+Strategy for intermediate steps: **keep `resolve_span` alive and
+unchanged from Step 1 through Step 12.** It acts as a thin compat layer
+for the old `FieldValue::Span.text` / `FieldValue::Span.source`
+population path until Step 12 rewrites that path on top of the new
+accessors. Steps 1–5 do not touch `resolve_span` at all; Step 6 adds
+the new accessors alongside it; Steps 7–11 migrate consumers one at a
+time; Step 12 migrates the last consumer (`FieldValue::Span`); Step 14
+deletes the old API.
+
+### Step 15 — Rename `syntaqlite_parser_source()` → `syntaqlite_parser_text()`
+
+Hard rename, no compat alias. Update CLI, WASM playground, Python
+bindings, and any tests referencing the old name. A grep for
+`parser_source\b` must return zero after this step.
+
+## What stays unchanged
+
+The following parts of the codebase should require **no changes**:
+
+- `synq_parser_expand_macro` (except for the arg-segment recording addition)
+- `expand_and_feed` / the tokenizer swap machinery
+- `synq_parser_try_macro_call` / balanced-paren arg scanning
+- `synq_parser_check_macro_straddle` (the invariant it enforces is still
+  needed)
+- Grammar actions, `synq_span` / `synq_span_dequote`
+- Lemon parser integration
+- Macro registration and lookup (registry data structures may gain
+  `def_line`/`def_col`, but the hashmap logic is unchanged)
+- AST arena, node construction, list handling
+- The `check_macro_straddle` diagnostic — still enforced at its existing
+  call site
+
+## Deferred / out of scope
+
+The following are intentionally not part of this plan. They can be added
+later if concrete need arises:
+
+- **Public `Rewriter` API.** Perfetto has one for transpilation patterns
+  (`RewriteToDummySql`, `ExecuteCreateFunction`). We have no analogous use
+  case today. If we ever want one (e.g., to wrap an engine-handled
+  statement with synthetic SQL while preserving traceback), we'll add it
+  then, modeled on Perfetto's 4-phase Build.
+- **Public `Substr` on `Span`.** Perfetto's `SqlSource::Substr` is used
+  to carve macro arguments out of caller source. Our expansion pipeline
+  doesn't need it at the public boundary — arg segments are internal
+  metadata.
+- **Flat expanded offset space.** We chose lazy / layer-local offsets.
+  If a future consumer genuinely needs "the expanded offset of this span
+  as a u32 in the expanded_text() string", we'd need either eager
+  materialization or a per-query translation. Not planned.
+- **Parameter-level source tracking in macro definitions.** Macro bodies
+  are stored as `(text, def_line, def_col)` in the registry. Perfetto
+  stores them as full `SqlSource` instances with their own nested trees,
+  so an error inside a macro body can trace to the module/file the macro
+  was defined in. We can approximate this with just `(def_line, def_col)`
+  for now; full fidelity would require registering macros with an
+  identifier for their containing file/module.
+- **Cross-statement macros through import boundaries.** If a macro is
+  defined in one file and called from another, the traceback frame for
+  the macro body should show the defining file's name. This depends on
+  the module resolver integration and can be added once we have the
+  basic layer tree working end to end.
+
+## Success criteria
+
+This refactor is done when:
+
+1. **Public API uses the new vocabulary.** Every `source` in a user-facing
+   name has become `text` or `expanded_text`. `SyntaqliteTextRange`
+   replaces `SourceRange`. All accessors are named per the table above.
+2. **`_layer_id` is never referenced by any public API signature.** It
+   exists as an implementation-detail field on `SyntaqliteSourceSpan` and
+   `SyntaqliteParserToken` but no public function takes it as a parameter
+   or returns it.
+3. **`statement_source` in `analyzer.rs` is deleted.** Its replacement
+   (`stmt.text()`) produces correct output for statements containing
+   macros — tested via a regression test that would have failed today.
+4. **`try_macro_verbatim` has no bespoke macro-region scan.** It calls
+   `subtree_text` on the child node and nothing else.
+5. **Traceback fidelity matches Perfetto.** A diagnostic at an offset
+   inside a substituted macro argument produces a traceback whose
+   innermost frame points at the user's authored arg text, not at the
+   whole `foo!(…)` call site. Tested via a unit test that exercises
+   `outer!(inner!(a+b))` and verifies the frame chain.
+6. **Issue #89 is trivially satisfied.** A dialect consumer calls
+   `subtree_expanded_text(subtree_root)` and gets the correct forwardable
+   SQL text. Tested via an integration test.
+7. **No allocation for macro-free parsing.** A parse of a statement with
+   no macro calls does not allocate any expansion layer buffers, any
+   subtree extent cache, or any expanded text cache unless a query
+   explicitly requests it.
+
+   This remains a design goal, enforced by the lazy-caching architecture
+   rather than a dedicated test. The caches are arena-allocated (see
+   "Lazy cache invalidation" below), so a parse that never touches a
+   lazy query makes no extra heap allocations beyond what the baseline
+   parse already does.
+
+### Lazy cache invalidation
+
+The per-statement lazy caches (`SynqSubtreeExtentCache`,
+`SynqExpandedTextCache`) live on the parser arena and are reset
+whenever `syntaqlite_parser_next` resets the arena between statements.
+Nothing explicit is needed at the end of a parse — the arena reset
+already invalidates them. The only cache-owned state on the parser
+struct is a pair of pointers to the cache heads in arena memory; those
+pointers are zeroed on reset and repopulated lazily on first query.
+
+## Resolved: macro body provenance for the definition frame
+
+When we push a layer for `foo!(…)`, the traceback frame for the macro
+definition needs some buffer to render the caret against. The registry
+entry already owns a copy of the macro's body text (`SynqMacroEntry.body`
+in `parser_internal.h`), stored at `register_macro` time. That copy is
+what `expand_template` reads from during substitution, and it outlives
+any parse that uses the macro.
+
+**Decision: point `SynqExpansionLayer.template_body` directly at the
+registry's `body` field.** No snapshot of the *defining statement* is
+captured — only the macro body itself, which is what the traceback
+needs for caret rendering. The `def_line` / `def_col` numbers are
+informational metadata for the frame header; they do not index into any
+buffer.
+
+The originally-considered options of (a) snapshotting the whole
+definition statement, (b) leaving the snippet empty, and (c) threading
+a module resolver, are all either more expensive or more coupled than
+using what the registry already has. We ship the registry-body pointer.

--- a/docs/text-expansion-model-plan.md
+++ b/docs/text-expansion-model-plan.md
@@ -546,7 +546,7 @@ additive/rename work lands first, then behavior changes, then deletions.
 | Step | Status | Notes |
 | ---- | ------ | ----- |
 | 1. Rename `_buf_idx` → `_layer_id`                  | ✅ done | |
-| 2. Rename `SynqMacroRegion` → `SynqExpansionLayer`  | ✅ done | Public `syntaqlite_result_macros` preserved via lazy `public_macros_view`. |
+| 2. Rename `SynqMacroRegion` → `SynqExpansionLayer`  | ✅ done | `syntaqlite_result_macros` replaced by count + indexed getter (`_macro_count` / `_macro_at`) so `p->layers` stays the single source of truth (no parallel view). |
 | 3. Add new layer metadata fields                    | ✅ done | `syntaqlite_parser_register_macro` gained `def_line`/`def_col` params; Rust wrappers currently pass `0, 0`. |
 | 4. Record `SynqArgSegment` during param substitution| ✅ done | `SynqMacroExpansion` carries arg segments until transferred onto the layer in `feed_macro_expansion`; `reset_stmt` / `destroy` free both expansion buffers and segment arrays. |
 | 5. Add `_layer_id` to `SyntaqliteParserToken`       | ✅ done | ABI change (16 → 20 bytes). Python bindings unaffected (they don't use the struct); Rust `CParserToken` mirror updated. |
@@ -556,9 +556,9 @@ additive/rename work lands first, then behavior changes, then deletions.
 | 9. Lazy expanded splicer + `subtree_expanded_text` / `expanded_text` | ⏳ deferred | |
 | 10. Migrate formatter's `try_macro_verbatim`        | ⏳ deferred | |
 | 11. Migrate analyzer's `statement_source`           | ⏳ deferred | |
-| 12. `FieldValue::Span` rename                       | ⏳ deferred | Step 6 Rust methods are `pub(crate)` and test-only; Step 12 promotes them and rewrites `extract_field_value`. |
+| 12. `FieldValue::Span` rename                       | ⏳ partial | `extract_field_value` now populates `FieldValue::Span` from the new trio (Session 1 follow-up, PR #90 review). Full rename of the variant's field names (`source` → `text_range`, adding a second authored-text field) still deferred. |
 | 13. Delete old expansion traceback API              | ⏳ deferred | |
-| 14. Delete `resolve_span` and `SyntaqliteResolvedSpan` | ⏳ deferred | Currently still the live path for `FieldValue::Span` population. |
+| 14. Delete `resolve_span` and `SyntaqliteResolvedSpan` | ✅ done | Brought forward from Session 1 follow-up (PR #90 review). Zero callers remain. |
 | 15. Rename `syntaqlite_parser_source()` → `syntaqlite_parser_text()` | ⏳ deferred | |
 
 **Notes on Step 6 (session 1):**
@@ -570,13 +570,11 @@ additive/rename work lands first, then behavior changes, then deletions.
   (`syntaqlite-buildtools/src/dialect_codegen/rust_ast.rs`) was updated to
   emit `span_expanded_text(...)` and generated files were regenerated.
   Generated call sites preserve their original behavior after the rename.
-- All three new Rust methods are `pub(crate)` for now. Test callers live
-  in the same crate (`parser/session.rs` tests), and the eventual
-  Step 12 migration will promote them to `pub` when `FieldValue::Span`
-  consumes them directly.
-- Methods are annotated with `#[cfg_attr(not(test), expect(dead_code,
-  reason = "wired into FieldValue::Span in Step 12"))]` where the only
-  non-test caller is tests; this is removed in Step 12.
+- The three new Rust methods started as `pub(crate)` for Step 6 since the
+  only caller was tests; after the Session 1 follow-up that rewired
+  `extract_field_value` on top of them, they are now genuinely used on
+  every span field extraction. Promoting them to `pub` happens in the
+  full Step 12 rework (still deferred).
 
 **Red-green discipline:** Steps 1–5 are mechanical renames and internal
 plumbing with no user-visible surface, so there is nothing to fail a
@@ -594,6 +592,15 @@ implementation and must fail on the pre-change tree.
   `span_text_inside_substituted_arg_drills_to_origin`. Full workspace
   tests, integration suites (`ast`, `fmt`, `grammar`), and clippy
   `-D warnings` all green at session end.
+- **Session 1 follow-up (PR #90 review)** brought forward the dedupe
+  work: removed `syntaqlite_parser_resolve_span` /
+  `SyntaqliteResolvedSpan` (Step 14) and migrated `extract_field_value`
+  to populate `FieldValue::Span` directly from `span_expanded_text` +
+  `span_text_range` + `sp.is_quoted()` — a partial Step 12 landing.
+  Also replaced `syntaqlite_result_macros` (array-pointer view over
+  `p->layers`) with a count + `_macro_at(idx)` pair so there is no
+  separate "public view" data structure. Updated C examples
+  (`select_columns.c` / `.cc`) accordingly.
 
 ### Step 1 — Rename `_buf_idx` to `_layer_id`
 

--- a/examples/select_columns.c
+++ b/examples/select_columns.c
@@ -63,14 +63,14 @@ static void span_to_str(SyntaqliteParser* p,
                         SyntaqliteSourceSpan span,
                         char* buf,
                         int buf_size) {
-  SyntaqliteResolvedSpan resolved = syntaqlite_parser_resolve_span(p, &span);
-  if (!resolved.text || resolved.text_len == 0) {
+  uint32_t len = 0;
+  const char* text = syntaqlite_parser_span_expanded_text(p, &span, &len);
+  if (!text || len == 0) {
     buf[0] = '\0';
     return;
   }
-  int n = (int)resolved.text_len < buf_size - 1 ? (int)resolved.text_len
-                                                : buf_size - 1;
-  memcpy(buf, resolved.text, n);
+  int n = (int)len < buf_size - 1 ? (int)len : buf_size - 1;
+  memcpy(buf, text, n);
   buf[n] = '\0';
 }
 

--- a/examples/select_columns.cc
+++ b/examples/select_columns.cc
@@ -19,10 +19,11 @@
 
 // Extract a std::string from a SyntaqliteSourceSpan.
 static std::string SpanText(SyntaqliteParser* p, SyntaqliteSourceSpan span) {
-  SyntaqliteResolvedSpan resolved = syntaqlite_parser_resolve_span(p, &span);
-  if (!resolved.text || resolved.text_len == 0)
+  uint32_t len = 0;
+  const char* text = syntaqlite_parser_span_expanded_text(p, &span, &len);
+  if (!text || len == 0)
     return {};
-  return {resolved.text, resolved.text_len};
+  return {text, len};
 }
 
 // Extract a std::string from an IdentName node ID.

--- a/syntaqlite-buildtools/parser-actions/utility_stmts.y
+++ b/syntaqlite-buildtools/parser-actions/utility_stmts.y
@@ -95,7 +95,7 @@ minus_num(A) ::= MINUS(M) number(X). {
     A.z = M.z;
     A.n = (int)(X.z - M.z) + X.n;
     A.offset = M.offset;
-    A.buf_idx = M.buf_idx;
+    A.layer_id = M.layer_id;
 }
 
 signed(A) ::= plus_num(A). {

--- a/syntaqlite-buildtools/parser-actions/virtual_table.y
+++ b/syntaqlite-buildtools/parser-actions/virtual_table.y
@@ -24,8 +24,8 @@ cmd(A) ::= create_vtab(X). {
 // With arguments in parentheses
 cmd(A) ::= create_vtab(X) LP(L) vtabarglist RP(R). {
     // Capture module arguments span (content between parens).
-    // Use token offsets/buf_idx so this works correctly when the statement
-    // is produced by a macro expansion; LP and RP share a buffer within the
+    // Use token offsets/layer_id so this works correctly when the statement
+    // is produced by a macro expansion; LP and RP share a layer within the
     // same reduction.
     SyntaqliteNode *vtab = AST_NODE(&pCtx->ast, X);
     uint32_t args_start = L.offset + L.n;
@@ -34,7 +34,7 @@ cmd(A) ::= create_vtab(X) LP(L) vtabarglist RP(R). {
         .offset = args_start,
         .length = (uint16_t)(args_end - args_start),
         .flags = 0,
-        ._buf_idx = L.buf_idx,
+        ._layer_id = L.layer_id,
     };
     A = X;
 }

--- a/syntaqlite-buildtools/src/dialect_codegen/rust_ast.rs
+++ b/syntaqlite-buildtools/src/dialect_codegen/rust_ast.rs
@@ -73,7 +73,7 @@ fn rust_view_accessor_body(field: &Field, ffi_path: &str) -> String {
             if t == "Bool" {
                 format!("self.raw.{fname} == {ffi_path}::Bool::True")
             } else if t == "SyntaqliteSourceSpan" {
-                format!("self.stmt_result.span_text(self.raw.{fname})")
+                format!("self.stmt_result.span_expanded_text(self.raw.{fname})")
             } else {
                 format!("self.raw.{fname}")
             }

--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -206,9 +206,6 @@ SYNTAQLITE_API void syntaqlite_parser_destroy(SyntaqliteParser* p) {
         p->mem.xFree(lyr->arg_segments);
     }
     syntaqlite_vec_free(&p->layers, p->mem);
-    if (p->public_macros_view) {
-      p->mem.xFree(p->public_macros_view);
-    }
     // Free macro registry.
     if (p->macro_table) {
       for (uint32_t i = 0; i < p->macro_table_size; i++) {
@@ -516,33 +513,21 @@ SYNTAQLITE_API const SyntaqliteParserToken* syntaqlite_result_tokens(
   return p->tokens.data;
 }
 
-SYNTAQLITE_API const SyntaqliteMacroRegion* syntaqlite_result_macros(
-    SyntaqliteParser* p,
-    uint32_t* count) {
+SYNTAQLITE_API uint32_t syntaqlite_result_macro_count(SyntaqliteParser* p) {
   uint32_t total = syntaqlite_vec_len(&p->layers);
-  // Skip sentinel at index 0.
-  if (total <= 1) {
-    *count = 0;
-    return NULL;
+  // Entry 0 is the source sentinel; real expansion layers start at 1.
+  return total <= 1 ? 0 : total - 1;
+}
+
+SYNTAQLITE_API SyntaqliteMacroRegion
+syntaqlite_result_macro_at(SyntaqliteParser* p, uint32_t idx) {
+  // +1 to skip the source sentinel at index 0.
+  uint32_t layer_idx = idx + 1;
+  if (layer_idx >= syntaqlite_vec_len(&p->layers)) {
+    return (SyntaqliteMacroRegion){0, 0};
   }
-  uint32_t needed = total - 1;
-  // Lazily (re)allocate the public view when the layer vector has grown
-  // past the current capacity.  Valid until the next parser_next / reset /
-  // destroy, matching the documented lifetime of result_*() pointers.
-  if (needed > p->public_macros_view_cap) {
-    p->public_macros_view =
-        p->public_macros_view
-            ? p->mem.xRealloc(p->public_macros_view,
-                              needed * sizeof(SyntaqliteMacroRegion))
-            : p->mem.xMalloc(needed * sizeof(SyntaqliteMacroRegion));
-    p->public_macros_view_cap = needed;
-  }
-  for (uint32_t i = 0; i < needed; i++) {
-    p->public_macros_view[i].call_offset = p->layers.data[i + 1].call_offset;
-    p->public_macros_view[i].call_length = p->layers.data[i + 1].call_length;
-  }
-  *count = needed;
-  return p->public_macros_view;
+  const SynqExpansionLayer* lyr = &p->layers.data[layer_idx];
+  return (SyntaqliteMacroRegion){lyr->call_offset, lyr->call_length};
 }
 
 // ---------------------------------------------------------------------------

--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -63,26 +63,32 @@ static void reset_stmt(SyntaqliteParser* p) {
   synq_parse_ctx_clear(&p->ctx);
   syntaqlite_vec_clear(&p->comments);
   syntaqlite_vec_clear(&p->tokens);
-  // Free owned expansion buffers from previous statement.
-  // Skip index 0 (sentinel) — its expansion_data points to source, not
-  // malloc'd.
-  for (uint32_t i = 1; i < syntaqlite_vec_len(&p->macro_regions); i++) {
-    if (p->macro_regions.data[i].expansion_data)
-      p->mem.xFree((void*)p->macro_regions.data[i].expansion_data);
+  // Free owned expansion buffers and arg-segment arrays from previous
+  // statement.  Skip index 0 (sentinel) — its expansion_data points to
+  // source (not malloc'd) and it has no arg_segments.
+  for (uint32_t i = 1; i < syntaqlite_vec_len(&p->layers); i++) {
+    SynqExpansionLayer* lyr = &p->layers.data[i];
+    if (lyr->expansion_data)
+      p->mem.xFree((void*)lyr->expansion_data);
+    if (lyr->arg_segments)
+      p->mem.xFree(lyr->arg_segments);
   }
-  syntaqlite_vec_clear(&p->macro_expansions);
-  syntaqlite_vec_clear(&p->macro_regions);
-  // Push sentinel at index 0 (source buffer).  p->source may be NULL on
+  syntaqlite_vec_clear(&p->layers);
+  // Push sentinel at index 0 (source layer).  p->source may be NULL on
   // the very first reset_stmt call (before syntaqlite_parser_reset sets it),
   // which is fine — syntaqlite_parser_reset re-clears and re-pushes.
   if (p->source) {
-    SyntaqliteMacroRegion pub_sentinel = {0, 0};
-    syntaqlite_vec_push(&p->macro_expansions, pub_sentinel, p->mem);
-    SynqMacroRegion sentinel = {p->source, p->source_len, 0};
-    syntaqlite_vec_push(&p->macro_regions, sentinel, p->mem);
+    SynqExpansionLayer sentinel = {
+        .call_offset = 0,
+        .call_length = 0,
+        .expansion_data = p->source,
+        .expansion_len = p->source_len,
+        .parent_layer_id = 0,
+    };
+    syntaqlite_vec_push(&p->layers, sentinel, p->mem);
   }
   p->expansion_depth = 0;
-  p->ctx.buf_idx = 0;
+  p->ctx.layer_id = 0;
   p->ctx.root = SYNTAQLITE_NULL_NODE;
   p->ctx.stmt_completed = 0;
   p->ctx.pending_explain_mode = 0;
@@ -135,8 +141,7 @@ SYNTAQLITE_API SyntaqliteParser* syntaqlite_parser_create_with_dialect(
   synq_parse_ctx_init(&p->ctx, m);
   syntaqlite_vec_init(&p->comments);
   syntaqlite_vec_init(&p->tokens);
-  syntaqlite_vec_init(&p->macro_expansions);
-  syntaqlite_vec_init(&p->macro_regions);
+  syntaqlite_vec_init(&p->layers);
   // macro_table, expansion state already zeroed by memset
   return p;
 }
@@ -166,15 +171,18 @@ SYNTAQLITE_API void syntaqlite_parser_reset(SyntaqliteParser* p,
   p->last_status = SYNTAQLITE_PARSE_DONE;
   p->macro_depth = 0;
 
-  // Re-push sentinels with the correct source pointer (reset_stmt may have
-  // pushed ones with the old source, or none if source was NULL).
-  syntaqlite_vec_clear(&p->macro_expansions);
-  syntaqlite_vec_clear(&p->macro_regions);
+  // Re-push the sentinel with the correct source pointer (reset_stmt may
+  // have pushed one with the old source, or none if source was NULL).
+  syntaqlite_vec_clear(&p->layers);
   {
-    SyntaqliteMacroRegion pub_sentinel = {0, 0};
-    syntaqlite_vec_push(&p->macro_expansions, pub_sentinel, p->mem);
-    SynqMacroRegion sentinel = {source, len, 0};
-    syntaqlite_vec_push(&p->macro_regions, sentinel, p->mem);
+    SynqExpansionLayer sentinel = {
+        .call_offset = 0,
+        .call_length = 0,
+        .expansion_data = source,
+        .expansion_len = len,
+        .parent_layer_id = 0,
+    };
+    syntaqlite_vec_push(&p->layers, sentinel, p->mem);
   }
 
   p->ctx.source = source;
@@ -187,15 +195,20 @@ SYNTAQLITE_API void syntaqlite_parser_destroy(SyntaqliteParser* p) {
     synq_parse_ctx_free(&p->ctx);
     syntaqlite_vec_free(&p->comments, p->mem);
     syntaqlite_vec_free(&p->tokens, p->mem);
-    // Free owned expansion buffers and macro vectors.
-    // Skip index 0 (sentinel) — its expansion_data points to source, not
-    // malloc'd.
-    for (uint32_t i = 1; i < syntaqlite_vec_len(&p->macro_regions); i++) {
-      if (p->macro_regions.data[i].expansion_data)
-        p->mem.xFree((void*)p->macro_regions.data[i].expansion_data);
+    // Free owned expansion buffers, arg-segment arrays, and the layer
+    // vector.  Skip index 0 (sentinel) — its expansion_data points to
+    // source (not malloc'd) and it has no arg_segments.
+    for (uint32_t i = 1; i < syntaqlite_vec_len(&p->layers); i++) {
+      SynqExpansionLayer* lyr = &p->layers.data[i];
+      if (lyr->expansion_data)
+        p->mem.xFree((void*)lyr->expansion_data);
+      if (lyr->arg_segments)
+        p->mem.xFree(lyr->arg_segments);
     }
-    syntaqlite_vec_free(&p->macro_expansions, p->mem);
-    syntaqlite_vec_free(&p->macro_regions, p->mem);
+    syntaqlite_vec_free(&p->layers, p->mem);
+    if (p->public_macros_view) {
+      p->mem.xFree(p->public_macros_view);
+    }
     // Free macro registry.
     if (p->macro_table) {
       for (uint32_t i = 0; i < p->macro_table_size; i++) {
@@ -230,7 +243,7 @@ int synq_parser_feed_one_token(SyntaqliteParser* p,
       .type = token_type,
       .token_idx = token_idx,
       .offset = tok_offset,
-      .buf_idx = (uint8_t)p->ctx.buf_idx,
+      .layer_id = (uint8_t)p->ctx.layer_id,
       ._pad = {0, 0, 0},
   };
   SYNQ_PARSER_FEED(p->dialect.tmpl, p->lemon, (int)token_type, minor);
@@ -301,7 +314,7 @@ static int finish_input(SyntaqliteParser* p) {
                         .type = 0,
                         .token_idx = 0xFFFFFFFF,
                         .offset = 0,
-                        .buf_idx = 0,
+                        .layer_id = 0,
                         ._pad = {0, 0, 0}};
   SYNQ_PARSER_FEED(p->dialect.tmpl, p->lemon, 0, eof);
   p->finished = 1;
@@ -342,7 +355,8 @@ int synq_parser_record_and_feed(SyntaqliteParser* p,
                                 uint32_t cur_len) {
   uint32_t tidx = 0xFFFFFFFF;
   if (p->collect_tokens) {
-    SyntaqliteParserToken tp = {cur_offset, cur_len, cur_type, 0};
+    SyntaqliteParserToken tp = {
+        cur_offset, cur_len, cur_type, 0, (uint8_t)p->ctx.layer_id, {0, 0, 0}};
     syntaqlite_vec_push(&p->tokens, tp, p->mem);
     tidx = syntaqlite_vec_len(&p->tokens) - 1;
   }
@@ -505,14 +519,30 @@ SYNTAQLITE_API const SyntaqliteParserToken* syntaqlite_result_tokens(
 SYNTAQLITE_API const SyntaqliteMacroRegion* syntaqlite_result_macros(
     SyntaqliteParser* p,
     uint32_t* count) {
-  uint32_t total = syntaqlite_vec_len(&p->macro_expansions);
+  uint32_t total = syntaqlite_vec_len(&p->layers);
   // Skip sentinel at index 0.
   if (total <= 1) {
     *count = 0;
     return NULL;
   }
-  *count = total - 1;
-  return p->macro_expansions.data + 1;
+  uint32_t needed = total - 1;
+  // Lazily (re)allocate the public view when the layer vector has grown
+  // past the current capacity.  Valid until the next parser_next / reset /
+  // destroy, matching the documented lifetime of result_*() pointers.
+  if (needed > p->public_macros_view_cap) {
+    p->public_macros_view =
+        p->public_macros_view
+            ? p->mem.xRealloc(p->public_macros_view,
+                              needed * sizeof(SyntaqliteMacroRegion))
+            : p->mem.xMalloc(needed * sizeof(SyntaqliteMacroRegion));
+    p->public_macros_view_cap = needed;
+  }
+  for (uint32_t i = 0; i < needed; i++) {
+    p->public_macros_view[i].call_offset = p->layers.data[i + 1].call_offset;
+    p->public_macros_view[i].call_length = p->layers.data[i + 1].call_length;
+  }
+  *count = needed;
+  return p->public_macros_view;
 }
 
 // ---------------------------------------------------------------------------
@@ -572,7 +602,8 @@ SYNTAQLITE_API int32_t syntaqlite_parser_feed_token(SyntaqliteParser* p,
   uint32_t tidx = 0xFFFFFFFF;
   if (p->collect_tokens && text) {
     uint32_t tok_offset = (uint32_t)(text - p->source);
-    SyntaqliteParserToken tp = {tok_offset, len, token_type, 0};
+    SyntaqliteParserToken tp = {
+        tok_offset, len, token_type, 0, (uint8_t)p->ctx.layer_id, {0, 0, 0}};
     syntaqlite_vec_push(&p->tokens, tp, p->mem);
     tidx = syntaqlite_vec_len(&p->tokens) - 1;
   }

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -75,19 +75,11 @@ typedef struct SynqMacroArg {
   uint32_t length;  // Byte length of the argument text.
 } SynqMacroArg;
 
-// Unified expansion layer record.  `_layer_id` on AST spans indexes
-// directly into the parser's layers vector.  Entry 0 is a sentinel for the
-// original source (expansion_data = source pointer, parent_layer_id = 0,
+// Expansion layer record.  `_layer_id` on AST spans indexes directly into
+// the parser's layers vector.  Entry 0 is a sentinel for the original
+// source (expansion_data = source pointer, parent_layer_id = 0,
 // call_offset/call_length = 0, template_body/name/arg_segments all NULL).
 // Actual expansions start at index 1.
-//
-// Carries the union of what were previously two parallel structs:
-//   - SyntaqliteMacroRegion (public): call_offset, call_length
-//   - SynqMacroRegion (internal): expansion_data, expansion_len,
-//   parent_layer_id
-//
-// syntaqlite_result_macros() builds a view over the call_offset/call_length
-// fields on demand via a lazy cached array in p->public_macros_view.
 //
 // Template/name/def_line/def_col are borrowed pointers into the macro
 // registry entry that was expanded to produce this layer; they outlive the
@@ -163,12 +155,6 @@ struct SyntaqliteParser {
   // source; actual expansions start at index 1.  `_layer_id` on AST spans
   // indexes directly into this vector.
   SYNQ_VEC(SynqExpansionLayer) layers;
-
-  // Lazy view returned by syntaqlite_result_macros().  Allocated on first
-  // call from p->layers[1..], freed and reallocated when layers grows.
-  // Freed on destroy.  Owned by p->mem.
-  SyntaqliteMacroRegion* public_macros_view;
-  uint32_t public_macros_view_cap;
 
   // ── Macro registry (open-addressing hashmap) ──────────────────────────
   SynqMacroEntry* macro_table;

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -43,8 +43,31 @@ typedef struct SynqMacroEntry {
   uint32_t* param_name_lens;
   uint32_t param_count;
 
+  // --- Definition provenance ---
+  // Line/column of the `CREATE PERFETTO MACRO` statement that defined this
+  // entry (1-based). Zero means "unknown". Used by traceback rendering to
+  // label macro-body frames with their authoring position. The macro body
+  // text itself is `body` above — traceback frames borrow that pointer.
+  uint32_t def_line;
+  uint32_t def_col;
+
   uint8_t state;  // SYNQ_MAP_EMPTY / LIVE / TOMBSTONE
 } SynqMacroEntry;
+
+// One parameter substitution recorded during macro expansion. Tracks where
+// the copied arg text landed in the child layer's buffer and where it came
+// from in the parent layer's buffer. Populated by expand_template during
+// Step 4; consumed by argument-level traceback (Step 7).
+typedef struct SynqArgSegment {
+  uint32_t sub_offset;       // Where the substituted arg landed in the child
+                             // layer's buffer.
+  uint32_t sub_length;       // Length of the substitution.
+  uint32_t origin_layer_id;  // Layer that owned the arg text.
+  uint32_t origin_offset;    // Where the arg text started in the origin layer.
+  uint32_t origin_length;    // Length of the origin arg text (may differ from
+                             // sub_length if the arg was rewritten — presently
+                             // the two are always equal).
+} SynqArgSegment;
 
 // A comma-separated argument extracted from a macro call site.
 typedef struct SynqMacroArg {
@@ -52,24 +75,62 @@ typedef struct SynqMacroArg {
   uint32_t length;  // Byte length of the argument text.
 } SynqMacroArg;
 
-// Internal macro expansion record, parallel to the public SyntaqliteMacroRegion
-// (which stores call_offset/call_length).  Entry 0 is a sentinel for the
-// original source; actual expansions start at index 1.  `buf_idx` on AST
-// spans indexes directly into the parser's macro_regions vector.
-typedef struct SynqMacroRegion {
+// Unified expansion layer record.  `_layer_id` on AST spans indexes
+// directly into the parser's layers vector.  Entry 0 is a sentinel for the
+// original source (expansion_data = source pointer, parent_layer_id = 0,
+// call_offset/call_length = 0, template_body/name/arg_segments all NULL).
+// Actual expansions start at index 1.
+//
+// Carries the union of what were previously two parallel structs:
+//   - SyntaqliteMacroRegion (public): call_offset, call_length
+//   - SynqMacroRegion (internal): expansion_data, expansion_len,
+//   parent_layer_id
+//
+// syntaqlite_result_macros() builds a view over the call_offset/call_length
+// fields on demand via a lazy cached array in p->public_macros_view.
+//
+// Template/name/def_line/def_col are borrowed pointers into the macro
+// registry entry that was expanded to produce this layer; they outlive the
+// layer because parse state is reset before any registry entries can be
+// freed.  For the sentinel (layer 0) and incremental-API begin_macro (no
+// registry entry), these fields are all NULL/0.
+typedef struct SynqExpansionLayer {
+  uint32_t call_offset;        // Byte offset of macro call in parent layer.
+  uint32_t call_length;        // Byte length of entire macro call.
   const char* expansion_data;  // Expanded text (NULL for sentinel/fallback).
   uint32_t expansion_len;      // Length of expanded text.
-  uint8_t parent_buf_idx;      // Buffer containing the call (0 = source).
-} SynqMacroRegion;
+
+  // Definition provenance (borrowed from macro registry entry).
+  const char* template_body;   // Registry body with $params visible.
+  uint32_t template_body_len;  // Length of template_body, or 0.
+  const char* name;            // Macro name (borrowed), or NULL.
+  uint32_t name_len;           // Length of name.
+  uint32_t def_line;           // Macro definition line (1-based, 0=unknown).
+  uint32_t def_col;            // Macro definition column (1-based, 0=unknown).
+
+  // Parameter substitutions recorded during expand_template (Step 4).
+  // Arg segments live in p->mem; freed in reset_stmt / destroy alongside
+  // expansion_data. Empty for layers without parameter substitution.
+  SynqArgSegment* arg_segments;
+  uint32_t arg_segment_count;
+
+  uint8_t parent_layer_id;  // Layer containing the call (0 = source).
+} SynqExpansionLayer;
 
 // Result of a successful macro expansion (pure template substitution).
-// `data` is caller-owned (allocated via p->mem); ownership transfers to
-// macro_regions when fed via synq_parser_feed_macro_expansion().
+// `data` and `arg_segments` are caller-owned (allocated via p->mem);
+// ownership transfers to the layer record when fed via
+// synq_parser_feed_macro_expansion().
 typedef struct SynqMacroExpansion {
   const SynqMacroEntry* entry;  // Registry entry (for blue-paint).
   char* data;                   // Expanded text.
   uint32_t data_len;            // Length of expanded text.
   uint32_t end_offset;          // Position past ')' in the source buf.
+  // Arg-segment list recorded during template substitution.  Sorted by
+  // sub_offset (ascending), non-overlapping.  NULL when the template has
+  // no $param placeholders.  Allocated via p->mem.
+  SynqArgSegment* arg_segments;
+  uint32_t arg_segment_count;
 } SynqMacroExpansion;
 
 // ── Parser struct ───────────────────────────────────────────────────────────
@@ -98,14 +159,16 @@ struct SyntaqliteParser {
   SYNQ_VEC(SyntaqliteParserToken) tokens;
   uint32_t macro_depth;  // Nesting depth (0 = not in macro).
 
-  // Public macro regions (call site ranges only), returned by
-  // syntaqlite_result_macros().
-  SYNQ_VEC(SyntaqliteMacroRegion) macro_expansions;
-  // Internal macro expansion records.  `buf_idx` on AST spans indexes
-  // directly into this vector.  Entry 0 is a sentinel representing the
-  // original source (parent_buf_idx=0, expansion_data=source pointer).
-  // Actual expansions start at index 1.
-  SYNQ_VEC(SynqMacroRegion) macro_regions;
+  // Unified layer tree.  Entry 0 is a sentinel representing the original
+  // source; actual expansions start at index 1.  `_layer_id` on AST spans
+  // indexes directly into this vector.
+  SYNQ_VEC(SynqExpansionLayer) layers;
+
+  // Lazy view returned by syntaqlite_result_macros().  Allocated on first
+  // call from p->layers[1..], freed and reallocated when layers grows.
+  // Freed on destroy.  Owned by p->mem.
+  SyntaqliteMacroRegion* public_macros_view;
+  uint32_t public_macros_view_cap;
 
   // ── Macro registry (open-addressing hashmap) ──────────────────────────
   SynqMacroEntry* macro_table;

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -723,71 +723,7 @@ SYNTAQLITE_API int syntaqlite_parser_deregister_macro(SyntaqliteParser* p,
 }
 
 // ---------------------------------------------------------------------------
-// Span resolution
-// ---------------------------------------------------------------------------
-
-// Walk the parent chain to resolve a (layer_id, offset, length) to the
-// outermost source-level call site.
-static void resolve_to_source(SyntaqliteParser* p,
-                              uint8_t layer_id,
-                              uint32_t offset,
-                              uint16_t length,
-                              uint32_t* out_offset,
-                              uint32_t* out_length) {
-  uint32_t off = offset;
-  uint32_t len = length;
-  uint8_t layer = layer_id;
-  while (layer > 0 && layer < syntaqlite_vec_len(&p->layers)) {
-    const SynqExpansionLayer* entry = &p->layers.data[layer];
-    off = entry->call_offset;
-    len = entry->call_length;
-    layer = entry->parent_layer_id;
-  }
-  *out_offset = off;
-  *out_length = len;
-}
-
-SYNTAQLITE_API SyntaqliteResolvedSpan
-syntaqlite_parser_resolve_span(SyntaqliteParser* p,
-                               const SyntaqliteSourceSpan* sp) {
-  SyntaqliteResolvedSpan result = {NULL, 0, 0, 0, 0};
-
-  if (!sp || sp->length == 0)
-    return result;
-
-  result.flags = sp->flags;
-
-  // Fast path for direct (non-expansion) spans: offset/length are already
-  // source positions and the text lives in the original source buffer.
-  if (!synq_span_needs_resolve(*sp)) {
-    if (sp->offset + sp->length <= p->source_len) {
-      result.text = p->source + sp->offset;
-      result.text_len = sp->length;
-    }
-    result.source_offset = sp->offset;
-    result.source_length = sp->length;
-    return result;
-  }
-
-  // Expansion span: pick the correct expansion layer for text.
-  uint8_t layer = sp->_layer_id;
-  if (layer < syntaqlite_vec_len(&p->layers)) {
-    const SynqExpansionLayer* r = &p->layers.data[layer];
-    if (r->expansion_data && sp->offset + sp->length <= r->expansion_len) {
-      result.text = r->expansion_data + sp->offset;
-      result.text_len = sp->length;
-    }
-  }
-
-  // Walk the parent chain to find the outermost call site in the source.
-  resolve_to_source(p, sp->_layer_id, sp->offset, sp->length,
-                    &result.source_offset, &result.source_length);
-
-  return result;
-}
-
-// ---------------------------------------------------------------------------
-// New span accessors: span_text, span_expanded_text, span_text_range
+// Span accessors: span_text, span_expanded_text, span_text_range
 // ---------------------------------------------------------------------------
 
 // Walk the layer chain to resolve (layer, offset, length) to an authored

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -105,15 +105,23 @@ uint32_t synq_parser_scan_macro_args(SyntaqliteParser* p,
 // Expand a template macro body by substituting $param references.
 // Uses the tokenizer to identify TK_VARIABLE tokens rather than
 // hand-rolling identifier scanning.
-// Allocates `*out_buf` via p->mem; caller owns the result.
+//
+// Allocates `*out_buf` via p->mem; caller owns the result.  Also allocates
+// `*out_segments` (one per $param substitution) via p->mem; caller owns it
+// and must free it (typically by moving it onto the pushed expansion
+// layer).  `origin_layer_id` identifies the layer that owns `arg_source`.
+//
 // Returns 0 on success, -1 on error (unknown $param).
 static int expand_template(SyntaqliteParser* p,
                            const SynqMacroEntry* entry,
                            const SynqMacroArg* args,
                            uint32_t arg_count,
                            const char* arg_source,
+                           uint32_t origin_layer_id,
                            char** out_buf,
-                           uint32_t* out_len) {
+                           uint32_t* out_len,
+                           SynqArgSegment** out_segments,
+                           uint32_t* out_segment_count) {
   // Pre-size: body length + some slack for arg text.
   uint32_t cap = entry->body_len + 64;
   char* buf = p->mem.xMalloc(cap);
@@ -121,6 +129,11 @@ static int expand_template(SyntaqliteParser* p,
   const char* body = entry->body;
   uint32_t blen = entry->body_len;
   const unsigned char* z = (const unsigned char*)body;
+
+  // Segment list (grows as substitutions happen; NULL until first push).
+  SynqArgSegment* segments = NULL;
+  uint32_t seg_count = 0;
+  uint32_t seg_cap = 0;
 
   uint32_t pos = 0;
   while (pos < blen) {
@@ -148,6 +161,8 @@ static int expand_template(SyntaqliteParser* p,
         snprintf(p->error_msg, sizeof(p->error_msg),
                  "unknown macro parameter '$%.*s'", (int)pname_len, pname);
         p->mem.xFree(buf);
+        if (segments)
+          p->mem.xFree(segments);
         return -1;
       }
 
@@ -158,10 +173,30 @@ static int expand_template(SyntaqliteParser* p,
           cap *= 2;
           buf = p->mem.xRealloc(buf, cap);
         }
+        uint32_t sub_offset = len;
         memcpy(buf + len, arg_source + args[found].offset, alen);
         len += alen;
+
+        // Record the substitution.  Empty args produce no segment — they
+        // have nothing for a traceback to point at.
+        if (alen > 0) {
+          if (seg_count == seg_cap) {
+            seg_cap = seg_cap == 0 ? 4 : seg_cap * 2;
+            segments = segments
+                           ? p->mem.xRealloc(segments,
+                                             seg_cap * sizeof(SynqArgSegment))
+                           : p->mem.xMalloc(seg_cap * sizeof(SynqArgSegment));
+          }
+          segments[seg_count++] = (SynqArgSegment){
+              .sub_offset = sub_offset,
+              .sub_length = alen,
+              .origin_layer_id = origin_layer_id,
+              .origin_offset = args[found].offset,
+              .origin_length = alen,
+          };
+        }
       }
-      // else: arg not provided — substitute empty string.
+      // else: arg not provided — substitute empty string (no segment).
     } else {
       // Copy token verbatim.
       while (len + (uint32_t)tlen > cap) {
@@ -184,6 +219,8 @@ static int expand_template(SyntaqliteParser* p,
 
   *out_buf = buf;
   *out_len = len;
+  *out_segments = segments;
+  *out_segment_count = seg_count;
   return 0;
 }
 
@@ -251,14 +288,14 @@ static int expand_and_feed(SyntaqliteParser* p,
     }
 
     // Feed token to Lemon.  `pos` is the offset within the expansion
-    // buffer; `p->ctx.buf_idx` was set to the current expansion's index
+    // layer; `p->ctx.layer_id` was set to the current expansion's index
     // before expand_and_feed was called.
     SynqParseToken minor = {.z = buf + pos,
                             .n = (uint32_t)tlen,
                             .type = ttype,
                             .token_idx = 0xFFFFFFFF,
                             .offset = pos,
-                            .buf_idx = (uint8_t)p->ctx.buf_idx,
+                            .layer_id = (uint8_t)p->ctx.layer_id,
                             ._pad = {0, 0, 0}};
     SYNQ_PARSER_FEED(p->dialect.tmpl, p->lemon, (int)ttype, minor);
     p->last_token_type = ttype;
@@ -331,11 +368,16 @@ int synq_parser_expand_macro(SyntaqliteParser* p,
     return -1;
   }
 
-  // Expand template.
+  // Expand template.  The origin layer for arg segments is the current
+  // layer being parsed — at top-level this is 0 (source), at nested
+  // expansion it's the enclosing macro's layer.
   char* expanded = NULL;
   uint32_t expanded_len = 0;
-  if (expand_template(p, entry, args, arg_count, buf, &expanded,
-                      &expanded_len) < 0) {
+  SynqArgSegment* segments = NULL;
+  uint32_t segment_count = 0;
+  if (expand_template(p, entry, args, arg_count, buf, p->ctx.layer_id,
+                      &expanded, &expanded_len, &segments,
+                      &segment_count) < 0) {
     p->had_error = 1;
     return -1;
   }
@@ -344,6 +386,8 @@ int synq_parser_expand_macro(SyntaqliteParser* p,
   out->data = expanded;
   out->data_len = expanded_len;
   out->end_offset = end_offset;
+  out->arg_segments = segments;
+  out->arg_segment_count = segment_count;
   return 0;
 }
 
@@ -351,40 +395,54 @@ int synq_parser_expand_macro(SyntaqliteParser* p,
 // Macro region tracking (internal helper + public begin/end)
 // ---------------------------------------------------------------------------
 
-// Internal: push a macro expansion record with optional expansion data.
+// Internal: push a new expansion layer with optional expansion data and
+// optional registry-entry provenance.  `entry` may be NULL for layers
+// created via the incremental begin/end_macro API (no definition metadata).
 static void begin_macro_expansion(SyntaqliteParser* p,
                                   uint32_t call_offset,
                                   uint32_t call_length,
                                   const char* expansion_data,
-                                  uint32_t expansion_len) {
-  SyntaqliteMacroRegion pub_region = {call_offset, call_length};
-  syntaqlite_vec_push(&p->macro_expansions, pub_region, p->mem);
-  SynqMacroRegion internal = {expansion_data, expansion_len,
-                              (uint8_t)p->ctx.buf_idx};
-  syntaqlite_vec_push(&p->macro_regions, internal, p->mem);
+                                  uint32_t expansion_len,
+                                  const SynqMacroEntry* entry) {
+  SynqExpansionLayer layer = {
+      .call_offset = call_offset,
+      .call_length = call_length,
+      .expansion_data = expansion_data,
+      .expansion_len = expansion_len,
+      .template_body = entry ? entry->body : NULL,
+      .template_body_len = entry ? entry->body_len : 0,
+      .name = entry ? entry->name : NULL,
+      .name_len = entry ? entry->name_len : 0,
+      .def_line = entry ? entry->def_line : 0,
+      .def_col = entry ? entry->def_col : 0,
+      .arg_segments = NULL,
+      .arg_segment_count = 0,
+      .parent_layer_id = (uint8_t)p->ctx.layer_id,
+  };
+  syntaqlite_vec_push(&p->layers, layer, p->mem);
   p->macro_depth++;
 }
 
 SYNTAQLITE_API void syntaqlite_parser_begin_macro(SyntaqliteParser* p,
                                                   uint32_t call_offset,
                                                   uint32_t call_length) {
-  begin_macro_expansion(p, call_offset, call_length, NULL, 0);
-  // Set buf_idx so spans created while this macro is active reference it.
-  p->ctx.buf_idx = syntaqlite_vec_len(&p->macro_regions) - 1;
+  begin_macro_expansion(p, call_offset, call_length, NULL, 0, NULL);
+  // Set layer_id so spans created while this macro is active reference it.
+  p->ctx.layer_id = syntaqlite_vec_len(&p->layers) - 1;
 }
 
 SYNTAQLITE_API void syntaqlite_parser_end_macro(SyntaqliteParser* p) {
   if (p->macro_depth > 0) {
     p->macro_depth--;
-    // Restore buf_idx to parent. If we're back to depth 0, that's buf_idx 0
-    // (source). Otherwise, find the parent from the current region.
+    // Restore layer_id to parent. If we're back to depth 0, that's layer 0
+    // (source). Otherwise, find the parent from the current layer.
     if (p->macro_depth == 0) {
-      p->ctx.buf_idx = 0;
+      p->ctx.layer_id = 0;
     } else {
-      // Walk back to find the still-active parent region.
-      uint32_t cur = p->ctx.buf_idx;
-      if (cur > 0 && cur < syntaqlite_vec_len(&p->macro_regions)) {
-        p->ctx.buf_idx = p->macro_regions.data[cur].parent_buf_idx;
+      // Walk back to find the still-active parent layer.
+      uint32_t cur = p->ctx.layer_id;
+      if (cur > 0 && cur < syntaqlite_vec_len(&p->layers)) {
+        p->ctx.layer_id = p->layers.data[cur].parent_layer_id;
       }
     }
   }
@@ -394,7 +452,7 @@ SYNTAQLITE_API void syntaqlite_parser_end_macro(SyntaqliteParser* p) {
 //
 // call_offset/call_length locate the macro call in the original source
 // (0/0 for nested expansions that have no source-level position).
-// Takes ownership of exp->data via macro_expansions.
+// Takes ownership of exp->data via the pushed expansion layer.
 // begin_macro and end_macro are called symmetrically within this function.
 // Returns 0 on success, -1 on error.
 int synq_parser_feed_macro_expansion(SyntaqliteParser* p,
@@ -402,12 +460,22 @@ int synq_parser_feed_macro_expansion(SyntaqliteParser* p,
                                      uint32_t call_length,
                                      SynqMacroExpansion* exp,
                                      uint32_t depth) {
-  // Push the unified record (tracks call site + owns expansion buffer).
-  begin_macro_expansion(p, call_offset, call_length, exp->data, exp->data_len);
+  // Push the new expansion layer (owns the expansion buffer).
+  begin_macro_expansion(p, call_offset, call_length, exp->data, exp->data_len,
+                        exp->entry);
 
-  // Set buf_idx so spans created during expansion reference this entry.
-  uint32_t saved_buf_idx = p->ctx.buf_idx;
-  p->ctx.buf_idx = syntaqlite_vec_len(&p->macro_regions) - 1;
+  // Transfer ownership of the arg segments onto the layer we just pushed.
+  // expand_template allocated them via p->mem; reset_stmt/destroy frees
+  // them along with the layer.
+  uint32_t new_layer_idx = syntaqlite_vec_len(&p->layers) - 1;
+  p->layers.data[new_layer_idx].arg_segments = exp->arg_segments;
+  p->layers.data[new_layer_idx].arg_segment_count = exp->arg_segment_count;
+  exp->arg_segments = NULL;
+  exp->arg_segment_count = 0;
+
+  // Set layer_id so spans created during expansion reference this entry.
+  uint32_t saved_layer_id = p->ctx.layer_id;
+  p->ctx.layer_id = new_layer_idx;
 
   // Push blue-paint for recursion detection.
   p->expansion_names[p->expansion_depth] = exp->entry->name;
@@ -420,8 +488,8 @@ int synq_parser_feed_macro_expansion(SyntaqliteParser* p,
   // Pop blue-paint.
   p->expansion_depth--;
 
-  // Restore buf_idx.
-  p->ctx.buf_idx = saved_buf_idx;
+  // Restore layer_id.
+  p->ctx.layer_id = saved_layer_id;
 
   syntaqlite_parser_end_macro(p);
 
@@ -505,8 +573,9 @@ int synq_parser_try_macro_call(SyntaqliteParser* p,
 // ---------------------------------------------------------------------------
 
 int synq_parser_check_macro_straddle(SyntaqliteParser* p) {
-  uint32_t macro_count = syntaqlite_vec_len(&p->macro_expansions);
-  if (macro_count == 0)
+  uint32_t layer_count = syntaqlite_vec_len(&p->layers);
+  // Sentinel occupies index 0; real expansion layers start at 1.
+  if (layer_count <= 1)
     return 0;
   if (!p->dialect.tmpl->range_meta) {
     snprintf(p->error_msg, sizeof(p->error_msg),
@@ -516,7 +585,7 @@ int synq_parser_check_macro_straddle(SyntaqliteParser* p) {
   }
 
   uint32_t node_count = syntaqlite_vec_len(&p->ctx.ast.offsets);
-  const SyntaqliteMacroRegion* macros = p->macro_expansions.data;
+  const SynqExpansionLayer* layers = p->layers.data;
 
   for (uint32_t nid = 0; nid < node_count; nid++) {
     const uint8_t* raw = (const uint8_t*)synq_arena_ptr(&p->ctx.ast, nid);
@@ -529,9 +598,9 @@ int synq_parser_check_macro_straddle(SyntaqliteParser* p) {
     if (entry->fields == NULL || entry->count == 0)
       continue;
 
-    for (uint32_t mi = 0; mi < macro_count; mi++) {
-      uint32_t r_start = macros[mi].call_offset;
-      uint32_t r_end = r_start + macros[mi].call_length;
+    for (uint32_t mi = 1; mi < layer_count; mi++) {
+      uint32_t r_start = layers[mi].call_offset;
+      uint32_t r_end = r_start + layers[mi].call_length;
 
       int has_inside = 0;
       int has_outside = 0;
@@ -603,7 +672,9 @@ SYNTAQLITE_API int syntaqlite_parser_register_macro(
     const char* const* param_names,
     uint32_t param_count,
     const char* body,
-    uint32_t body_len) {
+    uint32_t body_len,
+    uint32_t def_line,
+    uint32_t def_col) {
   SynqMacroEntry* slot;
   SYNQ_MAP_INSERT(p->macro_table, p->macro_table_size, p->macro_table_count,
                   name, name_len, p->mem, SYNQ_MACRO_TABLE_INITIAL_SIZE, slot);
@@ -619,6 +690,8 @@ SYNTAQLITE_API int syntaqlite_parser_register_macro(
   slot->body = synq_strdup(p->mem, body, body_len);
   slot->body_len = body_len;
   slot->param_count = param_count;
+  slot->def_line = def_line;
+  slot->def_col = def_col;
 
   if (param_count > 0) {
     slot->param_names = p->mem.xMalloc(param_count * sizeof(char*));
@@ -653,22 +726,22 @@ SYNTAQLITE_API int syntaqlite_parser_deregister_macro(SyntaqliteParser* p,
 // Span resolution
 // ---------------------------------------------------------------------------
 
-// Walk the parent chain to resolve a (buf_idx, offset, length) to the
+// Walk the parent chain to resolve a (layer_id, offset, length) to the
 // outermost source-level call site.
 static void resolve_to_source(SyntaqliteParser* p,
-                              uint8_t buf_idx,
+                              uint8_t layer_id,
                               uint32_t offset,
                               uint16_t length,
                               uint32_t* out_offset,
                               uint32_t* out_length) {
   uint32_t off = offset;
   uint32_t len = length;
-  uint8_t buf = buf_idx;
-  while (buf > 0 && buf < syntaqlite_vec_len(&p->macro_regions)) {
-    const SyntaqliteMacroRegion* pub_r = &p->macro_expansions.data[buf];
-    off = pub_r->call_offset;
-    len = pub_r->call_length;
-    buf = p->macro_regions.data[buf].parent_buf_idx;
+  uint8_t layer = layer_id;
+  while (layer > 0 && layer < syntaqlite_vec_len(&p->layers)) {
+    const SynqExpansionLayer* entry = &p->layers.data[layer];
+    off = entry->call_offset;
+    len = entry->call_length;
+    layer = entry->parent_layer_id;
   }
   *out_offset = off;
   *out_length = len;
@@ -696,10 +769,10 @@ syntaqlite_parser_resolve_span(SyntaqliteParser* p,
     return result;
   }
 
-  // Expansion span: pick the correct expansion buffer for text.
-  uint8_t buf = sp->_buf_idx;
-  if (buf < syntaqlite_vec_len(&p->macro_regions)) {
-    const SynqMacroRegion* r = &p->macro_regions.data[buf];
+  // Expansion span: pick the correct expansion layer for text.
+  uint8_t layer = sp->_layer_id;
+  if (layer < syntaqlite_vec_len(&p->layers)) {
+    const SynqExpansionLayer* r = &p->layers.data[layer];
     if (r->expansion_data && sp->offset + sp->length <= r->expansion_len) {
       result.text = r->expansion_data + sp->offset;
       result.text_len = sp->length;
@@ -707,10 +780,147 @@ syntaqlite_parser_resolve_span(SyntaqliteParser* p,
   }
 
   // Walk the parent chain to find the outermost call site in the source.
-  resolve_to_source(p, sp->_buf_idx, sp->offset, sp->length,
+  resolve_to_source(p, sp->_layer_id, sp->offset, sp->length,
                     &result.source_offset, &result.source_length);
 
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// New span accessors: span_text, span_expanded_text, span_text_range
+// ---------------------------------------------------------------------------
+
+// Walk the layer chain to resolve (layer, offset, length) to an authored
+// byte range in the source.  At each layer, first check whether the span
+// falls inside one of the layer's arg segments — if so, drill through to
+// the arg's origin layer at the translated offset.  Otherwise collapse to
+// the layer's call site in the parent and continue walking.
+//
+// Bounded by SYNQ_MAX_MACRO_DEPTH; typical case is one or two iterations.
+static void span_walk_to_source(SyntaqliteParser* p,
+                                uint8_t layer_id,
+                                uint32_t offset,
+                                uint32_t length,
+                                uint32_t* out_offset,
+                                uint32_t* out_length) {
+  uint32_t off = offset;
+  uint32_t len = length;
+  uint32_t layer = layer_id;
+  uint32_t layers_count = syntaqlite_vec_len(&p->layers);
+  // Bound the walk.  Each iteration either drills into an arg origin
+  // layer or moves up to a parent layer; cap defensively at twice the
+  // maximum expansion depth since a drill + collapse can both happen.
+  for (uint32_t step = 0; step < 2 * (SYNQ_MAX_MACRO_DEPTH + 1); step++) {
+    if (layer == 0 || layer >= layers_count) {
+      break;
+    }
+    const SynqExpansionLayer* cur = &p->layers.data[layer];
+
+    // Arg-segment drill: if the span lies fully inside a substituted arg
+    // of THIS layer, the authored bytes live in the segment's origin
+    // layer, not via the layer's call site.
+    int drilled = 0;
+    for (uint32_t i = 0; i < cur->arg_segment_count; i++) {
+      const SynqArgSegment* seg = &cur->arg_segments[i];
+      if (off >= seg->sub_offset &&
+          off + len <= seg->sub_offset + seg->sub_length) {
+        uint32_t delta = off - seg->sub_offset;
+        off = seg->origin_offset + delta;
+        // origin_length is always >= len at this point (the substituted
+        // text is copied verbatim), so len is unchanged.
+        layer = seg->origin_layer_id;
+        drilled = 1;
+        break;
+      }
+    }
+    if (drilled)
+      continue;
+
+    // Otherwise, collapse to the call site in the parent layer.
+    off = cur->call_offset;
+    len = cur->call_length;
+    layer = cur->parent_layer_id;
+  }
+  *out_offset = off;
+  *out_length = len;
+}
+
+SYNTAQLITE_API const char* syntaqlite_parser_span_expanded_text(
+    SyntaqliteParser* p,
+    const SyntaqliteSourceSpan* span,
+    uint32_t* out_len) {
+  if (!span || span->length == 0) {
+    *out_len = 0;
+    return NULL;
+  }
+  uint8_t layer = span->_layer_id;
+  if (layer >= syntaqlite_vec_len(&p->layers)) {
+    *out_len = 0;
+    return NULL;
+  }
+  const SynqExpansionLayer* lyr = &p->layers.data[layer];
+  if (!lyr->expansion_data ||
+      span->offset + span->length > lyr->expansion_len) {
+    *out_len = 0;
+    return NULL;
+  }
+  *out_len = span->length;
+  return lyr->expansion_data + span->offset;
+}
+
+SYNTAQLITE_API const char* syntaqlite_parser_span_text(
+    SyntaqliteParser* p,
+    const SyntaqliteSourceSpan* span,
+    uint32_t* out_len) {
+  if (!span || span->length == 0) {
+    *out_len = 0;
+    return NULL;
+  }
+  // Fast path: spans in the source layer are already authored positions.
+  if (span->_layer_id == 0) {
+    if (span->offset + span->length > p->source_len) {
+      *out_len = 0;
+      return NULL;
+    }
+    *out_len = span->length;
+    return p->source + span->offset;
+  }
+  // Walk the expansion chain to find the authored bytes.
+  uint32_t off = 0;
+  uint32_t len = 0;
+  span_walk_to_source(p, span->_layer_id, span->offset, span->length, &off,
+                      &len);
+  if (off + len > p->source_len) {
+    *out_len = 0;
+    return NULL;
+  }
+  *out_len = len;
+  return p->source + off;
+}
+
+SYNTAQLITE_API SyntaqliteTextRange
+syntaqlite_parser_span_text_range(SyntaqliteParser* p,
+                                  const SyntaqliteSourceSpan* span) {
+  SyntaqliteTextRange r = {0, 0};
+  if (!span || span->length == 0) {
+    return r;
+  }
+  if (span->_layer_id == 0) {
+    if (span->offset + span->length > p->source_len)
+      return r;
+    r.start = span->offset;
+    r.end = span->offset + span->length;
+    return r;
+  }
+  uint32_t off = 0;
+  uint32_t len = 0;
+  span_walk_to_source(p, span->_layer_id, span->offset, span->length, &off,
+                      &len);
+  if (off + len > p->source_len)
+    return r;
+  r.start = off;
+  r.end = off + len;
+  return r;
 }
 
 SYNTAQLITE_API uint32_t
@@ -727,26 +937,23 @@ syntaqlite_parser_expansion_traceback(SyntaqliteParser* p,
   uint32_t count = 0;
   uint32_t cur_off = sp->offset;
   uint32_t cur_len = sp->length;
-  uint8_t cur_buf = sp->_buf_idx;
+  uint8_t cur_layer = sp->_layer_id;
 
   while (count < SYNQ_MAX_MACRO_DEPTH + 1) {
-    if (cur_buf >= syntaqlite_vec_len(&p->macro_regions))
+    if (cur_layer >= syntaqlite_vec_len(&p->layers))
       break;
-    const SynqMacroRegion* r = &p->macro_regions.data[cur_buf];
+    const SynqExpansionLayer* r = &p->layers.data[cur_layer];
     tmp[count].buffer = r->expansion_data;
     tmp[count].buffer_len = r->expansion_len;
     tmp[count].offset = cur_off;
     tmp[count].length = cur_len;
     count++;
-    if (cur_buf == 0)
+    if (cur_layer == 0)
       break;
-    // Move to parent: the call site of this expansion in the parent buffer.
-    if (cur_buf < syntaqlite_vec_len(&p->macro_expansions)) {
-      const SyntaqliteMacroRegion* pub_r = &p->macro_expansions.data[cur_buf];
-      cur_off = pub_r->call_offset;
-      cur_len = pub_r->call_length;
-    }
-    cur_buf = r->parent_buf_idx;
+    // Move to parent: the call site of this expansion in the parent layer.
+    cur_off = r->call_offset;
+    cur_len = r->call_length;
+    cur_layer = r->parent_layer_id;
   }
 
   // Reverse so frames[0] is outermost (source) and frames[count-1] is

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
@@ -9627,7 +9627,7 @@ static YYACTIONTYPE yy_reduce(
       yylhsminor.yy0.n = (int)(yymsp[0].minor.yy0.z - yymsp[-1].minor.yy0.z) +
                          yymsp[0].minor.yy0.n;
       yylhsminor.yy0.offset = yymsp[-1].minor.yy0.offset;
-      yylhsminor.yy0.buf_idx = yymsp[-1].minor.yy0.buf_idx;
+      yylhsminor.yy0.layer_id = yymsp[-1].minor.yy0.layer_id;
     }
       yymsp[-1].minor.yy0 = yylhsminor.yy0;
       break;
@@ -9769,8 +9769,8 @@ static YYACTIONTYPE yy_reduce(
     case 372: /* cmd ::= create_vtab LP vtabarglist RP */
     {
       // Capture module arguments span (content between parens).
-      // Use token offsets/buf_idx so this works correctly when the statement
-      // is produced by a macro expansion; LP and RP share a buffer within the
+      // Use token offsets/layer_id so this works correctly when the statement
+      // is produced by a macro expansion; LP and RP share a layer within the
       // same reduction.
       SyntaqliteNode* vtab = AST_NODE(&pCtx->ast, yymsp[-3].minor.yy277);
       uint32_t args_start = yymsp[-2].minor.yy0.offset + yymsp[-2].minor.yy0.n;
@@ -9779,7 +9779,7 @@ static YYACTIONTYPE yy_reduce(
           .offset = args_start,
           .length = (uint16_t)(args_end - args_start),
           .flags = 0,
-          ._buf_idx = yymsp[-2].minor.yy0.buf_idx,
+          ._layer_id = yymsp[-2].minor.yy0.layer_id,
       };
       yylhsminor.yy277 = yymsp[-3].minor.yy277;
     }

--- a/syntaqlite-syntax/include/syntaqlite/dialect.h
+++ b/syntaqlite-syntax/include/syntaqlite/dialect.h
@@ -81,7 +81,7 @@ typedef struct SynqParseToken {
                        // shift time so reductions don't depend on
                        // ctx->source which may have been swapped back
                        // after a macro expansion
-  uint8_t buf_idx;     // 0 = original source, 1+ = expansion buffer index
+  uint8_t layer_id;    // 0 = original source, 1+ = expansion layer index
   uint8_t _pad[3];
 } SynqParseToken;
 

--- a/syntaqlite-syntax/include/syntaqlite/incremental.h
+++ b/syntaqlite-syntax/include/syntaqlite/incremental.h
@@ -43,7 +43,8 @@
 //
 // For macro region tracking, bracket expanded tokens with
 // syntaqlite_parser_begin_macro() / syntaqlite_parser_end_macro(). Read
-// accumulated regions via syntaqlite_result_macros() after parsing.
+// accumulated regions via syntaqlite_result_macro_count() /
+// syntaqlite_result_macro_at() after parsing.
 
 #ifndef SYNTAQLITE_INCREMENTAL_PARSER_H
 #define SYNTAQLITE_INCREMENTAL_PARSER_H

--- a/syntaqlite-syntax/include/syntaqlite/incremental.h
+++ b/syntaqlite-syntax/include/syntaqlite/incremental.h
@@ -111,6 +111,12 @@ SYNTAQLITE_API void syntaqlite_parser_end_macro(SyntaqliteParser* p);
 
 // Register a template macro.  Copies all strings.
 // The macro body uses $param placeholders (e.g. "$x + 1").
+//
+// `def_line` / `def_col` are the 1-based line/column of the defining
+// statement (e.g. `CREATE PERFETTO MACRO foo`).  They are stored on the
+// registry entry and surfaced by expansion tracebacks so error frames for
+// macro bodies can reference the authoring position.  Pass 0/0 if unknown.
+//
 // Returns 0 on success.
 SYNTAQLITE_API int syntaqlite_parser_register_macro(
     SyntaqliteParser* p,
@@ -119,7 +125,9 @@ SYNTAQLITE_API int syntaqlite_parser_register_macro(
     const char* const* param_names,
     uint32_t param_count,
     const char* body,
-    uint32_t body_len);
+    uint32_t body_len,
+    uint32_t def_line,
+    uint32_t def_col);
 
 // Deregister a macro by name.  Returns 0 on success, -1 if not found.
 SYNTAQLITE_API int syntaqlite_parser_deregister_macro(SyntaqliteParser* p,

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -98,11 +98,19 @@ typedef uint32_t SyntaqliteParserTokenFlags;
   ((SyntaqliteParserTokenFlags)4)  // Consumed as type name.
 
 // A non-whitespace, non-comment token position captured during parsing.
+//
+// For tokens produced by macro expansion, `offset` is a byte position in
+// the expansion layer's internal buffer (identified by `_layer_id`), not a
+// position in the input source.  Consumers that need source-level
+// positions should resolve the token's span via the parser's span
+// accessors rather than using `offset` directly.
 typedef struct SyntaqliteParserToken {
-  uint32_t offset;  // Byte offset in source.
+  uint32_t offset;  // Byte offset in the token's layer buffer.
   uint32_t length;  // Byte length.
   uint32_t type;    // Original token type from tokenizer (pre-fallback).
   SyntaqliteParserTokenFlags flags;  // Bitmask of SYNQ_TOKEN_FLAG_* values.
+  uint8_t _layer_id;  // Internal: 0 = original source, >0 = expansion layer.
+  uint8_t _pad[3];
 } SyntaqliteParserToken;
 
 // A recorded macro invocation region.
@@ -199,6 +207,13 @@ SYNTAQLITE_API uint32_t syntaqlite_parser_node_count(SyntaqliteParser* p);
 // Span resolution
 // ---------------------------------------------------------------------------
 
+// A byte range `[start, end)` in the user's authored input text.
+// Returned by `syntaqlite_parser_span_text_range`.
+typedef struct SyntaqliteTextRange {
+  uint32_t start;
+  uint32_t end;
+} SyntaqliteTextRange;
+
 // A fully-resolved span: text pointer, text length, source byte range, and
 // flags.  Returned by syntaqlite_parser_resolve_span().
 //
@@ -250,6 +265,43 @@ syntaqlite_parser_expansion_traceback(SyntaqliteParser* p,
                                       const SyntaqliteSourceSpan* span,
                                       SyntaqliteExpansionFrame* frames,
                                       uint32_t max_frames);
+
+// ── New span accessors (plan: text / expanded_text vocabulary) ──────────
+
+// Post-expansion text for `span` — the bytes the tokenizer actually saw.
+// For macro-free spans, a slice of the input source.  For spans inside a
+// macro expansion, a slice of the expansion layer's buffer.  Writes the
+// byte length to `*out_len`.  Always a direct slice — no allocation.
+//
+// Returns NULL (and writes 0 to `*out_len`) for empty or invalid spans.
+SYNTAQLITE_API const char* syntaqlite_parser_span_expanded_text(
+    SyntaqliteParser* p,
+    const SyntaqliteSourceSpan* span,
+    uint32_t* out_len);
+
+// Authored text for `span` — always a slice of the input source.
+//
+// For macro-free spans, identical to `span_expanded_text`.  For spans
+// inside a macro expansion, walks the expansion-layer chain:
+//   - If the span falls inside a substituted `$param` arg segment, drills
+//     to the arg's origin text in the caller's layer (recursively).
+//   - Otherwise, collapses to the outermost `name!(...)` call site.
+//
+// Always a direct slice of the source — no allocation.  Returns NULL
+// (and writes 0 to `*out_len`) for empty or invalid spans.
+SYNTAQLITE_API const char* syntaqlite_parser_span_text(
+    SyntaqliteParser* p,
+    const SyntaqliteSourceSpan* span,
+    uint32_t* out_len);
+
+// Byte range of `syntaqlite_parser_span_text(span)` in the input source.
+// The returned range satisfies:
+//   syntaqlite_parser_span_text(span) ==
+//       source[range.start .. range.end]
+// Returns `{0, 0}` for empty or invalid spans.
+SYNTAQLITE_API SyntaqliteTextRange
+syntaqlite_parser_span_text_range(SyntaqliteParser* p,
+                                  const SyntaqliteSourceSpan* span);
 
 // ---------------------------------------------------------------------------
 // Node and list helpers

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -170,8 +170,8 @@ SYNTAQLITE_API uint32_t syntaqlite_result_error_offset(SyntaqliteParser* p);
 // Byte length of error token (0 = unknown).
 SYNTAQLITE_API uint32_t syntaqlite_result_error_length(SyntaqliteParser* p);
 
-// Per-statement token/comment/macro arrays.
-// Token/comment arrays are empty unless collect_tokens is enabled via
+// Per-statement token/comment arrays.
+// Empty unless collect_tokens is enabled via
 // syntaqlite_parser_set_collect_tokens(p, 1) before first reset().
 SYNTAQLITE_API const SyntaqliteComment* syntaqlite_result_comments(
     SyntaqliteParser* p,
@@ -179,9 +179,14 @@ SYNTAQLITE_API const SyntaqliteComment* syntaqlite_result_comments(
 SYNTAQLITE_API const SyntaqliteParserToken* syntaqlite_result_tokens(
     SyntaqliteParser* p,
     uint32_t* count);
-SYNTAQLITE_API const SyntaqliteMacroRegion* syntaqlite_result_macros(
-    SyntaqliteParser* p,
-    uint32_t* count);
+
+// Macro-invocation call sites recorded during parsing.  Accessed via count
+// + indexed getter rather than an array pointer to avoid materializing a
+// separate view — the internal representation carries more data per entry
+// than `SyntaqliteMacroRegion` exposes.
+SYNTAQLITE_API uint32_t syntaqlite_result_macro_count(SyntaqliteParser* p);
+SYNTAQLITE_API SyntaqliteMacroRegion
+syntaqlite_result_macro_at(SyntaqliteParser* p, uint32_t idx);
 
 // ---------------------------------------------------------------------------
 // Arena accessors
@@ -204,7 +209,7 @@ SYNTAQLITE_API uint32_t syntaqlite_parser_source_length(SyntaqliteParser* p);
 SYNTAQLITE_API uint32_t syntaqlite_parser_node_count(SyntaqliteParser* p);
 
 // ---------------------------------------------------------------------------
-// Span resolution
+// Span accessors
 // ---------------------------------------------------------------------------
 
 // A byte range `[start, end)` in the user's authored input text.
@@ -213,33 +218,6 @@ typedef struct SyntaqliteTextRange {
   uint32_t start;
   uint32_t end;
 } SyntaqliteTextRange;
-
-// A fully-resolved span: text pointer, text length, source byte range, and
-// flags.  Returned by syntaqlite_parser_resolve_span().
-//
-// `text` points into the correct buffer — original source for direct spans,
-// expansion buffer for spans inside macros.  `source_offset`/`source_length`
-// are always in the original source; for spans inside a macro expansion,
-// they point at the entire macro call.
-typedef struct SyntaqliteResolvedSpan {
-  const char* text;
-  uint32_t text_len;
-  uint32_t source_offset;
-  uint32_t source_length;
-  uint8_t flags;
-} SyntaqliteResolvedSpan;
-
-// Resolve a source span to its text and source byte range.
-//
-// Walks the macro expansion parent chain for source position, picks the
-// correct buffer for text.  Returns all zeros for a NULL or empty span.
-//
-// This is the only correct way to read a span when macros may be involved:
-// the raw `offset`/`length` fields on `SyntaqliteSourceSpan` may reference
-// an internal expansion buffer.
-SYNTAQLITE_API SyntaqliteResolvedSpan
-syntaqlite_parser_resolve_span(SyntaqliteParser* p,
-                               const SyntaqliteSourceSpan* span);
 
 // One frame in an expansion traceback.  Each frame describes a position
 // inside a particular buffer (the original source or a macro expansion).
@@ -265,8 +243,6 @@ syntaqlite_parser_expansion_traceback(SyntaqliteParser* p,
                                       const SyntaqliteSourceSpan* span,
                                       SyntaqliteExpansionFrame* frames,
                                       uint32_t max_frames);
-
-// ── New span accessors (plan: text / expanded_text vocabulary) ──────────
 
 // Post-expansion text for `span` — the bytes the tokenizer actually saw.
 // For macro-free spans, a slice of the input source.  For spans inside a

--- a/syntaqlite-syntax/include/syntaqlite/types.h
+++ b/syntaqlite-syntax/include/syntaqlite/types.h
@@ -22,14 +22,21 @@ typedef uint32_t SyntaqliteCompletionContext;
 
 // A span field embedded in an AST node.
 //
-// Fast path: when `synq_span_needs_resolve(sp)` is false, `offset` and
-// `length` are directly usable as byte positions in the source string you
-// passed to `syntaqlite_parser_reset`.  Otherwise the span lives inside a
-// macro expansion layer and direct access will produce garbage — call
-// `syntaqlite_parser_resolve_span` to get the real source text + byte
-// range (which points at the entire macro call site for expanded spans),
-// or `syntaqlite_parser_expansion_traceback` if you need the full
-// outermost → innermost expansion chain.
+// The `offset` / `length` fields are not directly usable: for spans
+// tokenized from a macro expansion they reference an internal expansion
+// layer buffer, not the input source.  Always read a span through the
+// parser's span accessors:
+//
+//   - `syntaqlite_parser_span_text(p, &span, &len)` — authored bytes
+//     (slice of input source); walks through macro call sites and
+//     substituted arg segments.
+//   - `syntaqlite_parser_span_expanded_text(p, &span, &len)` — the
+//     bytes the tokenizer actually saw, which for macro-expanded spans
+//     live in an expansion layer buffer.
+//   - `syntaqlite_parser_span_text_range(p, &span)` — byte range of
+//     `span_text` in the input source.
+//   - `syntaqlite_parser_expansion_traceback(p, &span, ...)` — the full
+//     outermost → innermost expansion chain for diagnostics.
 typedef struct SyntaqliteSourceSpan {
   uint32_t offset;
   uint16_t length;
@@ -52,13 +59,6 @@ static inline SyntaqliteSourceSpan synq_span_set_quoted(
     SyntaqliteSourceSpan sp) {
   sp.flags |= SYNTAQLITE_SPAN_FLAG_QUOTED;
   return sp;
-}
-
-// Returns non-zero if this span requires `syntaqlite_parser_resolve_span` to
-// access its text and source position.  When zero, `offset`/`length` are
-// directly usable as byte positions in the parser's input string.
-static inline int synq_span_needs_resolve(SyntaqliteSourceSpan sp) {
-  return sp._layer_id != 0;
 }
 
 #ifdef __cplusplus

--- a/syntaqlite-syntax/include/syntaqlite/types.h
+++ b/syntaqlite-syntax/include/syntaqlite/types.h
@@ -25,7 +25,7 @@ typedef uint32_t SyntaqliteCompletionContext;
 // Fast path: when `synq_span_needs_resolve(sp)` is false, `offset` and
 // `length` are directly usable as byte positions in the source string you
 // passed to `syntaqlite_parser_reset`.  Otherwise the span lives inside a
-// macro expansion buffer and direct access will produce garbage — call
+// macro expansion layer and direct access will produce garbage — call
 // `syntaqlite_parser_resolve_span` to get the real source text + byte
 // range (which points at the entire macro call site for expanded spans),
 // or `syntaqlite_parser_expansion_traceback` if you need the full
@@ -34,7 +34,7 @@ typedef struct SyntaqliteSourceSpan {
   uint32_t offset;
   uint16_t length;
   uint8_t flags;
-  uint8_t _buf_idx;  // Internal: 0 = source, >0 = macro expansion buffer.
+  uint8_t _layer_id;  // Internal: 0 = source, >0 = macro expansion layer.
 } SyntaqliteSourceSpan;
 
 // ── Span flags ───────────────────────────────────────────────────────────────
@@ -58,7 +58,7 @@ static inline SyntaqliteSourceSpan synq_span_set_quoted(
 // access its text and source position.  When zero, `offset`/`length` are
 // directly usable as byte positions in the parser's input string.
 static inline int synq_span_needs_resolve(SyntaqliteSourceSpan sp) {
-  return sp._buf_idx != 0;
+  return sp._layer_id != 0;
 }
 
 #ifdef __cplusplus

--- a/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
@@ -68,9 +68,9 @@ typedef struct SynqParseCtx {
   // synq_mark_as_id() helper casts it to the right layout.
   void* tokens;
 
-  // Expansion buffer index for span construction.
-  // 0 = original source, 1+ = index into owned_bufs (1-based).
-  uint32_t buf_idx;
+  // Expansion layer index for span construction.
+  // 0 = original source, 1+ = index into the layer tree (1-based).
+  uint32_t layer_id;
 
   // Counter for "currently parsing inside a macro definition body".
   // While > 0, the tokenizer skips macro expansion so the body is captured
@@ -221,7 +221,7 @@ static inline SyntaqliteSourceSpan synq_span(SynqParseCtx* ctx,
       .offset = tok.offset,
       .length = (uint16_t)tok.n,
       .flags = 0,
-      ._buf_idx = tok.buf_idx,
+      ._layer_id = tok.layer_id,
   };
 }
 
@@ -241,11 +241,11 @@ static inline SyntaqliteSourceSpan synq_span_dequote(SynqParseCtx* ctx,
     if ((open == '"' && close == '"') || (open == '`' && close == '`') ||
         (open == '[' && close == ']')) {
       SyntaqliteSourceSpan sp = {tok.offset + 1, (uint16_t)(tok.n - 2), 0,
-                                 tok.buf_idx};
+                                 tok.layer_id};
       return synq_span_set_quoted(sp);
     }
   }
-  return (SyntaqliteSourceSpan){tok.offset, (uint16_t)tok.n, 0, tok.buf_idx};
+  return (SyntaqliteSourceSpan){tok.offset, (uint16_t)tok.n, 0, tok.layer_id};
 }
 
 #define SYNQ_NO_SPAN ((SyntaqliteSourceSpan){0, 0, 0, 0})

--- a/syntaqlite-syntax/src/ast.rs
+++ b/syntaqlite-syntax/src/ast.rs
@@ -480,10 +480,10 @@ mod ffi {
         offset: u32,
         length: u16,
         flags: u8,
-        /// Internal: 0 = original source, >0 = macro expansion buffer.
+        /// Internal: 0 = original source, >0 = macro expansion layer id.
         /// Read by the C-side `syntaqlite_parser_resolve_span` helper; the
         /// Rust side never inspects it directly.
-        _buf_idx: u8,
+        _layer_id: u8,
     }
 
     impl CSourceSpan {

--- a/syntaqlite-syntax/src/ast.rs
+++ b/syntaqlite-syntax/src/ast.rs
@@ -481,15 +481,26 @@ mod ffi {
         length: u16,
         flags: u8,
         /// Internal: 0 = original source, >0 = macro expansion layer id.
-        /// Read by the C-side `syntaqlite_parser_resolve_span` helper; the
-        /// Rust side never inspects it directly.
+        /// Read by the C-side span accessors; the Rust side passes the
+        /// whole struct across the FFI boundary without inspecting it.
         _layer_id: u8,
     }
+
+    /// Mirror of C `SYNTAQLITE_SPAN_FLAG_QUOTED` from `types.h`.
+    const SPAN_FLAG_QUOTED: u8 = 1;
 
     impl CSourceSpan {
         /// Returns `true` if the span covers zero bytes.
         pub(crate) fn is_empty(self) -> bool {
             self.length == 0
+        }
+
+        /// Returns `true` if the span was quoted in source (`"..."`,
+        /// `` `...` ``, or `[...]`).  The span points at the dequoted inner
+        /// text; the formatter re-wraps quoted spans in standard double
+        /// quotes.
+        pub(crate) fn is_quoted(self) -> bool {
+            (self.flags & SPAN_FLAG_QUOTED) != 0
         }
     }
 

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -62,6 +62,11 @@ pub(crate) struct CParserToken {
     pub length: u32,
     pub type_: u32,
     pub flags: CParserTokenFlags,
+    /// Internal: 0 = original source, >0 = expansion layer id.
+    /// Read only by C-side span accessors; the Rust side does not
+    /// inspect it directly.
+    pub _layer_id: u8,
+    pub _pad: [u8; 3],
 }
 
 /// A recorded macro invocation region.
@@ -87,6 +92,16 @@ pub(crate) struct CResolvedSpan {
     pub(crate) source_offset: u32,
     pub(crate) source_length: u32,
     pub(crate) flags: u8,
+}
+
+/// A byte range in the user's authored input.
+///
+/// Mirrors C `SyntaqliteTextRange` from `include/syntaqlite/parser.h`.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub(crate) struct CTextRange {
+    pub(crate) start: u32,
+    pub(crate) end: u32,
 }
 
 /// One frame in a macro expansion traceback.
@@ -203,6 +218,51 @@ impl CParser {
         // SAFETY: ptr is a valid pointer to `count` CParserToken values owned
         // by the parser arena; the slice is valid for the parser's lifetime.
         unsafe { std::slice::from_raw_parts(ptr, count as usize) }
+    }
+
+    pub(crate) unsafe fn span_expanded_text(
+        &self,
+        span: crate::ast::SourceSpan,
+        out_len: *mut u32,
+    ) -> *const u8 {
+        // SAFETY: self is a valid, non-null CParser pointer; span is a copy
+        // of an arena value with the SyntaqliteSourceSpan layout; out_len is
+        // a valid pointer owned by the caller.
+        unsafe {
+            syntaqlite_parser_span_expanded_text(
+                std::ptr::from_ref::<Self>(self).cast_mut(),
+                std::ptr::from_ref(&span).cast(),
+                out_len,
+            )
+        }
+    }
+
+    pub(crate) unsafe fn span_text(
+        &self,
+        span: crate::ast::SourceSpan,
+        out_len: *mut u32,
+    ) -> *const u8 {
+        // SAFETY: self is a valid, non-null CParser pointer; span is a copy
+        // of an arena value with the SyntaqliteSourceSpan layout; out_len is
+        // a valid pointer owned by the caller.
+        unsafe {
+            syntaqlite_parser_span_text(
+                std::ptr::from_ref::<Self>(self).cast_mut(),
+                std::ptr::from_ref(&span).cast(),
+                out_len,
+            )
+        }
+    }
+
+    pub(crate) unsafe fn span_text_range(&self, span: crate::ast::SourceSpan) -> CTextRange {
+        // SAFETY: self is a valid, non-null CParser pointer; span is a copy
+        // of an arena value with the SyntaqliteSourceSpan layout.
+        unsafe {
+            syntaqlite_parser_span_text_range(
+                std::ptr::from_ref::<Self>(self).cast_mut(),
+                std::ptr::from_ref(&span).cast(),
+            )
+        }
     }
 
     pub(crate) unsafe fn resolve_span(&self, span: crate::ast::SourceSpan) -> CResolvedSpan {
@@ -334,6 +394,7 @@ impl CParser {
         unsafe { syntaqlite_parser_end_macro(self) }
     }
 
+    #[expect(clippy::too_many_arguments, reason = "mirrors the C API surface 1:1")]
     pub(crate) unsafe fn register_macro(
         &mut self,
         name: *const c_char,
@@ -342,6 +403,8 @@ impl CParser {
         param_count: u32,
         body: *const c_char,
         body_len: u32,
+        def_line: u32,
+        def_col: u32,
     ) -> i32 {
         // SAFETY: self is a valid, non-null CParser pointer; name, param_names,
         // and body are valid pointers with the specified lengths.
@@ -354,6 +417,8 @@ impl CParser {
                 param_count,
                 body,
                 body_len,
+                def_line,
+                def_col,
             )
         }
     }
@@ -390,6 +455,17 @@ unsafe extern "C" {
 
     // Span resolution
     fn syntaqlite_parser_resolve_span(p: *mut CParser, span: *const c_void) -> CResolvedSpan;
+    fn syntaqlite_parser_span_expanded_text(
+        p: *mut CParser,
+        span: *const c_void,
+        out_len: *mut u32,
+    ) -> *const u8;
+    fn syntaqlite_parser_span_text(
+        p: *mut CParser,
+        span: *const c_void,
+        out_len: *mut u32,
+    ) -> *const u8;
+    fn syntaqlite_parser_span_text_range(p: *mut CParser, span: *const c_void) -> CTextRange;
     fn syntaqlite_parser_expansion_traceback(
         p: *mut CParser,
         span: *const c_void,
@@ -431,6 +507,8 @@ unsafe extern "C" {
         param_count: u32,
         body: *const c_char,
         body_len: u32,
+        def_line: u32,
+        def_col: u32,
     ) -> i32;
     fn syntaqlite_parser_deregister_macro(
         p: *mut CParser,
@@ -651,6 +729,8 @@ mod tests {
                 params.len() as u32,
                 body.as_ptr().cast(),
                 body.len() as u32,
+                0,
+                0,
             )
         };
         assert_eq!(rc, 0, "register_macro failed for '{name}'");
@@ -954,7 +1034,7 @@ mod tests {
         // Regression: synq_span() computes `tok.z - ctx->source` for ALL
         // tokens, but during macro expansion tok.z points into the expansion
         // buffer (a different allocation). This makes the offset garbage when
-        // buf_idx == 0 is not corrected. extract_fields then panics with
+        // layer_id == 0 is not corrected. extract_fields then panics with
         // "byte index N is out of bounds".
         use crate::ParserConfig;
         use crate::any::{AnyParser, ParseOutcome};

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -81,19 +81,6 @@ pub(crate) struct CMacroRegion {
     pub(crate) call_length: u32,
 }
 
-/// A fully-resolved span returned by `syntaqlite_parser_resolve_span`.
-///
-/// Mirrors C `SyntaqliteResolvedSpan` from `include/syntaqlite/parser.h`.
-#[derive(Debug, Clone, Copy)]
-#[repr(C)]
-pub(crate) struct CResolvedSpan {
-    pub(crate) text: *const u8,
-    pub(crate) text_len: u32,
-    pub(crate) source_offset: u32,
-    pub(crate) source_length: u32,
-    pub(crate) flags: u8,
-}
-
 /// A byte range in the user's authored input.
 ///
 /// Mirrors C `SyntaqliteTextRange` from `include/syntaqlite/parser.h`.
@@ -265,18 +252,6 @@ impl CParser {
         }
     }
 
-    pub(crate) unsafe fn resolve_span(&self, span: crate::ast::SourceSpan) -> CResolvedSpan {
-        // SAFETY: self is a valid, non-null CParser pointer; span is a copy
-        // of an arena value with the SyntaqliteSourceSpan layout; result
-        // accessors are valid after `next()` returns a non-DONE code.
-        unsafe {
-            syntaqlite_parser_resolve_span(
-                std::ptr::from_ref::<Self>(self).cast_mut(),
-                std::ptr::from_ref(&span).cast(),
-            )
-        }
-    }
-
     pub(crate) unsafe fn expansion_traceback(
         &self,
         span: crate::ast::SourceSpan,
@@ -310,19 +285,17 @@ impl CParser {
         frames
     }
 
-    pub(crate) unsafe fn result_macros(&self) -> &[CMacroRegion] {
-        let mut count: u32 = 0;
+    pub(crate) unsafe fn result_macro_count(&self) -> u32 {
         // SAFETY: self is a valid, non-null CParser pointer; result
         // accessors are valid after `next()` returns a non-DONE code.
-        let ptr = unsafe {
-            syntaqlite_result_macros(std::ptr::from_ref::<Self>(self).cast_mut(), &raw mut count)
-        };
-        if count == 0 || ptr.is_null() {
-            return &[];
-        }
-        // SAFETY: ptr is a valid pointer to `count` CMacroRegion values owned
-        // by the parser arena; the slice is valid for the parser's lifetime.
-        unsafe { std::slice::from_raw_parts(ptr, count as usize) }
+        unsafe { syntaqlite_result_macro_count(std::ptr::from_ref::<Self>(self).cast_mut()) }
+    }
+
+    pub(crate) unsafe fn result_macro_at(&self, idx: u32) -> CMacroRegion {
+        // SAFETY: self is a valid, non-null CParser pointer; result
+        // accessors are valid after `next()` returns a non-DONE code.
+        // The C side clamps out-of-range indices to {0, 0}.
+        unsafe { syntaqlite_result_macro_at(std::ptr::from_ref::<Self>(self).cast_mut(), idx) }
     }
 
     // Arena accessors
@@ -447,14 +420,14 @@ unsafe extern "C" {
     fn syntaqlite_result_error_length(p: *mut CParser) -> u32;
     fn syntaqlite_result_comments(p: *mut CParser, count: *mut u32) -> *const CComment;
     fn syntaqlite_result_tokens(p: *mut CParser, count: *mut u32) -> *const CParserToken;
-    fn syntaqlite_result_macros(p: *mut CParser, count: *mut u32) -> *const CMacroRegion;
+    fn syntaqlite_result_macro_count(p: *mut CParser) -> u32;
+    fn syntaqlite_result_macro_at(p: *mut CParser, idx: u32) -> CMacroRegion;
 
     // Arena accessors
     fn syntaqlite_parser_node(p: *mut CParser, node_id: u32) -> *const u32;
     fn syntaqlite_parser_node_count(p: *mut CParser) -> u32;
 
-    // Span resolution
-    fn syntaqlite_parser_resolve_span(p: *mut CParser, span: *const c_void) -> CResolvedSpan;
+    // Span accessors
     fn syntaqlite_parser_span_expanded_text(
         p: *mut CParser,
         span: *const c_void,
@@ -946,9 +919,10 @@ mod tests {
         assert_eq!(rc, PARSE_OK);
 
         // SAFETY: CParser wraps a valid C parser handle.
-        let regions = unsafe { parser.result_macros() };
-        assert_eq!(regions.len(), 1, "expected one macro region");
-        let r = &regions[0];
+        let count = unsafe { parser.result_macro_count() };
+        assert_eq!(count, 1, "expected one macro region");
+        // SAFETY: idx < count.
+        let r = unsafe { parser.result_macro_at(0) };
         #[expect(clippy::cast_possible_truncation)]
         let call_start = sql.find("foo!").unwrap() as u32;
         assert_eq!(r.call_offset, call_start);
@@ -1019,9 +993,10 @@ mod tests {
         );
 
         // SAFETY: CParser wraps a valid C parser handle.
-        let regions = unsafe { parser.result_macros() };
-        assert_eq!(regions.len(), 1);
-        let r = &regions[0];
+        let count = unsafe { parser.result_macro_count() };
+        assert_eq!(count, 1);
+        // SAFETY: idx < count.
+        let r = unsafe { parser.result_macro_at(0) };
         let call_text = &sql[r.call_offset as usize..(r.call_offset + r.call_length) as usize];
         assert!(
             call_text.starts_with("graph!(") && call_text.ends_with(')'),

--- a/syntaqlite-syntax/src/parser/incremental.rs
+++ b/syntaqlite-syntax/src/parser/incremental.rs
@@ -260,11 +260,6 @@ impl<G: TypedDialect> TypedIncrementalParseSession<G> {
         // SAFETY: raw is valid (owned via ParserInner, valid for &self).
         unsafe { (*self.raw_ptr()).result_tokens() }
     }
-
-    pub(crate) fn macro_regions(&self) -> &[ffi::CMacroRegion] {
-        // SAFETY: raw is valid (owned via ParserInner, valid for &self).
-        unsafe { (*self.raw_ptr()).result_macros() }
-    }
 }
 
 /// Type-erased incremental parser for runtime-selected dialects.
@@ -383,11 +378,6 @@ impl IncrementalParseSession {
     #[expect(dead_code)]
     pub(crate) fn tokens(&self) -> &[ffi::CParserToken] {
         self.0.tokens()
-    }
-
-    #[expect(dead_code)]
-    pub(crate) fn macro_regions(&self) -> &[ffi::CMacroRegion] {
-        self.0.macro_regions()
     }
 }
 

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -196,6 +196,8 @@ impl<G: TypedDialect> TypedParser<G> {
                 params.len() as u32,
                 body.as_ptr().cast(),
                 body.len() as u32,
+                0,
+                0,
             );
         }
     }
@@ -308,6 +310,8 @@ impl<G: TypedDialect> TypedParseSession<G> {
                 params.len() as u32,
                 body.as_ptr().cast(),
                 body.len() as u32,
+                0,
+                0,
             );
         }
     }
@@ -483,25 +487,73 @@ impl<'a> AnyParsedStatement<'a> {
             .collect()
     }
 
-    /// Resolved text for an arena span, picking the correct buffer.
+    /// Post-expansion text for an arena span — the bytes the tokenizer
+    /// actually saw.
     ///
-    /// For spans inside a macro expansion, returns the text from the
-    /// expansion buffer (e.g. `"a"` for `$name` expanded with arg `a`).
-    /// For direct spans, returns a slice of the original source.
-    pub(crate) fn span_text(&self, span: crate::ast::SourceSpan) -> &'a str {
+    /// For direct (macro-free) spans, returns a slice of the original
+    /// source.  For spans inside a macro expansion, returns the slice
+    /// from the appropriate expansion layer's buffer (e.g. `"a"` for
+    /// `$name` expanded with arg `a`).  Always a direct slice — no
+    /// allocation.
+    pub(crate) fn span_expanded_text(&self, span: crate::ast::SourceSpan) -> &'a str {
+        let mut out_len: u32 = 0;
         // SAFETY: self.raw is valid for 'a; span is a copy of an arena value.
-        let r = unsafe { self.raw.as_ref().resolve_span(span) };
-        if r.text.is_null() || r.text_len == 0 {
+        let ptr = unsafe { self.raw.as_ref().span_expanded_text(span, &raw mut out_len) };
+        if ptr.is_null() || out_len == 0 {
             return "";
         }
-        // SAFETY: C guarantees text points to text_len bytes of valid
-        // UTF-8 in a parser-owned buffer valid for 'a.
-        unsafe {
-            std::str::from_utf8_unchecked(std::slice::from_raw_parts(r.text, r.text_len as usize))
+        // SAFETY: C guarantees ptr points to out_len bytes of valid UTF-8
+        // in a parser-owned buffer valid for 'a.
+        unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize)) }
+    }
+
+    /// Authored text for an arena span — always a slice of the user's
+    /// input source (the text passed to `reset`).
+    ///
+    /// For direct (macro-free) spans, this is the same bytes as
+    /// `span_expanded_text`.  For spans inside a macro expansion, this
+    /// walks the expansion layer chain: if the span was tokenized inside
+    /// a substituted argument, it drills back to the arg's origin text in
+    /// the source; otherwise it collapses to the outermost `name!(...)`
+    /// call site in the source.  Always a direct slice — no allocation.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into FieldValue::Span in Step 12")
+    )]
+    pub(crate) fn span_text(&self, span: crate::ast::SourceSpan) -> &'a str {
+        let mut out_len: u32 = 0;
+        // SAFETY: self.raw is valid for 'a; span is a copy of an arena value.
+        let ptr = unsafe { self.raw.as_ref().span_text(span, &raw mut out_len) };
+        if ptr.is_null() || out_len == 0 {
+            return "";
+        }
+        // SAFETY: C guarantees ptr points to out_len bytes of valid UTF-8
+        // in a parser-owned buffer valid for 'a.
+        unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize)) }
+    }
+
+    /// Byte range of `span_text(span)` in the user's input source.  For
+    /// spans inside a macro expansion, this is the byte range of either
+    /// the outermost call site or the substituted arg's origin text —
+    /// matching the bytes returned by `span_text`.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into FieldValue::Span in Step 12")
+    )]
+    pub(crate) fn span_text_range(&self, span: crate::ast::SourceSpan) -> crate::ast::SourceRange {
+        // SAFETY: self.raw is valid for 'a; span is a copy of an arena value.
+        let r = unsafe { self.raw.as_ref().span_text_range(span) };
+        crate::ast::SourceRange {
+            start: r.start,
+            end: r.end,
         }
     }
 
-    fn field_span(&self, node_id: AnyNodeId, field_idx: u8) -> Option<crate::ast::SourceSpan> {
+    pub(crate) fn field_span(
+        &self,
+        node_id: AnyNodeId,
+        field_idx: u8,
+    ) -> Option<crate::ast::SourceSpan> {
         let (ptr, tag) = self.node_ptr(node_id)?;
         let meta = self.dialect.field_meta(tag).nth(field_idx as usize)?;
         if !matches!(meta.kind(), crate::dialect::FieldKind::Span) {
@@ -870,7 +922,7 @@ unsafe fn extract_field_value<'a>(
                 } else {
                     // Delegate to C: resolves text (picks the right buffer)
                     // and walks parent chain for source position.  Rust
-                    // never inspects buf_idx or expansion buffers directly.
+                    // never inspects layer_id or expansion layers directly.
                     let resolved = parser.resolve_span(span);
                     let text = if resolved.text.is_null() || resolved.text_len == 0 {
                         ""

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -442,11 +442,16 @@ impl<'a> AnyParsedStatement<'a> {
 
     /// Macro expansion call-site spans recorded during parsing.
     pub fn macro_regions(&self) -> impl Iterator<Item = MacroRegion> + use<'_> {
-        // SAFETY: self.raw is valid for 'a; the slice lives for the parser lifetime.
-        let raw: &[ffi::CMacroRegion] = unsafe { self.raw.as_ref().result_macros() };
-        raw.iter().map(|r| MacroRegion {
-            call_offset: r.call_offset,
-            call_length: r.call_length,
+        // SAFETY: self.raw is valid for 'a; the indexed accessor is stable
+        // until the next parser_next / reset / destroy call.
+        let count = unsafe { self.raw.as_ref().result_macro_count() };
+        (0..count).map(move |i| {
+            // SAFETY: i < count, so the C side returns a valid region.
+            let r = unsafe { self.raw.as_ref().result_macro_at(i) };
+            MacroRegion {
+                call_offset: r.call_offset,
+                call_length: r.call_length,
+            }
         })
     }
 
@@ -900,7 +905,7 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
 unsafe fn extract_field_value<'a>(
     ptr: *const u8,
     meta: &crate::dialect::FieldMeta<'_>,
-    parser: &CParser,
+    parser: &'a CParser,
 ) -> crate::ast::FieldValue<'a> {
     use crate::ast::{FieldValue, SourceRange, SourceSpan};
     use crate::dialect::FieldKind;
@@ -914,34 +919,28 @@ unsafe fn extract_field_value<'a>(
                 // use read_unaligned to avoid alignment assumptions.
                 let span = field_ptr.cast::<SourceSpan>().read_unaligned();
                 if span.is_empty() {
-                    FieldValue::Span {
+                    return FieldValue::Span {
                         text: "",
                         quoted: false,
                         source: SourceRange::default(),
-                    }
-                } else {
-                    // Delegate to C: resolves text (picks the right buffer)
-                    // and walks parent chain for source position.  Rust
-                    // never inspects layer_id or expansion layers directly.
-                    let resolved = parser.resolve_span(span);
-                    let text = if resolved.text.is_null() || resolved.text_len == 0 {
-                        ""
-                    } else {
-                        // SAFETY: C guarantees text points to text_len bytes
-                        // of valid UTF-8 in a parser-owned buffer valid for 'a.
-                        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-                            resolved.text,
-                            resolved.text_len as usize,
-                        ))
                     };
-                    FieldValue::Span {
-                        text,
-                        quoted: (resolved.flags & 1) != 0,
-                        source: SourceRange {
-                            start: resolved.source_offset,
-                            end: resolved.source_offset + resolved.source_length,
-                        },
-                    }
+                }
+                // Populate from the new span accessors.  `text` preserves
+                // the pre-rework semantics (post-expansion bytes — what
+                // the tokenizer saw); `source` is the authored byte range
+                // in the user's input, walking through the layer chain
+                // and arg segments as needed.  Step 12 of the
+                // text-expansion-model plan reshapes this variant into
+                // separate `text` / `expanded_text` / `text_range` fields.
+                let text = span_slice(parser, span, CParser::span_expanded_text);
+                let range = parser.span_text_range(span);
+                FieldValue::Span {
+                    text,
+                    quoted: span.is_quoted(),
+                    source: SourceRange {
+                        start: range.start,
+                        end: range.end,
+                    },
                 }
             }
             FieldKind::Bool => FieldValue::Bool(*(field_ptr.cast::<u32>()) != 0),
@@ -949,6 +948,28 @@ unsafe fn extract_field_value<'a>(
             FieldKind::Enum => FieldValue::Enum(*(field_ptr.cast::<u32>())),
         }
     }
+}
+
+/// Call a span text accessor (`span_text` or `span_expanded_text`) and
+/// materialize the returned pointer/length as a `&'a str`.
+///
+/// # Safety
+/// `parser` must be a valid `CParser` for lifetime `'a`; `span` must be a
+/// copy of an arena value with the `SyntaqliteSourceSpan` layout.
+unsafe fn span_slice(
+    parser: &CParser,
+    span: crate::ast::SourceSpan,
+    accessor: unsafe fn(&CParser, crate::ast::SourceSpan, *mut u32) -> *const u8,
+) -> &str {
+    let mut out_len: u32 = 0;
+    // SAFETY: delegated via function-level contract.
+    let ptr = unsafe { accessor(parser, span, &raw mut out_len) };
+    if ptr.is_null() || out_len == 0 {
+        return "";
+    }
+    // SAFETY: C guarantees `ptr` points to `out_len` bytes of valid UTF-8
+    // in a parser-owned buffer valid for `'a`.
+    unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize)) }
 }
 
 /// Parse failure for a single statement in dialect `G`.

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -648,4 +648,133 @@ mod tests {
         let mut parser = Parser::new();
         assert!(!parser.deregister_macro("nonexistent"));
     }
+
+    // ── Step 6: span_text / span_expanded_text / span_text_range ────────────
+
+    use super::super::AnyParsedStatement;
+
+    // Walk the tree depth-first looking for a non-empty Span field; return
+    // the raw SourceSpan of the first one found.
+    fn first_span_in_tree<'a>(stmt: &'a AnyParsedStatement<'a>) -> Option<crate::ast::SourceSpan> {
+        use crate::ast::FieldValue;
+        fn walk<'a>(
+            stmt: &'a AnyParsedStatement<'a>,
+            id: crate::ast::AnyNodeId,
+        ) -> Option<crate::ast::SourceSpan> {
+            if let Some((_, fields)) = stmt.extract_fields(id) {
+                for i in 0..fields.len() {
+                    if matches!(fields[i], FieldValue::Span { .. })
+                        && let Ok(field_idx) = u8::try_from(i)
+                        && let Some(sp) = stmt.field_span(id, field_idx)
+                        && !sp.is_empty()
+                    {
+                        return Some(sp);
+                    }
+                }
+            }
+            for child in stmt.child_node_ids(id) {
+                if let Some(found) = walk(stmt, child) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        let root = stmt.root_id();
+        if root.is_null() {
+            return None;
+        }
+        walk(stmt, root)
+    }
+
+    #[test]
+    fn span_text_macro_free_equals_authored_slice() {
+        let parser = Parser::new();
+        let source = "SELECT foo FROM bar";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+        let erased = stmt.erase();
+        let span = first_span_in_tree(&erased).expect("expected a Span field");
+
+        // Macro-free: span_text == span_expanded_text, range indexes into source.
+        let span_text = erased.span_text(span);
+        let span_expanded = erased.span_expanded_text(span);
+        let range = erased.span_text_range(span);
+
+        assert_eq!(span_text, span_expanded);
+        let slice = &source[range.start as usize..range.end as usize];
+        assert_eq!(span_text, slice);
+    }
+
+    #[test]
+    fn span_text_inside_macro_body_collapses_to_call_site() {
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        // Body produces an identifier token ("inner") that lives entirely in
+        // the template — no parameter substitution at the span location.
+        parser.register_macro("idmac", &[], "inner");
+
+        let source = "SELECT idmac!()";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+        let erased = stmt.erase();
+        // The first span in the tree should be "inner" from the expansion.
+        let span = first_span_in_tree(&erased).expect("expected a Span field");
+
+        let span_text = erased.span_text(span);
+        let span_expanded = erased.span_expanded_text(span);
+        let range = erased.span_text_range(span);
+
+        // span_text: authored slice — the whole macro call "idmac!()".
+        assert_eq!(
+            span_text, "idmac!()",
+            "span_text should collapse to the call site"
+        );
+        // span_expanded_text: the literal text the tokenizer saw — "inner".
+        assert_eq!(span_expanded, "inner");
+        // Range points at the call site in source.
+        let slice = &source[range.start as usize..range.end as usize];
+        assert_eq!(slice, "idmac!()");
+    }
+
+    #[test]
+    fn span_text_inside_substituted_arg_drills_to_origin() {
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        // Body is purely a $param substitution. The identifier token in the
+        // expansion is an arg-copy of the caller's text.
+        parser.register_macro("idmac", &["x"], "$x");
+
+        let source = "SELECT idmac!(authored)";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+        let erased = stmt.erase();
+        let span = first_span_in_tree(&erased).expect("expected a Span field");
+
+        let span_text = erased.span_text(span);
+        let span_expanded = erased.span_expanded_text(span);
+        let range = erased.span_text_range(span);
+
+        // Arg-segment drill: span_text points at the user's authored arg
+        // text, not at the whole call site.
+        assert_eq!(
+            span_text, "authored",
+            "span_text should drill through arg segment to origin"
+        );
+        // Expanded text (the token the tokenizer actually saw) is also
+        // "authored" because the arg was copied verbatim.
+        assert_eq!(span_expanded, "authored");
+        // Range points at the authored arg in source.
+        let slice = &source[range.start as usize..range.end as usize];
+        assert_eq!(slice, "authored");
+    }
 }

--- a/syntaqlite-syntax/src/sqlite/ast.rs
+++ b/syntaqlite-syntax/src/sqlite/ast.rs
@@ -1398,7 +1398,7 @@ impl<'a> AggregateFunctionCall<'a> {
         AggregateFunctionCallId(self.id)
     }
     pub fn func_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.func_name)
+        self.stmt_result.span_expanded_text(self.raw.func_name)
     }
     pub fn flags(&self) -> AggregateFunctionCallFlags {
         self.raw.flags
@@ -1482,7 +1482,7 @@ impl<'a> OrderedSetFunctionCall<'a> {
         OrderedSetFunctionCallId(self.id)
     }
     pub fn func_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.func_name)
+        self.stmt_result.span_expanded_text(self.raw.func_name)
     }
     pub fn flags(&self) -> AggregateFunctionCallFlags {
         self.raw.flags
@@ -1569,7 +1569,7 @@ impl<'a> CastExpr<'a> {
         GrammarNodeType::from_result(self.stmt_result, self.raw.expr)
     }
     pub fn type_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.type_name)
+        self.stmt_result.span_expanded_text(self.raw.type_name)
     }
 }
 
@@ -1638,13 +1638,13 @@ impl<'a> ColumnRef<'a> {
         ColumnRefId(self.id)
     }
     pub fn column(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.column)
+        self.stmt_result.span_expanded_text(self.raw.column)
     }
     pub fn table(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.table)
+        self.stmt_result.span_expanded_text(self.raw.table)
     }
     pub fn schema(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.schema)
+        self.stmt_result.span_expanded_text(self.raw.schema)
     }
 }
 
@@ -2382,7 +2382,7 @@ impl<'a> ForeignKeyClause<'a> {
         ForeignKeyClauseId(self.id)
     }
     pub fn ref_table(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.ref_table)
+        self.stmt_result.span_expanded_text(self.raw.ref_table)
     }
     pub fn ref_columns(&self) -> Option<ExprList<'a>> {
         GrammarNodeType::from_result(self.stmt_result, self.raw.ref_columns)
@@ -2466,7 +2466,8 @@ impl<'a> ColumnConstraint<'a> {
         self.raw.kind
     }
     pub fn constraint_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.constraint_name)
+        self.stmt_result
+            .span_expanded_text(self.raw.constraint_name)
     }
     pub fn onconf(&self) -> ConflictAction {
         self.raw.onconf
@@ -2478,7 +2479,7 @@ impl<'a> ColumnConstraint<'a> {
         self.raw.is_autoincrement == super::ffi::Bool::True
     }
     pub fn collation_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.collation_name)
+        self.stmt_result.span_expanded_text(self.raw.collation_name)
     }
     pub fn generated_storage(&self) -> GeneratedColumnStorage {
         self.raw.generated_storage
@@ -2565,7 +2566,7 @@ impl<'a> ColumnDef<'a> {
         GrammarNodeType::from_result(self.stmt_result, self.raw.column_name)
     }
     pub fn type_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.type_name)
+        self.stmt_result.span_expanded_text(self.raw.type_name)
     }
     pub fn constraints(&self) -> Option<ColumnConstraintList<'a>> {
         GrammarNodeType::from_result(self.stmt_result, self.raw.constraints)
@@ -2640,7 +2641,8 @@ impl<'a> TableConstraint<'a> {
         self.raw.kind
     }
     pub fn constraint_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.constraint_name)
+        self.stmt_result
+            .span_expanded_text(self.raw.constraint_name)
     }
     pub fn onconf(&self) -> ConflictAction {
         self.raw.onconf
@@ -2727,10 +2729,10 @@ impl<'a> CreateTableStmt<'a> {
         CreateTableStmtId(self.id)
     }
     pub fn table_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.table_name)
+        self.stmt_result.span_expanded_text(self.raw.table_name)
     }
     pub fn schema(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.schema)
+        self.stmt_result.span_expanded_text(self.raw.schema)
     }
     pub fn is_temp(&self) -> bool {
         self.raw.is_temp == super::ffi::Bool::True
@@ -2817,7 +2819,7 @@ impl<'a> CteDefinition<'a> {
         CteDefinitionId(self.id)
     }
     pub fn cte_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.cte_name)
+        self.stmt_result.span_expanded_text(self.raw.cte_name)
     }
     pub fn materialized(&self) -> Materialized {
         self.raw.materialized
@@ -3057,7 +3059,7 @@ impl<'a> DeleteStmt<'a> {
         self.raw.index_hint
     }
     pub fn index_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.index_name)
+        self.stmt_result.span_expanded_text(self.raw.index_name)
     }
     pub fn where_clause(&self) -> Option<Expr<'a>> {
         GrammarNodeType::from_result(self.stmt_result, self.raw.where_clause)
@@ -3138,7 +3140,7 @@ impl<'a> SetClause<'a> {
         SetClauseId(self.id)
     }
     pub fn column(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.column)
+        self.stmt_result.span_expanded_text(self.raw.column)
     }
     pub fn columns(&self) -> Option<ExprList<'a>> {
         GrammarNodeType::from_result(self.stmt_result, self.raw.columns)
@@ -3222,7 +3224,7 @@ impl<'a> UpdateStmt<'a> {
         self.raw.index_hint
     }
     pub fn index_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.index_name)
+        self.stmt_result.span_expanded_text(self.raw.index_name)
     }
     pub fn setlist(&self) -> Option<SetClauseList<'a>> {
         GrammarNodeType::from_result(self.stmt_result, self.raw.setlist)
@@ -3543,7 +3545,7 @@ impl<'a> Literal<'a> {
         self.raw.literal_type
     }
     pub fn source(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.source)
+        self.stmt_result.span_expanded_text(self.raw.source)
     }
 }
 
@@ -3612,7 +3614,7 @@ impl<'a> IdentName<'a> {
         IdentNameId(self.id)
     }
     pub fn source(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.source)
+        self.stmt_result.span_expanded_text(self.raw.source)
     }
 }
 
@@ -3681,7 +3683,7 @@ impl<'a> Error<'a> {
         ErrorId(self.id)
     }
     pub fn source(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.source)
+        self.stmt_result.span_expanded_text(self.raw.source)
     }
 }
 
@@ -3750,7 +3752,7 @@ impl<'a> FunctionCall<'a> {
         FunctionCallId(self.id)
     }
     pub fn func_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.func_name)
+        self.stmt_result.span_expanded_text(self.raw.func_name)
     }
     pub fn flags(&self) -> FunctionCallFlags {
         self.raw.flags
@@ -3831,7 +3833,7 @@ impl<'a> Variable<'a> {
         VariableId(self.id)
     }
     pub fn source(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.source)
+        self.stmt_result.span_expanded_text(self.raw.source)
     }
 }
 
@@ -3903,7 +3905,7 @@ impl<'a> CollateExpr<'a> {
         GrammarNodeType::from_result(self.stmt_result, self.raw.expr)
     }
     pub fn collation(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.collation)
+        self.stmt_result.span_expanded_text(self.raw.collation)
     }
 }
 
@@ -4728,10 +4730,10 @@ impl<'a> TableRef<'a> {
         TableRefId(self.id)
     }
     pub fn table_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.table_name)
+        self.stmt_result.span_expanded_text(self.raw.table_name)
     }
     pub fn schema(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.schema)
+        self.stmt_result.span_expanded_text(self.raw.schema)
     }
     pub fn alias(&self) -> Option<Name<'a>> {
         GrammarNodeType::from_result(self.stmt_result, self.raw.alias)
@@ -5103,10 +5105,10 @@ impl<'a> CreateTriggerStmt<'a> {
         CreateTriggerStmtId(self.id)
     }
     pub fn trigger_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.trigger_name)
+        self.stmt_result.span_expanded_text(self.raw.trigger_name)
     }
     pub fn schema(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.schema)
+        self.stmt_result.span_expanded_text(self.raw.schema)
     }
     pub fn is_temp(&self) -> bool {
         self.raw.is_temp == super::ffi::Bool::True
@@ -5196,19 +5198,19 @@ impl<'a> CreateVirtualTableStmt<'a> {
         CreateVirtualTableStmtId(self.id)
     }
     pub fn table_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.table_name)
+        self.stmt_result.span_expanded_text(self.raw.table_name)
     }
     pub fn schema(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.schema)
+        self.stmt_result.span_expanded_text(self.raw.schema)
     }
     pub fn module_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.module_name)
+        self.stmt_result.span_expanded_text(self.raw.module_name)
     }
     pub fn if_not_exists(&self) -> bool {
         self.raw.if_not_exists == super::ffi::Bool::True
     }
     pub fn module_args(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.module_args)
+        self.stmt_result.span_expanded_text(self.raw.module_args)
     }
 }
 
@@ -5277,13 +5279,13 @@ impl<'a> PragmaStmt<'a> {
         PragmaStmtId(self.id)
     }
     pub fn pragma_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.pragma_name)
+        self.stmt_result.span_expanded_text(self.raw.pragma_name)
     }
     pub fn schema(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.schema)
+        self.stmt_result.span_expanded_text(self.raw.schema)
     }
     pub fn value(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.value)
+        self.stmt_result.span_expanded_text(self.raw.value)
     }
     pub fn pragma_form(&self) -> PragmaForm {
         self.raw.pragma_form
@@ -5355,10 +5357,10 @@ impl<'a> AnalyzeOrReindexStmt<'a> {
         AnalyzeOrReindexStmtId(self.id)
     }
     pub fn target_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.target_name)
+        self.stmt_result.span_expanded_text(self.raw.target_name)
     }
     pub fn schema(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.schema)
+        self.stmt_result.span_expanded_text(self.raw.schema)
     }
     pub fn kind(&self) -> AnalyzeOrReindexOp {
         self.raw.kind
@@ -5574,7 +5576,7 @@ impl<'a> VacuumStmt<'a> {
         VacuumStmtId(self.id)
     }
     pub fn schema(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.schema)
+        self.stmt_result.span_expanded_text(self.raw.schema)
     }
     pub fn filename(&self) -> Option<Expr<'a>> {
         GrammarNodeType::from_result(self.stmt_result, self.raw.filename)
@@ -5718,13 +5720,13 @@ impl<'a> CreateIndexStmt<'a> {
         CreateIndexStmtId(self.id)
     }
     pub fn index_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.index_name)
+        self.stmt_result.span_expanded_text(self.raw.index_name)
     }
     pub fn schema(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.schema)
+        self.stmt_result.span_expanded_text(self.raw.schema)
     }
     pub fn table_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.table_name)
+        self.stmt_result.span_expanded_text(self.raw.table_name)
     }
     pub fn is_unique(&self) -> bool {
         self.raw.is_unique == super::ffi::Bool::True
@@ -5805,10 +5807,10 @@ impl<'a> CreateViewStmt<'a> {
         CreateViewStmtId(self.id)
     }
     pub fn view_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.view_name)
+        self.stmt_result.span_expanded_text(self.raw.view_name)
     }
     pub fn schema(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.schema)
+        self.stmt_result.span_expanded_text(self.raw.schema)
     }
     pub fn is_temp(&self) -> bool {
         self.raw.is_temp == super::ffi::Bool::True
@@ -6108,7 +6110,8 @@ impl<'a> WindowDef<'a> {
         WindowDefId(self.id)
     }
     pub fn base_window_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.base_window_name)
+        self.stmt_result
+            .span_expanded_text(self.raw.base_window_name)
     }
     pub fn partition_by(&self) -> Option<ExprList<'a>> {
         GrammarNodeType::from_result(self.stmt_result, self.raw.partition_by)
@@ -6186,7 +6189,7 @@ impl<'a> NamedWindowDef<'a> {
         NamedWindowDefId(self.id)
     }
     pub fn window_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.window_name)
+        self.stmt_result.span_expanded_text(self.raw.window_name)
     }
     pub fn window_def(&self) -> Option<WindowDef<'a>> {
         GrammarNodeType::from_result(self.stmt_result, self.raw.window_def)
@@ -6264,7 +6267,7 @@ impl<'a> FilterOver<'a> {
         GrammarNodeType::from_result(self.stmt_result, self.raw.over_def)
     }
     pub fn over_name(&self) -> &'a str {
-        self.stmt_result.span_text(self.raw.over_name)
+        self.stmt_result.span_expanded_text(self.raw.over_name)
     }
 }
 

--- a/tests/perfetto_validation_diff_tests/perfetto.py
+++ b/tests/perfetto_validation_diff_tests/perfetto.py
@@ -60,17 +60,20 @@ class PerfettoFunctionValidation(TestSuite):
 class MacroExpansionSpanRegression(TestSuite):
     def test_macro_expansion_unknown_column(self):
         """Macro expansion (#84): a column reference produced inside a macro
-        expansion should report "unknown column 'a'" pointing at the entire
-        macro call site `_d!(a)` in the original source, plus a traceback
-        showing the position inside the expansion buffer.
+        expansion should report "unknown column 'a'".  The primary span
+        drills through the macro's `$name` arg segment to the user's
+        authored arg text `a` in the original source (argument-level
+        fidelity, per the text-expansion-model plan's success criterion
+        #5), and a traceback frame shows the corresponding position
+        inside the expansion buffer.
         """
         return DiffTestBlueprint(
             sql="CREATE PERFETTO MACRO _d(name ColumnName) RETURNS Expr AS $name;\nSELECT _d!(a);",
             out="""warning: unknown column 'a'
- --> <stdin>:2:8
+ --> <stdin>:2:12
   |
 2 | SELECT _d!(a);
-  |        ^~~~~~
+  |            ^
 note: in macro expansion
  --> <macro expansion>:1:1
   |


### PR DESCRIPTION
## Motivation

The span/token/layer model for macro expansion has accreted inconsistent
vocabulary:

- `SyntaqliteSourceSpan._buf_idx` refers to an internal expansion-buffer
  index as a public struct field, with no principled way for Rust or C
  consumers to interact with it.
- `FieldValue::Span.text` returns the *expansion-buffer slice*, not the
  user's authored text — backwards from how most consumers think about
  "text", and silently broken for spans whose authored position differs
  from their expansion-layer position.
- Two parallel parser vectors (`macro_expansions`, `macro_regions`) hold
  different pieces of the same conceptual "expansion layer" record.
- `analyzer.rs::statement_source()` slices source by raw token offsets,
  which is silently broken for any statement containing a macro call.
- The formatter's `try_macro_verbatim` has a bespoke scan over macro
  regions instead of asking a shared primitive "what's the authored text
  of this subtree?".
- Argument-level traceback fidelity (errors inside a substituted arg
  should point at the user's authored arg expression, not the whole
  `foo!(…)` call) is impossible because arg provenance is not recorded.

`docs/text-expansion-model-plan.md` (added in this PR) lays out a
15-step refactor that replaces this ad-hoc surface with a coherent
`text` vs `expanded_text` vocabulary, a single `SynqExpansionLayer`
data model with arg-segment metadata, and lazy accessors that make
Issue #89 (subtree-level text accessor) fall out trivially.

## Changes

This PR lands **Steps 1–6** of the plan — the renames, the data-model
unification, and the new span accessor surface. No behavior changes
yet; everything is additive/mechanical. Follow-up PRs will land
Steps 7–15 (traceback rewrite, lazy subtree caches, splicer,
`FieldValue::Span` rework, and deletion of the old `resolve_span` /
`expansion_traceback` APIs).

- **Step 1:** `_buf_idx` → `_layer_id` rename across public C headers,
  the parser context, parse tokens, grammar actions (`.y`), Rust FFI,
  and Rust AST types. No semantic change.
- **Step 2:** `SynqMacroRegion` + `SyntaqliteMacroRegion` internal
  vectors collapsed into a single `SynqExpansionLayer` vector
  (`p->layers`). Public `syntaqlite_result_macros` preserved via a
  lazy cached `public_macros_view` rebuilt on demand.
- **Step 3:** Layer metadata added: `template_body` / `name` /
  `def_line` / `def_col` borrowed from the macro registry entry.
  `syntaqlite_parser_register_macro` gains `def_line` / `def_col`
  params (Rust wrappers currently pass `0, 0`).
- **Step 4:** `SynqArgSegment` recorded during `$param` substitution in
  `expand_template`, transferred onto the new expansion layer in
  `synq_parser_feed_macro_expansion`. `reset_stmt` / `destroy` free
  both expansion buffers and segment arrays.
- **Step 5:** `SyntaqliteParserToken` grows from 16 → 20 bytes with an
  `_layer_id` field, populated from `p->ctx.layer_id` at record time.
  ABI change — no in-tree consumers other than the Rust mirror and
  internal C code.
- **Step 6:** New C accessors `syntaqlite_parser_span_text`,
  `span_expanded_text`, `span_text_range`, plus a `SyntaqliteTextRange`
  type. Implemented via a layer walk with arg-segment drill-through:
  - `span_expanded_text` returns the direct slice of the span's layer
    buffer (what the tokenizer saw).
  - `span_text` walks the layer chain, drilling through arg segments
    back to the user's authored text, or collapsing to the outermost
    `name!(…)` call site.
  - `span_text_range` returns the byte range of `span_text` in the
    input source.

  The pre-existing Rust `AnyParsedStatement::span_text` method (which
  returned the expansion-buffer slice) is renamed to
  `span_expanded_text` so the new `span_text` name can carry the
  authored-text semantics. The `rust_ast` codegen emits the new name,
  and the regenerated `sqlite/ast.rs` call sites preserve their
  original behavior.

  All three new Rust methods are `pub(crate)` for now; Step 12 (a
  future PR) promotes them to `pub` when `FieldValue::Span` is reworked
  to consume them directly.

**Red-green tests.** Three new unit tests in
`syntaqlite-syntax/src/parser/session.rs` were written before the
Step 6 implementation:

- `span_text_macro_free_equals_authored_slice` — macro-free span:
  `span_text` == `span_expanded_text`, range indexes into source.
- `span_text_inside_macro_body_collapses_to_call_site` — span inside
  `idmac!()` body resolves to the full `idmac!()` call site; the
  expanded text is the template body token.
- `span_text_inside_substituted_arg_drills_to_origin` — span inside a
  `$x` substitution of `idmac!(authored)` drills through the arg
  segment to the authored `authored` token in source, not the whole
  call site.

## Test plan

- [x] `cargo check --tests --all-features --all-targets` clean
- [x] `cargo clippy --tests --all-features --all-targets -- -D warnings` clean
- [x] `tools/run-unit-tests` — all workspace tests green, including the
      three new Step 6 red-green tests
- [x] `tools/run-integration-tests --suite ast --suite fmt --suite grammar`
      green (370 / 409 / grammar invariants all pass)
- [x] `tools/pre-push --fix -q` passes end-to-end before push
- [ ] CI green on the PR