### PR TITLE
synq: bump cibuildwheel to v3.4 to restore cp314 wheels (#91)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,7 @@ jobs:
           python-version: "3.12"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23
+        uses: pypa/cibuildwheel@v3.4
         with:
           package-dir: python/
           output-dir: wheelhouse/


### PR DESCRIPTION
## Motivation

Fixes #91.

Python 3.14 users are pinned to `0.2.11` on PyPI because no release since `0.2.13` has published `cp314` wheels, even though `python/pyproject.toml` still declares them:

```toml
[tool.cibuildwheel]
build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
```

Root cause: the release workflow pinned `pypa/cibuildwheel@v2.23`. Python 3.14 support was a prerelease in the v2 line — `cp314-*` in the build selector is silently skipped unless the `cpython-prerelease` enable flag is set. cibuildwheel v3.0 (June 2025) made `cp314` GA and enabled it by default. So `0.2.11` (built with the old cargo-dist pipeline) happened to ship cp314 wheels, but every release after the cibuildwheel migration silently dropped them.

## Changes

- Bump `pypa/cibuildwheel@v2.23` → `@v3.4` in `.github/workflows/release.yml`.

No other config changes needed — `python/pyproject.toml` already lists `cp314-*` in the build selector, and cibuildwheel v3.x is backward-compatible with the existing linux/macos/windows archs, overrides, and before-all hooks. The next tagged release will publish cp314 wheels and unblock Python 3.14 installs.