### PR TITLE
synq: bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.1
+
+- Restored Python 3.14 (cp314) wheel publishing, which had been silently dropped since 0.2.13 ([#91](https://github.com/LalitMaganti/syntaqlite/issues/91)).
+- Added macro registration, module resolver, and DDL lineage tracking to the semantic model.
+- Added per-statement C and Python API for diagnostics, lineage, and defined relations.
+- Fixed panic when diagnostics spanned macro expansions ([#84](https://github.com/LalitMaganti/syntaqlite/issues/84)).
+- Improved macro expansion span tracking to report full traceback through nested expansions.
+
 ## 0.3.0
 
 - **Breaking:** Renamed `Grammar` to `Dialect` across C and Rust APIs (`SyntaqliteGrammar` → `SyntaqliteDialect`, `Grammar` → `Dialect`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "benches"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion",
  "syntaqlite",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "glob",
  "libloading",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-buildtools"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cc",
  "clap",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "glob",
@@ -1075,11 +1075,11 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-common"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "syntaqlite-syntax"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cc",
  "libloading",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-wasm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ cargo install syntaqlite-cli
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.3.0", features = ["fmt"] }
+syntaqlite = { version = "0.3.1", features = ["fmt"] }
 ```
 
 **Python** ([API docs](https://docs.syntaqlite.com/latest/reference/python-api/))

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syntaqlite",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "SQLite SQL language server — diagnostics, formatting, completions, and semantic tokens",
   "author": {
     "name": "Lalit Maganti"

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "syntaqlite",
   "displayName": "syntaqlite",
   "description": "SQL language support powered by syntaqlite — diagnostics, formatting, completions, and semantic highlighting",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "syntaqlite",
   "license": "Apache-2.0",
   "icon": "icon.png",

--- a/integrations/zed/Cargo.toml
+++ b/integrations/zed/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "syntaqlite-zed"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 
 [lib]

--- a/integrations/zed/extension.toml
+++ b/integrations/zed/extension.toml
@@ -3,7 +3,7 @@
 
 id = "syntaqlite"
 name = "Syntaqlite"
-version = "0.3.0"
+version = "0.3.1"
 schema_version = 1
 authors = ["Lalit Maganti <lalitmaganti@gmail.com>"]
 description = "SQL language support powered by syntaqlite — tokenizer, parser, formatter and validator built on SQLite's own grammar."

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntaqlite"
-version = "0.3.0"
+version = "0.3.1"
 description = "SQLite SQL tools — parser, formatter, validator, and MCP server"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}

--- a/python/syntaqlite/__init__.py
+++ b/python/syntaqlite/__init__.py
@@ -5,7 +5,7 @@ import stat
 import subprocess
 import sys
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 # Library API (requires _syntaqlite C extension).
 try:

--- a/syntaqlite-buildtools/Cargo.toml
+++ b/syntaqlite-buildtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-buildtools"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Internal codegen and build tools for syntaqlite — not intended for direct use"
 license = "Apache-2.0"
@@ -20,8 +20,8 @@ dist = false
 doc = false
 
 [dependencies]
-syntaqlite-common = { version = "0.3.0", path = "../syntaqlite-common" }
-syntaqlite-syntax = { version = "0.3.0", path = "../syntaqlite-syntax", default-features = false, features = ["embedded-sources"] }
+syntaqlite-common = { version = "0.3.1", path = "../syntaqlite-common" }
+syntaqlite-syntax = { version = "0.3.1", path = "../syntaqlite-syntax", default-features = false, features = ["embedded-sources"] }
 clap = { version = "4.5", features = ["derive"] }
 tempfile = "3.8"
 serde = { version = "1", features = ["derive"] }

--- a/syntaqlite-cli/Cargo.toml
+++ b/syntaqlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 repository.workspace = true
 description = "Fast, accurate SQLite SQL formatter, validator, and language server — built on SQLite's own grammar"
@@ -30,8 +30,8 @@ rmcp = { version = "0.1", features = ["server", "transport-io"], optional = true
 schemars = { version = "0.8", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-syntaqlite = { version = "0.3.0", path = "../syntaqlite", optional = true, features = ["fmt", "lsp", "validation", "experimental-embedded", "serde-json"] }
-syntaqlite-syntax = { version = "0.3.0", path = "../syntaqlite-syntax" }
-syntaqlite-buildtools = { version = "0.3.0", path = "../syntaqlite-buildtools", optional = true }
+syntaqlite = { version = "0.3.1", path = "../syntaqlite", optional = true, features = ["fmt", "lsp", "validation", "experimental-embedded", "serde-json"] }
+syntaqlite-syntax = { version = "0.3.1", path = "../syntaqlite-syntax" }
+syntaqlite-buildtools = { version = "0.3.1", path = "../syntaqlite-buildtools", optional = true }
 tempfile = "3.8"
 tokio = { version = "1", features = ["rt", "macros", "io-std"], optional = true }

--- a/syntaqlite-common/Cargo.toml
+++ b/syntaqlite-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-common"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Internal shared primitives for syntaqlite — not intended for direct use"
 license = "Apache-2.0"

--- a/syntaqlite-syntax/Cargo.toml
+++ b/syntaqlite-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-syntax"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 links = "syntaqlite_syntax"
 description = "Internal parser and tokenizer for syntaqlite — not intended for direct use"

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! syntaqlite = { version = "0.3.0", default-features = false, features = ["sqlite"] }
+//! syntaqlite = { version = "0.3.1", default-features = false, features = ["sqlite"] }
 //! ```
 
 // ==== Public API ====

--- a/syntaqlite-wasm/Cargo.toml
+++ b/syntaqlite-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-wasm"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 repository.workspace = true
 

--- a/syntaqlite/Cargo.toml
+++ b/syntaqlite/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "syntaqlite"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Parser, formatter, validator, and language server for SQLite SQL — built on SQLite's own grammar"
 license = "Apache-2.0"
@@ -40,8 +40,8 @@ pin-cflags = ["sqlite", "syntaqlite-syntax/pin-cflags"]    # Pin compile-time fl
 workspace = true
 
 [dependencies]
-syntaqlite-common = { version = "0.3.0", path = "../syntaqlite-common" }
-syntaqlite-syntax = { version = "0.3.0", path = "../syntaqlite-syntax", default-features = false }
+syntaqlite-common = { version = "0.3.1", path = "../syntaqlite-common" }
+syntaqlite-syntax = { version = "0.3.1", path = "../syntaqlite-syntax", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 libloading = { version = "0.8", optional = true }

--- a/tests/benches/Cargo.toml
+++ b/tests/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benches"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 publish = false
 

--- a/tests/comparison/parser/Cargo.toml
+++ b/tests/comparison/parser/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "parser-bench"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [[bin]]

--- a/web/docs/content/guides/rust-api.md
+++ b/web/docs/content/guides/rust-api.md
@@ -10,7 +10,7 @@ weight = 1
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.3.0", features = ["fmt"] }
+syntaqlite = { version = "0.3.1", features = ["fmt"] }
 ```
 
 ## Format a query
@@ -127,7 +127,7 @@ Add the `validation` and `sqlite` features:
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.3.0", features = ["validation", "sqlite"] }
+syntaqlite = { version = "0.3.1", features = ["validation", "sqlite"] }
 ```
 
 ```rust

--- a/web/syntaqlite-js/package.json
+++ b/web/syntaqlite-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syntaqlite",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "SQLite SQL parser, formatter, and validator for the browser — powered by WebAssembly",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Motivation

Cut the 0.3.1 release. Main driver is restoring Python 3.14 (cp314) wheel publishing (#91), which has been silently dropped since 0.2.13. Also rolls up the semantic-model/macro/module-resolver work that has landed since 0.3.0.

## Changes

- Bumps version to 0.3.1 across all Cargo.toml / pyproject.toml / integration manifests / README / docs.
- Adds 0.3.1 CHANGELOG entry.

Release notes:

- Restored Python 3.14 (cp314) wheel publishing, which had been silently dropped since 0.2.13 (#91).
- Added macro registration, module resolver, and DDL lineage tracking to the semantic model.
- Added per-statement C and Python API for diagnostics, lineage, and defined relations.
- Fixed panic when diagnostics spanned macro expansions (#84).
- Improved macro expansion span tracking to report full traceback through nested expansions.