### PR TITLE
synq: add span traceback + delete old API + Perfetto select_span

### DIFF
--- a/dialects/perfetto/actions/perfetto.y
+++ b/dialects/perfetto/actions/perfetto.y
@@ -128,31 +128,67 @@ perfetto_module_name(A) ::= perfetto_module_name(B) DOT ID|STAR|INTERSECT(C). {
     };
 }
 
+// Empty marker rules used to bracket a `select` subrule so the parent
+// production can compute an exact source span covering the authored
+// body.  The BEFORE marker reads `cur_shift_start` — the start offset
+// of the token Lemon is currently processing, so leading whitespace
+// between the previous terminal (AS) and the first token of select is
+// excluded.  The AFTER marker reads `last_shifted_end` — the end of
+// the last real terminal of select (set by `record_and_feed` after
+// Lemon finishes processing it).
+%type select_body_start {uint32_t}
+select_body_start(A) ::= . { A = pCtx->cur_shift_start; }
+
+%type select_body_end {uint32_t}
+select_body_end(A) ::= . { A = pCtx->last_shifted_end; }
+
 // ---------- CREATE PERFETTO TABLE ----------
 
-cmd(A) ::= CREATE perfetto_or_replace(R) PERFETTO TABLE nm(N) perfetto_table_schema(S) AS select(E). {
+cmd(A) ::= CREATE perfetto_or_replace(R) PERFETTO TABLE nm(N)
+           perfetto_table_schema(S) AS select_body_start(BS) select(E) select_body_end(BE). {
+    SyntaqliteSourceSpan select_span = {
+        BS,
+        (uint16_t)(BE - BS),
+        0,
+        /*layer_id=*/0,
+    };
     A = synq_parse_create_perfetto_table_stmt(pCtx,
         synq_span(pCtx, N),
         R ? SYNTAQLITE_BOOL_TRUE : SYNTAQLITE_BOOL_FALSE,
-        S, E);
+        S, E, select_span);
 }
 
 // ---------- CREATE PERFETTO VIEW ----------
 
-cmd(A) ::= CREATE perfetto_or_replace(R) PERFETTO VIEW nm(N) perfetto_table_schema(S) AS select(E). {
+cmd(A) ::= CREATE perfetto_or_replace(R) PERFETTO VIEW nm(N)
+           perfetto_table_schema(S) AS select_body_start(BS) select(E) select_body_end(BE). {
+    SyntaqliteSourceSpan select_span = {
+        BS,
+        (uint16_t)(BE - BS),
+        0,
+        /*layer_id=*/0,
+    };
     A = synq_parse_create_perfetto_view_stmt(pCtx,
         synq_span(pCtx, N),
         R ? SYNTAQLITE_BOOL_TRUE : SYNTAQLITE_BOOL_FALSE,
-        S, E);
+        S, E, select_span);
 }
 
 // ---------- CREATE PERFETTO FUNCTION ----------
 
-cmd(A) ::= CREATE perfetto_or_replace(R) PERFETTO FUNCTION nm(N) LP perfetto_arg_def_list(ARGS) RP RETURNS perfetto_return_type(RT) AS select(E). {
+cmd(A) ::= CREATE perfetto_or_replace(R) PERFETTO FUNCTION nm(N) LP
+           perfetto_arg_def_list(ARGS) RP RETURNS perfetto_return_type(RT)
+           AS select_body_start(BS) select(E) select_body_end(BE). {
+    SyntaqliteSourceSpan select_span = {
+        BS,
+        (uint16_t)(BE - BS),
+        0,
+        /*layer_id=*/0,
+    };
     A = synq_parse_create_perfetto_function_stmt(pCtx,
         synq_span(pCtx, N),
         R ? SYNTAQLITE_BOOL_TRUE : SYNTAQLITE_BOOL_FALSE,
-        ARGS, RT, E);
+        ARGS, RT, E, select_span);
 }
 
 // ---------- CREATE PERFETTO FUNCTION (delegating) ----------

--- a/dialects/perfetto/nodes/perfetto.synq
+++ b/dialects/perfetto/nodes/perfetto.synq
@@ -72,6 +72,7 @@ node CreatePerfettoTableStmt {
   or_replace: inline Bool
   schema: index PerfettoArgDefList
   select: index Select
+  select_span: inline SyntaqliteSourceSpan
 
   semantic { define_table(name: table_name, columns: schema, select: select) }
 
@@ -99,6 +100,7 @@ node CreatePerfettoViewStmt {
   or_replace: inline Bool
   schema: index PerfettoArgDefList
   select: index Select
+  select_span: inline SyntaqliteSourceSpan
 
   semantic { define_view(name: view_name, columns: schema, select: select) }
 
@@ -127,6 +129,7 @@ node CreatePerfettoFunctionStmt {
   args: index PerfettoArgDefList
   return_type: index PerfettoReturnType
   select: index Select
+  select_span: inline SyntaqliteSourceSpan
 
   semantic { define_function(name: function_name, args: args, return_type: return_type, select: select) }
 

--- a/docs/text-expansion-model-plan.md
+++ b/docs/text-expansion-model-plan.md
@@ -12,20 +12,19 @@ This model has leaked across the public API in inconsistent ways:
 - `analyzer.rs::statement_source()` slices source using raw token offsets,
   which is silently broken for any statement containing a macro call (token
   offsets for expansion-buffer tokens aren't source positions).
-- The formatter's `try_macro_verbatim` has a bespoke scan over macro
-  regions to decide when to emit an un-expanded call site, rather than
-  using a shared primitive.
-- Issue #89 asks for a subtree-level equivalent of `statement_source`, but
-  there's no single concept of "the text of a subtree" that consumers can
-  rely on.
+- Issue #89 asks for the authored text of a specific statement subtree
+  (e.g. the `select` body of `CREATE PERFETTO TABLE … AS <select>`), and
+  there's no principled way to reach it today.
 - `expansion_traceback` is powerful but low-fidelity: it doesn't track
   argument provenance, so an error at byte N inside a substituted argument
   collapses to the whole `foo!(…)` call site rather than pointing at the
   user's authored arg expression.
 
 The goal of this plan is to replace the ad-hoc multi-buffer surface with a
-coherent vocabulary and API, restore Perfetto-style traceback fidelity
-(argument-level), and make issue #89 fall out trivially as a side effect.
+coherent vocabulary and API, and restore Perfetto-style traceback fidelity
+(argument-level). Issue #89 is addressed via targeted per-node annotations
+rather than a generalized subtree-text API — see the Step 8 reshape in
+the session log.
 
 ## Core vocabulary
 
@@ -43,11 +42,11 @@ implementation term where appropriate).
 
 ### Duality, stated crisply
 
-|                     | Whole statement        | Span                        | Subtree                        |
-| ------------------- | ---------------------- | --------------------------- | ------------------------------ |
-| **Authored**        | `text()`               | `span_text(span)`           | `subtree_text(node)`           |
-| **Expanded**        | `expanded_text()`      | `span_expanded_text(span)`  | `subtree_expanded_text(node)`  |
-| **Range in text()** | —                      | `span_text_range(span)`     | (derivable)                    |
+|                     | Whole statement        | Span                        |
+| ------------------- | ---------------------- | --------------------------- |
+| **Authored**        | `text()`               | `span_text(span)`           |
+| **Expanded**        | `expanded_text()`      | `span_expanded_text(span)`  |
+| **Range in text()** | —                      | `span_text_range(span)`     |
 
 Invariants:
 
@@ -58,6 +57,13 @@ Invariants:
   not as "a pointer into some known buffer".
 - For macro-free statements, all four collapse: `text() == expanded_text()`
   and `span_text == span_expanded_text` for every element.
+
+**Subtree-level text is not a generalized API.** Specific grammar rules
+that need to forward authored SQL (e.g. the `select` body of
+`CREATE PERFETTO TABLE/VIEW/FUNCTION`) get a targeted span field (like
+`select_span`) populated explicitly by the grammar action. Consumers
+read that field like any other span. See the Step 8 reshape for
+details — there is no generalized `subtree_text(node)` accessor.
 
 ## Architectural decision: lazy layer tree, no materialization
 
@@ -71,9 +77,10 @@ landed on a **lazy** model:
   per-layer metadata).
 - `parser_next` returns immediately after Lemon finishes — there is no
   post-parse materialization pass.
-- Queries (`text`, `expanded_text`, `traceback`, subtree accessors) are
-  computed on demand from the layer tree, with caching for the expensive
-  ones (subtree extents, full expanded text splicer).
+- Queries (`text`, `expanded_text`, `traceback`) are computed on demand
+  from the layer tree. The traceback walk writes into a small
+  parser-owned scratch buffer (`traceback_buf`) that is cleared and
+  rewritten on each call.
 
 ### Why lazy?
 
@@ -107,10 +114,10 @@ traced back to caller positions) without importing any of its machinery.
 
 ### Why *not* eager materialization?
 
-An eager "build full expanded_text + per-node extents at end of parse"
-approach works, but it unconditionally allocates O(statement size) on every
-parse, even for the vast majority of parses that never query expanded text.
-Lazy gives us the same end-state queryability without the baseline cost.
+An eager "build full expanded_text at end of parse" approach works, but
+it unconditionally allocates O(statement size) on every parse, even for
+the vast majority of parses that never query expanded text. Lazy gives
+us the same end-state queryability without the baseline cost.
 
 The eager design also committed us to a single flat offset space, which
 would have made every span carry a rewritten-sql offset rather than a
@@ -204,14 +211,10 @@ struct SyntaqliteParser {
     // The layer tree. layers.data[0] is the root, always present.
     SYNQ_VEC(SynqExpansionLayer) layers;
 
-    // Side vector parallel to p->tokens, storing layer_id per token.
-    // Only needed if we keep the public SyntaqliteParserToken struct
-    // unchanged. See "Token layer_id" below.
-    SYNQ_VEC(uint8_t) token_layer_ids;
-
-    // Lazy caches (allocated on first query, freed on parser_next):
-    SynqSubtreeExtentCache* extent_cache;       // per-node text ranges
-    SynqExpandedTextCache* expanded_cache;      // spliced expanded strings
+    // Scratch buffer owned by the parser for `syntaqlite_parser_traceback`.
+    // Cleared and rewritten on each call; the returned pointer is
+    // invalidated by the next traceback() call or by reset_stmt.
+    SYNQ_VEC(SyntaqliteTracebackFrame) traceback_buf;
 };
 ```
 
@@ -232,14 +235,17 @@ typedef struct SyntaqliteTextRange {
     uint32_t end;
 } SyntaqliteTextRange;
 
-// Self-contained traceback frame. No pointers back to layers.
+// Self-contained traceback frame. Borrows name/snippet from parser-
+// owned memory (macro registry for `name`, layer buffers for `snippet`).
 typedef struct SyntaqliteTracebackFrame {
-    const char* name;             // "File \"stdin\"" or "Macro 'foo'"
+    const char* name;             // NULL for root, macro name otherwise
+    uint32_t name_len;
     uint32_t line;
     uint32_t col;
     const char* snippet;          // the buffer to render the caret against
     uint32_t snippet_len;
     uint32_t offset_in_snippet;
+    uint32_t length_in_snippet;
 } SyntaqliteTracebackFrame;
 ```
 
@@ -279,20 +285,17 @@ typedef struct SyntaqliteParserToken {
 // ── Whole-statement text ─────────────────────────────────────────────────
 
 // The user's authored input. Same as syntaqlite_parser_source() today,
-// renamed for vocabulary consistency.
+// renamed for vocabulary consistency. (Deferred — see Step 15.)
 SYNTAQLITE_API const char*
 syntaqlite_parser_text(SyntaqliteParser* p, uint32_t* out_len);
-
-// The full post-expansion text. Lazily built on first call; cached. For
-// macro-free statements, aliases parser_text() (no allocation).
-SYNTAQLITE_API const char*
-syntaqlite_parser_expanded_text(SyntaqliteParser* p, uint32_t* out_len);
 
 // ── Span accessors ───────────────────────────────────────────────────────
 
 // Authored slice of text() corresponding to this span. For spans inside
-// a macro expansion, collapses to the outermost call site's range in
-// text(). Always a direct slice of text() — no allocation.
+// a macro expansion, walks the expansion chain: drills through
+// substituted arg segments, otherwise collapses to the outermost
+// `name!(...)` call site in text(). Always a direct slice of text() —
+// no allocation.
 SYNTAQLITE_API const char*
 syntaqlite_parser_span_text(SyntaqliteParser* p,
                             const SyntaqliteSourceSpan* span,
@@ -312,34 +315,24 @@ SYNTAQLITE_API SyntaqliteTextRange
 syntaqlite_parser_span_text_range(SyntaqliteParser* p,
                                   const SyntaqliteSourceSpan* span);
 
-// ── Subtree accessors ────────────────────────────────────────────────────
-
-// Authored text covering the entire subtree rooted at node_id. Lazily
-// computes per-node extents on first call; cached for subsequent queries.
-SYNTAQLITE_API const char*
-syntaqlite_parser_subtree_text(SyntaqliteParser* p,
-                               uint32_t node_id,
-                               uint32_t* out_len);
-
-// Post-expansion text of the subtree. May require splicing across
-// layer buffers when the subtree spans macro boundaries. Lazily built
-// and cached.
-SYNTAQLITE_API const char*
-syntaqlite_parser_subtree_expanded_text(SyntaqliteParser* p,
-                                        uint32_t node_id,
-                                        uint32_t* out_len);
-
 // ── Traceback ────────────────────────────────────────────────────────────
 
-// Write up to max_frames traceback frames for the given span, ordered
-// outermost (root) to innermost (deepest macro expansion). Returns the
-// total number of frames available (caller can call with max_frames=0
-// to query the count).
-SYNTAQLITE_API uint32_t
+// Build a traceback for a span and return a pointer to a parser-owned
+// frame array. Frames are ordered outermost (the root source frame) to
+// innermost (the position inside the deepest macro expansion layer).
+//
+// The returned pointer is backed by `p->traceback_buf`, which is cleared
+// and rewritten on every call. It remains valid until the next call to
+// syntaqlite_parser_traceback on the same parser or until the next
+// syntaqlite_parser_next resets the current statement — callers that
+// need to retain frames must copy them out.
+//
+// Writes the frame count to `*out_count`. Returns NULL (and 0) for
+// empty or invalid spans.
+SYNTAQLITE_API const SyntaqliteTracebackFrame*
 syntaqlite_parser_traceback(SyntaqliteParser* p,
                             const SyntaqliteSourceSpan* span,
-                            SyntaqliteTracebackFrame* frames,
-                            uint32_t max_frames);
+                            uint32_t* out_count);
 ```
 
 ### Rust side
@@ -349,23 +342,31 @@ lifetime.
 
 ```rust
 impl<'a> AnyParsedStatement<'a> {
-    // Whole
+    // Whole (text() to land with Step 15).
     pub fn text(&self) -> &'a str;
-    pub fn expanded_text(&self) -> &'a str;
 
     // Span
     pub fn span_text(&self, span: Span) -> &'a str;
     pub fn span_expanded_text(&self, span: Span) -> &'a str;
-    pub fn span_text_range(&self, span: Span) -> TextRange;
+    pub fn span_text_range(&self, span: Span) -> SourceRange;
 
-    // Subtree
-    pub fn subtree_text(&self, node: NodeId) -> &'a str;
-    pub fn subtree_expanded_text(&self, node: NodeId) -> &'a str;
-
-    // Traceback
-    pub fn traceback(&self, span: Span) -> impl Iterator<Item = Frame<'a>> + '_;
+    // Traceback: `&mut self` because the iterator borrows from the
+    // parser's internal `traceback_buf` scratch vec, which the next
+    // traceback() call overwrites. The borrow checker enforces "one
+    // live traceback iterator at a time"; callers who need to retain
+    // frames across another call must `.collect::<Vec<_>>()`.
+    pub fn traceback(
+        &mut self,
+        node_id: AnyNodeId,
+        field_idx: u8,
+    ) -> impl Iterator<Item = TracebackFrame<'a>> + use<'_, 'a>;
 }
 ```
+
+**Subtree-level text is not part of this API.** Consumers that need
+the authored text of a specific grammar rule (e.g. the `select` body
+of `CREATE PERFETTO TABLE`) read a dedicated span field placed on the
+parent AST node by the grammar action. See the Step 8 reshape.
 
 ### `FieldValue::Span` — final shape
 
@@ -424,92 +425,66 @@ Trivial.
 Same walk as `span_text`, but return the final `(off, off+len)` pair
 instead of slicing.
 
-### `subtree_text(node)` — O(subtree) first call, O(1) cached
-
-On first call for any node in the statement: do one traversal of the AST,
-populating a per-node extent array `[start, end) × node_count` with the
-text-range of each subtree (computed from its descendants' direct field
-spans via `span_text_range`). Cache on the parser.
-
-Subsequent calls: direct array lookup, slice `text()`.
-
-### `subtree_expanded_text(node)` — O(expanded size) first call, O(1) cached
-
-More intricate because the result may need to splice across layer buffers.
-On first call, walk the subtree:
-
-1. Find the subtree's "host layer" — the layer that contains its root
-   node's direct fields.
-2. Inside the host layer's buf, find the start/end of the subtree as
-   min/max of its direct field spans.
-3. If the subtree has no descendants in other layers (no nested macro
-   calls), return a direct slice of the host layer's buf.
-4. Otherwise, splice: walk child layers whose `call_offset_in_parent`
-   falls inside the subtree's range, recursively producing their expanded
-   text and substituting at the correct positions.
-
-Cache the result on the parser, indexed by node_id.
-
-### `expanded_text()` — O(total) first call, O(1) cached
-
-Same splicer as `subtree_expanded_text`, rooted at the statement's root
-node. Fast path for macro-free statements: alias `text()`, no allocation.
-
 ### `traceback(span)` — O(depth)
 
 Start at `span._layer_id` and walk toward root, emitting one frame per
-layer. Drill through arg segments when the span's position falls inside
-one:
+layer into a small on-stack buffer (innermost first). Drill through
+arg segments when the span's position falls inside one, skipping that
+layer's frame entirely. Then reverse into the parser's owned
+`traceback_buf` vec so frame[0] is outermost.
 
 ```
 fn traceback(span):
   layer_id = span._layer_id
   off = span.offset
-  frames = []
+  len = span.length
+  tmp = []
   loop:
     layer = layers[layer_id]
 
     # Is our current position inside an arg segment of this layer?
     # If so, the "real" provenance at this level is the arg's origin
-    # layer, not the expansion layer itself. Redirect.
+    # layer, not the expansion layer itself. Redirect without
+    # emitting a frame.
     if arg_seg = find_arg_segment(layer, off):
       off = arg_seg.origin_offset + (off - arg_seg.sub_offset)
       layer_id = arg_seg.origin_layer_id
       continue  # retry at the origin layer
 
     # Emit a frame for this layer.
-    if layer.parent_layer_id == UINT32_MAX:
-      # Root — frame rendered against user source.
-      frames.push(Frame {
-        name: "File \"stdin\"" (or similar),
-        line/col computed from off in text(),
-        snippet: text(), offset_in_snippet: off,
-      })
-      break
-    else:
-      # Macro expansion — frame rendered against template body.
-      frames.push(Frame {
-        name: layer.name,  # e.g. "Macro 'foo'"
-        line/col: layer.def_line/def_col adjusted by off,
-        snippet: layer.template_body, offset_in_snippet: template_off,
-      })
-      # Walk up to parent at the call site.
-      off = layer.call_offset_in_parent
-      layer_id = layer.parent_layer_id
+    tmp.push(Frame {
+      name: layer.name,                  # NULL for root, macro name otherwise
+      snippet: layer.expansion_data,     # source buf for root, expansion buf for macros
+      offset_in_snippet: off,
+      length_in_snippet: len,
+      line/col: computed from (snippet, off),
+    })
 
-  reverse(frames)  # outermost first
-  return frames
+    if layer_id == 0:
+      break  # reached root sentinel
+
+    # Walk up to parent at this layer's call site. The call site spans
+    # the whole `name!(...)` call.
+    off = layer.call_offset
+    len = layer.call_length
+    layer_id = layer.parent_layer_id
+
+  # Reverse into parser-owned buffer so frame[0] is outermost.
+  traceback_buf.clear()
+  traceback_buf.extend(tmp.iter().rev())
+  return &traceback_buf[..]
 ```
 
-The frame rendered against a layer's `template_body` uses the template,
-not the layer's `buf` (which has $params already substituted). This gives
-the Perfetto-style behavior where a macro frame shows the original
-template with `$param` references visible.
+The frame for a macro expansion renders against the layer's
+`expansion_data` (the already-substituted buffer), not the raw template
+body. Rendering against the substituted buffer is what the validator's
+"in macro expansion" note needs.
 
 The arg-segment drill is the fidelity-adding mechanism: when a span was
 tokenized inside a substituted arg, its provenance chain follows the arg
 back to where the user typed it, not to the macro body's `$param`
-reference.
+reference. This is what makes the common "unknown column inside a
+substituted arg" diagnostic land directly on the user's code.
 
 ## What disappears
 
@@ -527,11 +502,9 @@ From today's codebase:
   entirely).
 - `syntaqlite_parser_expansion_traceback` (replaced by the new
   `syntaqlite_parser_traceback` with argument fidelity).
-- `try_macro_verbatim`'s bespoke scan in `fmt/formatter.rs` (replaced by
-  a call to `subtree_text` on the child node).
 - `analyzer.rs::statement_source()` helper (replaced by
   `stmt.text()` — which is now correct for macros instead of silently
-  broken).
+  broken; deferred to Step 11/15).
 - `FieldValue::Span::text` referring to the expansion-buffer slice (the
   name is reassigned to mean authored slice, with a new `expanded_text`
   field for the expansion-buffer slice).
@@ -551,7 +524,7 @@ additive/rename work lands first, then behavior changes, then deletions.
 | 4. Record `SynqArgSegment` during param substitution| ✅ done | `SynqMacroExpansion` carries arg segments until transferred onto the layer in `feed_macro_expansion`; `reset_stmt` / `destroy` free both expansion buffers and segment arrays. |
 | 5. Add `_layer_id` to `SyntaqliteParserToken`       | ✅ done | ABI change (16 → 20 bytes). Python bindings unaffected (they don't use the struct); Rust `CParserToken` mirror updated. |
 | 6. Add `span_text` / `span_expanded_text` / `span_text_range` | ✅ done | See "Notes on Step 6" below. |
-| 7. Add `traceback` with arg-segment drilling        | ✅ done | New `SyntaqliteTracebackFrame` struct + `syntaqlite_parser_traceback` C API, `TracebackFrame<'a>` + `AnyParsedStatement::traceback` Rust method. Validator migrated off the old API. See session 2 notes. |
+| 7. Add `traceback` with arg-segment drilling        | ✅ done | New `SyntaqliteTracebackFrame` struct + `syntaqlite_parser_traceback` C API, `TracebackFrame<'a>` + `AnyParsedStatement::traceback` Rust method. Validator migrated off the old API. The C side owns a `SYNQ_VEC(SyntaqliteTracebackFrame) traceback_buf` scratch buffer (rewritten per call, freed on destroy); the function returns `const SyntaqliteTracebackFrame*` + `*out_count` in a single call. The Rust method takes `&mut self` and returns `impl Iterator<Item = TracebackFrame<'a>>` zero-copy borrowed from that buffer — `&mut self` makes "one live iterator at a time" a compile-time invariant. See session notes. |
 | 8. Targeted `select_span` on Perfetto CREATE stmts (was: subtree extent cache) | ✅ done (reshaped) | **Scope change**: the generalized `subtree_text` API was dropped in favor of a targeted grammar-annotation mechanism. Added `cur_shift_start`/`last_shifted_end` tracking on `SynqParseCtx` (updated in `record_and_feed` before/after `feed_one_token`) plus empty-marker rules `select_body_start` / `select_body_end` in `perfetto.y`. Added `select_span` field to `CreatePerfettoTableStmt` / `CreatePerfettoViewStmt` / `CreatePerfettoFunctionStmt`. Consumers read the field like any other span and call `span_text_range(select_span)` for the authored byte range. Perfetto macro body already lands as a span via existing `synq_span` conversion — no change needed. |
 | 9. Lazy expanded splicer + `subtree_expanded_text` / `expanded_text` | ❌ dropped | Obviated by Step 8's reshape. Macro-containing subtrees don't need a generalized splicer; Perfetto's actual use cases are handled by the `select_span` field (whose authored bytes come from the root layer directly). |
 | 10. Migrate formatter's `try_macro_verbatim`        | ❌ dropped | Obviated by Step 8's reshape. The formatter's existing `MacroRegion` + peek-next-token approach is correct and doesn't benefit from a subtree accessor. |
@@ -627,6 +600,26 @@ implementation and must fail on the pre-change tree.
   already handled by the existing `body` span — no changes needed.
   Steps 9/10 are dropped (they only existed to support the
   generalized subtree abstraction).
+- **Session 2 follow-up (PR #96 review)** reworked the `traceback`
+  API shape. The C side now owns a `SYNQ_VEC(SyntaqliteTracebackFrame)
+  traceback_buf` scratch buffer on the parser; the function signature
+  became `const SyntaqliteTracebackFrame* syntaqlite_parser_traceback(p,
+  span, *out_count)` — single call, parser-owned storage, no
+  caller-provided buffer. The Rust wrapper takes `&mut self` and
+  returns `impl Iterator<Item = TracebackFrame<'a>>` that borrows
+  directly from that buffer (zero copy). The `&mut` receiver makes
+  "only one live traceback iterator at a time" a compile-time
+  invariant — a second traceback call requires re-acquiring `&mut`,
+  which conflicts with any outstanding iterator. Cascade: the
+  validator's `ValidationPass` methods that transitively reach
+  `emit()` take `stmt: &mut AnyParsedStatement<'b>` with a
+  method-level `<'b>` lifetime generic (distinct from the pass's
+  own `'a` for catalog / diagnostics borrows, so the two stay
+  separable). Helper methods like `name_text` keep `&` and rely on
+  auto-reborrow at call sites. `visit_children` collects child IDs
+  into a `Vec` up front so the `child_node_ids` borrow is dropped
+  before the recursive `&mut` visits. Traceback unit tests
+  `.collect::<Vec<_>>()` the iterator.
 
 ### Step 1 — Rename `_buf_idx` to `_layer_id`
 
@@ -704,32 +697,87 @@ New C + Rust API. Replaces `expansion_traceback` semantically but is NOT
 wired up yet (the old API stays in parallel during migration).
 
 Unit tests exercising:
-- Traceback from a root-level span (single frame)
-- Traceback from inside a macro body (two frames)
-- Traceback from inside a substituted arg (three frames: root → macro → arg origin)
-- Traceback from nested macro inside an arg (root → outer → arg origin → inner)
-- Per Perfetto's "Fully expanded statement" header, the root frame
-  includes the expanded snippet when the statement contains any
-  expansion; deeper frames don't.
+- Traceback from a root-level span (single frame).
+- Traceback from inside a macro body with no substitution in the path
+  (two frames: root + macro).
+- Traceback from inside a substituted arg, where the arg-segment drill
+  collapses through to a single root frame at the user's authored arg
+  text. This is success criterion #5.
 
-### Step 8 — Lazy subtree extent cache + `subtree_text`
+The C function owns a `SYNQ_VEC(SyntaqliteTracebackFrame) traceback_buf`
+scratch buffer on the parser. Each call clears and rewrites it, then
+returns a pointer + count. The Rust wrapper takes `&mut self` and
+returns `impl Iterator<Item = TracebackFrame<'a>>` borrowed from the
+buffer — the `&mut` makes "one live iterator at a time" compile-time
+enforced.
 
-Add the per-statement cache structure and the single-pass extent walker.
-Implement `subtree_text(node)`. Unit tests for macro-free and macro-laden
-subtrees.
+### Step 8 — Targeted `select_span` on Perfetto CREATE stmts
+
+**(Reshaped from the originally-planned generalized `subtree_text` API.)**
+
+Scope: add a dedicated `select_span: inline SyntaqliteSourceSpan` field
+on `CreatePerfettoTableStmt`, `CreatePerfettoViewStmt`, and
+`CreatePerfettoFunctionStmt` in `perfetto.synq`, populated explicitly by
+the grammar action with the byte range of the authored `select` body
+(trimmed of leading/trailing whitespace around the body).
+
+Mechanism:
+
+1. Add `cur_shift_start: u32` and `last_shifted_end: u32` fields on
+   `SynqParseCtx` (in `ast_builder.h`). The former is set at the start
+   of `synq_parser_record_and_feed` *before* `feed_one_token`; the
+   latter is set *after* `feed_one_token` returns. This timing ensures
+   that empty-rule reductions firing inside `feed_one_token(X)` see:
+   - `cur_shift_start` = start of X (the token currently being
+     processed), used by BEFORE-style markers to capture "start of the
+     next real token";
+   - `last_shifted_end` = end of the previously shifted terminal, used
+     by AFTER-style markers to capture "end of the last real terminal".
+   Both fields are tracked only for tokens shifted from the root
+   source layer.
+2. Add two empty marker rules in `perfetto.y`:
+   ```
+   %type select_body_start {uint32_t}
+   select_body_start(A) ::= . { A = pCtx->cur_shift_start; }
+   %type select_body_end {uint32_t}
+   select_body_end(A) ::= . { A = pCtx->last_shifted_end; }
+   ```
+3. Update the three `cmd` actions to bracket `select(E)`:
+   ```
+   cmd(A) ::= CREATE … AS select_body_start(BS) select(E) select_body_end(BE). {
+       SyntaqliteSourceSpan select_span = {
+           BS, (uint16_t)(BE - BS), 0, /*layer_id=*/0,
+       };
+       A = synq_parse_create_perfetto_table_stmt(pCtx, …, E, select_span);
+   }
+   ```
+
+Consumers read `select_span` like any other AST span field and call
+`span_text_range(select_span)` / `span_text(select_span)` to obtain
+the authored byte range or slice.
+
+Perfetto `perfetto_macro_body` already produces a `SynqParseToken` with
+`.z`/`.n` merged across its ANY-wildcard tokens, which lands as a
+`body` span via the existing `synq_span(pCtx, BODY)` conversion — no
+change needed for the macro body case.
+
+Test: an amalg diff test for `CREATE PERFETTO TABLE foo AS    SELECT 1   `
+verifies that the recorded `select_span` is exactly `"SELECT 1"` (no
+leading or trailing whitespace).
 
 ### Step 9 — Lazy expanded splicer + `subtree_expanded_text` / `expanded_text`
 
-Implement the splicer for subtree_expanded_text and expanded_text. Unit
-tests covering:
-- Macro-free subtree (fast path: direct slice, no splice)
-- Single-macro subtree
-- Nested macros with arg substitutions
+**Dropped.** This step only existed to support the generalized
+`subtree_text` / `subtree_expanded_text` accessors, which were also
+dropped in the Step 8 reshape. Perfetto's actual use cases (issue #89)
+are handled by the `select_span` field.
 
 ### Step 10 — Migrate formatter's `try_macro_verbatim`
 
-Replace the bespoke macro region scan with `ctx.reader.subtree_text(child_id)`.
-Diff-test the formatter to ensure zero behavioral change.
+**Dropped.** The formatter's existing `MacroRegion` + peek-next-token
+approach is correct and requires no changes. This step was a
+consequence of the generalized subtree API that is no longer being
+built.
 
 ### Step 11 — Migrate analyzer's `statement_source`
 
@@ -755,25 +803,12 @@ no callers remain (likely none after #87, but verify).
 
 ### Step 14 — Delete `resolve_span` and `SyntaqliteResolvedSpan`
 
-By this point, all in-tree callers of `syntaqlite_parser_resolve_span`
-have been migrated to the new span accessors:
-- `FieldValue::Span` is populated directly from `span_text` /
-  `span_expanded_text` / `span_text_range` (Step 12).
-- The formatter uses `subtree_text` (Step 10).
-- The validator uses `stmt.text()` (Step 11).
-
-Remove the C function and the `SyntaqliteResolvedSpan` struct entirely.
-No thin shim is retained — a hard delete, verified by a final grep for
-`resolve_span` turning up zero matches.
-
-Strategy for intermediate steps: **keep `resolve_span` alive and
-unchanged from Step 1 through Step 12.** It acts as a thin compat layer
-for the old `FieldValue::Span.text` / `FieldValue::Span.source`
-population path until Step 12 rewrites that path on top of the new
-accessors. Steps 1–5 do not touch `resolve_span` at all; Step 6 adds
-the new accessors alongside it; Steps 7–11 migrate consumers one at a
-time; Step 12 migrates the last consumer (`FieldValue::Span`); Step 14
-deletes the old API.
+Already done in the PR #90 follow-up: `extract_field_value` was
+migrated to populate `FieldValue::Span` directly from
+`span_expanded_text` + `span_text_range` + `sp.is_quoted()`, which
+removed the last caller of `resolve_span`. The C function and the
+`SyntaqliteResolvedSpan` struct were then deleted (hard removal, no
+shim retained).
 
 ### Step 15 — Rename `syntaqlite_parser_source()` → `syntaqlite_parser_text()`
 
@@ -803,6 +838,14 @@ The following parts of the codebase should require **no changes**:
 The following are intentionally not part of this plan. They can be added
 later if concrete need arises:
 
+- **Generalized `subtree_text(node)` / `subtree_expanded_text(node)`.**
+  Dropped in the Step 8 reshape. Field-span based subtree extents miss
+  leading keywords, and the real-world use cases (Perfetto issue #89,
+  the formatter's macro verbatim pass) don't need a generalized
+  accessor. If a future consumer genuinely needs per-node authored
+  text, the path forward is another targeted grammar-annotated span
+  field like `select_span`, not a reintroduction of the generalized
+  API.
 - **Public `Rewriter` API.** Perfetto has one for transpilation patterns
   (`RewriteToDummySql`, `ExecuteCreateFunction`). We have no analogous use
   case today. If we ever want one (e.g., to wrap an engine-handled
@@ -834,45 +877,36 @@ later if concrete need arises:
 This refactor is done when:
 
 1. **Public API uses the new vocabulary.** Every `source` in a user-facing
-   name has become `text` or `expanded_text`. `SyntaqliteTextRange`
-   replaces `SourceRange`. All accessors are named per the table above.
+   name has become `text` or `expanded_text`. All accessors are named
+   per the table above. *(Partially done — `parser_source` → `text`
+   rename is deferred to Step 15.)*
 2. **`_layer_id` is never referenced by any public API signature.** It
    exists as an implementation-detail field on `SyntaqliteSourceSpan` and
    `SyntaqliteParserToken` but no public function takes it as a parameter
-   or returns it.
+   or returns it. *(Done.)*
 3. **`statement_source` in `analyzer.rs` is deleted.** Its replacement
    (`stmt.text()`) produces correct output for statements containing
    macros — tested via a regression test that would have failed today.
-4. **`try_macro_verbatim` has no bespoke macro-region scan.** It calls
-   `subtree_text` on the child node and nothing else.
-5. **Traceback fidelity matches Perfetto.** A diagnostic at an offset
+   *(Deferred to Step 11.)*
+4. **Traceback fidelity matches Perfetto.** A diagnostic at an offset
    inside a substituted macro argument produces a traceback whose
    innermost frame points at the user's authored arg text, not at the
-   whole `foo!(…)` call site. Tested via a unit test that exercises
-   `outer!(inner!(a+b))` and verifies the frame chain.
-6. **Issue #89 is trivially satisfied.** A dialect consumer calls
-   `subtree_expanded_text(subtree_root)` and gets the correct forwardable
-   SQL text. Tested via an integration test.
-7. **No allocation for macro-free parsing.** A parse of a statement with
-   no macro calls does not allocate any expansion layer buffers, any
-   subtree extent cache, or any expanded text cache unless a query
-   explicitly requests it.
+   whole `foo!(…)` call site. Tested by the Perfetto
+   `MacroExpansionSpanRegression` diff test and by
+   `traceback_span_inside_substituted_arg_drills_to_origin` unit test.
+   *(Done.)*
+5. **Issue #89 is satisfied for Perfetto's CREATE statements.** A
+   consumer reads the `select_span` field on `CreatePerfettoTableStmt`
+   / `CreatePerfettoViewStmt` / `CreatePerfettoFunctionStmt` to get
+   the authored byte range of the `select` body. Tested via an amalg
+   diff test. *(Done.)*
+6. **No allocation for macro-free parsing beyond baseline.** A parse
+   of a statement with no macro calls does not allocate any expansion
+   layer buffers. The parser-owned `traceback_buf` is only grown when
+   `traceback()` is called, and reused across calls.
 
-   This remains a design goal, enforced by the lazy-caching architecture
-   rather than a dedicated test. The caches are arena-allocated (see
-   "Lazy cache invalidation" below), so a parse that never touches a
-   lazy query makes no extra heap allocations beyond what the baseline
-   parse already does.
-
-### Lazy cache invalidation
-
-The per-statement lazy caches (`SynqSubtreeExtentCache`,
-`SynqExpandedTextCache`) live on the parser arena and are reset
-whenever `syntaqlite_parser_next` resets the arena between statements.
-Nothing explicit is needed at the end of a parse — the arena reset
-already invalidates them. The only cache-owned state on the parser
-struct is a pair of pointers to the cache heads in arena memory; those
-pointers are zeroed on reset and repopulated lazily on first query.
+   This remains a design goal enforced by the lazy-allocation
+   architecture rather than a dedicated test.
 
 ## Resolved: macro body provenance for the definition frame
 

--- a/docs/text-expansion-model-plan.md
+++ b/docs/text-expansion-model-plan.md
@@ -551,13 +551,13 @@ additive/rename work lands first, then behavior changes, then deletions.
 | 4. Record `SynqArgSegment` during param substitution| ✅ done | `SynqMacroExpansion` carries arg segments until transferred onto the layer in `feed_macro_expansion`; `reset_stmt` / `destroy` free both expansion buffers and segment arrays. |
 | 5. Add `_layer_id` to `SyntaqliteParserToken`       | ✅ done | ABI change (16 → 20 bytes). Python bindings unaffected (they don't use the struct); Rust `CParserToken` mirror updated. |
 | 6. Add `span_text` / `span_expanded_text` / `span_text_range` | ✅ done | See "Notes on Step 6" below. |
-| 7. Add `traceback` with arg-segment drilling        | ⏳ deferred | |
-| 8. Lazy subtree extent cache + `subtree_text`       | ⏳ deferred | |
-| 9. Lazy expanded splicer + `subtree_expanded_text` / `expanded_text` | ⏳ deferred | |
-| 10. Migrate formatter's `try_macro_verbatim`        | ⏳ deferred | |
+| 7. Add `traceback` with arg-segment drilling        | ✅ done | New `SyntaqliteTracebackFrame` struct + `syntaqlite_parser_traceback` C API, `TracebackFrame<'a>` + `AnyParsedStatement::traceback` Rust method. Validator migrated off the old API. See session 2 notes. |
+| 8. Targeted `select_span` on Perfetto CREATE stmts (was: subtree extent cache) | ✅ done (reshaped) | **Scope change**: the generalized `subtree_text` API was dropped in favor of a targeted grammar-annotation mechanism. Added `cur_shift_start`/`last_shifted_end` tracking on `SynqParseCtx` (updated in `record_and_feed` before/after `feed_one_token`) plus empty-marker rules `select_body_start` / `select_body_end` in `perfetto.y`. Added `select_span` field to `CreatePerfettoTableStmt` / `CreatePerfettoViewStmt` / `CreatePerfettoFunctionStmt`. Consumers read the field like any other span and call `span_text_range(select_span)` for the authored byte range. Perfetto macro body already lands as a span via existing `synq_span` conversion — no change needed. |
+| 9. Lazy expanded splicer + `subtree_expanded_text` / `expanded_text` | ❌ dropped | Obviated by Step 8's reshape. Macro-containing subtrees don't need a generalized splicer; Perfetto's actual use cases are handled by the `select_span` field (whose authored bytes come from the root layer directly). |
+| 10. Migrate formatter's `try_macro_verbatim`        | ❌ dropped | Obviated by Step 8's reshape. The formatter's existing `MacroRegion` + peek-next-token approach is correct and doesn't benefit from a subtree accessor. |
 | 11. Migrate analyzer's `statement_source`           | ⏳ deferred | |
 | 12. `FieldValue::Span` rename                       | ⏳ partial | `extract_field_value` now populates `FieldValue::Span` from the new trio (Session 1 follow-up, PR #90 review). Full rename of the variant's field names (`source` → `text_range`, adding a second authored-text field) still deferred. |
-| 13. Delete old expansion traceback API              | ⏳ deferred | |
+| 13. Delete old expansion traceback API              | ✅ done | Removed `syntaqlite_parser_expansion_traceback`, `SyntaqliteExpansionFrame`, `ExpansionFrame`, `field_expansion_traceback`. Validator migrated to `traceback()`. |
 | 14. Delete `resolve_span` and `SyntaqliteResolvedSpan` | ✅ done | Brought forward from Session 1 follow-up (PR #90 review). Zero callers remain. |
 | 15. Rename `syntaqlite_parser_source()` → `syntaqlite_parser_text()` | ⏳ deferred | |
 
@@ -601,6 +601,32 @@ implementation and must fail on the pre-change tree.
   `p->layers`) with a count + `_macro_at(idx)` pair so there is no
   separate "public view" data structure. Updated C examples
   (`select_columns.c` / `.cc`) accordingly.
+- **Session 2** landed Steps 7, 8 (reshaped), and 13, plus dropped
+  Steps 9/10 entirely. Step 7 added the new `traceback` API with
+  arg-segment drilling (`SyntaqliteTracebackFrame` C struct, `CTracebackFrame`
+  FFI mirror, `TracebackFrame<'a>` public Rust type, and a
+  `compute_line_col` helper). The validator's `emit()` method now
+  uses `stmt.traceback(node_id, field_idx)`. Step 13 followed
+  immediately: the old `expansion_traceback` / `ExpansionFrame` /
+  `field_expansion_traceback` symbols are gone entirely. The Perfetto
+  `MacroExpansionSpanRegression` diff test split into two cases — one
+  for the arg-drill collapse (`_d!(a)` → single root frame, no "in
+  macro expansion" note) and one for the macro-body case (`m!()`
+  where the body contains a literal unknown ident, yielding two
+  frames and the multi-frame render path). New `traceback_*` tests in
+  `session.rs`. **Step 8 reshape**: during prototyping the plan's
+  generalized `subtree_text` API was discarded because (a) field-span
+  based extent computation misses leading keywords like `SELECT`,
+  (b) Perfetto's actual use case is a *specific* grammar rule, not
+  every node, and (c) the formatter's `try_macro_verbatim` doesn't
+  benefit from a subtree accessor. Replaced with a targeted `select_span`
+  field on `CreatePerfettoTableStmt` / `ViewStmt` / `FunctionStmt`
+  populated via `cur_shift_start` / `last_shifted_end` ctx fields
+  and `select_body_start` / `select_body_end` empty-marker rules.
+  The span excludes leading/trailing whitespace. Macro body was
+  already handled by the existing `body` span — no changes needed.
+  Steps 9/10 are dropped (they only existed to support the
+  generalized subtree abstraction).
 
 ### Step 1 — Rename `_buf_idx` to `_layer_id`
 

--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -63,6 +63,7 @@ static void reset_stmt(SyntaqliteParser* p) {
   synq_parse_ctx_clear(&p->ctx);
   syntaqlite_vec_clear(&p->comments);
   syntaqlite_vec_clear(&p->tokens);
+  syntaqlite_vec_clear(&p->traceback_buf);
   // Free owned expansion buffers and arg-segment arrays from previous
   // statement.  Skip index 0 (sentinel) — its expansion_data points to
   // source (not malloc'd) and it has no arg_segments.
@@ -144,6 +145,7 @@ SYNTAQLITE_API SyntaqliteParser* syntaqlite_parser_create_with_dialect(
   syntaqlite_vec_init(&p->comments);
   syntaqlite_vec_init(&p->tokens);
   syntaqlite_vec_init(&p->layers);
+  syntaqlite_vec_init(&p->traceback_buf);
   // macro_table, expansion state already zeroed by memset
   return p;
 }
@@ -208,6 +210,7 @@ SYNTAQLITE_API void syntaqlite_parser_destroy(SyntaqliteParser* p) {
         p->mem.xFree(lyr->arg_segments);
     }
     syntaqlite_vec_free(&p->layers, p->mem);
+    syntaqlite_vec_free(&p->traceback_buf, p->mem);
     // Free macro registry.
     if (p->macro_table) {
       for (uint32_t i = 0; i < p->macro_table_size; i++) {

--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -89,6 +89,8 @@ static void reset_stmt(SyntaqliteParser* p) {
   }
   p->expansion_depth = 0;
   p->ctx.layer_id = 0;
+  p->ctx.cur_shift_start = 0;
+  p->ctx.last_shifted_end = 0;
   p->ctx.root = SYNTAQLITE_NULL_NODE;
   p->ctx.stmt_completed = 0;
   p->ctx.pending_explain_mode = 0;
@@ -357,7 +359,20 @@ int synq_parser_record_and_feed(SyntaqliteParser* p,
     syntaqlite_vec_push(&p->tokens, tp, p->mem);
     tidx = syntaqlite_vec_len(&p->tokens) - 1;
   }
+  // Publish the upcoming token's start *before* Lemon processes it so
+  // that BEFORE-style empty-marker reductions firing inside feed_one_token
+  // see the start of the token about to be shifted (whitespace between
+  // the previous terminal and this one is excluded).  Only track
+  // positions for tokens shifted from the root source layer.
+  if (p->ctx.layer_id == 0)
+    p->ctx.cur_shift_start = cur_offset;
   int rc = feed_one_token(p, cur_type, p->source + cur_offset, cur_len, tidx);
+  // Advance the "last shifted terminal end" cursor *after* Lemon finishes
+  // processing `cur`, so that any empty-rule reductions that fired inside
+  // feed_one_token observed the previous shifted token's end.  AFTER-style
+  // markers use this to capture the end position of a non-terminal.
+  if (p->ctx.layer_id == 0)
+    p->ctx.last_shifted_end = cur_offset + cur_len;
   // After parse_failure, Lemon stops reducing — force a boundary on SEMI
   // so errors don't bleed into subsequent statements.
   if (p->had_error && rc == 0 && cur_type == SYNTAQLITE_TK_SEMI)

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -10,6 +10,7 @@
 
 #include "syntaqlite/config.h"
 #include "syntaqlite/dialect.h"
+#include "syntaqlite/parser.h"
 #include "syntaqlite_dialect/ast_builder.h"
 
 #ifdef __cplusplus
@@ -155,6 +156,11 @@ struct SyntaqliteParser {
   // source; actual expansions start at index 1.  `_layer_id` on AST spans
   // indexes directly into this vector.
   SYNQ_VEC(SynqExpansionLayer) layers;
+
+  // Scratch buffer owned by the parser for `syntaqlite_parser_traceback`.
+  // Rewritten on every call; pointers returned from one call are
+  // invalidated by the next (and by `reset_stmt`).
+  SYNQ_VEC(SyntaqliteTracebackFrame) traceback_buf;
 
   // ── Macro registry (open-addressing hashmap) ──────────────────────────
   SynqMacroEntry* macro_table;

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -859,41 +859,94 @@ syntaqlite_parser_span_text_range(SyntaqliteParser* p,
   return r;
 }
 
+// Compute 1-based (line, col) for `offset` within `buf[..buf_len]`.  The
+// offset is clamped to `buf_len`.
+static void compute_line_col(const char* buf,
+                             uint32_t buf_len,
+                             uint32_t offset,
+                             uint32_t* out_line,
+                             uint32_t* out_col) {
+  if (offset > buf_len)
+    offset = buf_len;
+  uint32_t line = 1;
+  uint32_t col = 1;
+  for (uint32_t i = 0; i < offset; i++) {
+    if (buf[i] == '\n') {
+      line++;
+      col = 1;
+    } else {
+      col++;
+    }
+  }
+  *out_line = line;
+  *out_col = col;
+}
+
 SYNTAQLITE_API uint32_t
-syntaqlite_parser_expansion_traceback(SyntaqliteParser* p,
-                                      const SyntaqliteSourceSpan* sp,
-                                      SyntaqliteExpansionFrame* frames,
-                                      uint32_t max_frames) {
+syntaqlite_parser_traceback(SyntaqliteParser* p,
+                            const SyntaqliteSourceSpan* sp,
+                            SyntaqliteTracebackFrame* frames,
+                            uint32_t max_frames) {
   if (!sp || sp->length == 0)
     return 0;
 
-  // Walk the parent chain from innermost to outermost, collecting frames
-  // in a temporary buffer.  Then reverse them so frame 0 is outermost.
-  SyntaqliteExpansionFrame tmp[SYNQ_MAX_MACRO_DEPTH + 1];
+  // Walk the layer chain, emitting one frame per layer.  When the
+  // current position lies inside a substituted arg segment, drill
+  // through to the arg's origin layer and retry — no frame is emitted
+  // for the layer we drilled past, because the span's "real" location
+  // at that level is the arg-origin text, not the substitution site.
+  SyntaqliteTracebackFrame tmp[SYNQ_MAX_MACRO_DEPTH + 2];
   uint32_t count = 0;
-  uint32_t cur_off = sp->offset;
-  uint32_t cur_len = sp->length;
-  uint8_t cur_layer = sp->_layer_id;
+  uint32_t off = sp->offset;
+  uint32_t len = sp->length;
+  uint8_t layer_id = sp->_layer_id;
+  uint32_t layers_count = syntaqlite_vec_len(&p->layers);
 
-  while (count < SYNQ_MAX_MACRO_DEPTH + 1) {
-    if (cur_layer >= syntaqlite_vec_len(&p->layers))
+  // Bound the walk: each iteration either drills or walks up one parent,
+  // so at most 2 * (depth + 1) iterations.
+  for (uint32_t step = 0; step < 2 * (SYNQ_MAX_MACRO_DEPTH + 1) &&
+                          count < SYNQ_MAX_MACRO_DEPTH + 2;
+       step++) {
+    if (layer_id >= layers_count)
       break;
-    const SynqExpansionLayer* r = &p->layers.data[cur_layer];
-    tmp[count].buffer = r->expansion_data;
-    tmp[count].buffer_len = r->expansion_len;
-    tmp[count].offset = cur_off;
-    tmp[count].length = cur_len;
-    count++;
-    if (cur_layer == 0)
+    const SynqExpansionLayer* lyr = &p->layers.data[layer_id];
+
+    // Arg-segment drill: skip emitting a frame for this layer.
+    int drilled = 0;
+    for (uint32_t i = 0; i < lyr->arg_segment_count; i++) {
+      const SynqArgSegment* seg = &lyr->arg_segments[i];
+      if (off >= seg->sub_offset && off < seg->sub_offset + seg->sub_length) {
+        off = seg->origin_offset + (off - seg->sub_offset);
+        layer_id = seg->origin_layer_id;
+        drilled = 1;
+        break;
+      }
+    }
+    if (drilled)
+      continue;
+
+    SyntaqliteTracebackFrame* f = &tmp[count++];
+    f->name = lyr->name;
+    f->name_len = lyr->name_len;
+    f->snippet = lyr->expansion_data;
+    f->snippet_len = lyr->expansion_len;
+    f->offset_in_snippet = off;
+    f->length_in_snippet = len;
+    compute_line_col(lyr->expansion_data, lyr->expansion_len, off, &f->line,
+                     &f->col);
+
+    if (layer_id == 0) {
+      // Root (sentinel) — walk terminates.
       break;
-    // Move to parent: the call site of this expansion in the parent layer.
-    cur_off = r->call_offset;
-    cur_len = r->call_length;
-    cur_layer = r->parent_layer_id;
+    }
+    // Walk up to parent at this layer's call site.  The call site spans
+    // the whole `name!(...)` call.
+    off = lyr->call_offset;
+    len = lyr->call_length;
+    layer_id = lyr->parent_layer_id;
   }
 
-  // Reverse so frames[0] is outermost (source) and frames[count-1] is
-  // innermost (deepest expansion).
+  // Reverse so frames[0] is outermost and frames[count-1] is innermost.
   uint32_t to_write = count < max_frames ? count : max_frames;
   for (uint32_t i = 0; i < to_write; i++) {
     frames[i] = tmp[count - 1 - i];

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -882,19 +882,25 @@ static void compute_line_col(const char* buf,
   *out_col = col;
 }
 
-SYNTAQLITE_API uint32_t
-syntaqlite_parser_traceback(SyntaqliteParser* p,
-                            const SyntaqliteSourceSpan* sp,
-                            SyntaqliteTracebackFrame* frames,
-                            uint32_t max_frames) {
+SYNTAQLITE_API const SyntaqliteTracebackFrame* syntaqlite_parser_traceback(
+    SyntaqliteParser* p,
+    const SyntaqliteSourceSpan* sp,
+    uint32_t* out_count) {
+  if (out_count)
+    *out_count = 0;
+  // Clear the scratch buffer from any previous call.  Keeps the
+  // allocation so repeat calls reuse the same heap block.
+  syntaqlite_vec_clear(&p->traceback_buf);
   if (!sp || sp->length == 0)
-    return 0;
+    return NULL;
 
-  // Walk the layer chain, emitting one frame per layer.  When the
-  // current position lies inside a substituted arg segment, drill
-  // through to the arg's origin layer and retry — no frame is emitted
-  // for the layer we drilled past, because the span's "real" location
-  // at that level is the arg-origin text, not the substitution site.
+  // Walk the layer chain, emitting one frame per layer into a small
+  // on-stack buffer (innermost first).  When the current position lies
+  // inside a substituted arg segment, drill through to the arg's
+  // origin layer and retry — no frame is emitted for the layer we
+  // drilled past, because the span's "real" location at that level is
+  // the arg-origin text, not the substitution site.  Then reverse
+  // into the parser's owned vec so the caller sees outermost first.
   SyntaqliteTracebackFrame tmp[SYNQ_MAX_MACRO_DEPTH + 2];
   uint32_t count = 0;
   uint32_t off = sp->offset;
@@ -946,10 +952,16 @@ syntaqlite_parser_traceback(SyntaqliteParser* p,
     layer_id = lyr->parent_layer_id;
   }
 
-  // Reverse so frames[0] is outermost and frames[count-1] is innermost.
-  uint32_t to_write = count < max_frames ? count : max_frames;
-  for (uint32_t i = 0; i < to_write; i++) {
-    frames[i] = tmp[count - 1 - i];
+  if (count == 0)
+    return NULL;
+
+  // Reverse into the parser's owned buffer so frame[0] is outermost.
+  syntaqlite_vec_ensure(&p->traceback_buf, count, p->mem);
+  for (uint32_t i = 0; i < count; i++) {
+    p->traceback_buf.data[i] = tmp[count - 1 - i];
   }
-  return count;
+  p->traceback_buf.count = count;
+  if (out_count)
+    *out_count = count;
+  return p->traceback_buf.data;
 }

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -868,18 +868,22 @@ static void compute_line_col(const char* buf,
                              uint32_t* out_col) {
   if (offset > buf_len)
     offset = buf_len;
+  // Walk newline-to-newline with memchr instead of char-by-char so
+  // long single-line SQL doesn't become O(offset) per frame.
   uint32_t line = 1;
-  uint32_t col = 1;
-  for (uint32_t i = 0; i < offset; i++) {
-    if (buf[i] == '\n') {
-      line++;
-      col = 1;
-    } else {
-      col++;
-    }
+  uint32_t last_nl_end = 0;  // byte position just past the most recent '\n'
+  uint32_t scanned = 0;
+  while (scanned < offset) {
+    const char* nl =
+        (const char*)memchr(buf + scanned, '\n', (size_t)(offset - scanned));
+    if (!nl)
+      break;
+    line++;
+    last_nl_end = (uint32_t)(nl - buf) + 1;
+    scanned = last_nl_end;
   }
   *out_line = line;
-  *out_col = col;
+  *out_col = offset - last_nl_end + 1;
 }
 
 SYNTAQLITE_API const SyntaqliteTracebackFrame* syntaqlite_parser_traceback(

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -243,9 +243,10 @@ typedef struct SyntaqliteTracebackFrame {
   uint32_t length_in_snippet;
 } SyntaqliteTracebackFrame;
 
-// Build a traceback for a span.  Frames are written from outermost (the
-// root source frame) to innermost (the position inside the deepest
-// macro expansion layer).
+// Build a traceback for a span and return a pointer to a parser-owned
+// frame array.  Frames are ordered from outermost (the root source
+// frame) to innermost (the position inside the deepest macro
+// expansion layer).
 //
 // When the span was tokenized inside a substituted macro argument, the
 // walk drills through the substitution to the argument's origin layer
@@ -253,17 +254,19 @@ typedef struct SyntaqliteTracebackFrame {
 // than at the macro call site.  This is the argument-level fidelity
 // described in the text-expansion-model plan (success criterion #5).
 //
-// Writes up to `max_frames` frames into `frames[]`.  Returns the total
-// number of frames available (caller can pre-size by calling with
-// `max_frames=0` to get the count, then allocating).
+// Writes the number of frames into `*out_count`.  For a span not
+// inside any macro expansion, returns a single-frame slice with
+// `name == NULL`.  Returns NULL (and writes 0 to `*out_count`) for
+// empty or invalid spans.
 //
-// For a span not inside any macro expansion, returns 1 frame pointing
-// at the span's position in the original source with `name == NULL`.
-SYNTAQLITE_API uint32_t
-syntaqlite_parser_traceback(SyntaqliteParser* p,
-                            const SyntaqliteSourceSpan* span,
-                            SyntaqliteTracebackFrame* frames,
-                            uint32_t max_frames);
+// The returned pointer is valid until the next call to
+// `syntaqlite_parser_traceback` on the same parser or until the next
+// `syntaqlite_parser_next` resets the current statement — callers
+// that need to retain frames across such calls must copy them out.
+SYNTAQLITE_API const SyntaqliteTracebackFrame* syntaqlite_parser_traceback(
+    SyntaqliteParser* p,
+    const SyntaqliteSourceSpan* span,
+    uint32_t* out_count);
 
 // Post-expansion text for `span` — the bytes the tokenizer actually saw.
 // For macro-free spans, a slice of the input source.  For spans inside a

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -219,30 +219,51 @@ typedef struct SyntaqliteTextRange {
   uint32_t end;
 } SyntaqliteTextRange;
 
-// One frame in an expansion traceback.  Each frame describes a position
-// inside a particular buffer (the original source or a macro expansion).
-typedef struct SyntaqliteExpansionFrame {
-  const char* buffer;   // Buffer text (source or expansion)
-  uint32_t buffer_len;  // Length of buffer
-  uint32_t offset;      // Byte offset within buffer
-  uint32_t length;      // Byte length within buffer
-} SyntaqliteExpansionFrame;
+// One frame in a span traceback, produced by
+// `syntaqlite_parser_traceback`.  Each frame is self-contained: it
+// carries a snippet buffer to render the caret against, the offset
+// within that buffer, and an optional macro name for non-root frames.
+//
+// `name` is `NULL` (and `name_len == 0`) for the root source frame, and
+// borrows from the macro registry entry (valid for the parse's lifetime)
+// for macro expansion frames.  `snippet` borrows either the user's input
+// source (for the root frame) or the corresponding expansion layer's
+// buffer (for macro frames).
+//
+// `line` and `col` are 1-based and computed from `offset_in_snippet`
+// within `snippet`.
+typedef struct SyntaqliteTracebackFrame {
+  const char* name;
+  uint32_t name_len;
+  uint32_t line;
+  uint32_t col;
+  const char* snippet;
+  uint32_t snippet_len;
+  uint32_t offset_in_snippet;
+  uint32_t length_in_snippet;
+} SyntaqliteTracebackFrame;
 
-// Build an expansion traceback for a span.  Frames are written from
-// outermost (call site in original source) to innermost (position inside
-// the deepest expansion buffer).
+// Build a traceback for a span.  Frames are written from outermost (the
+// root source frame) to innermost (the position inside the deepest
+// macro expansion layer).
+//
+// When the span was tokenized inside a substituted macro argument, the
+// walk drills through the substitution to the argument's origin layer
+// — the innermost frame points at the user's authored arg text rather
+// than at the macro call site.  This is the argument-level fidelity
+// described in the text-expansion-model plan (success criterion #5).
 //
 // Writes up to `max_frames` frames into `frames[]`.  Returns the total
 // number of frames available (caller can pre-size by calling with
 // `max_frames=0` to get the count, then allocating).
 //
-// For a span not inside any macro expansion, returns 1 frame pointing at
-// the span's position in the original source.
+// For a span not inside any macro expansion, returns 1 frame pointing
+// at the span's position in the original source with `name == NULL`.
 SYNTAQLITE_API uint32_t
-syntaqlite_parser_expansion_traceback(SyntaqliteParser* p,
-                                      const SyntaqliteSourceSpan* span,
-                                      SyntaqliteExpansionFrame* frames,
-                                      uint32_t max_frames);
+syntaqlite_parser_traceback(SyntaqliteParser* p,
+                            const SyntaqliteSourceSpan* span,
+                            SyntaqliteTracebackFrame* frames,
+                            uint32_t max_frames);
 
 // Post-expansion text for `span` — the bytes the tokenizer actually saw.
 // For macro-free spans, a slice of the input source.  For spans inside a

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -251,8 +251,7 @@ typedef struct SyntaqliteTracebackFrame {
 // When the span was tokenized inside a substituted macro argument, the
 // walk drills through the substitution to the argument's origin layer
 // — the innermost frame points at the user's authored arg text rather
-// than at the macro call site.  This is the argument-level fidelity
-// described in the text-expansion-model plan (success criterion #5).
+// than at the macro call site.
 //
 // Writes the number of frames into `*out_count`.  For a span not
 // inside any macro expansion, returns a single-frame slice with

--- a/syntaqlite-syntax/include/syntaqlite/types.h
+++ b/syntaqlite-syntax/include/syntaqlite/types.h
@@ -35,8 +35,9 @@ typedef uint32_t SyntaqliteCompletionContext;
 //     live in an expansion layer buffer.
 //   - `syntaqlite_parser_span_text_range(p, &span)` — byte range of
 //     `span_text` in the input source.
-//   - `syntaqlite_parser_expansion_traceback(p, &span, ...)` — the full
-//     outermost → innermost expansion chain for diagnostics.
+//   - `syntaqlite_parser_traceback(p, &span, ...)` — the full outermost
+//     → innermost expansion chain for diagnostics, with argument-level
+//     drill-through fidelity for spans inside substituted macro args.
 typedef struct SyntaqliteSourceSpan {
   uint32_t offset;
   uint16_t length;

--- a/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
@@ -77,6 +77,25 @@ typedef struct SynqParseCtx {
   // verbatim instead of being recursively expanded.  Set/cleared by
   // grammar actions on entering/leaving the body production.
   uint32_t in_macro_def_body;
+
+  // Byte offset of the token Lemon is currently processing (in
+  // root-source coordinates).  Set at the start of
+  // `synq_parser_record_and_feed` *before* `feed_one_token` runs, so
+  // empty-rule reductions firing inside the feed observe the offset of
+  // the token they're about to be shifted alongside.  BEFORE-style
+  // markers use this to capture the start position of a non-terminal
+  // (whitespace before the first terminal is excluded).  Valid only
+  // for tokens shifted from the root source layer.
+  uint32_t cur_shift_start;
+
+  // Byte offset just past the end of the most recently shifted terminal
+  // (in root-source coordinates).  Updated in
+  // `synq_parser_record_and_feed` *after* `feed_one_token` returns, so
+  // that empty-rule reductions firing inside the feed see the end of
+  // the *previous* shifted terminal, not the current one.  AFTER-style
+  // markers use this to capture the end position of a non-terminal.
+  // Valid only for tokens shifted from the root source layer.
+  uint32_t last_shifted_end;
 } SynqParseCtx;
 
 // Common header for all list nodes in the arena.

--- a/syntaqlite-syntax/src/ast.rs
+++ b/syntaqlite-syntax/src/ast.rs
@@ -195,7 +195,7 @@ pub trait TypedNodeId: Copy + Into<AnyNodeId> {
 ///
 /// For spans inside a macro expansion, points at the macro call site in the
 /// original source (not the expansion buffer).  Use
-/// [`AnyParsedStatement::field_expansion_traceback`](crate::parser::AnyParsedStatement::field_expansion_traceback)
+/// [`AnyParsedStatement::traceback`](crate::parser::AnyParsedStatement::traceback)
 /// if you need position info inside the expansion.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct SourceRange {

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -86,7 +86,7 @@ pub mod any {
     #[doc(inline)]
     pub use crate::parser::{
         AnyIncrementalParseSession, AnyParseError, AnyParseSession, AnyParsedStatement, AnyParser,
-        AnyParserToken, ExpansionFrame, MacroRegion, ParseOutcome,
+        AnyParserToken, MacroRegion, ParseOutcome, TracebackFrame,
     };
     #[doc(inline)]
     pub use crate::tokenizer::{AnyToken, AnyTokenizer};

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -91,16 +91,29 @@ pub(crate) struct CTextRange {
     pub(crate) end: u32,
 }
 
-/// One frame in a macro expansion traceback.
+/// One frame in a traceback produced by the span traceback API.
 ///
-/// Mirrors C `SyntaqliteExpansionFrame` from `include/syntaqlite/parser.h`.
+/// Mirrors C `SyntaqliteTracebackFrame` from `include/syntaqlite/parser.h`.
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
-pub(crate) struct CExpansionFrame {
-    pub(crate) buffer: *const u8,
-    pub(crate) buffer_len: u32,
-    pub(crate) offset: u32,
-    pub(crate) length: u32,
+pub(crate) struct CTracebackFrame {
+    /// Macro name pointer (borrowed from the macro registry), or null for
+    /// the root source frame.
+    pub(crate) name: *const u8,
+    /// Length of `name`, or 0 for the root frame.
+    pub(crate) name_len: u32,
+    /// 1-based line number of `offset_in_snippet` within `snippet`.
+    pub(crate) line: u32,
+    /// 1-based column number of `offset_in_snippet` within `snippet`.
+    pub(crate) col: u32,
+    /// Buffer to render the frame against — the original source for the
+    /// root frame, or an expansion layer's buffer for macro frames.
+    pub(crate) snippet: *const u8,
+    pub(crate) snippet_len: u32,
+    /// Byte offset of this frame's position within `snippet`.
+    pub(crate) offset_in_snippet: u32,
+    /// Byte length of this frame's position within `snippet`.
+    pub(crate) length_in_snippet: u32,
 }
 
 impl CParser {
@@ -252,15 +265,12 @@ impl CParser {
         }
     }
 
-    pub(crate) unsafe fn expansion_traceback(
-        &self,
-        span: crate::ast::SourceSpan,
-    ) -> Vec<CExpansionFrame> {
+    pub(crate) unsafe fn traceback(&self, span: crate::ast::SourceSpan) -> Vec<CTracebackFrame> {
         // First call with max=0 to get the count.
         // SAFETY: self is a valid CParser pointer; span is a copy of an
         // arena value with the SyntaqliteSourceSpan layout.
         let count = unsafe {
-            syntaqlite_parser_expansion_traceback(
+            syntaqlite_parser_traceback(
                 std::ptr::from_ref::<Self>(self).cast_mut(),
                 std::ptr::from_ref(&span).cast(),
                 std::ptr::null_mut(),
@@ -270,11 +280,11 @@ impl CParser {
         if count == 0 {
             return Vec::new();
         }
-        let mut frames: Vec<CExpansionFrame> = Vec::with_capacity(count as usize);
+        let mut frames: Vec<CTracebackFrame> = Vec::with_capacity(count as usize);
         // SAFETY: capacity is at least `count`; the C function writes
         // exactly `count` frames into the buffer.
         unsafe {
-            syntaqlite_parser_expansion_traceback(
+            syntaqlite_parser_traceback(
                 std::ptr::from_ref::<Self>(self).cast_mut(),
                 std::ptr::from_ref(&span).cast(),
                 frames.as_mut_ptr(),
@@ -439,10 +449,10 @@ unsafe extern "C" {
         out_len: *mut u32,
     ) -> *const u8;
     fn syntaqlite_parser_span_text_range(p: *mut CParser, span: *const c_void) -> CTextRange;
-    fn syntaqlite_parser_expansion_traceback(
+    fn syntaqlite_parser_traceback(
         p: *mut CParser,
         span: *const c_void,
-        frames: *mut CExpansionFrame,
+        frames: *mut CTracebackFrame,
         max_frames: u32,
     ) -> u32;
 

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -265,34 +265,26 @@ impl CParser {
         }
     }
 
-    pub(crate) unsafe fn traceback(&self, span: crate::ast::SourceSpan) -> Vec<CTracebackFrame> {
-        // First call with max=0 to get the count.
+    pub(crate) unsafe fn traceback(&self, span: crate::ast::SourceSpan) -> &[CTracebackFrame] {
+        let mut count: u32 = 0;
         // SAFETY: self is a valid CParser pointer; span is a copy of an
-        // arena value with the SyntaqliteSourceSpan layout.
-        let count = unsafe {
+        // arena value with the SyntaqliteSourceSpan layout.  The returned
+        // pointer is backed by the parser's owned `traceback_buf` vec and
+        // remains valid until the next call to this function or until the
+        // parser is mutated through another `&mut` method.
+        let ptr = unsafe {
             syntaqlite_parser_traceback(
                 std::ptr::from_ref::<Self>(self).cast_mut(),
                 std::ptr::from_ref(&span).cast(),
-                std::ptr::null_mut(),
-                0,
+                &raw mut count,
             )
         };
-        if count == 0 {
-            return Vec::new();
+        if ptr.is_null() || count == 0 {
+            return &[];
         }
-        let mut frames: Vec<CTracebackFrame> = Vec::with_capacity(count as usize);
-        // SAFETY: capacity is at least `count`; the C function writes
-        // exactly `count` frames into the buffer.
-        unsafe {
-            syntaqlite_parser_traceback(
-                std::ptr::from_ref::<Self>(self).cast_mut(),
-                std::ptr::from_ref(&span).cast(),
-                frames.as_mut_ptr(),
-                count,
-            );
-            frames.set_len(count as usize);
-        }
-        frames
+        // SAFETY: ptr + count describe a valid slice of CTracebackFrame
+        // values owned by the parser for the duration of the next call.
+        unsafe { std::slice::from_raw_parts(ptr, count as usize) }
     }
 
     pub(crate) unsafe fn result_macro_count(&self) -> u32 {
@@ -452,9 +444,8 @@ unsafe extern "C" {
     fn syntaqlite_parser_traceback(
         p: *mut CParser,
         span: *const c_void,
-        frames: *mut CTracebackFrame,
-        max_frames: u32,
-    ) -> u32;
+        out_count: *mut u32,
+    ) -> *const CTracebackFrame;
 
     // Configuration
     fn syntaqlite_parser_set_trace(p: *mut CParser, enable: u32) -> i32;

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -25,8 +25,8 @@ pub use incremental::{AnyIncrementalParseSession, TypedIncrementalParseSession};
 #[cfg(feature = "sqlite")]
 pub use session::{ParseError, ParseSession, ParsedStatement, Parser, ParserToken};
 pub use types::{
-    AnyParserToken, Comment, CommentKind, CommentSpan, CompletionContext, ExpansionFrame,
-    MacroRegion, ParseOutcome, ParserTokenFlags, TypedParserToken,
+    AnyParserToken, Comment, CommentKind, CommentSpan, CompletionContext, MacroRegion,
+    ParseOutcome, ParserTokenFlags, TracebackFrame, TypedParserToken,
 };
 
 /// Indicates whether parsing can continue after an error.
@@ -455,39 +455,58 @@ impl<'a> AnyParsedStatement<'a> {
         })
     }
 
-    /// Expansion traceback for a span field.
+    /// Build a traceback for a span field.
     ///
-    /// Returns a list of [`ExpansionFrame`]s from outermost (call site in
-    /// the original source) to innermost (the position inside the deepest
-    /// expansion buffer).  Returns a single frame for non-expansion spans.
+    /// Returns a list of [`TracebackFrame`]s from outermost (the root
+    /// source frame) to innermost (the position inside the deepest
+    /// macro expansion layer).  For macro-free spans, returns a single
+    /// root frame.
+    ///
+    /// When a span was tokenized inside a substituted macro argument,
+    /// the walk drills through the substitution: the innermost frame
+    /// points at the user's authored arg text rather than at the
+    /// `foo!(…)` call site.  This is the argument-level fidelity
+    /// described by the text-expansion-model plan (success criterion
+    /// #5).
+    ///
     /// Returns an empty vec for invalid/non-span fields.
-    pub fn field_expansion_traceback(
-        &self,
-        node_id: AnyNodeId,
-        field_idx: u8,
-    ) -> Vec<ExpansionFrame<'a>> {
+    pub fn traceback(&self, node_id: AnyNodeId, field_idx: u8) -> Vec<TracebackFrame<'a>> {
         let Some(sp) = self.field_span(node_id, field_idx) else {
             return Vec::new();
         };
         // SAFETY: self.raw is valid for 'a; sp is a copy of an arena value.
-        let raw_frames = unsafe { self.raw.as_ref().expansion_traceback(sp) };
+        let raw_frames = unsafe { self.raw.as_ref().traceback(sp) };
         raw_frames
             .into_iter()
-            .map(|f| ExpansionFrame {
-                buffer: if f.buffer.is_null() || f.buffer_len == 0 {
+            .map(|f| TracebackFrame {
+                name: if f.name.is_null() || f.name_len == 0 {
+                    None
+                } else {
+                    // SAFETY: C guarantees name points to name_len bytes of
+                    // valid UTF-8 in a parser-owned buffer valid for 'a.
+                    Some(unsafe {
+                        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+                            f.name,
+                            f.name_len as usize,
+                        ))
+                    })
+                },
+                line: f.line,
+                col: f.col,
+                snippet: if f.snippet.is_null() || f.snippet_len == 0 {
                     ""
                 } else {
-                    // SAFETY: C guarantees buffer points to buffer_len bytes
+                    // SAFETY: C guarantees snippet points to snippet_len bytes
                     // of valid UTF-8 in a parser-owned buffer valid for 'a.
                     unsafe {
                         std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-                            f.buffer,
-                            f.buffer_len as usize,
+                            f.snippet,
+                            f.snippet_len as usize,
                         ))
                     }
                 },
-                offset: f.offset as usize,
-                length: f.length as usize,
+                offset_in_snippet: f.offset_in_snippet as usize,
+                length_in_snippet: f.length_in_snippet as usize,
             })
             .collect()
     }

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -457,10 +457,10 @@ impl<'a> AnyParsedStatement<'a> {
 
     /// Build a traceback for a span field.
     ///
-    /// Returns a list of [`TracebackFrame`]s from outermost (the root
-    /// source frame) to innermost (the position inside the deepest
-    /// macro expansion layer).  For macro-free spans, returns a single
-    /// root frame.
+    /// Yields [`TracebackFrame`]s in outermost-to-innermost order —
+    /// frame 0 is the root source frame, and the final frame is the
+    /// position inside the deepest macro expansion layer.  For
+    /// macro-free spans, yields exactly one root frame.
     ///
     /// When a span was tokenized inside a substituted macro argument,
     /// the walk drills through the substitution: the innermost frame
@@ -469,46 +469,59 @@ impl<'a> AnyParsedStatement<'a> {
     /// described by the text-expansion-model plan (success criterion
     /// #5).
     ///
-    /// Returns an empty vec for invalid/non-span fields.
-    pub fn traceback(&self, node_id: AnyNodeId, field_idx: u8) -> Vec<TracebackFrame<'a>> {
-        let Some(sp) = self.field_span(node_id, field_idx) else {
-            return Vec::new();
+    /// Yields no frames for invalid or non-span fields.
+    ///
+    /// Takes `&mut self` because the traceback result lives in a
+    /// parser-owned scratch buffer that is overwritten on every call.
+    /// The `&mut` borrow enforces that only one traceback iterator is
+    /// live at a time — callers who need to retain frames across
+    /// another `traceback` call must copy them out (e.g. via
+    /// `.collect::<Vec<_>>()`).
+    pub fn traceback(
+        &mut self,
+        node_id: AnyNodeId,
+        field_idx: u8,
+    ) -> impl Iterator<Item = TracebackFrame<'a>> + use<'_, 'a> {
+        let sp = self.field_span(node_id, field_idx);
+        // The returned slice borrows from the parser's internal
+        // `traceback_buf` vec.  The `&mut self` receiver on this method
+        // ensures no other traceback call can overwrite that buffer
+        // while the returned iterator is live.
+        let raw_frames: &[ffi::CTracebackFrame] = match sp {
+            // SAFETY: self.raw is valid for 'a; sp is a copy of an arena value.
+            Some(sp) => unsafe { self.raw.as_ref().traceback(sp) },
+            None => &[],
         };
-        // SAFETY: self.raw is valid for 'a; sp is a copy of an arena value.
-        let raw_frames = unsafe { self.raw.as_ref().traceback(sp) };
-        raw_frames
-            .into_iter()
-            .map(|f| TracebackFrame {
-                name: if f.name.is_null() || f.name_len == 0 {
-                    None
-                } else {
-                    // SAFETY: C guarantees name points to name_len bytes of
-                    // valid UTF-8 in a parser-owned buffer valid for 'a.
-                    Some(unsafe {
-                        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-                            f.name,
-                            f.name_len as usize,
-                        ))
-                    })
-                },
-                line: f.line,
-                col: f.col,
-                snippet: if f.snippet.is_null() || f.snippet_len == 0 {
-                    ""
-                } else {
-                    // SAFETY: C guarantees snippet points to snippet_len bytes
-                    // of valid UTF-8 in a parser-owned buffer valid for 'a.
-                    unsafe {
-                        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-                            f.snippet,
-                            f.snippet_len as usize,
-                        ))
-                    }
-                },
-                offset_in_snippet: f.offset_in_snippet as usize,
-                length_in_snippet: f.length_in_snippet as usize,
-            })
-            .collect()
+        raw_frames.iter().map(|f| TracebackFrame {
+            name: if f.name.is_null() || f.name_len == 0 {
+                None
+            } else {
+                // SAFETY: C guarantees name points to name_len bytes of
+                // valid UTF-8 in a parser-owned buffer valid for 'a.
+                Some(unsafe {
+                    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+                        f.name,
+                        f.name_len as usize,
+                    ))
+                })
+            },
+            line: f.line,
+            col: f.col,
+            snippet: if f.snippet.is_null() || f.snippet_len == 0 {
+                ""
+            } else {
+                // SAFETY: C guarantees snippet points to snippet_len bytes
+                // of valid UTF-8 in a parser-owned buffer valid for 'a.
+                unsafe {
+                    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+                        f.snippet,
+                        f.snippet_len as usize,
+                    ))
+                }
+            },
+            offset_in_snippet: f.offset_in_snippet as usize,
+            length_in_snippet: f.length_in_snippet as usize,
+        })
     }
 
     /// Post-expansion text for an arena span — the bytes the tokenizer

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -458,25 +458,21 @@ impl<'a> AnyParsedStatement<'a> {
     /// Build a traceback for a span field.
     ///
     /// Yields [`TracebackFrame`]s in outermost-to-innermost order —
-    /// frame 0 is the root source frame, and the final frame is the
-    /// position inside the deepest macro expansion layer.  For
-    /// macro-free spans, yields exactly one root frame.
+    /// frame 0 is the root source, and the final frame is the position
+    /// inside the deepest macro expansion layer.  For macro-free spans,
+    /// yields exactly one root frame.
     ///
     /// When a span was tokenized inside a substituted macro argument,
     /// the walk drills through the substitution: the innermost frame
     /// points at the user's authored arg text rather than at the
-    /// `foo!(…)` call site.  This is the argument-level fidelity
-    /// described by the text-expansion-model plan (success criterion
-    /// #5).
+    /// `foo!(…)` call site.
     ///
     /// Yields no frames for invalid or non-span fields.
     ///
-    /// Takes `&mut self` because the traceback result lives in a
-    /// parser-owned scratch buffer that is overwritten on every call.
-    /// The `&mut` borrow enforces that only one traceback iterator is
-    /// live at a time — callers who need to retain frames across
-    /// another `traceback` call must copy them out (e.g. via
-    /// `.collect::<Vec<_>>()`).
+    /// Frames live in a parser-owned scratch buffer that is overwritten
+    /// on every call, so this method takes `&mut self`; `.collect()` the
+    /// iterator before calling `traceback` again if you need to retain
+    /// frames across calls.
     pub fn traceback(
         &mut self,
         node_id: AnyNodeId,
@@ -666,7 +662,12 @@ impl<'a> AnyParsedStatement<'a> {
     }
 
     /// Iterate direct child node IDs for the node at `id`.
-    pub fn child_node_ids(&self, id: AnyNodeId) -> impl Iterator<Item = AnyNodeId> + '_ {
+    ///
+    /// The returned iterator owns its data and does not borrow from
+    /// `self`, so it can be held across `&mut self` method calls on the
+    /// statement (e.g. while recursively invoking a visitor that itself
+    /// takes `&mut AnyParsedStatement`).
+    pub fn child_node_ids(&self, id: AnyNodeId) -> impl Iterator<Item = AnyNodeId> + use<> {
         let mut out = Vec::new();
         if let Some((_, fields)) = self.extract_fields(id) {
             for i in 0..fields.len() {

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -777,4 +777,122 @@ mod tests {
         let slice = &source[range.start as usize..range.end as usize];
         assert_eq!(slice, "authored");
     }
+
+    // ── Step 7: traceback with arg-segment drilling ─────────────────────────
+
+    // Walk the tree depth-first looking for the first non-empty Span field;
+    // return (owning node, field index) for use with `traceback`.
+    fn first_span_field<'a>(
+        stmt: &'a AnyParsedStatement<'a>,
+    ) -> Option<(crate::ast::AnyNodeId, u8)> {
+        use crate::ast::FieldValue;
+        fn walk<'a>(
+            stmt: &'a AnyParsedStatement<'a>,
+            id: crate::ast::AnyNodeId,
+        ) -> Option<(crate::ast::AnyNodeId, u8)> {
+            if let Some((_, fields)) = stmt.extract_fields(id) {
+                for i in 0..fields.len() {
+                    if matches!(fields[i], FieldValue::Span { .. })
+                        && let Ok(field_idx) = u8::try_from(i)
+                        && let Some(sp) = stmt.field_span(id, field_idx)
+                        && !sp.is_empty()
+                    {
+                        return Some((id, field_idx));
+                    }
+                }
+            }
+            for child in stmt.child_node_ids(id) {
+                if let Some(found) = walk(stmt, child) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        let root = stmt.root_id();
+        if root.is_null() {
+            return None;
+        }
+        walk(stmt, root)
+    }
+
+    #[test]
+    fn traceback_macro_free_yields_single_root_frame() {
+        let parser = Parser::new();
+        let source = "SELECT foo FROM bar";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+        let erased = stmt.erase();
+        let (nid, fidx) = first_span_field(&erased).expect("span field");
+
+        let frames = erased.traceback(nid, fidx);
+        assert_eq!(frames.len(), 1, "macro-free span → single root frame");
+        let f = &frames[0];
+        assert_eq!(f.name, None, "root frame has no macro name");
+        assert_eq!(f.snippet, source, "root snippet is the authored source");
+        // Offset points somewhere inside source.
+        assert!(f.offset_in_snippet < source.len());
+    }
+
+    #[test]
+    fn traceback_span_inside_macro_body_yields_two_frames() {
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        // Body has a hardcoded identifier; not an arg substitution.
+        parser.register_macro("idmac", &[], "inner");
+        let source = "SELECT idmac!()";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+        let erased = stmt.erase();
+        let (nid, fidx) = first_span_field(&erased).expect("span field");
+
+        let frames = erased.traceback(nid, fidx);
+        assert_eq!(
+            frames.len(),
+            2,
+            "span inside macro body → root + macro frames"
+        );
+        // Outermost = root
+        assert_eq!(frames[0].name, None);
+        assert_eq!(frames[0].snippet, source);
+        // Innermost = macro expansion
+        assert_eq!(frames[1].name, Some("idmac"));
+        assert_eq!(frames[1].snippet, "inner");
+        assert_eq!(frames[1].offset_in_snippet, 0);
+    }
+
+    #[test]
+    fn traceback_span_inside_substituted_arg_drills_to_origin() {
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        parser.register_macro("idmac", &["x"], "$x");
+        let source = "SELECT idmac!(authored)";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+        let erased = stmt.erase();
+        let (nid, fidx) = first_span_field(&erased).expect("span field");
+
+        let frames = erased.traceback(nid, fidx);
+        // Arg-segment drill collapses the macro frame: the innermost frame
+        // is the user's authored arg text in the original source.
+        assert_eq!(
+            frames.len(),
+            1,
+            "span in substituted arg collapses to a single root frame"
+        );
+        assert_eq!(frames[0].name, None, "root frame after drill");
+        assert_eq!(frames[0].snippet, source);
+        let off = frames[0].offset_in_snippet;
+        let end = off + "authored".len();
+        assert_eq!(&source[off..end], "authored");
+    }
 }

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -825,10 +825,10 @@ mod tests {
             ParseOutcome::Done => panic!("expected statement"),
             ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
         };
-        let erased = stmt.erase();
+        let mut erased = stmt.erase();
         let (nid, fidx) = first_span_field(&erased).expect("span field");
 
-        let frames = erased.traceback(nid, fidx);
+        let frames: Vec<_> = erased.traceback(nid, fidx).collect();
         assert_eq!(frames.len(), 1, "macro-free span → single root frame");
         let f = &frames[0];
         assert_eq!(f.name, None, "root frame has no macro name");
@@ -849,10 +849,10 @@ mod tests {
             ParseOutcome::Done => panic!("expected statement"),
             ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
         };
-        let erased = stmt.erase();
+        let mut erased = stmt.erase();
         let (nid, fidx) = first_span_field(&erased).expect("span field");
 
-        let frames = erased.traceback(nid, fidx);
+        let frames: Vec<_> = erased.traceback(nid, fidx).collect();
         assert_eq!(
             frames.len(),
             2,
@@ -878,10 +878,10 @@ mod tests {
             ParseOutcome::Done => panic!("expected statement"),
             ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
         };
-        let erased = stmt.erase();
+        let mut erased = stmt.erase();
         let (nid, fidx) = first_span_field(&erased).expect("span field");
 
-        let frames = erased.traceback(nid, fidx);
+        let frames: Vec<_> = erased.traceback(nid, fidx).collect();
         // Arg-segment drill collapses the macro frame: the innermost frame
         // is the user's authored arg text in the original source.
         assert_eq!(

--- a/syntaqlite-syntax/src/parser/types.rs
+++ b/syntaqlite-syntax/src/parser/types.rs
@@ -225,22 +225,33 @@ impl MacroRegion {
 
 /// One frame in a macro expansion traceback.
 ///
-/// Each frame describes a position inside a particular buffer.  Frame 0
-/// is the outermost (the call site in the original source), and the last
-/// frame is the innermost (the position inside the deepest expansion
-/// buffer).
+/// Each frame describes a position inside either the original authored
+/// source (root frame, `name` is `None`) or a macro expansion layer
+/// (inner frame, `name` carries the macro name).
 ///
-/// Returned by
-/// [`super::AnyParsedStatement::field_expansion_traceback`].
+/// Frame 0 is the outermost — the root frame if the span originates in a
+/// macro, or the only frame for a macro-free span. The last frame is the
+/// innermost position along the expansion chain.
+///
+/// `snippet` is the buffer to render the caret against, and
+/// `offset_in_snippet` is the byte offset within that snippet.
+///
+/// Returned by [`super::AnyParsedStatement::traceback`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ExpansionFrame<'a> {
-    /// The buffer text — the original source for the outermost frame, or
-    /// an expansion buffer for inner frames.
-    pub buffer: &'a str,
-    /// Byte offset of this frame's span within `buffer`.
-    pub offset: usize,
-    /// Byte length of this frame's span within `buffer`.
-    pub length: usize,
+pub struct TracebackFrame<'a> {
+    /// Frame name — `None` for the root source frame, `Some("foo")` for a
+    /// macro expansion frame from `CREATE PERFETTO MACRO foo …`.
+    pub name: Option<&'a str>,
+    /// 1-based line number of `offset_in_snippet` within `snippet`.
+    pub line: u32,
+    /// 1-based column number of `offset_in_snippet` within `snippet`.
+    pub col: u32,
+    /// Buffer to render the caret against.
+    pub snippet: &'a str,
+    /// Byte offset of the frame's position within `snippet`.
+    pub offset_in_snippet: usize,
+    /// Byte length of the frame's position within `snippet`.
+    pub length_in_snippet: usize,
 }
 
 /// Parser's best guess about what kind of token fits next.

--- a/syntaqlite-syntax/src/parser/types.rs
+++ b/syntaqlite-syntax/src/parser/types.rs
@@ -223,15 +223,14 @@ impl MacroRegion {
     }
 }
 
-/// One frame in a macro expansion traceback.
+/// One frame in a span traceback.
 ///
 /// Each frame describes a position inside either the original authored
 /// source (root frame, `name` is `None`) or a macro expansion layer
 /// (inner frame, `name` carries the macro name).
 ///
-/// Frame 0 is the outermost — the root frame if the span originates in a
-/// macro, or the only frame for a macro-free span. The last frame is the
-/// innermost position along the expansion chain.
+/// Frame 0 is the outermost (root source); the last frame is the
+/// innermost expansion layer.
 ///
 /// `snippet` is the buffer to render the caret against, and
 /// `offset_in_snippet` is the byte offset within that snippet.
@@ -239,8 +238,9 @@ impl MacroRegion {
 /// Returned by [`super::AnyParsedStatement::traceback`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TracebackFrame<'a> {
-    /// Frame name — `None` for the root source frame, `Some("foo")` for a
-    /// macro expansion frame from `CREATE PERFETTO MACRO foo …`.
+    /// Frame name — `None` for the root source frame, or `Some(name)`
+    /// for a macro expansion frame, where `name` is the macro's
+    /// registered name.
     pub name: Option<&'a str>,
     /// 1-based line number of `offset_in_snippet` within `snippet`.
     pub line: u32,

--- a/syntaqlite/src/semantic/analyzer.rs
+++ b/syntaqlite/src/semantic/analyzer.rs
@@ -334,9 +334,9 @@ impl SemanticAnalyzer {
             // The erased statement borrows the session, so we must extract
             // owned macro data before dropping it and calling register_macro.
             let (stmt_model, macro_reg) = {
-                let erased = stmt.erase();
+                let mut erased = stmt.erase();
                 let model = self.analyze_statement(
-                    &erased,
+                    &mut erased,
                     config,
                     &mut resolutions,
                     &mut definition_offsets,
@@ -370,7 +370,7 @@ impl SemanticAnalyzer {
 
     fn analyze_statement(
         &mut self,
-        erased: &AnyParsedStatement<'_>,
+        erased: &mut AnyParsedStatement<'_>,
         config: &ValidationConfig,
         resolutions: &mut Vec<Resolution>,
         definition_offsets: &mut HashMap<String, (usize, usize)>,
@@ -1014,7 +1014,7 @@ impl<'a> ValidationPass<'a> {
     /// determined entirely by the check level — callers do not specify it.
     fn emit(
         &mut self,
-        stmt: &AnyParsedStatement<'a>,
+        stmt: &mut AnyParsedStatement<'_>,
         node_id: AnyNodeId,
         field_idx: u8,
         source: SourceRange,
@@ -1026,7 +1026,6 @@ impl<'a> ValidationPass<'a> {
         };
         let frames = stmt
             .traceback(node_id, field_idx)
-            .into_iter()
             .map(|f| crate::semantic::diagnostics::DiagnosticFrame {
                 buffer: f.snippet.to_string(),
                 start: f.offset_in_snippet,
@@ -1068,8 +1067,8 @@ impl<'a> ValidationPass<'a> {
     }
 
     #[expect(clippy::too_many_arguments)]
-    fn run(
-        stmt: &AnyParsedStatement<'a>,
+    fn run<'b>(
+        stmt: &mut AnyParsedStatement<'b>,
         root: AnyNodeId,
         dialect: &AnyDialect,
         catalog: &'a mut Catalog,
@@ -1093,7 +1092,7 @@ impl<'a> ValidationPass<'a> {
 
     // ── Core visitor ─────────────────────────────────────────────────────────
 
-    fn visit(&mut self, stmt: &AnyParsedStatement<'a>, node_id: AnyNodeId) {
+    fn visit(&mut self, stmt: &mut AnyParsedStatement<'_>, node_id: AnyNodeId) {
         if node_id.is_null() {
             return;
         }
@@ -1187,8 +1186,11 @@ impl<'a> ValidationPass<'a> {
         }
     }
 
-    fn visit_children(&mut self, stmt: &AnyParsedStatement<'a>, node_id: AnyNodeId) {
-        for child in stmt.child_node_ids(node_id) {
+    fn visit_children(&mut self, stmt: &mut AnyParsedStatement<'_>, node_id: AnyNodeId) {
+        // Collect child IDs up front so the iterator's borrow on stmt is
+        // dropped before the recursive `&mut` visits.
+        let children: Vec<AnyNodeId> = stmt.child_node_ids(node_id).collect();
+        for child in children {
             if !child.is_null() {
                 self.visit(stmt, child);
             }
@@ -1204,7 +1206,7 @@ impl<'a> ValidationPass<'a> {
         }
     }
 
-    fn visit_opt(&mut self, stmt: &AnyParsedStatement<'a>, id: Option<AnyNodeId>) {
+    fn visit_opt(&mut self, stmt: &mut AnyParsedStatement<'_>, id: Option<AnyNodeId>) {
         if let Some(id) = id {
             self.visit(stmt, id);
         }
@@ -1214,10 +1216,10 @@ impl<'a> ValidationPass<'a> {
     /// (`IdentName` or `Error`).  Both node kinds store their span at field 0.
     /// Returns `(text, source_start, source_end)`.  For spans inside a macro
     /// expansion, the source range points at the macro call site.
-    fn name_text(
-        stmt: &AnyParsedStatement<'a>,
+    fn name_text<'b>(
+        stmt: &AnyParsedStatement<'b>,
         node_id: Option<AnyNodeId>,
-    ) -> (&'a str, usize, usize) {
+    ) -> (&'b str, usize, usize) {
         let Some(node_id) = node_id else {
             return ("", 0, 0);
         };
@@ -1237,11 +1239,11 @@ impl<'a> ValidationPass<'a> {
 
     // ── Role handlers ─────────────────────────────────────────────────────────
 
-    fn visit_source_ref(
+    fn visit_source_ref<'b>(
         &mut self,
-        stmt: &AnyParsedStatement<'a>,
+        stmt: &mut AnyParsedStatement<'b>,
         node_id: AnyNodeId,
-        fields: &NodeFields<'a>,
+        fields: &NodeFields<'b>,
         name_idx: u8,
         alias_idx: u8,
     ) {
@@ -1312,11 +1314,11 @@ impl<'a> ValidationPass<'a> {
             .add_table(scope_name, columns, without_rowid.into());
     }
 
-    fn visit_call(
+    fn visit_call<'b>(
         &mut self,
-        stmt: &AnyParsedStatement<'a>,
+        stmt: &mut AnyParsedStatement<'b>,
         node_id: AnyNodeId,
-        fields: &NodeFields<'a>,
+        fields: &NodeFields<'b>,
         name_idx: u8,
         args_idx: u8,
     ) {
@@ -1385,11 +1387,11 @@ impl<'a> ValidationPass<'a> {
         self.visit_children(stmt, node_id);
     }
 
-    fn visit_column_ref(
+    fn visit_column_ref<'b>(
         &mut self,
-        stmt: &AnyParsedStatement<'a>,
+        stmt: &mut AnyParsedStatement<'b>,
         node_id: AnyNodeId,
-        fields: &NodeFields<'a>,
+        fields: &NodeFields<'b>,
         column_idx: u8,
         table_idx: u8,
     ) {
@@ -1499,10 +1501,10 @@ impl<'a> ValidationPass<'a> {
         }
     }
 
-    fn visit_scoped_source(
+    fn visit_scoped_source<'b>(
         &mut self,
-        stmt: &AnyParsedStatement<'a>,
-        fields: &NodeFields<'a>,
+        stmt: &mut AnyParsedStatement<'b>,
+        fields: &NodeFields<'b>,
         body_idx: u8,
         alias_idx: u8,
     ) {
@@ -1521,10 +1523,10 @@ impl<'a> ValidationPass<'a> {
     }
 
     #[expect(clippy::too_many_arguments)]
-    fn visit_query(
+    fn visit_query<'b>(
         &mut self,
-        stmt: &AnyParsedStatement<'a>,
-        fields: &NodeFields<'a>,
+        stmt: &mut AnyParsedStatement<'b>,
+        fields: &NodeFields<'b>,
         from: u8,
         columns: u8,
         where_clause: u8,
@@ -1557,10 +1559,10 @@ impl<'a> ValidationPass<'a> {
     }
 
     /// Extract alias names from the SELECT result column list.
-    fn collect_select_aliases(
+    fn collect_select_aliases<'b>(
         &self,
-        stmt: &AnyParsedStatement<'a>,
-        fields: &NodeFields<'a>,
+        stmt: &mut AnyParsedStatement<'b>,
+        fields: &NodeFields<'b>,
         columns_idx: u8,
     ) -> Vec<String> {
         let mut aliases = Vec::new();
@@ -1597,10 +1599,10 @@ impl<'a> ValidationPass<'a> {
         aliases
     }
 
-    fn visit_cte_scope(
+    fn visit_cte_scope<'b>(
         &mut self,
-        stmt: &AnyParsedStatement<'a>,
-        fields: &NodeFields<'a>,
+        stmt: &mut AnyParsedStatement<'b>,
+        fields: &NodeFields<'b>,
         recursive_idx: u8,
         bindings_idx: u8,
         body_idx: u8,
@@ -1679,7 +1681,7 @@ impl<'a> ValidationPass<'a> {
     /// alias names `a` and `b` so go-to-definition can jump to them.
     fn record_select_column_offsets(
         &mut self,
-        stmt: &AnyParsedStatement<'a>,
+        stmt: &mut AnyParsedStatement<'_>,
         body_id: Option<AnyNodeId>,
         table_key: &str,
     ) {
@@ -1729,11 +1731,11 @@ impl<'a> ValidationPass<'a> {
     }
 
     /// Extract CTE binding info from a node, or `None` if it's not a CTE.
-    fn extract_cte_binding(
+    fn extract_cte_binding<'b>(
         &self,
-        stmt: &AnyParsedStatement<'a>,
+        stmt: &mut AnyParsedStatement<'b>,
         cte_id: AnyNodeId,
-    ) -> Option<CteBindingInfo<'a>> {
+    ) -> Option<CteBindingInfo<'b>> {
         if cte_id.is_null() {
             return None;
         }
@@ -1769,17 +1771,17 @@ impl<'a> ValidationPass<'a> {
     }
 
     /// Extract declared CTE column names from the column list field.
-    fn extract_declared_cols(
-        stmt: &AnyParsedStatement<'a>,
-        fields: &NodeFields<'a>,
+    fn extract_declared_cols<'b>(
+        stmt: &mut AnyParsedStatement<'b>,
+        fields: &NodeFields<'b>,
         cols_idx: u8,
-    ) -> Option<Vec<(&'a str, usize, usize)>> {
+    ) -> Option<Vec<(&'b str, usize, usize)>> {
         if cols_idx == FIELD_ABSENT {
             return None;
         }
         let list_id = Self::field_node_id(fields, cols_idx)?;
         let children = stmt.list_children(list_id)?;
-        let names: Vec<(&'a str, usize, usize)> = children
+        let names: Vec<(&'b str, usize, usize)> = children
             .iter()
             .copied()
             .filter(|id| !id.is_null())
@@ -1792,7 +1794,7 @@ impl<'a> ValidationPass<'a> {
     /// Emit a diagnostic if the CTE body has a different column count than declared.
     fn check_cte_column_count(
         &mut self,
-        stmt: &AnyParsedStatement<'a>,
+        stmt: &mut AnyParsedStatement<'_>,
         cte_name: &str,
         cte_name_range: (usize, usize),
         declared: &[&str],
@@ -1822,7 +1824,7 @@ impl<'a> ValidationPass<'a> {
     /// column uses `*` (wildcard), which would require catalog expansion to count.
     fn count_result_columns(
         &self,
-        stmt: &AnyParsedStatement<'a>,
+        stmt: &mut AnyParsedStatement<'_>,
         body_id: Option<AnyNodeId>,
     ) -> Option<usize> {
         let body_id = body_id?;
@@ -1874,10 +1876,10 @@ impl<'a> ValidationPass<'a> {
         Some(count)
     }
 
-    fn visit_trigger_scope(
+    fn visit_trigger_scope<'b>(
         &mut self,
-        stmt: &AnyParsedStatement<'a>,
-        fields: &NodeFields<'a>,
+        stmt: &mut AnyParsedStatement<'b>,
+        fields: &NodeFields<'b>,
         when_idx: u8,
         body_idx: u8,
     ) {

--- a/syntaqlite/src/semantic/analyzer.rs
+++ b/syntaqlite/src/semantic/analyzer.rs
@@ -1025,12 +1025,12 @@ impl<'a> ValidationPass<'a> {
             return;
         };
         let frames = stmt
-            .field_expansion_traceback(node_id, field_idx)
+            .traceback(node_id, field_idx)
             .into_iter()
             .map(|f| crate::semantic::diagnostics::DiagnosticFrame {
-                buffer: f.buffer.to_string(),
-                start: f.offset,
-                end: f.offset + f.length,
+                buffer: f.snippet.to_string(),
+                start: f.offset_in_snippet,
+                end: f.offset_in_snippet + f.length_in_snippet,
             })
             .collect::<Vec<_>>();
         // Only attach if there's actual expansion (more than 1 frame).

--- a/syntaqlite/src/semantic/analyzer.rs
+++ b/syntaqlite/src/semantic/analyzer.rs
@@ -1187,10 +1187,9 @@ impl<'a> ValidationPass<'a> {
     }
 
     fn visit_children(&mut self, stmt: &mut AnyParsedStatement<'_>, node_id: AnyNodeId) {
-        // Collect child IDs up front so the iterator's borrow on stmt is
-        // dropped before the recursive `&mut` visits.
-        let children: Vec<AnyNodeId> = stmt.child_node_ids(node_id).collect();
-        for child in children {
+        // `child_node_ids` owns its data (no borrow on `stmt`), so we
+        // can hold it while recursively `&mut`-borrowing `stmt`.
+        for child in stmt.child_node_ids(node_id) {
             if !child.is_null() {
                 self.visit(stmt, child);
             }

--- a/tests/amalg_tests/perfetto.py
+++ b/tests/amalg_tests/perfetto.py
@@ -44,6 +44,7 @@ class PerfettoExtension(TestSuite):
                   orderby: (none)
                   limit_clause: (none)
                   window_clause: (none)
+              select_span: "SELECT 1"
 """,
         )
 
@@ -75,6 +76,7 @@ class PerfettoExtension(TestSuite):
                   orderby: (none)
                   limit_clause: (none)
                   window_clause: (none)
+              select_span: "SELECT 1"
 """,
         )
 
@@ -108,6 +110,7 @@ class PerfettoExtension(TestSuite):
                   orderby: (none)
                   limit_clause: (none)
                   window_clause: (none)
+              select_span: "SELECT 1"
 """,
         )
 
@@ -153,6 +156,7 @@ class PerfettoExtension(TestSuite):
                   orderby: (none)
                   limit_clause: (none)
                   window_clause: (none)
+              select_span: "SELECT 1"
 """,
         )
 
@@ -189,6 +193,43 @@ class PerfettoExtension(TestSuite):
                   orderby: (none)
                   limit_clause: (none)
                   window_clause: (none)
+              select_span: "SELECT 42"
+""",
+        )
+
+    def test_create_perfetto_table_select_span_leading_ws(self):
+        """select_span must exclude leading/trailing whitespace around the
+        body, demonstrating that the BEFORE marker captures the start of
+        the first real token (not the end of `AS`) and the AFTER marker
+        captures the end of the last real token (not the start of `;`).
+        """
+        return DiffTestBlueprint(
+            sql="CREATE PERFETTO TABLE foo AS    SELECT 1   ",
+            out="""\
+            CreatePerfettoTableStmt
+              table_name: "foo"
+              or_replace: FALSE
+              schema: (none)
+              select:
+                SelectStmt
+                  flags: (none)
+                  columns:
+                    ResultColumnList [1 items]
+                      ResultColumn
+                        flags: (none)
+                        alias: (none)
+                        expr:
+                          Literal
+                            literal_type: INTEGER
+                            source: "1"
+                  from_clause: (none)
+                  where_clause: (none)
+                  groupby: (none)
+                  having: (none)
+                  orderby: (none)
+                  limit_clause: (none)
+                  window_clause: (none)
+              select_span: "SELECT 1"
 """,
         )
 

--- a/tests/amalg_tests/perfetto_dialect_only.py
+++ b/tests/amalg_tests/perfetto_dialect_only.py
@@ -68,5 +68,6 @@ class PerfettoAmalgDialectOnly(TestSuite):
                   orderby: (none)
                   limit_clause: (none)
                   window_clause: (none)
+              select_span: "SELECT 1"
 """,
         )

--- a/tests/perfetto_validation_diff_tests/perfetto.py
+++ b/tests/perfetto_validation_diff_tests/perfetto.py
@@ -58,14 +58,16 @@ class PerfettoFunctionValidation(TestSuite):
 
 
 class MacroExpansionSpanRegression(TestSuite):
-    def test_macro_expansion_unknown_column(self):
-        """Macro expansion (#84): a column reference produced inside a macro
-        expansion should report "unknown column 'a'".  The primary span
-        drills through the macro's `$name` arg segment to the user's
-        authored arg text `a` in the original source (argument-level
+    def test_macro_expansion_unknown_column_in_substituted_arg(self):
+        """Macro expansion (#84): a column reference produced from a `$param`
+        substitution should drill through the arg segment back to the
+        user's authored arg text in the original source (argument-level
         fidelity, per the text-expansion-model plan's success criterion
-        #5), and a traceback frame shows the corresponding position
-        inside the expansion buffer.
+        #5).  Because the span lies fully inside a substituted arg, the
+        new `traceback` API collapses the macro frame — the span's
+        provenance at every level in the chain is the arg origin in
+        user source — so the rendered diagnostic shows only the primary
+        span with no "in macro expansion" note.
         """
         return DiffTestBlueprint(
             sql="CREATE PERFETTO MACRO _d(name ColumnName) RETURNS Expr AS $name;\nSELECT _d!(a);",
@@ -73,12 +75,30 @@ class MacroExpansionSpanRegression(TestSuite):
  --> <stdin>:2:12
   |
 2 | SELECT _d!(a);
-  |            ^
+  |            ^""",
+        )
+
+    def test_macro_expansion_unknown_column_in_macro_body(self):
+        """Dual of the arg-substitution case: when the unresolved reference
+        is authored *in the macro body itself* (not in a `$param`
+        substitution), the traceback does not drill — the span's
+        authored provenance collapses to the `m!()` call site in user
+        source, and a "note: in macro expansion" frame shows the
+        position inside the expanded body.  This guards the
+        multi-frame traceback rendering path.
+        """
+        return DiffTestBlueprint(
+            sql="CREATE PERFETTO MACRO m() RETURNS Expr AS unknown_col;\nSELECT m!();",
+            out="""warning: unknown column 'unknown_col'
+ --> <stdin>:2:8
+  |
+2 | SELECT m!();
+  |        ^~~~
 note: in macro expansion
  --> <macro expansion>:1:1
   |
-1 | a
-  | ^""",
+1 | unknown_col
+  | ^~~~~~~~~~~""",
         )
 
 

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -908,13 +908,13 @@ pub fn syntaqlite_syntax::any::AnyNodeTag::from_raw(v: u32) -> Self
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::child_node_ids(&self, id: syntaqlite_syntax::any::AnyNodeId) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::AnyNodeId> + '_
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::comment_spans(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::CommentSpan> + use<'_>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::extract_fields(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(syntaqlite_syntax::any::AnyNodeTag, syntaqlite_syntax::any::NodeFields<'a>)>
-pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::field_expansion_traceback(&self, node_id: syntaqlite_syntax::any::AnyNodeId, field_idx: u8) -> alloc::vec::Vec<syntaqlite_syntax::any::ExpansionFrame<'a>>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::list_children(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a [syntaqlite_syntax::any::AnyNodeId]>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::macro_regions(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRegion> + use<'_>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_id(&self) -> syntaqlite_syntax::any::AnyNodeId
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_node(&self) -> core::option::Option<syntaqlite_syntax::any::AnyNode<'_>>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::source(&self) -> &'a str
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::token_spans(&self) -> impl core::iter::traits::iterator::Iterator<Item = (u32, u32)> + use<'_>
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::traceback(&self, node_id: syntaqlite_syntax::any::AnyNodeId, field_idx: u8) -> alloc::vec::Vec<syntaqlite_syntax::any::TracebackFrame<'a>>
 pub fn syntaqlite_syntax::any::AnyTokenType::from(t: syntaqlite_syntax::TokenType) -> syntaqlite_syntax::any::AnyTokenType
 pub fn syntaqlite_syntax::any::AnyTokenType::from_raw(v: u32) -> Self
 pub fn syntaqlite_syntax::any::AnyTokenType::from_token_type(raw: syntaqlite_syntax::any::AnyTokenType) -> core::option::Option<Self>
@@ -1679,12 +1679,12 @@ pub struct syntaqlite_syntax::ParserTokenFlags(_)
 pub struct syntaqlite_syntax::any::AnyDialect
 pub struct syntaqlite_syntax::any::AnyNode<'a>
 pub struct syntaqlite_syntax::any::AnyParsedStatement<'a>
-pub struct syntaqlite_syntax::any::ExpansionFrame<'a>
 pub struct syntaqlite_syntax::any::FieldMeta<'a>(_)
 pub struct syntaqlite_syntax::any::KeywordEntry
 pub struct syntaqlite_syntax::any::MacroRegion
 pub struct syntaqlite_syntax::any::NodeFields<'a>
 pub struct syntaqlite_syntax::any::SourceRange
+pub struct syntaqlite_syntax::any::TracebackFrame<'a>
 pub struct syntaqlite_syntax::nodes::AggregateFunctionCall<'a>
 pub struct syntaqlite_syntax::nodes::AggregateFunctionCallId(_)
 pub struct syntaqlite_syntax::nodes::AlterTableStmt<'a>
@@ -2043,9 +2043,6 @@ pub syntaqlite_syntax::TokenType::Window = 167
 pub syntaqlite_syntax::TokenType::With = 69
 pub syntaqlite_syntax::TokenType::Within = 86
 pub syntaqlite_syntax::TokenType::Without = 70
-pub syntaqlite_syntax::any::ExpansionFrame::buffer: &'a str
-pub syntaqlite_syntax::any::ExpansionFrame::length: usize
-pub syntaqlite_syntax::any::ExpansionFrame::offset: usize
 pub syntaqlite_syntax::any::FieldKind::Bool = 2
 pub syntaqlite_syntax::any::FieldKind::Enum = 4
 pub syntaqlite_syntax::any::FieldKind::Flags = 3
@@ -2075,6 +2072,12 @@ pub syntaqlite_syntax::any::TokenCategory::Parameter
 pub syntaqlite_syntax::any::TokenCategory::Punctuation
 pub syntaqlite_syntax::any::TokenCategory::String
 pub syntaqlite_syntax::any::TokenCategory::Type
+pub syntaqlite_syntax::any::TracebackFrame::col: u32
+pub syntaqlite_syntax::any::TracebackFrame::length_in_snippet: usize
+pub syntaqlite_syntax::any::TracebackFrame::line: u32
+pub syntaqlite_syntax::any::TracebackFrame::name: core::option::Option<&'a str>
+pub syntaqlite_syntax::any::TracebackFrame::offset_in_snippet: usize
+pub syntaqlite_syntax::any::TracebackFrame::snippet: &'a str
 pub syntaqlite_syntax::nodes::AlterOp::AddColumn = 3
 pub syntaqlite_syntax::nodes::AlterOp::DropColumn = 2
 pub syntaqlite_syntax::nodes::AlterOp::RenameColumn = 1

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -914,7 +914,7 @@ pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_id(&self) -> syntaql
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_node(&self) -> core::option::Option<syntaqlite_syntax::any::AnyNode<'_>>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::source(&self) -> &'a str
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::token_spans(&self) -> impl core::iter::traits::iterator::Iterator<Item = (u32, u32)> + use<'_>
-pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::traceback(&self, node_id: syntaqlite_syntax::any::AnyNodeId, field_idx: u8) -> alloc::vec::Vec<syntaqlite_syntax::any::TracebackFrame<'a>>
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::traceback(&mut self, node_id: syntaqlite_syntax::any::AnyNodeId, field_idx: u8) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::TracebackFrame<'a>> + use<'_, 'a>
 pub fn syntaqlite_syntax::any::AnyTokenType::from(t: syntaqlite_syntax::TokenType) -> syntaqlite_syntax::any::AnyTokenType
 pub fn syntaqlite_syntax::any::AnyTokenType::from_raw(v: u32) -> Self
 pub fn syntaqlite_syntax::any::AnyTokenType::from_token_type(raw: syntaqlite_syntax::any::AnyTokenType) -> core::option::Option<Self>


### PR DESCRIPTION
## Motivation

Stacked on top of #90. Implements the next chunk of the text-expansion-model plan: Steps 7 (new `traceback` API with arg-segment drilling), 13 (delete the old `expansion_traceback` API), and a reshaped Step 8 that abandons the planned generalized `subtree_text` in favor of a targeted grammar-annotation mechanism for the specific Perfetto use case (issue #89).

Steps 9 and 10 are dropped entirely — they only existed to support the generalized subtree abstraction, which doesn't actually solve the real use cases.

## Changes

### Step 7 — new `traceback` API with arg-segment drilling
- New C struct `SyntaqliteTracebackFrame` (`name` / `line` / `col` / `snippet` / `offset_in_snippet` / `length_in_snippet`) and `syntaqlite_parser_traceback` function in `parser_macros.c`.
- New Rust `TracebackFrame<'a>` public type and `AnyParsedStatement::traceback(node_id, field_idx)` method.
- Drill-through: when a span's position lies inside a `SynqArgSegment`, the walk jumps to the arg's origin layer *without* emitting a frame for the macro layer. The innermost frame always points at the user's authored arg text — success criterion #5 from the plan.
- Validator's `emit()` migrated to the new API.
- Three new unit tests in `session.rs`: macro-free single frame, macro-body two frames, substituted arg drill to origin.

### Step 13 — delete old `expansion_traceback` API
- Removed `syntaqlite_parser_expansion_traceback`, `SyntaqliteExpansionFrame`, `ExpansionFrame<'a>`, `field_expansion_traceback`, `CExpansionFrame` FFI mirror, and the corresponding extern declarations.
- Perfetto `MacroExpansionSpanRegression` diff test split into two cases:
  - **arg-drill case** (`_d!(a)` where body is `$name`): single root frame, no "in macro expansion" note — the drill collapses through to the authored arg.
  - **macro-body case** (`m!()` where body contains a literal unknown ident): two frames, exercising the multi-frame render path.

### Step 8 reshape — targeted `select_span` field instead of generalized `subtree_text`
Original plan: lazy per-node extent cache with a `subtree_text(any node)` API. After prototyping and discussion, this was dropped:
1. Field-span-based extents miss leading keywords (`SELECT`, `FROM`, etc.) because those tokens have no AST representation — `subtree_text(root)` returned `"foo FROM bar"` instead of `"SELECT foo FROM bar"`.
2. Perfetto's actual use case (issue #89) is a *specific* grammar rule, not every node.
3. The formatter's `try_macro_verbatim` doesn't benefit from a subtree accessor — its existing `MacroRegion` + peek-next-token approach is correct.

New targeted mechanism:
- Added two fields on `SynqParseCtx`: `cur_shift_start` (set at the *start* of `record_and_feed` before `feed_one_token`, so BEFORE-style empty-rule reductions see the offset of the token currently being processed) and `last_shifted_end` (set *after* `feed_one_token` returns, so AFTER-style reductions see the end of the previously shifted terminal). Both are only tracked for tokens shifted from the root source layer.
- Added empty-marker rules `select_body_start ::= .` and `select_body_end ::= .` in `perfetto.y`, bracketing the `select(E)` sub-rule in `CREATE PERFETTO TABLE/VIEW/FUNCTION ... AS select`.
- Added `select_span: inline SyntaqliteSourceSpan` field to `CreatePerfettoTableStmt`, `CreatePerfettoViewStmt`, and `CreatePerfettoFunctionStmt`. Populated explicitly in the `cmd` grammar actions from `BS` and `BE`.
- Consumers read `select_span` like any other span and use `span_text_range(select_span)` / `span_text(select_span)` to get the authored byte range / slice. The span excludes leading/trailing whitespace around the body.
- Perfetto `perfetto_macro_body` already produced a `SynqParseToken` with `.z`/`.n` merged across ANY-wildcard tokens, which lands as a `body` span via the existing `synq_span(pCtx, BODY)` conversion — **no change needed** for the macro body case.

New amalg test `test_create_perfetto_table_select_span_leading_ws` explicitly verifies whitespace trimming: `"CREATE PERFETTO TABLE foo AS    SELECT 1   "` produces `select_span: "SELECT 1"`.

## Test plan
- [x] `tools/pre-push --fix -q` passes
- [x] `cargo test -p syntaqlite-syntax --lib traceback_` — 3 new traceback tests
- [x] `tools/run-integration-tests --suite amalg` — 24 tests green (existing + new multiline-trim test)
- [x] `tools/run-integration-tests --suite perfetto-val` — 8 tests green (existing + new macro-body traceback case)
- [x] Public API snapshot regenerated (`ExpansionFrame` removed, `TracebackFrame` added)