### PR TITLE
synq: align Rust span API 1:1 with C (TextSpan, FieldValue::Span newtype)

### DIFF
--- a/dialects/perfetto/actions/perfetto.y
+++ b/dialects/perfetto/actions/perfetto.y
@@ -146,7 +146,7 @@ select_body_end(A) ::= . { A = pCtx->last_shifted_end; }
 
 cmd(A) ::= CREATE perfetto_or_replace(R) PERFETTO TABLE nm(N)
            perfetto_table_schema(S) AS select_body_start(BS) select(E) select_body_end(BE). {
-    SyntaqliteSourceSpan select_span = {
+    SyntaqliteTextSpan select_span = {
         BS,
         (uint16_t)(BE - BS),
         0,
@@ -162,7 +162,7 @@ cmd(A) ::= CREATE perfetto_or_replace(R) PERFETTO TABLE nm(N)
 
 cmd(A) ::= CREATE perfetto_or_replace(R) PERFETTO VIEW nm(N)
            perfetto_table_schema(S) AS select_body_start(BS) select(E) select_body_end(BE). {
-    SyntaqliteSourceSpan select_span = {
+    SyntaqliteTextSpan select_span = {
         BS,
         (uint16_t)(BE - BS),
         0,
@@ -179,7 +179,7 @@ cmd(A) ::= CREATE perfetto_or_replace(R) PERFETTO VIEW nm(N)
 cmd(A) ::= CREATE perfetto_or_replace(R) PERFETTO FUNCTION nm(N) LP
            perfetto_arg_def_list(ARGS) RP RETURNS perfetto_return_type(RT)
            AS select_body_start(BS) select(E) select_body_end(BE). {
-    SyntaqliteSourceSpan select_span = {
+    SyntaqliteTextSpan select_span = {
         BS,
         (uint16_t)(BE - BS),
         0,

--- a/dialects/perfetto/nodes/perfetto.synq
+++ b/dialects/perfetto/nodes/perfetto.synq
@@ -1,6 +1,6 @@
 node PerfettoArgDef {
   arg_name: index Name
-  arg_type: inline SyntaqliteSourceSpan
+  arg_type: inline SyntaqliteTextSpan
   is_variadic: inline Bool
 
   semantic { column_def(name: arg_name, type: arg_type) }
@@ -17,8 +17,8 @@ list PerfettoArgDefList {
 }
 
 node PerfettoMacroArg {
-  arg_name: inline SyntaqliteSourceSpan
-  arg_type: inline SyntaqliteSourceSpan
+  arg_name: inline SyntaqliteTextSpan
+  arg_type: inline SyntaqliteTextSpan
 
   fmt {
     span(arg_name) " " span(arg_type)
@@ -31,7 +31,7 @@ list PerfettoMacroArgList {
 }
 
 node PerfettoIndexedColumn {
-  column_name: inline SyntaqliteSourceSpan
+  column_name: inline SyntaqliteTextSpan
 
   fmt { span(column_name) }
 }
@@ -45,7 +45,7 @@ enum PerfettoReturnKind { SCALAR TABLE }
 
 node PerfettoReturnType {
   kind: inline PerfettoReturnKind
-  scalar_type: inline SyntaqliteSourceSpan
+  scalar_type: inline SyntaqliteTextSpan
   table_columns: index PerfettoArgDefList
 
   semantic { return_spec(table_columns: table_columns) }
@@ -68,11 +68,11 @@ node PerfettoReturnType {
 }
 
 node CreatePerfettoTableStmt {
-  table_name: inline SyntaqliteSourceSpan
+  table_name: inline SyntaqliteTextSpan
   or_replace: inline Bool
   schema: index PerfettoArgDefList
   select: index Select
-  select_span: inline SyntaqliteSourceSpan
+  select_span: inline SyntaqliteTextSpan
 
   semantic { define_table(name: table_name, columns: schema, select: select) }
 
@@ -96,11 +96,11 @@ node CreatePerfettoTableStmt {
 }
 
 node CreatePerfettoViewStmt {
-  view_name: inline SyntaqliteSourceSpan
+  view_name: inline SyntaqliteTextSpan
   or_replace: inline Bool
   schema: index PerfettoArgDefList
   select: index Select
-  select_span: inline SyntaqliteSourceSpan
+  select_span: inline SyntaqliteTextSpan
 
   semantic { define_view(name: view_name, columns: schema, select: select) }
 
@@ -124,12 +124,12 @@ node CreatePerfettoViewStmt {
 }
 
 node CreatePerfettoFunctionStmt {
-  function_name: inline SyntaqliteSourceSpan
+  function_name: inline SyntaqliteTextSpan
   or_replace: inline Bool
   args: index PerfettoArgDefList
   return_type: index PerfettoReturnType
   select: index Select
-  select_span: inline SyntaqliteSourceSpan
+  select_span: inline SyntaqliteTextSpan
 
   semantic { define_function(name: function_name, args: args, return_type: return_type, select: select) }
 
@@ -155,11 +155,11 @@ node CreatePerfettoFunctionStmt {
 }
 
 node CreatePerfettoDelegatingFunctionStmt {
-  function_name: inline SyntaqliteSourceSpan
+  function_name: inline SyntaqliteTextSpan
   or_replace: inline Bool
   args: index PerfettoArgDefList
   return_type: index PerfettoReturnType
-  delegate_to: inline SyntaqliteSourceSpan
+  delegate_to: inline SyntaqliteTextSpan
 
   fmt {
     group {
@@ -182,9 +182,9 @@ node CreatePerfettoDelegatingFunctionStmt {
 }
 
 node CreatePerfettoIndexStmt {
-  index_name: inline SyntaqliteSourceSpan
+  index_name: inline SyntaqliteTextSpan
   or_replace: inline Bool
-  table_name: inline SyntaqliteSourceSpan
+  table_name: inline SyntaqliteTextSpan
   columns: index PerfettoIndexedColumnList
 
   fmt {
@@ -204,10 +204,10 @@ node CreatePerfettoIndexStmt {
 }
 
 node CreatePerfettoMacroStmt {
-  macro_name: inline SyntaqliteSourceSpan
+  macro_name: inline SyntaqliteTextSpan
   or_replace: inline Bool
-  return_type: inline SyntaqliteSourceSpan
-  body: inline SyntaqliteSourceSpan
+  return_type: inline SyntaqliteTextSpan
+  body: inline SyntaqliteTextSpan
   args: index PerfettoMacroArgList
 
   macro_def(name: macro_name, body: body, args: args, arg_name: arg_name)
@@ -233,7 +233,7 @@ node CreatePerfettoMacroStmt {
 }
 
 node IncludePerfettoModuleStmt {
-  module_name: inline SyntaqliteSourceSpan
+  module_name: inline SyntaqliteTextSpan
 
   semantic { import(module: module_name) }
 
@@ -243,8 +243,8 @@ node IncludePerfettoModuleStmt {
 }
 
 node DropPerfettoIndexStmt {
-  index_name: inline SyntaqliteSourceSpan
-  table_name: inline SyntaqliteSourceSpan
+  index_name: inline SyntaqliteTextSpan
+  table_name: inline SyntaqliteTextSpan
 
   fmt {
     "DROP PERFETTO INDEX " span(index_name) " ON " span(table_name)

--- a/docs/extensions-ai-plan.md
+++ b/docs/extensions-ai-plan.md
@@ -330,7 +330,7 @@ Node definition (`perfetto_stmts.synq`):
 
 ```
 node PerfettoFunctionStmt {
-    func_name: inline SourceSpan
+    func_name: inline TextSpan
     body: index Stmt
     is_replace: inline Bool
     fmt {

--- a/docs/semantic-analyzer-ai-plan.md
+++ b/docs/semantic-analyzer-ai-plan.md
@@ -163,7 +163,7 @@ pub trait LanguageExtractor {
     type Fragment;
     fn extract(source: &str) -> Vec<Self::Fragment>;
     fn sql_text<'a>(fragment: &'a Self::Fragment) -> &'a str;
-    fn map_span(fragment: &Self::Fragment, sql_span: SourceSpan) -> SourceSpan;
+    fn map_span(fragment: &Self::Fragment, sql_span: TextSpan) -> TextSpan;
 }
 ```
 

--- a/docs/semantic-roles-plan.md
+++ b/docs/semantic-roles-plan.md
@@ -111,7 +111,7 @@ The `.synq` grammar files already have semantic annotations for DDL:
 ```synq
 -- syntaqlite-syntax/parser-nodes/create_table.synq
 node CreateTableStmt {
-  table_name: inline SyntaqliteSourceSpan
+  table_name: inline SyntaqliteTextSpan
   columns: index ColumnDefList
   as_select: index Select
   ...
@@ -120,7 +120,7 @@ node CreateTableStmt {
 
 -- syntaqlite-syntax/parser-nodes/utility_stmts.synq
 node CreateViewStmt {
-  view_name: inline SyntaqliteSourceSpan
+  view_name: inline SyntaqliteTextSpan
   select: index Select
   ...
   session_schema { view(name: view_name, as_select: select) }
@@ -128,7 +128,7 @@ node CreateViewStmt {
 
 -- dialects/perfetto/nodes/perfetto.synq
 node CreatePerfettoTableStmt {
-  table_name: inline SyntaqliteSourceSpan
+  table_name: inline SyntaqliteTextSpan
   schema: index PerfettoArgDefList      -- explicit column list
   select: index Select
   ...
@@ -137,14 +137,14 @@ node CreatePerfettoTableStmt {
 }
 
 node CreatePerfettoFunctionStmt {
-  function_name: inline SyntaqliteSourceSpan
+  function_name: inline SyntaqliteTextSpan
   args: index PerfettoArgDefList
   ...
   session_schema { function(name: function_name, args: args) }
 }
 
 node IncludePerfettoModuleStmt {
-  module_name: inline SyntaqliteSourceSpan
+  module_name: inline SyntaqliteTextSpan
   ...
   session_schema { import(name: module_name) }
 }
@@ -216,15 +216,15 @@ annotation:
 ```synq
 node ColumnDef {
   column_name: index Name
-  type_name: inline SyntaqliteSourceSpan
+  type_name: inline SyntaqliteTextSpan
   constraints: index ColumnConstraintList
   ...
   semantic { column_def(name: column_name, type: type_name, constraints: constraints) }
 }
 
 node PerfettoArgDef {
-  arg_name: inline SyntaqliteSourceSpan
-  arg_type: inline SyntaqliteSourceSpan
+  arg_name: inline SyntaqliteTextSpan
+  arg_type: inline SyntaqliteTextSpan
   ...
   semantic { column_def(name: arg_name, type: arg_type) }
 }
@@ -249,7 +249,7 @@ These are the nodes that produce values or reference names. They are the primary
 
 ```synq
 node FunctionCall {
-  func_name: inline SyntaqliteSourceSpan
+  func_name: inline SyntaqliteTextSpan
   args: index ExprList
   filter_clause: index Expr
   over_clause: index WindowDef
@@ -258,8 +258,8 @@ node FunctionCall {
 }
 
 node ColumnRef {
-  column: inline SyntaqliteSourceSpan
-  table: inline SyntaqliteSourceSpan
+  column: inline SyntaqliteTextSpan
+  table: inline SyntaqliteTextSpan
   ...
   semantic { column_ref(column: column, table: table) }
 }
@@ -283,7 +283,7 @@ These are nodes that appear in FROM clauses and introduce names into the current
 
 ```synq
 node TableRef {
-  table_name: inline SyntaqliteSourceSpan
+  table_name: inline SyntaqliteTextSpan
   alias: index Name
   ...
   semantic { source_ref(kind: table, name: table_name, alias: alias) }
@@ -327,7 +327,7 @@ node SelectStmt {
 }
 
 node CteDefinition {
-  cte_name: inline SyntaqliteSourceSpan
+  cte_name: inline SyntaqliteTextSpan
   select: index Select
   ...
   semantic { cte_binding(name: cte_name, body: select) }
@@ -760,7 +760,7 @@ All `.synq` files migrated from `session_schema { ... }` to `semantic { define_*
   `CreatePerfettoTableStmt` bug fixed: `columns: schema` now included so the explicit
   `PerfettoArgDefList` is captured rather than relying solely on AS SELECT inference.
 
-`PerfettoArgDef.arg_name` changed from `inline SyntaqliteSourceSpan` to `index Name` to match
+`PerfettoArgDef.arg_name` changed from `inline SyntaqliteTextSpan` to `index Name` to match
 `ColumnDef.column_name`, giving `columns_from_column_list` a single NodeId-based code path for
 both dialects. The four `perfetto_arg_def_list_ne` parser action rules updated to wrap the name
 token with `synq_parse_ident_name(pCtx, synq_span(pCtx, N))`.

--- a/docs/text-expansion-model-plan.md
+++ b/docs/text-expansion-model-plan.md
@@ -222,12 +222,12 @@ struct SyntaqliteParser {
 
 ```c
 // Public struct; _layer_id is an implementation-detail field.
-typedef struct SyntaqliteSourceSpan {
+typedef struct SyntaqliteTextSpan {
     uint32_t offset;
     uint16_t length;
     uint8_t flags;
     uint8_t _layer_id;   // Internal. Do not access.
-} SyntaqliteSourceSpan;
+} SyntaqliteTextSpan;
 
 // Byte range in text() (the user's authored input).
 typedef struct SyntaqliteTextRange {
@@ -284,7 +284,7 @@ typedef struct SyntaqliteParserToken {
 ```c
 // ── Whole-statement text ─────────────────────────────────────────────────
 
-// The user's authored input. Same as syntaqlite_parser_source() today,
+// The user's authored input. Same as syntaqlite_parser_text() today,
 // renamed for vocabulary consistency. (Deferred — see Step 15.)
 SYNTAQLITE_API const char*
 syntaqlite_parser_text(SyntaqliteParser* p, uint32_t* out_len);
@@ -298,7 +298,7 @@ syntaqlite_parser_text(SyntaqliteParser* p, uint32_t* out_len);
 // no allocation.
 SYNTAQLITE_API const char*
 syntaqlite_parser_span_text(SyntaqliteParser* p,
-                            const SyntaqliteSourceSpan* span,
+                            const SyntaqliteTextSpan* span,
                             uint32_t* out_len);
 
 // What the parser's tokenizer saw for this span. For spans outside a
@@ -306,14 +306,14 @@ syntaqlite_parser_span_text(SyntaqliteParser* p,
 // expansion layer's buffer. Always a direct slice — no allocation.
 SYNTAQLITE_API const char*
 syntaqlite_parser_span_expanded_text(SyntaqliteParser* p,
-                                     const SyntaqliteSourceSpan* span,
+                                     const SyntaqliteTextSpan* span,
                                      uint32_t* out_len);
 
 // Byte range of span_text in text(). Always a valid range in the user's
 // authored input.
 SYNTAQLITE_API SyntaqliteTextRange
 syntaqlite_parser_span_text_range(SyntaqliteParser* p,
-                                  const SyntaqliteSourceSpan* span);
+                                  const SyntaqliteTextSpan* span);
 
 // ── Traceback ────────────────────────────────────────────────────────────
 
@@ -331,7 +331,7 @@ syntaqlite_parser_span_text_range(SyntaqliteParser* p,
 // empty or invalid spans.
 SYNTAQLITE_API const SyntaqliteTracebackFrame*
 syntaqlite_parser_traceback(SyntaqliteParser* p,
-                            const SyntaqliteSourceSpan* span,
+                            const SyntaqliteTextSpan* span,
                             uint32_t* out_count);
 ```
 
@@ -490,7 +490,7 @@ substituted arg" diagnostic land directly on the user's code.
 
 From today's codebase:
 
-- `SyntaqliteSourceSpan._buf_idx` field name (renamed to `_layer_id`).
+- `SyntaqliteTextSpan._buf_idx` field name (renamed to `_layer_id`).
 - `SynqMacroRegion` type (unified into `SynqExpansionLayer`).
 - `macro_regions` and `macro_expansions` parser vectors (unified into
   `layers`).
@@ -532,7 +532,7 @@ additive/rename work lands first, then behavior changes, then deletions.
 | 12. `FieldValue::Span` rename                       | ⏳ partial | `extract_field_value` now populates `FieldValue::Span` from the new trio (Session 1 follow-up, PR #90 review). Full rename of the variant's field names (`source` → `text_range`, adding a second authored-text field) still deferred. |
 | 13. Delete old expansion traceback API              | ✅ done | Removed `syntaqlite_parser_expansion_traceback`, `SyntaqliteExpansionFrame`, `ExpansionFrame`, `field_expansion_traceback`. Validator migrated to `traceback()`. |
 | 14. Delete `resolve_span` and `SyntaqliteResolvedSpan` | ✅ done | Brought forward from Session 1 follow-up (PR #90 review). Zero callers remain. |
-| 15. Rename `syntaqlite_parser_source()` → `syntaqlite_parser_text()` | ⏳ deferred | |
+| 15. Rename `syntaqlite_parser_text()` → `syntaqlite_parser_text()` | ⏳ deferred | |
 
 **Notes on Step 6 (session 1):**
 - The existing Rust `AnyParsedStatement::span_text` method (which returned
@@ -624,7 +624,7 @@ implementation and must fail on the pre-change tree.
 ### Step 1 — Rename `_buf_idx` to `_layer_id`
 
 Pure rename at the field level. Touches:
-- `include/syntaqlite/types.h` — `SyntaqliteSourceSpan._buf_idx` → `_layer_id`
+- `include/syntaqlite/types.h` — `SyntaqliteTextSpan._buf_idx` → `_layer_id`
 - `include/syntaqlite/dialect.h` — `SynqParseToken.buf_idx` → `layer_id`
 - `include/syntaqlite_dialect/ast_builder.h` — `SynqParseCtx.buf_idx` → `layer_id`
 - `csrc/parser*.c` — all references, including `synq_span`, `synq_span_dequote`
@@ -715,7 +715,7 @@ enforced.
 
 **(Reshaped from the originally-planned generalized `subtree_text` API.)**
 
-Scope: add a dedicated `select_span: inline SyntaqliteSourceSpan` field
+Scope: add a dedicated `select_span: inline SyntaqliteTextSpan` field
 on `CreatePerfettoTableStmt`, `CreatePerfettoViewStmt`, and
 `CreatePerfettoFunctionStmt` in `perfetto.synq`, populated explicitly by
 the grammar action with the byte range of the authored `select` body
@@ -745,7 +745,7 @@ Mechanism:
 3. Update the three `cmd` actions to bracket `select(E)`:
    ```
    cmd(A) ::= CREATE … AS select_body_start(BS) select(E) select_body_end(BE). {
-       SyntaqliteSourceSpan select_span = {
+       SyntaqliteTextSpan select_span = {
            BS, (uint16_t)(BE - BS), 0, /*layer_id=*/0,
        };
        A = synq_parse_create_perfetto_table_stmt(pCtx, …, E, select_span);
@@ -810,7 +810,7 @@ removed the last caller of `resolve_span`. The C function and the
 `SyntaqliteResolvedSpan` struct were then deleted (hard removal, no
 shim retained).
 
-### Step 15 — Rename `syntaqlite_parser_source()` → `syntaqlite_parser_text()`
+### Step 15 — Rename `syntaqlite_parser_text()` → `syntaqlite_parser_text()`
 
 Hard rename, no compat alias. Update CLI, WASM playground, Python
 bindings, and any tests referencing the old name. A grep for
@@ -881,7 +881,7 @@ This refactor is done when:
    per the table above. *(Partially done — `parser_source` → `text`
    rename is deferred to Step 15.)*
 2. **`_layer_id` is never referenced by any public API signature.** It
-   exists as an implementation-detail field on `SyntaqliteSourceSpan` and
+   exists as an implementation-detail field on `SyntaqliteTextSpan` and
    `SyntaqliteParserToken` but no public function takes it as a parameter
    or returns it. *(Done.)*
 3. **`statement_source` in `analyzer.rs` is deleted.** Its replacement

--- a/examples/select_columns.c
+++ b/examples/select_columns.c
@@ -60,7 +60,7 @@ static const TableSchema* schema_get(const Schema* s, const char* name) {
 // ── Helpers ─────────────────────────────────────────────────────────────
 
 static void span_to_str(SyntaqliteParser* p,
-                        SyntaqliteSourceSpan span,
+                        SyntaqliteTextSpan span,
                         char* buf,
                         int buf_size) {
   uint32_t len = 0;

--- a/examples/select_columns.cc
+++ b/examples/select_columns.cc
@@ -17,8 +17,8 @@
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
-// Extract a std::string from a SyntaqliteSourceSpan.
-static std::string SpanText(SyntaqliteParser* p, SyntaqliteSourceSpan span) {
+// Extract a std::string from a SyntaqliteTextSpan.
+static std::string SpanText(SyntaqliteParser* p, SyntaqliteTextSpan span) {
   uint32_t len = 0;
   const char* text = syntaqlite_parser_span_expanded_text(p, &span, &len);
   if (!text || len == 0)

--- a/python/csrc/_py_ast_wrap.h
+++ b/python/csrc/_py_ast_wrap.h
@@ -24,9 +24,9 @@ syntaqlite_py_wrap_list(SyntaqliteParser *p, const void *raw) {
 }
 
 static PyObject *
-syntaqlite_py_wrap_span(SyntaqliteParser *p, SyntaqliteSourceSpan span) {
+syntaqlite_py_wrap_span(SyntaqliteParser *p, SyntaqliteTextSpan span) {
     if (span.length == 0) Py_RETURN_NONE;
-    const char *src = syntaqlite_parser_source(p);
+    const char *src = syntaqlite_parser_text(p);
     return PyUnicode_FromStringAndSize(src + span.offset, span.length);
 }
 

--- a/syntaqlite-buildtools/parser-actions/_common.y
+++ b/syntaqlite-buildtools/parser-actions/_common.y
@@ -12,7 +12,7 @@
 // - pCtx->root: Set to root node ID at input rule
 // - Terminals are SynqParseToken with .z (pointer), .n (length), .type (token ID)
 // - Non-terminals default to uint32_t (node IDs)
-// - synq_span(pCtx, tok) converts a SynqParseToken into SyntaqliteSourceSpan
+// - synq_span(pCtx, tok) converts a SynqParseToken into SyntaqliteTextSpan
 // - SYNQ_NO_SPAN is the zero sentinel span
 
 %token_prefix SYNTAQLITE_TK_
@@ -46,19 +46,19 @@
 // columnname: passes name span + typetoken span from column definition.
 typedef struct SynqColumnNameValue {
   uint32_t name;
-  SyntaqliteSourceSpan typetoken;
+  SyntaqliteTextSpan typetoken;
 } SynqColumnNameValue;
 
 // ccons / tcons / generated: a constraint node + pending constraint name.
 typedef struct SynqConstraintValue {
   uint32_t node;
-  SyntaqliteSourceSpan pending_name;
+  SyntaqliteTextSpan pending_name;
 } SynqConstraintValue;
 
 // carglist / conslist: accumulated constraint list + pending name for next.
 typedef struct SynqConstraintListValue {
   uint32_t list;
-  SyntaqliteSourceSpan pending_name;
+  SyntaqliteTextSpan pending_name;
 } SynqConstraintListValue;
 
 // on_using: ON expr / USING column-list discriminator.
@@ -89,7 +89,7 @@ typedef struct SynqUpsertValue {
 #define YYPARSEFREENEVERNULL 1
 
 // Map parser error bookkeeping to a best-effort source span.
-static inline SyntaqliteSourceSpan synq_error_span(SynqParseCtx* pCtx) {
+static inline SyntaqliteTextSpan synq_error_span(SynqParseCtx* pCtx) {
   if (pCtx->error_offset == 0xFFFFFFFF || pCtx->error_length == 0) {
     return SYNQ_NO_SPAN;
   }
@@ -97,7 +97,7 @@ static inline SyntaqliteSourceSpan synq_error_span(SynqParseCtx* pCtx) {
   if (len > UINT16_MAX) {
     len = UINT16_MAX;
   }
-  return (SyntaqliteSourceSpan){
+  return (SyntaqliteTextSpan){
       .offset = pCtx->error_offset,
       .length = (uint16_t)len,
       .flags = 0,

--- a/syntaqlite-buildtools/parser-actions/create_table.y
+++ b/syntaqlite-buildtools/parser-actions/create_table.y
@@ -50,8 +50,8 @@ cmd(A) ::= create_table(CT) create_table_args(ARGS). {
 }
 
 create_table(A) ::= createkw temp(T) TABLE ifnotexists(E) nm(Y) dbnm(Z). {
-    SyntaqliteSourceSpan tbl_name = Z.z ? synq_span_dequote(pCtx, Z) : synq_span_dequote(pCtx, Y);
-    SyntaqliteSourceSpan tbl_schema = Z.z ? synq_span_dequote(pCtx, Y) : SYNQ_NO_SPAN;
+    SyntaqliteTextSpan tbl_name = Z.z ? synq_span_dequote(pCtx, Z) : synq_span_dequote(pCtx, Y);
+    SyntaqliteTextSpan tbl_schema = Z.z ? synq_span_dequote(pCtx, Y) : SYNQ_NO_SPAN;
     A = synq_parse_create_table_stmt(pCtx,
         tbl_name, tbl_schema, (SyntaqliteBool)T, (SyntaqliteBool)E,
         (SyntaqliteCreateTableStmtFlags){.raw = 0}, SYNTAQLITE_NULL_NODE, SYNTAQLITE_NULL_NODE, SYNTAQLITE_NULL_NODE);
@@ -469,7 +469,7 @@ conslist_opt(A) ::= COMMA conslist(L). {
 
 conslist(A) ::= conslist(L) tconscomma(SEP) tcons(TC). {
     // If comma separator was present, clear pending constraint name
-    SyntaqliteSourceSpan pending = SEP ? SYNQ_NO_SPAN : L.pending_name;
+    SyntaqliteTextSpan pending = SEP ? SYNQ_NO_SPAN : L.pending_name;
     if (TC.node != SYNTAQLITE_NULL_NODE) {
         SyntaqliteNode *node = AST_NODE(&pCtx->ast, TC.node);
         node->table_constraint.constraint_name = pending;

--- a/syntaqlite-buildtools/parser-actions/table_source.y
+++ b/syntaqlite-buildtools/parser-actions/table_source.y
@@ -32,8 +32,8 @@ stl_prefix(A) ::= . {
 // Simple table reference: FROM t, FROM t AS x, FROM schema.t
 seltablist(A) ::= stl_prefix(A) nm(Y) dbnm(D) as(Z) on_using(N). {
     uint32_t alias = Z;
-    SyntaqliteSourceSpan table_name;
-    SyntaqliteSourceSpan schema;
+    SyntaqliteTextSpan table_name;
+    SyntaqliteTextSpan schema;
     if (D.z != NULL) {
         table_name = synq_span_dequote(pCtx, D);
         schema = synq_span_dequote(pCtx, Y);
@@ -57,8 +57,8 @@ seltablist(A) ::= stl_prefix(A) nm(Y) dbnm(D) as(Z) on_using(N). {
 seltablist(A) ::= stl_prefix(A) nm(Y) dbnm(D) as(Z) indexed_by(I) on_using(N). {
     (void)I;
     uint32_t alias = Z;
-    SyntaqliteSourceSpan table_name;
-    SyntaqliteSourceSpan schema;
+    SyntaqliteTextSpan table_name;
+    SyntaqliteTextSpan schema;
     if (D.z != NULL) {
         table_name = synq_span_dequote(pCtx, D);
         schema = synq_span_dequote(pCtx, Y);
@@ -81,8 +81,8 @@ seltablist(A) ::= stl_prefix(A) nm(Y) dbnm(D) as(Z) indexed_by(I) on_using(N). {
 // Table-valued function: FROM t(args)
 seltablist(A) ::= stl_prefix(A) nm(Y) dbnm(D) LP exprlist(E) RP as(Z) on_using(N). {
     uint32_t alias = Z;
-    SyntaqliteSourceSpan table_name;
-    SyntaqliteSourceSpan schema;
+    SyntaqliteTextSpan table_name;
+    SyntaqliteTextSpan schema;
     if (D.z != NULL) {
         table_name = synq_span_dequote(pCtx, D);
         schema = synq_span_dequote(pCtx, Y);

--- a/syntaqlite-buildtools/parser-actions/trigger.y
+++ b/syntaqlite-buildtools/parser-actions/trigger.y
@@ -31,8 +31,8 @@ cmd(A) ::= createkw trigger_decl(D) BEGIN trigger_cmd_list(S) END. {
 trigger_decl(A) ::= temp(T) TRIGGER ifnotexists(NOERR) nm(B) dbnm(Z)
                     trigger_time(C) trigger_event(D)
                     ON fullname(E) foreach_clause when_clause(G). {
-    SyntaqliteSourceSpan trig_name = Z.z ? synq_span(pCtx, Z) : synq_span(pCtx, B);
-    SyntaqliteSourceSpan trig_schema = Z.z ? synq_span(pCtx, B) : SYNQ_NO_SPAN;
+    SyntaqliteTextSpan trig_name = Z.z ? synq_span(pCtx, Z) : synq_span(pCtx, B);
+    SyntaqliteTextSpan trig_schema = Z.z ? synq_span(pCtx, B) : SYNQ_NO_SPAN;
     A = synq_parse_create_trigger_stmt(pCtx,
         trig_name,
         trig_schema,

--- a/syntaqlite-buildtools/parser-actions/utility_stmts.y
+++ b/syntaqlite-buildtools/parser-actions/utility_stmts.y
@@ -30,32 +30,32 @@
 // We swap so pragma_name always has the pragma name, schema always has the schema.
 
 cmd(A) ::= PRAGMA nm(X) dbnm(Z). {
-    SyntaqliteSourceSpan name_span = Z.z ? synq_span(pCtx, Z) : synq_span(pCtx, X);
-    SyntaqliteSourceSpan schema_span = Z.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
+    SyntaqliteTextSpan name_span = Z.z ? synq_span(pCtx, Z) : synq_span(pCtx, X);
+    SyntaqliteTextSpan schema_span = Z.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
     A = synq_parse_pragma_stmt(pCtx, name_span, schema_span, SYNQ_NO_SPAN, SYNTAQLITE_PRAGMA_FORM_BARE);
 }
 
 cmd(A) ::= PRAGMA nm(X) dbnm(Z) EQ nmnum(Y). {
-    SyntaqliteSourceSpan name_span = Z.z ? synq_span(pCtx, Z) : synq_span(pCtx, X);
-    SyntaqliteSourceSpan schema_span = Z.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
+    SyntaqliteTextSpan name_span = Z.z ? synq_span(pCtx, Z) : synq_span(pCtx, X);
+    SyntaqliteTextSpan schema_span = Z.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
     A = synq_parse_pragma_stmt(pCtx, name_span, schema_span, synq_span(pCtx, Y), SYNTAQLITE_PRAGMA_FORM_EQ);
 }
 
 cmd(A) ::= PRAGMA nm(X) dbnm(Z) LP nmnum(Y) RP. {
-    SyntaqliteSourceSpan name_span = Z.z ? synq_span(pCtx, Z) : synq_span(pCtx, X);
-    SyntaqliteSourceSpan schema_span = Z.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
+    SyntaqliteTextSpan name_span = Z.z ? synq_span(pCtx, Z) : synq_span(pCtx, X);
+    SyntaqliteTextSpan schema_span = Z.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
     A = synq_parse_pragma_stmt(pCtx, name_span, schema_span, synq_span(pCtx, Y), SYNTAQLITE_PRAGMA_FORM_CALL);
 }
 
 cmd(A) ::= PRAGMA nm(X) dbnm(Z) EQ minus_num(Y). {
-    SyntaqliteSourceSpan name_span = Z.z ? synq_span(pCtx, Z) : synq_span(pCtx, X);
-    SyntaqliteSourceSpan schema_span = Z.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
+    SyntaqliteTextSpan name_span = Z.z ? synq_span(pCtx, Z) : synq_span(pCtx, X);
+    SyntaqliteTextSpan schema_span = Z.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
     A = synq_parse_pragma_stmt(pCtx, name_span, schema_span, synq_span(pCtx, Y), SYNTAQLITE_PRAGMA_FORM_EQ);
 }
 
 cmd(A) ::= PRAGMA nm(X) dbnm(Z) LP minus_num(Y) RP. {
-    SyntaqliteSourceSpan name_span = Z.z ? synq_span(pCtx, Z) : synq_span(pCtx, X);
-    SyntaqliteSourceSpan schema_span = Z.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
+    SyntaqliteTextSpan name_span = Z.z ? synq_span(pCtx, Z) : synq_span(pCtx, X);
+    SyntaqliteTextSpan schema_span = Z.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
     A = synq_parse_pragma_stmt(pCtx, name_span, schema_span, synq_span(pCtx, Y), SYNTAQLITE_PRAGMA_FORM_CALL);
 }
 
@@ -116,8 +116,8 @@ cmd(A) ::= ANALYZE. {
 }
 
 cmd(A) ::= ANALYZE nm(X) dbnm(Y). {
-    SyntaqliteSourceSpan name_span = Y.z ? synq_span(pCtx, Y) : synq_span(pCtx, X);
-    SyntaqliteSourceSpan schema_span = Y.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
+    SyntaqliteTextSpan name_span = Y.z ? synq_span(pCtx, Y) : synq_span(pCtx, X);
+    SyntaqliteTextSpan schema_span = Y.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
     A = synq_parse_analyze_or_reindex_stmt(pCtx, name_span, schema_span, SYNTAQLITE_ANALYZE_OR_REINDEX_OP_ANALYZE);
 }
 
@@ -131,8 +131,8 @@ cmd(A) ::= REINDEX. {
 }
 
 cmd(A) ::= REINDEX nm(X) dbnm(Y). {
-    SyntaqliteSourceSpan name_span = Y.z ? synq_span(pCtx, Y) : synq_span(pCtx, X);
-    SyntaqliteSourceSpan schema_span = Y.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
+    SyntaqliteTextSpan name_span = Y.z ? synq_span(pCtx, Y) : synq_span(pCtx, X);
+    SyntaqliteTextSpan schema_span = Y.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
     A = synq_parse_analyze_or_reindex_stmt(pCtx, name_span, schema_span, 1);
 }
 
@@ -204,8 +204,8 @@ explain(A) ::= EXPLAIN QUERY PLAN. {
 // ============ CREATE INDEX ============
 
 cmd(A) ::= createkw uniqueflag(U) INDEX ifnotexists(NE) nm(X) dbnm(D) ON nm(Y) LP sortlist(Z) RP where_opt(W). {
-    SyntaqliteSourceSpan idx_name = D.z ? synq_span(pCtx, D) : synq_span(pCtx, X);
-    SyntaqliteSourceSpan idx_schema = D.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
+    SyntaqliteTextSpan idx_name = D.z ? synq_span(pCtx, D) : synq_span(pCtx, X);
+    SyntaqliteTextSpan idx_schema = D.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
     A = synq_parse_create_index_stmt(pCtx,
         idx_name,
         idx_schema,
@@ -235,8 +235,8 @@ ifnotexists(A) ::= IF NOT EXISTS. {
 // ============ CREATE VIEW ============
 
 cmd(A) ::= createkw temp(T) VIEW ifnotexists(E) nm(Y) dbnm(Z) eidlist_opt(C) AS select(S). {
-    SyntaqliteSourceSpan view_name = Z.z ? synq_span(pCtx, Z) : synq_span(pCtx, Y);
-    SyntaqliteSourceSpan view_schema = Z.z ? synq_span(pCtx, Y) : SYNQ_NO_SPAN;
+    SyntaqliteTextSpan view_name = Z.z ? synq_span(pCtx, Z) : synq_span(pCtx, Y);
+    SyntaqliteTextSpan view_schema = Z.z ? synq_span(pCtx, Y) : SYNQ_NO_SPAN;
     A = synq_parse_create_view_stmt(pCtx,
         view_name,
         view_schema,

--- a/syntaqlite-buildtools/parser-actions/virtual_table.y
+++ b/syntaqlite-buildtools/parser-actions/virtual_table.y
@@ -30,7 +30,7 @@ cmd(A) ::= create_vtab(X) LP(L) vtabarglist RP(R). {
     SyntaqliteNode *vtab = AST_NODE(&pCtx->ast, X);
     uint32_t args_start = L.offset + L.n;
     uint32_t args_end = R.offset;
-    vtab->create_virtual_table_stmt.module_args = (SyntaqliteSourceSpan){
+    vtab->create_virtual_table_stmt.module_args = (SyntaqliteTextSpan){
         .offset = args_start,
         .length = (uint16_t)(args_end - args_start),
         .flags = 0,
@@ -41,8 +41,8 @@ cmd(A) ::= create_vtab(X) LP(L) vtabarglist RP(R). {
 
 // create_vtab builds the node with table name, schema, module name
 create_vtab(A) ::= createkw VIRTUAL TABLE ifnotexists(E) nm(X) dbnm(Y) USING nm(Z). {
-    SyntaqliteSourceSpan tbl_name = Y.z ? synq_span(pCtx, Y) : synq_span(pCtx, X);
-    SyntaqliteSourceSpan tbl_schema = Y.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
+    SyntaqliteTextSpan tbl_name = Y.z ? synq_span(pCtx, Y) : synq_span(pCtx, X);
+    SyntaqliteTextSpan tbl_schema = Y.z ? synq_span(pCtx, X) : SYNQ_NO_SPAN;
     A = synq_parse_create_virtual_table_stmt(pCtx,
         tbl_name,
         tbl_schema,

--- a/syntaqlite-buildtools/parser-nodes/SYNTAX.md
+++ b/syntaqlite-buildtools/parser-nodes/SYNTAX.md
@@ -18,7 +18,7 @@ Here's everything you need to represent and format `CAST(expr AS type)`:
 ```synq
 node CastExpr {
   expr: index Expr
-  type_name: inline SyntaqliteSourceSpan
+  type_name: inline SyntaqliteTextSpan
 
   fmt { "CAST(" child(expr) " AS " span(type_name) ")" }
 }
@@ -34,7 +34,7 @@ storage class, and a type:
 - `expr: index Expr` — an `index` field is a reference to another
   node in the AST arena. The generated struct stores a node index; the
   builder function takes a node index parameter.
-- `type_name: inline SyntaqliteSourceSpan` — an `inline` field is
+- `type_name: inline SyntaqliteTextSpan` — an `inline` field is
   stored directly in the node struct. Source spans, enums, flags, and
   bools are all inline.
 

--- a/syntaqlite-buildtools/parser-nodes/aggregate.synq
+++ b/syntaqlite-buildtools/parser-nodes/aggregate.synq
@@ -1,7 +1,7 @@
 flags AggregateFunctionCallFlags { DISTINCT = 1 }
 
 node AggregateFunctionCall {
-  func_name: inline SyntaqliteSourceSpan
+  func_name: inline SyntaqliteTextSpan
   flags: inline AggregateFunctionCallFlags
   args: index ExprList
   orderby: index OrderByList
@@ -25,7 +25,7 @@ node AggregateFunctionCall {
 }
 
 node OrderedSetFunctionCall {
-  func_name: inline SyntaqliteSourceSpan
+  func_name: inline SyntaqliteTextSpan
   flags: inline AggregateFunctionCallFlags
   args: index ExprList
   orderby_expr: index Expr

--- a/syntaqlite-buildtools/parser-nodes/cast.synq
+++ b/syntaqlite-buildtools/parser-nodes/cast.synq
@@ -1,6 +1,6 @@
 node CastExpr {
   expr: index Expr
-  type_name: inline SyntaqliteSourceSpan
+  type_name: inline SyntaqliteTextSpan
 
   fmt { "CAST(" child_paren_list(expr) " AS " span(type_name) ")" }
 }

--- a/syntaqlite-buildtools/parser-nodes/column_ref.synq
+++ b/syntaqlite-buildtools/parser-nodes/column_ref.synq
@@ -1,7 +1,7 @@
 node ColumnRef {
-  column: inline SyntaqliteSourceSpan
-  table: inline SyntaqliteSourceSpan
-  schema: inline SyntaqliteSourceSpan
+  column: inline SyntaqliteTextSpan
+  table: inline SyntaqliteTextSpan
+  schema: inline SyntaqliteTextSpan
 
   semantic { column_ref(column: column, table: table) }
 

--- a/syntaqlite-buildtools/parser-nodes/create_table.synq
+++ b/syntaqlite-buildtools/parser-nodes/create_table.synq
@@ -6,7 +6,7 @@ enum TableConstraintType { PRIMARY_KEY UNIQUE CHECK FOREIGN_KEY }
 flags CreateTableStmtFlags { WITHOUT_ROWID = 1 STRICT = 2 }
 
 node ForeignKeyClause {
-  ref_table: inline SyntaqliteSourceSpan
+  ref_table: inline SyntaqliteTextSpan
   ref_columns: index ExprList
   on_delete: inline ForeignKeyAction
   on_update: inline ForeignKeyAction
@@ -33,11 +33,11 @@ node ForeignKeyClause {
 
 node ColumnConstraint {
   kind: inline ColumnConstraintType
-  constraint_name: inline SyntaqliteSourceSpan
+  constraint_name: inline SyntaqliteTextSpan
   onconf: inline ConflictAction
   sort_order: inline SortOrder
   is_autoincrement: inline Bool
-  collation_name: inline SyntaqliteSourceSpan
+  collation_name: inline SyntaqliteTextSpan
   generated_storage: inline GeneratedColumnStorage
   default_expr: index Expr
   check_expr: index Expr
@@ -99,7 +99,7 @@ list ColumnConstraintList {
 
 node ColumnDef {
   column_name: index Name
-  type_name: inline SyntaqliteSourceSpan
+  type_name: inline SyntaqliteTextSpan
   constraints: index ColumnConstraintList
 
   semantic { column_def(name: column_name, type: type_name, constraints: constraints) }
@@ -120,7 +120,7 @@ list ColumnDefList {
 
 node TableConstraint {
   kind: inline TableConstraintType
-  constraint_name: inline SyntaqliteSourceSpan
+  constraint_name: inline SyntaqliteTextSpan
   onconf: inline ConflictAction
   is_autoincrement: inline Bool
   pk_columns: index OrderByList
@@ -163,8 +163,8 @@ list TableConstraintList {
 }
 
 node CreateTableStmt {
-  table_name: inline SyntaqliteSourceSpan
-  schema: inline SyntaqliteSourceSpan
+  table_name: inline SyntaqliteTextSpan
+  schema: inline SyntaqliteTextSpan
   is_temp: inline Bool
   if_not_exists: inline Bool
   flags: inline CreateTableStmtFlags

--- a/syntaqlite-buildtools/parser-nodes/cte.synq
+++ b/syntaqlite-buildtools/parser-nodes/cte.synq
@@ -1,7 +1,7 @@
 enum Materialized { DEFAULT MATERIALIZED NOT_MATERIALIZED }
 
 node CteDefinition {
-  cte_name: inline SyntaqliteSourceSpan
+  cte_name: inline SyntaqliteTextSpan
   materialized: inline Materialized
   columns: index ExprList
   select: index Select

--- a/syntaqlite-buildtools/parser-nodes/dml.synq
+++ b/syntaqlite-buildtools/parser-nodes/dml.synq
@@ -34,7 +34,7 @@ list UpsertClauseList {
 node DeleteStmt {
   table: index TableRef
   index_hint: inline IndexHint
-  index_name: inline SyntaqliteSourceSpan
+  index_name: inline SyntaqliteTextSpan
   where_clause: index Expr
   orderby: index OrderByList
   limit_clause: index LimitClause
@@ -58,7 +58,7 @@ node DeleteStmt {
 }
 
 node SetClause {
-  column: inline SyntaqliteSourceSpan
+  column: inline SyntaqliteTextSpan
   columns: index ExprList
   value: index Expr
 
@@ -76,7 +76,7 @@ node UpdateStmt {
   conflict_action: inline ConflictAction
   table: index TableRef
   index_hint: inline IndexHint
-  index_name: inline SyntaqliteSourceSpan
+  index_name: inline SyntaqliteTextSpan
   setlist: index SetClauseList
   from_clause: index TableSource
   where_clause: index Expr

--- a/syntaqlite-buildtools/parser-nodes/expressions.synq
+++ b/syntaqlite-buildtools/parser-nodes/expressions.synq
@@ -37,19 +37,19 @@ node UnaryExpr {
 
 node Literal {
   literal_type: inline LiteralType
-  source: inline SyntaqliteSourceSpan
+  source: inline SyntaqliteTextSpan
 
   fmt { span(source) }
 }
 
 node IdentName {
-  source: inline SyntaqliteSourceSpan
+  source: inline SyntaqliteTextSpan
 
   fmt { span(source) }
 }
 
 node Error {
-  source: inline SyntaqliteSourceSpan
+  source: inline SyntaqliteTextSpan
 
   fmt {
     if_span(source) {

--- a/syntaqlite-buildtools/parser-nodes/functions.synq
+++ b/syntaqlite-buildtools/parser-nodes/functions.synq
@@ -1,7 +1,7 @@
 flags FunctionCallFlags { DISTINCT = 1 STAR = 2 }
 
 node FunctionCall {
-  func_name: inline SyntaqliteSourceSpan
+  func_name: inline SyntaqliteTextSpan
   flags: inline FunctionCallFlags
   args: index ExprList
   filter_clause: index Expr

--- a/syntaqlite-buildtools/parser-nodes/misc_expr.synq
+++ b/syntaqlite-buildtools/parser-nodes/misc_expr.synq
@@ -1,12 +1,12 @@
 node Variable {
-  source: inline SyntaqliteSourceSpan
+  source: inline SyntaqliteTextSpan
 
   fmt { span(source) }
 }
 
 node CollateExpr {
   expr: index Expr
-  collation: inline SyntaqliteSourceSpan
+  collation: inline SyntaqliteTextSpan
 
   fmt_precedence(9)
   fmt_group(0)

--- a/syntaqlite-buildtools/parser-nodes/table_source.synq
+++ b/syntaqlite-buildtools/parser-nodes/table_source.synq
@@ -4,8 +4,8 @@ enum JoinType {
 }
 
 node TableRef {
-  table_name: inline SyntaqliteSourceSpan
-  schema: inline SyntaqliteSourceSpan
+  table_name: inline SyntaqliteTextSpan
+  schema: inline SyntaqliteTextSpan
   alias: index Name
   args: index ExprList
 

--- a/syntaqlite-buildtools/parser-nodes/trigger.synq
+++ b/syntaqlite-buildtools/parser-nodes/trigger.synq
@@ -25,8 +25,8 @@ list TriggerCmdList {
 }
 
 node CreateTriggerStmt {
-  trigger_name: inline SyntaqliteSourceSpan
-  schema: inline SyntaqliteSourceSpan
+  trigger_name: inline SyntaqliteTextSpan
+  schema: inline SyntaqliteTextSpan
   is_temp: inline Bool
   if_not_exists: inline Bool
   timing: inline TriggerTiming
@@ -59,11 +59,11 @@ node CreateTriggerStmt {
 }
 
 node CreateVirtualTableStmt {
-  table_name: inline SyntaqliteSourceSpan
-  schema: inline SyntaqliteSourceSpan
-  module_name: inline SyntaqliteSourceSpan
+  table_name: inline SyntaqliteTextSpan
+  schema: inline SyntaqliteTextSpan
+  module_name: inline SyntaqliteTextSpan
   if_not_exists: inline Bool
-  module_args: inline SyntaqliteSourceSpan
+  module_args: inline SyntaqliteTextSpan
 
   fmt {
     "CREATE VIRTUAL TABLE"

--- a/syntaqlite-buildtools/parser-nodes/utility_stmts.synq
+++ b/syntaqlite-buildtools/parser-nodes/utility_stmts.synq
@@ -3,9 +3,9 @@ enum PragmaForm { BARE EQ CALL }
 enum AnalyzeOrReindexOp { ANALYZE REINDEX }
 
 node PragmaStmt {
-  pragma_name: inline SyntaqliteSourceSpan
-  schema: inline SyntaqliteSourceSpan
-  value: inline SyntaqliteSourceSpan
+  pragma_name: inline SyntaqliteTextSpan
+  schema: inline SyntaqliteTextSpan
+  value: inline SyntaqliteTextSpan
   pragma_form: inline PragmaForm
 
   fmt {
@@ -20,8 +20,8 @@ node PragmaStmt {
 }
 
 node AnalyzeOrReindexStmt {
-  target_name: inline SyntaqliteSourceSpan
-  schema: inline SyntaqliteSourceSpan
+  target_name: inline SyntaqliteTextSpan
+  schema: inline SyntaqliteTextSpan
   kind: inline AnalyzeOrReindexOp
 
   fmt {
@@ -52,7 +52,7 @@ node DetachStmt {
 }
 
 node VacuumStmt {
-  schema: inline SyntaqliteSourceSpan
+  schema: inline SyntaqliteTextSpan
   filename: index Expr
 
   fmt {
@@ -73,9 +73,9 @@ node ExplainStmt {
 }
 
 node CreateIndexStmt {
-  index_name: inline SyntaqliteSourceSpan
-  schema: inline SyntaqliteSourceSpan
-  table_name: inline SyntaqliteSourceSpan
+  index_name: inline SyntaqliteTextSpan
+  schema: inline SyntaqliteTextSpan
+  table_name: inline SyntaqliteTextSpan
   is_unique: inline Bool
   if_not_exists: inline Bool
   columns: index OrderByList
@@ -98,8 +98,8 @@ node CreateIndexStmt {
 }
 
 node CreateViewStmt {
-  view_name: inline SyntaqliteSourceSpan
-  schema: inline SyntaqliteSourceSpan
+  view_name: inline SyntaqliteTextSpan
+  schema: inline SyntaqliteTextSpan
   is_temp: inline Bool
   if_not_exists: inline Bool
   column_names: index ExprList

--- a/syntaqlite-buildtools/parser-nodes/window.synq
+++ b/syntaqlite-buildtools/parser-nodes/window.synq
@@ -40,7 +40,7 @@ node FrameSpec {
 }
 
 node WindowDef {
-  base_window_name: inline SyntaqliteSourceSpan
+  base_window_name: inline SyntaqliteTextSpan
   partition_by: index ExprList
   orderby: index OrderByList
   frame: index FrameSpec
@@ -72,7 +72,7 @@ node WindowDef {
 list WindowDefList { WindowDef }
 
 node NamedWindowDef {
-  window_name: inline SyntaqliteSourceSpan
+  window_name: inline SyntaqliteTextSpan
   window_def: index WindowDef
 
   fmt { span(window_name) " AS " child(window_def) }
@@ -83,7 +83,7 @@ list NamedWindowDefList { NamedWindowDef }
 node FilterOver {
   filter_expr: index Expr
   over_def: index WindowDef
-  over_name: inline SyntaqliteSourceSpan
+  over_name: inline SyntaqliteTextSpan
 
   fmt {
     if_set(filter_expr) { group { "FILTER (" nest { softline "WHERE " child(filter_expr) } softline ")" } }

--- a/syntaqlite-buildtools/src/dialect_codegen/c_meta_codegen.rs
+++ b/syntaqlite-buildtools/src/dialect_codegen/c_meta_codegen.rs
@@ -280,7 +280,7 @@ impl AstModel<'_> {
             let span_fields: Vec<_> = node
                 .fields
                 .iter()
-                .filter(|f| f.storage == Storage::Inline && f.type_name == "SyntaqliteSourceSpan")
+                .filter(|f| f.storage == Storage::Inline && f.type_name == "SyntaqliteTextSpan")
                 .collect();
             if span_fields.is_empty() {
                 continue;
@@ -334,7 +334,7 @@ impl AstModel<'_> {
                         .fields
                         .iter()
                         .filter(|f| {
-                            f.storage == Storage::Inline && f.type_name == "SyntaqliteSourceSpan"
+                            f.storage == Storage::Inline && f.type_name == "SyntaqliteTextSpan"
                         })
                         .count();
                     if span_count > 0 {
@@ -410,7 +410,7 @@ fn c_field_kind(
         Storage::Index => Ok("SYNTAQLITE_FIELD_NODE_ID"),
         Storage::Inline => {
             let t = &field.type_name;
-            if t == "SyntaqliteSourceSpan" {
+            if t == "SyntaqliteTextSpan" {
                 Ok("SYNTAQLITE_FIELD_SPAN")
             } else if t == "Bool" {
                 Ok("SYNTAQLITE_FIELD_BOOL")

--- a/syntaqlite-buildtools/src/dialect_codegen/fmt_compiler.rs
+++ b/syntaqlite-buildtools/src/dialect_codegen/fmt_compiler.rs
@@ -173,7 +173,7 @@ impl EnumDisplayTable {
 struct FieldInfo {
     /// Index into the `FieldVal` array for this node.
     idx: u16,
-    /// The type name (e.g. "`SelectStmtFlags`", "`SortOrder`", "`SyntaqliteSourceSpan`").
+    /// The type name (e.g. "`SelectStmtFlags`", "`SortOrder`", "`SyntaqliteTextSpan`").
     type_name: String,
 }
 
@@ -1014,7 +1014,7 @@ mod tests {
             fields: vec![Field {
                 name: "source".into(),
                 storage: Storage::Inline,
-                type_name: "SyntaqliteSourceSpan".into(),
+                type_name: "SyntaqliteTextSpan".into(),
             }],
             fmt: Some(vec![Fmt::Span("source".into())]),
             semantic: None,

--- a/syntaqlite-buildtools/src/dialect_codegen/python_c_codegen.rs
+++ b/syntaqlite-buildtools/src/dialect_codegen/python_c_codegen.rs
@@ -135,7 +135,7 @@ fn emit_node_field_setter(
                 w.line(&format!(
                     "PyDict_SetItemString(d, \"{py_key}\", n->{fname} ? Py_True : Py_False);"
                 ));
-            } else if t == "SyntaqliteSourceSpan" {
+            } else if t == "SyntaqliteTextSpan" {
                 w.line(&format!(
                     "PyObject *val = syntaqlite_py_wrap_span(p, n->{fname});"
                 ));
@@ -187,10 +187,10 @@ fn emit_wrap_list_fn(w: &mut CWriter) {
 /// Emit the helper function that wraps a source span into a Python str.
 fn emit_wrap_span_fn(w: &mut CWriter) {
     w.line("static PyObject *");
-    w.line("syntaqlite_py_wrap_span(SyntaqliteParser *p, SyntaqliteSourceSpan span) {");
+    w.line("syntaqlite_py_wrap_span(SyntaqliteParser *p, SyntaqliteTextSpan span) {");
     w.indent();
     w.line("if (span.length == 0) Py_RETURN_NONE;");
-    w.line("const char *src = syntaqlite_parser_source(p);");
+    w.line("const char *src = syntaqlite_parser_text(p);");
     w.line("return PyUnicode_FromStringAndSize(src + span.offset, span.length);");
     w.dedent();
     w.line("}");
@@ -205,7 +205,7 @@ mod tests {
     fn generates_switch_for_nodes() {
         let items = parse_synq_file(
             r"
-            node Foo { x: inline Bool  y: inline SyntaqliteSourceSpan }
+            node Foo { x: inline Bool  y: inline SyntaqliteTextSpan }
             node Bar { child: index Foo }
             list FooList { Foo }
             ",

--- a/syntaqlite-buildtools/src/dialect_codegen/python_codegen.rs
+++ b/syntaqlite-buildtools/src/dialect_codegen/python_codegen.rs
@@ -323,7 +323,7 @@ fn field_type_and_expr(
             let t = &field.type_name;
             if t == "Bool" {
                 ("bool".to_string(), format!("d[\"{py_name}\"]"))
-            } else if t == "SyntaqliteSourceSpan" {
+            } else if t == "SyntaqliteTextSpan" {
                 ("str | None".to_string(), format!("d.get(\"{py_name}\")"))
             } else if enum_names.contains(t.as_str()) || flags_names.contains(t.as_str()) {
                 (t.clone(), format!("{t}(d[\"{py_name}\"])"))
@@ -366,7 +366,7 @@ mod tests {
             r"
             enum SortOrder { ASC DESC }
             flags SelectStmtFlags { DISTINCT = 1 }
-            node Foo { x: inline Bool  y: inline SyntaqliteSourceSpan }
+            node Foo { x: inline Bool  y: inline SyntaqliteTextSpan }
             node Bar { child: index Foo  order: inline SortOrder }
             list FooList { Foo }
             node Baz { items: index FooList  flags: inline SelectStmtFlags }

--- a/syntaqlite-buildtools/src/dialect_codegen/rust_ast.rs
+++ b/syntaqlite-buildtools/src/dialect_codegen/rust_ast.rs
@@ -26,8 +26,8 @@ fn rust_ffi_field_type(
                 "Bool".into()
             } else if enum_names.contains(t.as_str()) || flags_names.contains(t.as_str()) {
                 format!("super::ast::{t}")
-            } else if t == "SyntaqliteSourceSpan" {
-                "SourceSpan".into()
+            } else if t == "SyntaqliteTextSpan" {
+                "TextSpan".into()
             } else {
                 t.clone()
             }
@@ -52,7 +52,7 @@ fn rust_view_return_type(
             let t = &field.type_name;
             if t == "Bool" {
                 "bool".into()
-            } else if t == "SyntaqliteSourceSpan" {
+            } else if t == "SyntaqliteTextSpan" {
                 "&'a str".into()
             } else {
                 t.clone()
@@ -72,7 +72,7 @@ fn rust_view_accessor_body(field: &Field, ffi_path: &str) -> String {
             let t = &field.type_name;
             if t == "Bool" {
                 format!("self.raw.{fname} == {ffi_path}::Bool::True")
-            } else if t == "SyntaqliteSourceSpan" {
+            } else if t == "SyntaqliteTextSpan" {
                 format!("self.stmt_result.span_expanded_text(self.raw.{fname})")
             } else {
                 format!("self.raw.{fname}")
@@ -355,7 +355,7 @@ pub(crate) struct RustAstPaths<'a> {
     pub crate_prefix: &'a str,
     /// Path to FFI node structs, e.g. `"crate::ffi"`.
     pub ffi_path: &'a str,
-    /// Path to `NodeId`/`SourceSpan`/`NodeList`, e.g. `"syntaqlite_parser::nodes"`.
+    /// Path to `NodeId`/`TextSpan`/`NodeList`, e.g. `"syntaqlite_parser::nodes"`.
     pub nodes_path: &'a str,
     /// Fully-qualified path to the dialect struct, e.g.
     /// `"super::dialect::Dialect"`. Used as the `G` parameter in
@@ -382,7 +382,7 @@ impl AstModel<'_> {
         w.newline();
         w.lines(&format!(
             "
-        use {nodes_path}::{{ArenaNode, AnyNodeId, SourceSpan}};
+        use {nodes_path}::{{ArenaNode, AnyNodeId, TextSpan}};
     ",
         ));
         w.newline();

--- a/syntaqlite-buildtools/src/dialect_codegen/semantic_roles_codegen.rs
+++ b/syntaqlite-buildtools/src/dialect_codegen/semantic_roles_codegen.rs
@@ -495,7 +495,7 @@ mod tests {
 
     #[test]
     fn transparent_for_node_without_annotation() {
-        let items = model_from("node Foo { x: inline SyntaqliteSourceSpan }");
+        let items = model_from("node Foo { x: inline SyntaqliteTextSpan }");
         let model = AstModel::new(&items);
         let header = generate_c_roles_h(&model, "test");
         let bytes = extract_bytes_from_header(&header, "test");
@@ -510,8 +510,8 @@ mod tests {
     fn define_table_with_correct_field_indices() {
         let items = model_from(
             r"node CreateTableStmt {
-                table_name: inline SyntaqliteSourceSpan
-                schema: inline SyntaqliteSourceSpan
+                table_name: inline SyntaqliteTextSpan
+                schema: inline SyntaqliteTextSpan
                 columns: index ColumnDefList
                 as_select: index Select
                 semantic { define_table(name: table_name, columns: columns, select: as_select) }
@@ -537,7 +537,7 @@ mod tests {
     fn define_table_optional_fields_absent_when_not_given() {
         let items = model_from(
             r"node CreateTableStmt {
-                table_name: inline SyntaqliteSourceSpan
+                table_name: inline SyntaqliteTextSpan
                 semantic { define_table(name: table_name) }
             }",
         );
@@ -560,8 +560,8 @@ mod tests {
     fn define_view_with_correct_field_indices() {
         let items = model_from(
             r"node CreateViewStmt {
-                view_name: inline SyntaqliteSourceSpan
-                schema: inline SyntaqliteSourceSpan
+                view_name: inline SyntaqliteTextSpan
+                schema: inline SyntaqliteTextSpan
                 select: index Select
                 semantic { define_view(name: view_name, select: select) }
             }",
@@ -584,7 +584,7 @@ mod tests {
     #[test]
     fn list_always_emits_transparent() {
         let items = model_from(
-            r"node Foo { x: inline SyntaqliteSourceSpan }
+            r"node Foo { x: inline SyntaqliteTextSpan }
                list FooList { Foo }",
         );
         let model = AstModel::new(&items);
@@ -600,8 +600,8 @@ mod tests {
     #[test]
     fn count_matches_node_count() {
         let items = model_from(
-            r"node Foo { x: inline SyntaqliteSourceSpan }
-               node Bar { y: inline SyntaqliteSourceSpan }",
+            r"node Foo { x: inline SyntaqliteTextSpan }
+               node Bar { y: inline SyntaqliteTextSpan }",
         );
         let model = AstModel::new(&items);
         let header = generate_c_roles_h(&model, "test");
@@ -616,9 +616,9 @@ mod tests {
     fn source_ref_kind_bytes_correct() {
         let items = model_from(
             r"node TableRef {
-                name: inline SyntaqliteSourceSpan
-                schema: inline SyntaqliteSourceSpan
-                alias: inline SyntaqliteSourceSpan
+                name: inline SyntaqliteTextSpan
+                schema: inline SyntaqliteTextSpan
+                alias: inline SyntaqliteTextSpan
                 semantic { source_ref(kind: table, name: name, alias: alias) }
             }",
         );

--- a/syntaqlite-buildtools/src/util/synq_parser.rs
+++ b/syntaqlite-buildtools/src/util/synq_parser.rs
@@ -1140,7 +1140,7 @@ mod tests {
     fn semantic_define_table_parses() {
         let item = parse_node(
             r"node CreateTableStmt {
-                table_name: inline SyntaqliteSourceSpan
+                table_name: inline SyntaqliteTextSpan
                 columns: index ColumnDefList
                 as_select: index Select
                 semantic { define_table(name: table_name, columns: columns, select: as_select) }
@@ -1167,7 +1167,7 @@ mod tests {
     fn semantic_import_uses_module_key() {
         let item = parse_node(
             r"node IncludePerfettoModuleStmt {
-                module_name: inline SyntaqliteSourceSpan
+                module_name: inline SyntaqliteTextSpan
                 semantic { import(module: module_name) }
             }",
         );
@@ -1182,7 +1182,7 @@ mod tests {
     fn semantic_unknown_field_is_error() {
         let result = parse_synq_file(
             r"node Foo {
-                bar: inline SyntaqliteSourceSpan
+                bar: inline SyntaqliteTextSpan
                 semantic { define_table(name: nonexistent) }
             }",
         );
@@ -1194,7 +1194,7 @@ mod tests {
     fn semantic_unknown_role_is_error() {
         let result = parse_synq_file(
             r"node Foo {
-                bar: inline SyntaqliteSourceSpan
+                bar: inline SyntaqliteTextSpan
                 semantic { frobnicate(name: bar) }
             }",
         );
@@ -1211,7 +1211,7 @@ mod tests {
     fn node_without_semantic_has_none() {
         let item = parse_node(
             r"node Foo {
-                bar: inline SyntaqliteSourceSpan
+                bar: inline SyntaqliteTextSpan
             }",
         );
         assert!(node_semantic(item).is_none());

--- a/syntaqlite-common/src/lib.rs
+++ b/syntaqlite-common/src/lib.rs
@@ -265,9 +265,9 @@ pub mod roles {
         pub node_tag_lo: u8,
         /// Node tag high byte (little-endian).
         pub node_tag_hi: u8,
-        /// Field index for the macro name (`SyntaqliteSourceSpan`).
+        /// Field index for the macro name (`SyntaqliteTextSpan`).
         pub name_field: FieldIdx,
-        /// Field index for the macro body (`SyntaqliteSourceSpan`).
+        /// Field index for the macro body (`SyntaqliteTextSpan`).
         pub body_field: FieldIdx,
         /// Field index for the args list node (`FIELD_ABSENT` if no params).
         pub args_field: FieldIdx,

--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -561,11 +561,11 @@ SYNTAQLITE_API uint32_t syntaqlite_parser_node_count(SyntaqliteParser* p) {
   return syntaqlite_vec_len(&p->ctx.ast.offsets);
 }
 
-SYNTAQLITE_API const char* syntaqlite_parser_source(SyntaqliteParser* p) {
+SYNTAQLITE_API const char* syntaqlite_parser_text(SyntaqliteParser* p) {
   return p->source;
 }
 
-SYNTAQLITE_API uint32_t syntaqlite_parser_source_length(SyntaqliteParser* p) {
+SYNTAQLITE_API uint32_t syntaqlite_parser_text_length(SyntaqliteParser* p) {
   return p->source_len;
 }
 

--- a/syntaqlite-syntax/csrc/parser_dump.c
+++ b/syntaqlite-syntax/csrc/parser_dump.c
@@ -107,7 +107,7 @@ static void dump_node_recursive(DumpBuf* b,
         break;
       }
       case SYNTAQLITE_FIELD_SPAN: {
-        SyntaqliteSourceSpan sp;
+        SyntaqliteTextSpan sp;
         memcpy(&sp, field_ptr, sizeof(sp));
         dump_indent(b, mem, indent + 1);
         if (sp.length == 0) {

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -57,8 +57,9 @@ typedef struct SynqMacroEntry {
 
 // One parameter substitution recorded during macro expansion. Tracks where
 // the copied arg text landed in the child layer's buffer and where it came
-// from in the parent layer's buffer. Populated by expand_template during
-// Step 4; consumed by argument-level traceback (Step 7).
+// from in the parent layer's buffer. Populated by expand_template; consumed
+// by argument-level traceback to drill span positions back through `$param`
+// substitutions to the caller's authored arg text.
 typedef struct SynqArgSegment {
   uint32_t sub_offset;       // Where the substituted arg landed in the child
                              // layer's buffer.
@@ -101,7 +102,7 @@ typedef struct SynqExpansionLayer {
   uint32_t def_line;           // Macro definition line (1-based, 0=unknown).
   uint32_t def_col;            // Macro definition column (1-based, 0=unknown).
 
-  // Parameter substitutions recorded during expand_template (Step 4).
+  // Parameter substitutions recorded during expand_template.
   // Arg segments live in p->mem; freed in reset_stmt / destroy alongside
   // expansion_data. Empty for layers without parameter substitution.
   SynqArgSegment* arg_segments;

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -607,9 +607,9 @@ int synq_parser_check_macro_straddle(SyntaqliteParser* p) {
 
       for (uint8_t fi = 0; fi < entry->count; fi++) {
         if (entry->fields[fi].kind != 1)
-          continue;  // Not a SourceSpan.
-        const SyntaqliteSourceSpan* sp =
-            (const SyntaqliteSourceSpan*)(raw + entry->fields[fi].offset);
+          continue;  // Not a TextSpan.
+        const SyntaqliteTextSpan* sp =
+            (const SyntaqliteTextSpan*)(raw + entry->fields[fi].offset);
         if (sp->length == 0)
           continue;
 
@@ -723,7 +723,7 @@ SYNTAQLITE_API int syntaqlite_parser_deregister_macro(SyntaqliteParser* p,
 }
 
 // ---------------------------------------------------------------------------
-// Span accessors: span_text, span_expanded_text, span_text_range
+// Span accessors: span_text, span_expanded_text
 // ---------------------------------------------------------------------------
 
 // Walk the layer chain to resolve (layer, offset, length) to an authored
@@ -783,7 +783,7 @@ static void span_walk_to_source(SyntaqliteParser* p,
 
 SYNTAQLITE_API const char* syntaqlite_parser_span_expanded_text(
     SyntaqliteParser* p,
-    const SyntaqliteSourceSpan* span,
+    const SyntaqliteTextSpan* span,
     uint32_t* out_len) {
   if (!span || span->length == 0) {
     *out_len = 0;
@@ -806,8 +806,11 @@ SYNTAQLITE_API const char* syntaqlite_parser_span_expanded_text(
 
 SYNTAQLITE_API const char* syntaqlite_parser_span_text(
     SyntaqliteParser* p,
-    const SyntaqliteSourceSpan* span,
-    uint32_t* out_len) {
+    const SyntaqliteTextSpan* span,
+    uint32_t* out_len,
+    uint32_t* out_offset) {
+  if (out_offset)
+    *out_offset = 0;
   if (!span || span->length == 0) {
     *out_len = 0;
     return NULL;
@@ -819,6 +822,8 @@ SYNTAQLITE_API const char* syntaqlite_parser_span_text(
       return NULL;
     }
     *out_len = span->length;
+    if (out_offset)
+      *out_offset = span->offset;
     return p->source + span->offset;
   }
   // Walk the expansion chain to find the authored bytes.
@@ -831,32 +836,9 @@ SYNTAQLITE_API const char* syntaqlite_parser_span_text(
     return NULL;
   }
   *out_len = len;
+  if (out_offset)
+    *out_offset = off;
   return p->source + off;
-}
-
-SYNTAQLITE_API SyntaqliteTextRange
-syntaqlite_parser_span_text_range(SyntaqliteParser* p,
-                                  const SyntaqliteSourceSpan* span) {
-  SyntaqliteTextRange r = {0, 0};
-  if (!span || span->length == 0) {
-    return r;
-  }
-  if (span->_layer_id == 0) {
-    if (span->offset + span->length > p->source_len)
-      return r;
-    r.start = span->offset;
-    r.end = span->offset + span->length;
-    return r;
-  }
-  uint32_t off = 0;
-  uint32_t len = 0;
-  span_walk_to_source(p, span->_layer_id, span->offset, span->length, &off,
-                      &len);
-  if (off + len > p->source_len)
-    return r;
-  r.start = off;
-  r.end = off + len;
-  return r;
 }
 
 // Compute 1-based (line, col) for `offset` within `buf[..buf_len]`.  The
@@ -888,7 +870,7 @@ static void compute_line_col(const char* buf,
 
 SYNTAQLITE_API const SyntaqliteTracebackFrame* syntaqlite_parser_traceback(
     SyntaqliteParser* p,
-    const SyntaqliteSourceSpan* sp,
+    const SyntaqliteTextSpan* sp,
     uint32_t* out_count) {
   if (out_count)
     *out_count = 0;

--- a/syntaqlite-syntax/csrc/sqlite/dialect_builder.h
+++ b/syntaqlite-syntax/csrc/sqlite/dialect_builder.h
@@ -18,7 +18,7 @@ extern "C" {
 
 static inline uint32_t synq_parse_aggregate_function_call(
     SynqParseCtx* ctx,
-    SyntaqliteSourceSpan func_name,
+    SyntaqliteTextSpan func_name,
     SyntaqliteAggregateFunctionCallFlags flags,
     uint32_t args,
     uint32_t orderby,
@@ -38,7 +38,7 @@ static inline uint32_t synq_parse_aggregate_function_call(
 
 static inline uint32_t synq_parse_ordered_set_function_call(
     SynqParseCtx* ctx,
-    SyntaqliteSourceSpan func_name,
+    SyntaqliteTextSpan func_name,
     SyntaqliteAggregateFunctionCallFlags flags,
     uint32_t args,
     uint32_t orderby_expr,
@@ -58,7 +58,7 @@ static inline uint32_t synq_parse_ordered_set_function_call(
 
 static inline uint32_t synq_parse_cast_expr(SynqParseCtx* ctx,
                                             uint32_t expr,
-                                            SyntaqliteSourceSpan type_name) {
+                                            SyntaqliteTextSpan type_name) {
   return synq_parse_build(
       ctx,
       &(SyntaqliteCastExpr){.tag = SYNTAQLITE_NODE_CAST_EXPR,
@@ -68,9 +68,9 @@ static inline uint32_t synq_parse_cast_expr(SynqParseCtx* ctx,
 }
 
 static inline uint32_t synq_parse_column_ref(SynqParseCtx* ctx,
-                                             SyntaqliteSourceSpan column,
-                                             SyntaqliteSourceSpan table,
-                                             SyntaqliteSourceSpan schema) {
+                                             SyntaqliteTextSpan column,
+                                             SyntaqliteTextSpan table,
+                                             SyntaqliteTextSpan schema) {
   return synq_parse_build(
       ctx,
       &(SyntaqliteColumnRef){.tag = SYNTAQLITE_NODE_COLUMN_REF,
@@ -193,7 +193,7 @@ static inline uint32_t synq_parse_case_when(SynqParseCtx* ctx,
 
 static inline uint32_t synq_parse_foreign_key_clause(
     SynqParseCtx* ctx,
-    SyntaqliteSourceSpan ref_table,
+    SyntaqliteTextSpan ref_table,
     uint32_t ref_columns,
     SyntaqliteForeignKeyAction on_delete,
     SyntaqliteForeignKeyAction on_update,
@@ -212,11 +212,11 @@ static inline uint32_t synq_parse_foreign_key_clause(
 static inline uint32_t synq_parse_column_constraint(
     SynqParseCtx* ctx,
     SyntaqliteColumnConstraintType kind,
-    SyntaqliteSourceSpan constraint_name,
+    SyntaqliteTextSpan constraint_name,
     SyntaqliteConflictAction onconf,
     SyntaqliteSortOrder sort_order,
     SyntaqliteBool is_autoincrement,
-    SyntaqliteSourceSpan collation_name,
+    SyntaqliteTextSpan collation_name,
     SyntaqliteGeneratedColumnStorage generated_storage,
     uint32_t default_expr,
     uint32_t check_expr,
@@ -241,7 +241,7 @@ static inline uint32_t synq_parse_column_constraint(
 
 static inline uint32_t synq_parse_column_def(SynqParseCtx* ctx,
                                              uint32_t column_name,
-                                             SyntaqliteSourceSpan type_name,
+                                             SyntaqliteTextSpan type_name,
                                              uint32_t constraints) {
   return synq_parse_build(
       ctx,
@@ -255,7 +255,7 @@ static inline uint32_t synq_parse_column_def(SynqParseCtx* ctx,
 static inline uint32_t synq_parse_table_constraint(
     SynqParseCtx* ctx,
     SyntaqliteTableConstraintType kind,
-    SyntaqliteSourceSpan constraint_name,
+    SyntaqliteTextSpan constraint_name,
     SyntaqliteConflictAction onconf,
     SyntaqliteBool is_autoincrement,
     uint32_t pk_columns,
@@ -278,8 +278,8 @@ static inline uint32_t synq_parse_table_constraint(
 
 static inline uint32_t synq_parse_create_table_stmt(
     SynqParseCtx* ctx,
-    SyntaqliteSourceSpan table_name,
-    SyntaqliteSourceSpan schema,
+    SyntaqliteTextSpan table_name,
+    SyntaqliteTextSpan schema,
     SyntaqliteBool is_temp,
     SyntaqliteBool if_not_exists,
     SyntaqliteCreateTableStmtFlags flags,
@@ -302,7 +302,7 @@ static inline uint32_t synq_parse_create_table_stmt(
 
 static inline uint32_t synq_parse_cte_definition(
     SynqParseCtx* ctx,
-    SyntaqliteSourceSpan cte_name,
+    SyntaqliteTextSpan cte_name,
     SyntaqliteMaterialized materialized,
     uint32_t columns,
     uint32_t select) {
@@ -349,7 +349,7 @@ static inline uint32_t synq_parse_upsert_clause(SynqParseCtx* ctx,
 static inline uint32_t synq_parse_delete_stmt(SynqParseCtx* ctx,
                                               uint32_t table,
                                               SyntaqliteIndexHint index_hint,
-                                              SyntaqliteSourceSpan index_name,
+                                              SyntaqliteTextSpan index_name,
                                               uint32_t where_clause,
                                               uint32_t orderby,
                                               uint32_t limit_clause,
@@ -368,7 +368,7 @@ static inline uint32_t synq_parse_delete_stmt(SynqParseCtx* ctx,
 }
 
 static inline uint32_t synq_parse_set_clause(SynqParseCtx* ctx,
-                                             SyntaqliteSourceSpan column,
+                                             SyntaqliteTextSpan column,
                                              uint32_t columns,
                                              uint32_t value) {
   return synq_parse_build(
@@ -385,7 +385,7 @@ static inline uint32_t synq_parse_update_stmt(
     SyntaqliteConflictAction conflict_action,
     uint32_t table,
     SyntaqliteIndexHint index_hint,
-    SyntaqliteSourceSpan index_name,
+    SyntaqliteTextSpan index_name,
     uint32_t setlist,
     uint32_t from_clause,
     uint32_t where_clause,
@@ -453,7 +453,7 @@ static inline uint32_t synq_parse_unary_expr(SynqParseCtx* ctx,
 
 static inline uint32_t synq_parse_literal(SynqParseCtx* ctx,
                                           SyntaqliteLiteralType literal_type,
-                                          SyntaqliteSourceSpan source) {
+                                          SyntaqliteTextSpan source) {
   return synq_parse_build(ctx,
                           &(SyntaqliteLiteral){.tag = SYNTAQLITE_NODE_LITERAL,
                                                .literal_type = literal_type,
@@ -462,7 +462,7 @@ static inline uint32_t synq_parse_literal(SynqParseCtx* ctx,
 }
 
 static inline uint32_t synq_parse_ident_name(SynqParseCtx* ctx,
-                                             SyntaqliteSourceSpan source) {
+                                             SyntaqliteTextSpan source) {
   return synq_parse_build(
       ctx,
       &(SyntaqliteIdentName){.tag = SYNTAQLITE_NODE_IDENT_NAME,
@@ -471,7 +471,7 @@ static inline uint32_t synq_parse_ident_name(SynqParseCtx* ctx,
 }
 
 static inline uint32_t synq_parse_error(SynqParseCtx* ctx,
-                                        SyntaqliteSourceSpan source) {
+                                        SyntaqliteTextSpan source) {
   return synq_parse_build(
       ctx, &(SyntaqliteError){.tag = SYNTAQLITE_NODE_ERROR, .source = source},
       (uint32_t)sizeof(SyntaqliteError));
@@ -479,7 +479,7 @@ static inline uint32_t synq_parse_error(SynqParseCtx* ctx,
 
 static inline uint32_t synq_parse_function_call(
     SynqParseCtx* ctx,
-    SyntaqliteSourceSpan func_name,
+    SyntaqliteTextSpan func_name,
     SyntaqliteFunctionCallFlags flags,
     uint32_t args,
     uint32_t filter_clause,
@@ -496,7 +496,7 @@ static inline uint32_t synq_parse_function_call(
 }
 
 static inline uint32_t synq_parse_variable(SynqParseCtx* ctx,
-                                           SyntaqliteSourceSpan source) {
+                                           SyntaqliteTextSpan source) {
   return synq_parse_build(
       ctx,
       &(SyntaqliteVariable){.tag = SYNTAQLITE_NODE_VARIABLE, .source = source},
@@ -505,7 +505,7 @@ static inline uint32_t synq_parse_variable(SynqParseCtx* ctx,
 
 static inline uint32_t synq_parse_collate_expr(SynqParseCtx* ctx,
                                                uint32_t expr,
-                                               SyntaqliteSourceSpan collation) {
+                                               SyntaqliteTextSpan collation) {
   return synq_parse_build(
       ctx,
       &(SyntaqliteCollateExpr){.tag = SYNTAQLITE_NODE_COLLATE_EXPR,
@@ -653,8 +653,8 @@ static inline uint32_t synq_parse_limit_clause(SynqParseCtx* ctx,
 }
 
 static inline uint32_t synq_parse_table_ref(SynqParseCtx* ctx,
-                                            SyntaqliteSourceSpan table_name,
-                                            SyntaqliteSourceSpan schema,
+                                            SyntaqliteTextSpan table_name,
+                                            SyntaqliteTextSpan schema,
                                             uint32_t alias,
                                             uint32_t args) {
   return synq_parse_build(
@@ -720,8 +720,8 @@ static inline uint32_t synq_parse_trigger_event(
 
 static inline uint32_t synq_parse_create_trigger_stmt(
     SynqParseCtx* ctx,
-    SyntaqliteSourceSpan trigger_name,
-    SyntaqliteSourceSpan schema,
+    SyntaqliteTextSpan trigger_name,
+    SyntaqliteTextSpan schema,
     SyntaqliteBool is_temp,
     SyntaqliteBool if_not_exists,
     SyntaqliteTriggerTiming timing,
@@ -746,11 +746,11 @@ static inline uint32_t synq_parse_create_trigger_stmt(
 
 static inline uint32_t synq_parse_create_virtual_table_stmt(
     SynqParseCtx* ctx,
-    SyntaqliteSourceSpan table_name,
-    SyntaqliteSourceSpan schema,
-    SyntaqliteSourceSpan module_name,
+    SyntaqliteTextSpan table_name,
+    SyntaqliteTextSpan schema,
+    SyntaqliteTextSpan module_name,
     SyntaqliteBool if_not_exists,
-    SyntaqliteSourceSpan module_args) {
+    SyntaqliteTextSpan module_args) {
   return synq_parse_build(ctx,
                           &(SyntaqliteCreateVirtualTableStmt){
                               .tag = SYNTAQLITE_NODE_CREATE_VIRTUAL_TABLE_STMT,
@@ -764,9 +764,9 @@ static inline uint32_t synq_parse_create_virtual_table_stmt(
 
 static inline uint32_t synq_parse_pragma_stmt(
     SynqParseCtx* ctx,
-    SyntaqliteSourceSpan pragma_name,
-    SyntaqliteSourceSpan schema,
-    SyntaqliteSourceSpan value,
+    SyntaqliteTextSpan pragma_name,
+    SyntaqliteTextSpan schema,
+    SyntaqliteTextSpan value,
     SyntaqlitePragmaForm pragma_form) {
   return synq_parse_build(
       ctx,
@@ -780,8 +780,8 @@ static inline uint32_t synq_parse_pragma_stmt(
 
 static inline uint32_t synq_parse_analyze_or_reindex_stmt(
     SynqParseCtx* ctx,
-    SyntaqliteSourceSpan target_name,
-    SyntaqliteSourceSpan schema,
+    SyntaqliteTextSpan target_name,
+    SyntaqliteTextSpan schema,
     SyntaqliteAnalyzeOrReindexOp kind) {
   return synq_parse_build(ctx,
                           &(SyntaqliteAnalyzeOrReindexStmt){
@@ -815,7 +815,7 @@ static inline uint32_t synq_parse_detach_stmt(SynqParseCtx* ctx,
 }
 
 static inline uint32_t synq_parse_vacuum_stmt(SynqParseCtx* ctx,
-                                              SyntaqliteSourceSpan schema,
+                                              SyntaqliteTextSpan schema,
                                               uint32_t filename) {
   return synq_parse_build(
       ctx,
@@ -839,9 +839,9 @@ static inline uint32_t synq_parse_explain_stmt(
 
 static inline uint32_t synq_parse_create_index_stmt(
     SynqParseCtx* ctx,
-    SyntaqliteSourceSpan index_name,
-    SyntaqliteSourceSpan schema,
-    SyntaqliteSourceSpan table_name,
+    SyntaqliteTextSpan index_name,
+    SyntaqliteTextSpan schema,
+    SyntaqliteTextSpan table_name,
     SyntaqliteBool is_unique,
     SyntaqliteBool if_not_exists,
     uint32_t columns,
@@ -859,14 +859,13 @@ static inline uint32_t synq_parse_create_index_stmt(
       (uint32_t)sizeof(SyntaqliteCreateIndexStmt));
 }
 
-static inline uint32_t synq_parse_create_view_stmt(
-    SynqParseCtx* ctx,
-    SyntaqliteSourceSpan view_name,
-    SyntaqliteSourceSpan schema,
-    SyntaqliteBool is_temp,
-    SyntaqliteBool if_not_exists,
-    uint32_t column_names,
-    uint32_t select) {
+static inline uint32_t synq_parse_create_view_stmt(SynqParseCtx* ctx,
+                                                   SyntaqliteTextSpan view_name,
+                                                   SyntaqliteTextSpan schema,
+                                                   SyntaqliteBool is_temp,
+                                                   SyntaqliteBool if_not_exists,
+                                                   uint32_t column_names,
+                                                   uint32_t select) {
   return synq_parse_build(
       ctx,
       &(SyntaqliteCreateViewStmt){.tag = SYNTAQLITE_NODE_CREATE_VIEW_STMT,
@@ -917,7 +916,7 @@ static inline uint32_t synq_parse_frame_spec(SynqParseCtx* ctx,
 
 static inline uint32_t synq_parse_window_def(
     SynqParseCtx* ctx,
-    SyntaqliteSourceSpan base_window_name,
+    SyntaqliteTextSpan base_window_name,
     uint32_t partition_by,
     uint32_t orderby,
     uint32_t frame) {
@@ -933,7 +932,7 @@ static inline uint32_t synq_parse_window_def(
 
 static inline uint32_t synq_parse_named_window_def(
     SynqParseCtx* ctx,
-    SyntaqliteSourceSpan window_name,
+    SyntaqliteTextSpan window_name,
     uint32_t window_def) {
   return synq_parse_build(
       ctx,
@@ -946,7 +945,7 @@ static inline uint32_t synq_parse_named_window_def(
 static inline uint32_t synq_parse_filter_over(SynqParseCtx* ctx,
                                               uint32_t filter_expr,
                                               uint32_t over_def,
-                                              SyntaqliteSourceSpan over_name) {
+                                              SyntaqliteTextSpan over_name) {
   return synq_parse_build(
       ctx,
       &(SyntaqliteFilterOver){.tag = SYNTAQLITE_NODE_FILTER_OVER,

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
@@ -47,19 +47,19 @@
 // columnname: passes name span + typetoken span from column definition.
 typedef struct SynqColumnNameValue {
   uint32_t name;
-  SyntaqliteSourceSpan typetoken;
+  SyntaqliteTextSpan typetoken;
 } SynqColumnNameValue;
 
 // ccons / tcons / generated: a constraint node + pending constraint name.
 typedef struct SynqConstraintValue {
   uint32_t node;
-  SyntaqliteSourceSpan pending_name;
+  SyntaqliteTextSpan pending_name;
 } SynqConstraintValue;
 
 // carglist / conslist: accumulated constraint list + pending name for next.
 typedef struct SynqConstraintListValue {
   uint32_t list;
-  SyntaqliteSourceSpan pending_name;
+  SyntaqliteTextSpan pending_name;
 } SynqConstraintListValue;
 
 // on_using: ON expr / USING column-list discriminator.
@@ -90,7 +90,7 @@ typedef struct SynqUpsertValue {
 #define YYPARSEFREENEVERNULL 1
 
 // Map parser error bookkeeping to a best-effort source span.
-static inline SyntaqliteSourceSpan synq_error_span(SynqParseCtx* pCtx) {
+static inline SyntaqliteTextSpan synq_error_span(SynqParseCtx* pCtx) {
   if (pCtx->error_offset == 0xFFFFFFFF || pCtx->error_length == 0) {
     return SYNQ_NO_SPAN;
   }
@@ -98,7 +98,7 @@ static inline SyntaqliteSourceSpan synq_error_span(SynqParseCtx* pCtx) {
   if (len > UINT16_MAX) {
     len = UINT16_MAX;
   }
-  return (SyntaqliteSourceSpan){
+  return (SyntaqliteTextSpan){
       .offset = pCtx->error_offset,
       .length = (uint16_t)len,
       .flags = 0,
@@ -7676,10 +7676,10 @@ static YYACTIONTYPE yy_reduce(
       break;
     case 58: /* create_table ::= createkw temp TABLE ifnotexists nm dbnm */
     {
-      SyntaqliteSourceSpan tbl_name =
+      SyntaqliteTextSpan tbl_name =
           yymsp[0].minor.yy0.z ? synq_span_dequote(pCtx, yymsp[0].minor.yy0)
                                : synq_span_dequote(pCtx, yymsp[-1].minor.yy0);
-      SyntaqliteSourceSpan tbl_schema =
+      SyntaqliteTextSpan tbl_schema =
           yymsp[0].minor.yy0.z ? synq_span_dequote(pCtx, yymsp[-1].minor.yy0)
                                : SYNQ_NO_SPAN;
       yymsp[-5].minor.yy277 = synq_parse_create_table_stmt(
@@ -8114,9 +8114,9 @@ static YYACTIONTYPE yy_reduce(
     case 108: /* conslist ::= conslist tconscomma tcons */
     {
       // If comma separator was present, clear pending constraint name
-      SyntaqliteSourceSpan pending = yymsp[-1].minor.yy320
-                                         ? SYNQ_NO_SPAN
-                                         : yymsp[-2].minor.yy430.pending_name;
+      SyntaqliteTextSpan pending = yymsp[-1].minor.yy320
+                                       ? SYNQ_NO_SPAN
+                                       : yymsp[-2].minor.yy430.pending_name;
       if (yymsp[0].minor.yy150.node != SYNTAQLITE_NULL_NODE) {
         SyntaqliteNode* node = AST_NODE(&pCtx->ast, yymsp[0].minor.yy150.node);
         node->table_constraint.constraint_name = pending;
@@ -9159,8 +9159,8 @@ static YYACTIONTYPE yy_reduce(
     case 286: /* seltablist ::= stl_prefix nm dbnm as on_using */
     {
       uint32_t alias = yymsp[-1].minor.yy277;
-      SyntaqliteSourceSpan table_name;
-      SyntaqliteSourceSpan schema;
+      SyntaqliteTextSpan table_name;
+      SyntaqliteTextSpan schema;
       if (yymsp[-2].minor.yy0.z != NULL) {
         table_name = synq_span_dequote(pCtx, yymsp[-2].minor.yy0);
         schema = synq_span_dequote(pCtx, yymsp[-3].minor.yy0);
@@ -9183,8 +9183,8 @@ static YYACTIONTYPE yy_reduce(
     {
       (void)yymsp[-1].minor.yy0;
       uint32_t alias = yymsp[-2].minor.yy277;
-      SyntaqliteSourceSpan table_name;
-      SyntaqliteSourceSpan schema;
+      SyntaqliteTextSpan table_name;
+      SyntaqliteTextSpan schema;
       if (yymsp[-3].minor.yy0.z != NULL) {
         table_name = synq_span_dequote(pCtx, yymsp[-3].minor.yy0);
         schema = synq_span_dequote(pCtx, yymsp[-4].minor.yy0);
@@ -9206,8 +9206,8 @@ static YYACTIONTYPE yy_reduce(
     case 288: /* seltablist ::= stl_prefix nm dbnm LP exprlist RP as on_using */
     {
       uint32_t alias = yymsp[-1].minor.yy277;
-      SyntaqliteSourceSpan table_name;
-      SyntaqliteSourceSpan schema;
+      SyntaqliteTextSpan table_name;
+      SyntaqliteTextSpan schema;
       if (yymsp[-5].minor.yy0.z != NULL) {
         table_name = synq_span_dequote(pCtx, yymsp[-5].minor.yy0);
         schema = synq_span_dequote(pCtx, yymsp[-6].minor.yy0);
@@ -9431,10 +9431,10 @@ static YYACTIONTYPE yy_reduce(
     case 303: /* trigger_decl ::= temp TRIGGER ifnotexists nm dbnm trigger_time
                  trigger_event ON fullname foreach_clause when_clause */
     {
-      SyntaqliteSourceSpan trig_name =
-          yymsp[-6].minor.yy0.z ? synq_span(pCtx, yymsp[-6].minor.yy0)
-                                : synq_span(pCtx, yymsp[-7].minor.yy0);
-      SyntaqliteSourceSpan trig_schema =
+      SyntaqliteTextSpan trig_name = yymsp[-6].minor.yy0.z
+                                         ? synq_span(pCtx, yymsp[-6].minor.yy0)
+                                         : synq_span(pCtx, yymsp[-7].minor.yy0);
+      SyntaqliteTextSpan trig_schema =
           yymsp[-6].minor.yy0.z ? synq_span(pCtx, yymsp[-7].minor.yy0)
                                 : SYNQ_NO_SPAN;
       yylhsminor.yy277 = synq_parse_create_trigger_stmt(
@@ -9576,10 +9576,10 @@ static YYACTIONTYPE yy_reduce(
     } break;
     case 325: /* cmd ::= PRAGMA nm dbnm */
     {
-      SyntaqliteSourceSpan name_span =
-          yymsp[0].minor.yy0.z ? synq_span(pCtx, yymsp[0].minor.yy0)
-                               : synq_span(pCtx, yymsp[-1].minor.yy0);
-      SyntaqliteSourceSpan schema_span =
+      SyntaqliteTextSpan name_span = yymsp[0].minor.yy0.z
+                                         ? synq_span(pCtx, yymsp[0].minor.yy0)
+                                         : synq_span(pCtx, yymsp[-1].minor.yy0);
+      SyntaqliteTextSpan schema_span =
           yymsp[0].minor.yy0.z ? synq_span(pCtx, yymsp[-1].minor.yy0)
                                : SYNQ_NO_SPAN;
       yymsp[-2].minor.yy277 =
@@ -9590,10 +9590,10 @@ static YYACTIONTYPE yy_reduce(
     case 328: /* cmd ::= PRAGMA nm dbnm EQ minus_num */
       yytestcase(yyruleno == 328);
       {
-        SyntaqliteSourceSpan name_span =
+        SyntaqliteTextSpan name_span =
             yymsp[-2].minor.yy0.z ? synq_span(pCtx, yymsp[-2].minor.yy0)
                                   : synq_span(pCtx, yymsp[-3].minor.yy0);
-        SyntaqliteSourceSpan schema_span =
+        SyntaqliteTextSpan schema_span =
             yymsp[-2].minor.yy0.z ? synq_span(pCtx, yymsp[-3].minor.yy0)
                                   : SYNQ_NO_SPAN;
         yymsp[-4].minor.yy277 = synq_parse_pragma_stmt(
@@ -9605,10 +9605,10 @@ static YYACTIONTYPE yy_reduce(
     case 329: /* cmd ::= PRAGMA nm dbnm LP minus_num RP */
       yytestcase(yyruleno == 329);
       {
-        SyntaqliteSourceSpan name_span =
+        SyntaqliteTextSpan name_span =
             yymsp[-3].minor.yy0.z ? synq_span(pCtx, yymsp[-3].minor.yy0)
                                   : synq_span(pCtx, yymsp[-4].minor.yy0);
-        SyntaqliteSourceSpan schema_span =
+        SyntaqliteTextSpan schema_span =
             yymsp[-3].minor.yy0.z ? synq_span(pCtx, yymsp[-4].minor.yy0)
                                   : SYNQ_NO_SPAN;
         yymsp[-5].minor.yy277 = synq_parse_pragma_stmt(
@@ -9639,10 +9639,10 @@ static YYACTIONTYPE yy_reduce(
     } break;
     case 341: /* cmd ::= ANALYZE nm dbnm */
     {
-      SyntaqliteSourceSpan name_span =
-          yymsp[0].minor.yy0.z ? synq_span(pCtx, yymsp[0].minor.yy0)
-                               : synq_span(pCtx, yymsp[-1].minor.yy0);
-      SyntaqliteSourceSpan schema_span =
+      SyntaqliteTextSpan name_span = yymsp[0].minor.yy0.z
+                                         ? synq_span(pCtx, yymsp[0].minor.yy0)
+                                         : synq_span(pCtx, yymsp[-1].minor.yy0);
+      SyntaqliteTextSpan schema_span =
           yymsp[0].minor.yy0.z ? synq_span(pCtx, yymsp[-1].minor.yy0)
                                : SYNQ_NO_SPAN;
       yymsp[-2].minor.yy277 = synq_parse_analyze_or_reindex_stmt(
@@ -9657,10 +9657,10 @@ static YYACTIONTYPE yy_reduce(
     } break;
     case 343: /* cmd ::= REINDEX nm dbnm */
     {
-      SyntaqliteSourceSpan name_span =
-          yymsp[0].minor.yy0.z ? synq_span(pCtx, yymsp[0].minor.yy0)
-                               : synq_span(pCtx, yymsp[-1].minor.yy0);
-      SyntaqliteSourceSpan schema_span =
+      SyntaqliteTextSpan name_span = yymsp[0].minor.yy0.z
+                                         ? synq_span(pCtx, yymsp[0].minor.yy0)
+                                         : synq_span(pCtx, yymsp[-1].minor.yy0);
+      SyntaqliteTextSpan schema_span =
           yymsp[0].minor.yy0.z ? synq_span(pCtx, yymsp[-1].minor.yy0)
                                : SYNQ_NO_SPAN;
       yymsp[-2].minor.yy277 =
@@ -9715,12 +9715,12 @@ static YYACTIONTYPE yy_reduce(
     case 357: /* cmd ::= createkw uniqueflag INDEX ifnotexists nm dbnm ON nm LP
                  sortlist RP where_opt */
     {
-      SyntaqliteSourceSpan idx_name =
-          yymsp[-6].minor.yy0.z ? synq_span(pCtx, yymsp[-6].minor.yy0)
-                                : synq_span(pCtx, yymsp[-7].minor.yy0);
-      SyntaqliteSourceSpan idx_schema =
-          yymsp[-6].minor.yy0.z ? synq_span(pCtx, yymsp[-7].minor.yy0)
-                                : SYNQ_NO_SPAN;
+      SyntaqliteTextSpan idx_name = yymsp[-6].minor.yy0.z
+                                        ? synq_span(pCtx, yymsp[-6].minor.yy0)
+                                        : synq_span(pCtx, yymsp[-7].minor.yy0);
+      SyntaqliteTextSpan idx_schema = yymsp[-6].minor.yy0.z
+                                          ? synq_span(pCtx, yymsp[-7].minor.yy0)
+                                          : SYNQ_NO_SPAN;
       yymsp[-11].minor.yy277 = synq_parse_create_index_stmt(
           pCtx, idx_name, idx_schema, synq_span(pCtx, yymsp[-4].minor.yy0),
           (SyntaqliteBool)yymsp[-10].minor.yy320,
@@ -9734,10 +9734,10 @@ static YYACTIONTYPE yy_reduce(
     case 362: /* cmd ::= createkw temp VIEW ifnotexists nm dbnm eidlist_opt AS
                  select */
     {
-      SyntaqliteSourceSpan view_name =
-          yymsp[-3].minor.yy0.z ? synq_span(pCtx, yymsp[-3].minor.yy0)
-                                : synq_span(pCtx, yymsp[-4].minor.yy0);
-      SyntaqliteSourceSpan view_schema =
+      SyntaqliteTextSpan view_name = yymsp[-3].minor.yy0.z
+                                         ? synq_span(pCtx, yymsp[-3].minor.yy0)
+                                         : synq_span(pCtx, yymsp[-4].minor.yy0);
+      SyntaqliteTextSpan view_schema =
           yymsp[-3].minor.yy0.z ? synq_span(pCtx, yymsp[-4].minor.yy0)
                                 : SYNQ_NO_SPAN;
       yymsp[-8].minor.yy277 = synq_parse_create_view_stmt(
@@ -9775,7 +9775,7 @@ static YYACTIONTYPE yy_reduce(
       SyntaqliteNode* vtab = AST_NODE(&pCtx->ast, yymsp[-3].minor.yy277);
       uint32_t args_start = yymsp[-2].minor.yy0.offset + yymsp[-2].minor.yy0.n;
       uint32_t args_end = yymsp[0].minor.yy0.offset;
-      vtab->create_virtual_table_stmt.module_args = (SyntaqliteSourceSpan){
+      vtab->create_virtual_table_stmt.module_args = (SyntaqliteTextSpan){
           .offset = args_start,
           .length = (uint16_t)(args_end - args_start),
           .flags = 0,
@@ -9788,12 +9788,12 @@ static YYACTIONTYPE yy_reduce(
     case 373: /* create_vtab ::= createkw VIRTUAL TABLE ifnotexists nm dbnm
                  USING nm */
     {
-      SyntaqliteSourceSpan tbl_name =
-          yymsp[-2].minor.yy0.z ? synq_span(pCtx, yymsp[-2].minor.yy0)
-                                : synq_span(pCtx, yymsp[-3].minor.yy0);
-      SyntaqliteSourceSpan tbl_schema =
-          yymsp[-2].minor.yy0.z ? synq_span(pCtx, yymsp[-3].minor.yy0)
-                                : SYNQ_NO_SPAN;
+      SyntaqliteTextSpan tbl_name = yymsp[-2].minor.yy0.z
+                                        ? synq_span(pCtx, yymsp[-2].minor.yy0)
+                                        : synq_span(pCtx, yymsp[-3].minor.yy0);
+      SyntaqliteTextSpan tbl_schema = yymsp[-2].minor.yy0.z
+                                          ? synq_span(pCtx, yymsp[-3].minor.yy0)
+                                          : SYNQ_NO_SPAN;
       yymsp[-7].minor.yy277 = synq_parse_create_virtual_table_stmt(
           pCtx, tbl_name, tbl_schema, synq_span(pCtx, yymsp[0].minor.yy0),
           (SyntaqliteBool)yymsp[-4].minor.yy320,

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -200,10 +200,10 @@ SYNTAQLITE_API const void* syntaqlite_parser_node(SyntaqliteParser* p,
                                                   uint32_t node_id);
 
 // Return a pointer to the source text bound by the last reset() call.
-SYNTAQLITE_API const char* syntaqlite_parser_source(SyntaqliteParser* p);
+SYNTAQLITE_API const char* syntaqlite_parser_text(SyntaqliteParser* p);
 
 // Return the byte length of the source text bound by the last reset() call.
-SYNTAQLITE_API uint32_t syntaqlite_parser_source_length(SyntaqliteParser* p);
+SYNTAQLITE_API uint32_t syntaqlite_parser_text_length(SyntaqliteParser* p);
 
 // Return the number of nodes currently in the arena.
 SYNTAQLITE_API uint32_t syntaqlite_parser_node_count(SyntaqliteParser* p);
@@ -211,13 +211,6 @@ SYNTAQLITE_API uint32_t syntaqlite_parser_node_count(SyntaqliteParser* p);
 // ---------------------------------------------------------------------------
 // Span accessors
 // ---------------------------------------------------------------------------
-
-// A byte range `[start, end)` in the user's authored input text.
-// Returned by `syntaqlite_parser_span_text_range`.
-typedef struct SyntaqliteTextRange {
-  uint32_t start;
-  uint32_t end;
-} SyntaqliteTextRange;
 
 // One frame in a span traceback, produced by
 // `syntaqlite_parser_traceback`.  Each frame is self-contained: it
@@ -264,7 +257,7 @@ typedef struct SyntaqliteTracebackFrame {
 // that need to retain frames across such calls must copy them out.
 SYNTAQLITE_API const SyntaqliteTracebackFrame* syntaqlite_parser_traceback(
     SyntaqliteParser* p,
-    const SyntaqliteSourceSpan* span,
+    const SyntaqliteTextSpan* span,
     uint32_t* out_count);
 
 // Post-expansion text for `span` — the bytes the tokenizer actually saw.
@@ -275,7 +268,7 @@ SYNTAQLITE_API const SyntaqliteTracebackFrame* syntaqlite_parser_traceback(
 // Returns NULL (and writes 0 to `*out_len`) for empty or invalid spans.
 SYNTAQLITE_API const char* syntaqlite_parser_span_expanded_text(
     SyntaqliteParser* p,
-    const SyntaqliteSourceSpan* span,
+    const SyntaqliteTextSpan* span,
     uint32_t* out_len);
 
 // Authored text for `span` — always a slice of the input source.
@@ -288,19 +281,16 @@ SYNTAQLITE_API const char* syntaqlite_parser_span_expanded_text(
 //
 // Always a direct slice of the source — no allocation.  Returns NULL
 // (and writes 0 to `*out_len`) for empty or invalid spans.
+//
+// `out_offset` is optional; when non-NULL it receives the byte offset
+// in the input source where the returned slice begins (so callers can
+// compute source-relative positions without pointer arithmetic).
+// Written 0 for empty or invalid spans.
 SYNTAQLITE_API const char* syntaqlite_parser_span_text(
     SyntaqliteParser* p,
-    const SyntaqliteSourceSpan* span,
-    uint32_t* out_len);
-
-// Byte range of `syntaqlite_parser_span_text(span)` in the input source.
-// The returned range satisfies:
-//   syntaqlite_parser_span_text(span) ==
-//       source[range.start .. range.end]
-// Returns `{0, 0}` for empty or invalid spans.
-SYNTAQLITE_API SyntaqliteTextRange
-syntaqlite_parser_span_text_range(SyntaqliteParser* p,
-                                  const SyntaqliteSourceSpan* span);
+    const SyntaqliteTextSpan* span,
+    uint32_t* out_len,
+    uint32_t* out_offset);
 
 // ---------------------------------------------------------------------------
 // Node and list helpers

--- a/syntaqlite-syntax/include/syntaqlite/types.h
+++ b/syntaqlite-syntax/include/syntaqlite/types.h
@@ -33,17 +33,15 @@ typedef uint32_t SyntaqliteCompletionContext;
 //   - `syntaqlite_parser_span_expanded_text(p, &span, &len)` — the
 //     bytes the tokenizer actually saw, which for macro-expanded spans
 //     live in an expansion layer buffer.
-//   - `syntaqlite_parser_span_text_range(p, &span)` — byte range of
-//     `span_text` in the input source.
 //   - `syntaqlite_parser_traceback(p, &span, ...)` — the full outermost
 //     → innermost expansion chain for diagnostics, with argument-level
 //     drill-through fidelity for spans inside substituted macro args.
-typedef struct SyntaqliteSourceSpan {
+typedef struct SyntaqliteTextSpan {
   uint32_t offset;
   uint16_t length;
   uint8_t flags;
   uint8_t _layer_id;  // Internal: 0 = source, >0 = macro expansion layer.
-} SyntaqliteSourceSpan;
+} SyntaqliteTextSpan;
 
 // ── Span flags ───────────────────────────────────────────────────────────────
 
@@ -52,12 +50,11 @@ typedef struct SyntaqliteSourceSpan {
 // `"..."`.
 #define SYNTAQLITE_SPAN_FLAG_QUOTED ((uint8_t)1u)
 
-static inline int synq_span_is_quoted(SyntaqliteSourceSpan sp) {
+static inline int synq_span_is_quoted(SyntaqliteTextSpan sp) {
   return (sp.flags & SYNTAQLITE_SPAN_FLAG_QUOTED) != 0;
 }
 
-static inline SyntaqliteSourceSpan synq_span_set_quoted(
-    SyntaqliteSourceSpan sp) {
+static inline SyntaqliteTextSpan synq_span_set_quoted(SyntaqliteTextSpan sp) {
   sp.flags |= SYNTAQLITE_SPAN_FLAG_QUOTED;
   return sp;
 }

--- a/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
@@ -6,7 +6,7 @@
 //   - SynqParseCtx: parse/AST state threaded via %extra_argument
 //   - SynqParseToken: terminal token type (used as %token_type in lemon
 //   grammar)
-//   - synq_span(): converts SynqParseToken to SyntaqliteSourceSpan
+//   - synq_span(): converts SynqParseToken to SyntaqliteTextSpan
 //   - AST builder functions: synq_parse_build, synq_parse_list_append, etc.
 //   - AST_NODE macro for in-place AST node mutation
 //
@@ -231,12 +231,12 @@ static inline void synq_parse_list_flush(SynqParseCtx* ctx) {
 // Token → span conversion
 // ---------------------------------------------------------------------------
 
-static inline SyntaqliteSourceSpan synq_span(SynqParseCtx* ctx,
-                                             SynqParseToken tok) {
+static inline SyntaqliteTextSpan synq_span(SynqParseCtx* ctx,
+                                           SynqParseToken tok) {
   (void)ctx;
   if (tok.z == NULL)
-    return (SyntaqliteSourceSpan){0, 0, 0, 0};
-  return (SyntaqliteSourceSpan){
+    return (SyntaqliteTextSpan){0, 0, 0, 0};
+  return (SyntaqliteTextSpan){
       .offset = tok.offset,
       .length = (uint16_t)tok.n,
       .flags = 0,
@@ -249,25 +249,25 @@ static inline SyntaqliteSourceSpan synq_span(SynqParseCtx* ctx,
 // Handles "...", `...`, and [...] forms.  For unquoted tokens, equivalent
 // to synq_span().  Sets SYNTAQLITE_SPAN_FLAG_QUOTED when quotes are stripped
 // so the formatter can re-wrap in standard double quotes.
-static inline SyntaqliteSourceSpan synq_span_dequote(SynqParseCtx* ctx,
-                                                     SynqParseToken tok) {
+static inline SyntaqliteTextSpan synq_span_dequote(SynqParseCtx* ctx,
+                                                   SynqParseToken tok) {
   (void)ctx;
   if (tok.z == NULL)
-    return (SyntaqliteSourceSpan){0, 0, 0, 0};
+    return (SyntaqliteTextSpan){0, 0, 0, 0};
   if (tok.n >= 2) {
     char open = tok.z[0];
     char close = tok.z[tok.n - 1];
     if ((open == '"' && close == '"') || (open == '`' && close == '`') ||
         (open == '[' && close == ']')) {
-      SyntaqliteSourceSpan sp = {tok.offset + 1, (uint16_t)(tok.n - 2), 0,
-                                 tok.layer_id};
+      SyntaqliteTextSpan sp = {tok.offset + 1, (uint16_t)(tok.n - 2), 0,
+                               tok.layer_id};
       return synq_span_set_quoted(sp);
     }
   }
-  return (SyntaqliteSourceSpan){tok.offset, (uint16_t)tok.n, 0, tok.layer_id};
+  return (SyntaqliteTextSpan){tok.offset, (uint16_t)tok.n, 0, tok.layer_id};
 }
 
-#define SYNQ_NO_SPAN ((SyntaqliteSourceSpan){0, 0, 0, 0})
+#define SYNQ_NO_SPAN ((SyntaqliteTextSpan){0, 0, 0, 0})
 
 // Mark a token as "used as identifier" (fallback from keyword).
 // O(1) — uses the token_idx stored in SynqParseToken at collection time.

--- a/syntaqlite-syntax/include/syntaqlite_sqlite/sqlite_node.h
+++ b/syntaqlite-syntax/include/syntaqlite_sqlite/sqlite_node.h
@@ -391,7 +391,7 @@ typedef enum SyntaqliteNodeTag {
 
 typedef struct SyntaqliteAggregateFunctionCall {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan func_name;
+  SyntaqliteTextSpan func_name;
   SyntaqliteAggregateFunctionCallFlags flags;
   uint32_t args;
   uint32_t orderby;
@@ -401,7 +401,7 @@ typedef struct SyntaqliteAggregateFunctionCall {
 
 typedef struct SyntaqliteOrderedSetFunctionCall {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan func_name;
+  SyntaqliteTextSpan func_name;
   SyntaqliteAggregateFunctionCallFlags flags;
   uint32_t args;
   uint32_t orderby_expr;
@@ -412,14 +412,14 @@ typedef struct SyntaqliteOrderedSetFunctionCall {
 typedef struct SyntaqliteCastExpr {
   SyntaqliteNodeTag tag;
   uint32_t expr;
-  SyntaqliteSourceSpan type_name;
+  SyntaqliteTextSpan type_name;
 } SyntaqliteCastExpr;
 
 typedef struct SyntaqliteColumnRef {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan column;
-  SyntaqliteSourceSpan table;
-  SyntaqliteSourceSpan schema;
+  SyntaqliteTextSpan column;
+  SyntaqliteTextSpan table;
+  SyntaqliteTextSpan schema;
 } SyntaqliteColumnRef;
 
 typedef struct SyntaqliteCompoundSelect {
@@ -492,7 +492,7 @@ typedef struct SyntaqliteCaseWhenList {
 
 typedef struct SyntaqliteForeignKeyClause {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan ref_table;
+  SyntaqliteTextSpan ref_table;
   uint32_t ref_columns;
   SyntaqliteForeignKeyAction on_delete;
   SyntaqliteForeignKeyAction on_update;
@@ -502,11 +502,11 @@ typedef struct SyntaqliteForeignKeyClause {
 typedef struct SyntaqliteColumnConstraint {
   SyntaqliteNodeTag tag;
   SyntaqliteColumnConstraintType kind;
-  SyntaqliteSourceSpan constraint_name;
+  SyntaqliteTextSpan constraint_name;
   SyntaqliteConflictAction onconf;
   SyntaqliteSortOrder sort_order;
   SyntaqliteBool is_autoincrement;
-  SyntaqliteSourceSpan collation_name;
+  SyntaqliteTextSpan collation_name;
   SyntaqliteGeneratedColumnStorage generated_storage;
   uint32_t default_expr;
   uint32_t check_expr;
@@ -524,7 +524,7 @@ typedef struct SyntaqliteColumnConstraintList {
 typedef struct SyntaqliteColumnDef {
   SyntaqliteNodeTag tag;
   uint32_t column_name;
-  SyntaqliteSourceSpan type_name;
+  SyntaqliteTextSpan type_name;
   uint32_t constraints;
 } SyntaqliteColumnDef;
 
@@ -538,7 +538,7 @@ typedef struct SyntaqliteColumnDefList {
 typedef struct SyntaqliteTableConstraint {
   SyntaqliteNodeTag tag;
   SyntaqliteTableConstraintType kind;
-  SyntaqliteSourceSpan constraint_name;
+  SyntaqliteTextSpan constraint_name;
   SyntaqliteConflictAction onconf;
   SyntaqliteBool is_autoincrement;
   uint32_t pk_columns;
@@ -556,8 +556,8 @@ typedef struct SyntaqliteTableConstraintList {
 
 typedef struct SyntaqliteCreateTableStmt {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan table_name;
-  SyntaqliteSourceSpan schema;
+  SyntaqliteTextSpan table_name;
+  SyntaqliteTextSpan schema;
   SyntaqliteBool is_temp;
   SyntaqliteBool if_not_exists;
   SyntaqliteCreateTableStmtFlags flags;
@@ -568,7 +568,7 @@ typedef struct SyntaqliteCreateTableStmt {
 
 typedef struct SyntaqliteCteDefinition {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan cte_name;
+  SyntaqliteTextSpan cte_name;
   SyntaqliteMaterialized materialized;
   uint32_t columns;
   uint32_t select;
@@ -608,7 +608,7 @@ typedef struct SyntaqliteDeleteStmt {
   SyntaqliteNodeTag tag;
   uint32_t table;
   SyntaqliteIndexHint index_hint;
-  SyntaqliteSourceSpan index_name;
+  SyntaqliteTextSpan index_name;
   uint32_t where_clause;
   uint32_t orderby;
   uint32_t limit_clause;
@@ -617,7 +617,7 @@ typedef struct SyntaqliteDeleteStmt {
 
 typedef struct SyntaqliteSetClause {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan column;
+  SyntaqliteTextSpan column;
   uint32_t columns;
   uint32_t value;
 } SyntaqliteSetClause;
@@ -634,7 +634,7 @@ typedef struct SyntaqliteUpdateStmt {
   SyntaqliteConflictAction conflict_action;
   uint32_t table;
   SyntaqliteIndexHint index_hint;
-  SyntaqliteSourceSpan index_name;
+  SyntaqliteTextSpan index_name;
   uint32_t setlist;
   uint32_t from_clause;
   uint32_t where_clause;
@@ -669,17 +669,17 @@ typedef struct SyntaqliteUnaryExpr {
 typedef struct SyntaqliteLiteral {
   SyntaqliteNodeTag tag;
   SyntaqliteLiteralType literal_type;
-  SyntaqliteSourceSpan source;
+  SyntaqliteTextSpan source;
 } SyntaqliteLiteral;
 
 typedef struct SyntaqliteIdentName {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan source;
+  SyntaqliteTextSpan source;
 } SyntaqliteIdentName;
 
 typedef struct SyntaqliteError {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan source;
+  SyntaqliteTextSpan source;
 } SyntaqliteError;
 
 // List of Expr
@@ -691,7 +691,7 @@ typedef struct SyntaqliteExprList {
 
 typedef struct SyntaqliteFunctionCall {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan func_name;
+  SyntaqliteTextSpan func_name;
   SyntaqliteFunctionCallFlags flags;
   uint32_t args;
   uint32_t filter_clause;
@@ -700,13 +700,13 @@ typedef struct SyntaqliteFunctionCall {
 
 typedef struct SyntaqliteVariable {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan source;
+  SyntaqliteTextSpan source;
 } SyntaqliteVariable;
 
 typedef struct SyntaqliteCollateExpr {
   SyntaqliteNodeTag tag;
   uint32_t expr;
-  SyntaqliteSourceSpan collation;
+  SyntaqliteTextSpan collation;
 } SyntaqliteCollateExpr;
 
 typedef struct SyntaqliteRaiseExpr {
@@ -797,8 +797,8 @@ typedef struct SyntaqliteLimitClause {
 
 typedef struct SyntaqliteTableRef {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan table_name;
-  SyntaqliteSourceSpan schema;
+  SyntaqliteTextSpan table_name;
+  SyntaqliteTextSpan schema;
   uint32_t alias;
   uint32_t args;
 } SyntaqliteTableRef;
@@ -839,8 +839,8 @@ typedef struct SyntaqliteTriggerCmdList {
 
 typedef struct SyntaqliteCreateTriggerStmt {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan trigger_name;
-  SyntaqliteSourceSpan schema;
+  SyntaqliteTextSpan trigger_name;
+  SyntaqliteTextSpan schema;
   SyntaqliteBool is_temp;
   SyntaqliteBool if_not_exists;
   SyntaqliteTriggerTiming timing;
@@ -852,25 +852,25 @@ typedef struct SyntaqliteCreateTriggerStmt {
 
 typedef struct SyntaqliteCreateVirtualTableStmt {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan table_name;
-  SyntaqliteSourceSpan schema;
-  SyntaqliteSourceSpan module_name;
+  SyntaqliteTextSpan table_name;
+  SyntaqliteTextSpan schema;
+  SyntaqliteTextSpan module_name;
   SyntaqliteBool if_not_exists;
-  SyntaqliteSourceSpan module_args;
+  SyntaqliteTextSpan module_args;
 } SyntaqliteCreateVirtualTableStmt;
 
 typedef struct SyntaqlitePragmaStmt {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan pragma_name;
-  SyntaqliteSourceSpan schema;
-  SyntaqliteSourceSpan value;
+  SyntaqliteTextSpan pragma_name;
+  SyntaqliteTextSpan schema;
+  SyntaqliteTextSpan value;
   SyntaqlitePragmaForm pragma_form;
 } SyntaqlitePragmaStmt;
 
 typedef struct SyntaqliteAnalyzeOrReindexStmt {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan target_name;
-  SyntaqliteSourceSpan schema;
+  SyntaqliteTextSpan target_name;
+  SyntaqliteTextSpan schema;
   SyntaqliteAnalyzeOrReindexOp kind;
 } SyntaqliteAnalyzeOrReindexStmt;
 
@@ -888,7 +888,7 @@ typedef struct SyntaqliteDetachStmt {
 
 typedef struct SyntaqliteVacuumStmt {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan schema;
+  SyntaqliteTextSpan schema;
   uint32_t filename;
 } SyntaqliteVacuumStmt;
 
@@ -900,9 +900,9 @@ typedef struct SyntaqliteExplainStmt {
 
 typedef struct SyntaqliteCreateIndexStmt {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan index_name;
-  SyntaqliteSourceSpan schema;
-  SyntaqliteSourceSpan table_name;
+  SyntaqliteTextSpan index_name;
+  SyntaqliteTextSpan schema;
+  SyntaqliteTextSpan table_name;
   SyntaqliteBool is_unique;
   SyntaqliteBool if_not_exists;
   uint32_t columns;
@@ -911,8 +911,8 @@ typedef struct SyntaqliteCreateIndexStmt {
 
 typedef struct SyntaqliteCreateViewStmt {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan view_name;
-  SyntaqliteSourceSpan schema;
+  SyntaqliteTextSpan view_name;
+  SyntaqliteTextSpan schema;
   SyntaqliteBool is_temp;
   SyntaqliteBool if_not_exists;
   uint32_t column_names;
@@ -947,7 +947,7 @@ typedef struct SyntaqliteFrameSpec {
 
 typedef struct SyntaqliteWindowDef {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan base_window_name;
+  SyntaqliteTextSpan base_window_name;
   uint32_t partition_by;
   uint32_t orderby;
   uint32_t frame;
@@ -962,7 +962,7 @@ typedef struct SyntaqliteWindowDefList {
 
 typedef struct SyntaqliteNamedWindowDef {
   SyntaqliteNodeTag tag;
-  SyntaqliteSourceSpan window_name;
+  SyntaqliteTextSpan window_name;
   uint32_t window_def;
 } SyntaqliteNamedWindowDef;
 
@@ -977,7 +977,7 @@ typedef struct SyntaqliteFilterOver {
   SyntaqliteNodeTag tag;
   uint32_t filter_expr;
   uint32_t over_def;
-  SyntaqliteSourceSpan over_name;
+  SyntaqliteTextSpan over_name;
 } SyntaqliteFilterOver;
 
 // ============ Node Union ============

--- a/syntaqlite-syntax/src/ast.rs
+++ b/syntaqlite-syntax/src/ast.rs
@@ -191,59 +191,24 @@ pub trait TypedNodeId: Copy + Into<AnyNodeId> {
     type Node<'a>: GrammarNodeType<'a>;
 }
 
-/// Byte range in the original source text.
-///
-/// For spans inside a macro expansion, points at the macro call site in the
-/// original source (not the expansion buffer).  Use
-/// [`AnyParsedStatement::traceback`](crate::parser::AnyParsedStatement::traceback)
-/// if you need position info inside the expansion.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct SourceRange {
-    /// Inclusive start offset, in bytes.
-    pub start: u32,
-    /// Exclusive end offset, in bytes.
-    pub end: u32,
-}
-
-impl SourceRange {
-    /// Returns `true` if this range covers zero bytes.
-    pub fn is_empty(self) -> bool {
-        self.start == self.end
-    }
-
-    /// Byte length of the range.
-    pub fn len(self) -> u32 {
-        self.end - self.start
-    }
-}
-
-impl From<SourceRange> for std::ops::Range<usize> {
-    fn from(r: SourceRange) -> std::ops::Range<usize> {
-        r.start as usize..r.end as usize
-    }
-}
-
 /// Reflected field value extracted from a node.
 ///
 /// Used by dialect-agnostic AST tooling built on
 /// [`AnyParsedStatement::extract_fields`](crate::parser::AnyParsedStatement::extract_fields).
+///
+/// Mirrors the C-side 1:1: `Span` wraps the raw `TextSpan` struct and
+/// callers use the accessor methods on
+/// [`AnyParsedStatement`](crate::parser::AnyParsedStatement) (e.g.
+/// [`span_text`](crate::parser::AnyParsedStatement::span_text)) to get
+/// the bytes / authored offset / expansion-layer view.
 #[derive(Clone, Copy, Debug)]
-pub enum FieldValue<'a> {
+pub enum FieldValue {
     /// A child node reference.
     NodeId(AnyNodeId),
-    /// A source text span.
-    Span {
-        /// The span text.  When `quoted` is true this is the bare identifier
-        /// with surrounding quotes stripped.  For spans inside a macro
-        /// expansion, this is the resolved text in the expansion buffer.
-        text: &'a str,
-        /// Whether the identifier was quoted in source.  The formatter
-        /// re-wraps quoted spans in standard double quotes (`"..."`).
-        quoted: bool,
-        /// Byte range in the original source.  For spans inside a macro
-        /// expansion, points at the entire macro call site.
-        source: SourceRange,
-    },
+    /// A source text span.  Use
+    /// [`AnyParsedStatement::span_text`](crate::parser::AnyParsedStatement::span_text)
+    /// to resolve to authored bytes.
+    Span(TextSpan),
     /// A boolean flag.
     Bool(bool),
     /// A compact bitfield of flags.
@@ -256,12 +221,12 @@ pub enum FieldValue<'a> {
 ///
 /// Returned by [`AnyParsedStatement::extract_fields`](crate::parser::AnyParsedStatement::extract_fields)
 /// and indexable via `fields[idx]`.
-pub struct NodeFields<'a> {
-    buf: [std::mem::MaybeUninit<FieldValue<'a>>; 16],
+pub struct NodeFields {
+    buf: [std::mem::MaybeUninit<FieldValue>; 16],
     len: usize,
 }
 
-impl<'a> NodeFields<'a> {
+impl NodeFields {
     /// Create an empty `NodeFields`.
     pub(crate) fn new() -> Self {
         Self {
@@ -274,7 +239,7 @@ impl<'a> NodeFields<'a> {
     ///
     /// # Panics
     /// Panics if more than 16 fields are pushed.
-    pub(crate) fn push(&mut self, val: FieldValue<'a>) {
+    pub(crate) fn push(&mut self, val: FieldValue) {
         assert!(self.len < 16, "NodeFields overflow: more than 16 fields");
         self.buf[self.len] = std::mem::MaybeUninit::new(val);
         self.len += 1;
@@ -291,10 +256,10 @@ impl<'a> NodeFields<'a> {
     }
 }
 
-impl<'a> std::ops::Index<usize> for NodeFields<'a> {
-    type Output = FieldValue<'a>;
+impl std::ops::Index<usize> for NodeFields {
+    type Output = FieldValue;
 
-    fn index(&self, idx: usize) -> &FieldValue<'a> {
+    fn index(&self, idx: usize) -> &FieldValue {
         assert!(
             idx < self.len,
             "field index {} out of bounds (len={})",
@@ -306,7 +271,7 @@ impl<'a> std::ops::Index<usize> for NodeFields<'a> {
     }
 }
 
-impl std::fmt::Debug for NodeFields<'_> {
+impl std::fmt::Debug for NodeFields {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut list = f.debug_list();
         for i in 0..self.len {
@@ -402,26 +367,27 @@ mod serde_impl {
     /// `"field_name": <this>`.
     struct FieldValueSerializer<'a, 'b> {
         meta: &'b FieldMeta<'static>,
-        value: &'b FieldValue<'a>,
+        value: &'b FieldValue,
         stmt: &'b AnyParsedStatement<'a>,
     }
 
     impl serde::Serialize for FieldValueSerializer<'_, '_> {
         fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-            match (self.meta.kind(), self.value) {
+            match (self.meta.kind(), *self.value) {
                 // Node field: recurse, or null if absent.
                 (FieldKind::NodeId, FieldValue::NodeId(id)) => {
                     if id.is_null() {
                         serializer.serialize_none()
                     } else {
-                        match AnyNode::from_result(self.stmt, *id) {
+                        match AnyNode::from_result(self.stmt, id) {
                             Some(node) => node.serialize(serializer),
                             None => serializer.serialize_none(),
                         }
                     }
                 }
-                // Span: text string, or null for an absent/empty span.
-                (FieldKind::Span, FieldValue::Span { text, .. }) => {
+                // Span: authored text slice of the source, or null when empty.
+                (FieldKind::Span, FieldValue::Span(span)) => {
+                    let (text, _) = self.stmt.span_text(span);
                     if text.is_empty() {
                         serializer.serialize_none()
                     } else {
@@ -429,10 +395,10 @@ mod serde_impl {
                     }
                 }
                 // Bool: plain boolean.
-                (FieldKind::Bool, FieldValue::Bool(b)) => serializer.serialize_bool(*b),
+                (FieldKind::Bool, FieldValue::Bool(b)) => serializer.serialize_bool(b),
                 // Enum: display-name string, or null if no display name.
                 (FieldKind::Enum, FieldValue::Enum(discriminant)) => {
-                    match self.meta.display_name(*discriminant as usize) {
+                    match self.meta.display_name(discriminant as usize) {
                         Some(s) => serializer.serialize_str(s),
                         None => serializer.serialize_none(),
                     }
@@ -440,7 +406,6 @@ mod serde_impl {
                 // Flags: array of active flag-name strings (empty array when none set).
                 (FieldKind::Flags, FieldValue::Flags(bits)) => {
                     use serde::ser::SerializeSeq;
-                    let bits = *bits;
                     let active: Vec<&'static str> = (0..self.meta.display_count())
                         .filter(|&i| bits & (1u8 << i) != 0)
                         .filter_map(|i| self.meta.display_name(i))
@@ -461,37 +426,39 @@ mod serde_impl {
 // ── ffi ───────────────────────────────────────────────────────────────────────
 
 pub(crate) use ffi::CNodeList as RawNodeList;
-pub(crate) use ffi::CSourceSpan as SourceSpan;
+pub use ffi::CTextSpan as TextSpan;
 
 mod ffi {
     use crate::ast::AnyNodeId;
 
     /// A source byte range stored in an AST node.
     ///
-    /// Mirrors the C `SyntaqliteSourceSpan` layout.  Embedded in generated
-    /// node structs for token-valued fields (identifiers, literals).
-    ///
-    /// Rust callers normally never see a raw `CSourceSpan`: span fields are
-    /// eagerly resolved into [`FieldValue::Span`](super::FieldValue) values
-    /// with text and a [`SourceRange`](super::SourceRange) already populated.
+    /// Mirrors the C `SyntaqliteTextSpan` layout 1:1.  The fields are
+    /// deliberately opaque to Rust callers: the encoded position may
+    /// refer to either the input source or an internal macro expansion
+    /// buffer.  Resolve a `TextSpan` via the accessor methods on
+    /// [`AnyParsedStatement`](crate::parser::AnyParsedStatement):
+    /// [`span_text`](crate::parser::AnyParsedStatement::span_text),
+    /// [`span_expanded_text`](crate::parser::AnyParsedStatement::span_expanded_text),
+    /// [`span_text_offset`](crate::parser::AnyParsedStatement::span_text_offset).
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
     #[repr(C)]
-    pub(crate) struct CSourceSpan {
-        offset: u32,
-        length: u16,
-        flags: u8,
+    pub struct CTextSpan {
+        pub(crate) offset: u32,
+        pub(crate) length: u16,
+        pub(crate) flags: u8,
         /// Internal: 0 = original source, >0 = macro expansion layer id.
         /// Read by the C-side span accessors; the Rust side passes the
         /// whole struct across the FFI boundary without inspecting it.
-        _layer_id: u8,
+        pub(crate) _layer_id: u8,
     }
 
     /// Mirror of C `SYNTAQLITE_SPAN_FLAG_QUOTED` from `types.h`.
     const SPAN_FLAG_QUOTED: u8 = 1;
 
-    impl CSourceSpan {
+    impl CTextSpan {
         /// Returns `true` if the span covers zero bytes.
-        pub(crate) fn is_empty(self) -> bool {
+        pub fn is_empty(self) -> bool {
             self.length == 0
         }
 
@@ -499,7 +466,7 @@ mod ffi {
         /// `` `...` ``, or `[...]`).  The span points at the dequoted inner
         /// text; the formatter re-wraps quoted spans in standard double
         /// quotes.
-        pub(crate) fn is_quoted(self) -> bool {
+        pub fn is_quoted(self) -> bool {
             (self.flags & SPAN_FLAG_QUOTED) != 0
         }
     }

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -79,7 +79,7 @@ pub mod util;
 pub mod any {
     #[doc(inline)]
     pub use crate::ast::{
-        AnyNode, AnyNodeId, AnyNodeTag, AnyTokenType, FieldValue, NodeFields, SourceRange,
+        AnyNode, AnyNodeId, AnyNodeTag, AnyTokenType, FieldValue, NodeFields, TextSpan,
     };
     #[doc(inline)]
     pub use crate::dialect::{AnyDialect, FieldKind, FieldMeta, KeywordEntry, TokenCategory};

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -81,16 +81,6 @@ pub(crate) struct CMacroRegion {
     pub(crate) call_length: u32,
 }
 
-/// A byte range in the user's authored input.
-///
-/// Mirrors C `SyntaqliteTextRange` from `include/syntaqlite/parser.h`.
-#[derive(Debug, Clone, Copy)]
-#[repr(C)]
-pub(crate) struct CTextRange {
-    pub(crate) start: u32,
-    pub(crate) end: u32,
-}
-
 /// One frame in a traceback produced by the span traceback API.
 ///
 /// Mirrors C `SyntaqliteTracebackFrame` from `include/syntaqlite/parser.h`.
@@ -222,11 +212,11 @@ impl CParser {
 
     pub(crate) unsafe fn span_expanded_text(
         &self,
-        span: crate::ast::SourceSpan,
+        span: crate::ast::TextSpan,
         out_len: *mut u32,
     ) -> *const u8 {
         // SAFETY: self is a valid, non-null CParser pointer; span is a copy
-        // of an arena value with the SyntaqliteSourceSpan layout; out_len is
+        // of an arena value with the SyntaqliteTextSpan layout; out_len is
         // a valid pointer owned by the caller.
         unsafe {
             syntaqlite_parser_span_expanded_text(
@@ -239,36 +229,27 @@ impl CParser {
 
     pub(crate) unsafe fn span_text(
         &self,
-        span: crate::ast::SourceSpan,
+        span: crate::ast::TextSpan,
         out_len: *mut u32,
+        out_offset: *mut u32,
     ) -> *const u8 {
         // SAFETY: self is a valid, non-null CParser pointer; span is a copy
-        // of an arena value with the SyntaqliteSourceSpan layout; out_len is
-        // a valid pointer owned by the caller.
+        // of an arena value with the SyntaqliteTextSpan layout; out_len and
+        // out_offset are valid pointers (or null).
         unsafe {
             syntaqlite_parser_span_text(
                 std::ptr::from_ref::<Self>(self).cast_mut(),
                 std::ptr::from_ref(&span).cast(),
                 out_len,
+                out_offset,
             )
         }
     }
 
-    pub(crate) unsafe fn span_text_range(&self, span: crate::ast::SourceSpan) -> CTextRange {
-        // SAFETY: self is a valid, non-null CParser pointer; span is a copy
-        // of an arena value with the SyntaqliteSourceSpan layout.
-        unsafe {
-            syntaqlite_parser_span_text_range(
-                std::ptr::from_ref::<Self>(self).cast_mut(),
-                std::ptr::from_ref(&span).cast(),
-            )
-        }
-    }
-
-    pub(crate) unsafe fn traceback(&self, span: crate::ast::SourceSpan) -> &[CTracebackFrame] {
+    pub(crate) unsafe fn traceback(&self, span: crate::ast::TextSpan) -> &[CTracebackFrame] {
         let mut count: u32 = 0;
         // SAFETY: self is a valid CParser pointer; span is a copy of an
-        // arena value with the SyntaqliteSourceSpan layout.  The returned
+        // arena value with the SyntaqliteTextSpan layout.  The returned
         // pointer is backed by the parser's owned `traceback_buf` vec and
         // remains valid until the next call to this function or until the
         // parser is mutated through another `&mut` method.
@@ -428,7 +409,6 @@ unsafe extern "C" {
     // Arena accessors
     fn syntaqlite_parser_node(p: *mut CParser, node_id: u32) -> *const u32;
     fn syntaqlite_parser_node_count(p: *mut CParser) -> u32;
-
     // Span accessors
     fn syntaqlite_parser_span_expanded_text(
         p: *mut CParser,
@@ -439,8 +419,8 @@ unsafe extern "C" {
         p: *mut CParser,
         span: *const c_void,
         out_len: *mut u32,
+        out_offset: *mut u32,
     ) -> *const u8;
-    fn syntaqlite_parser_span_text_range(p: *mut CParser, span: *const c_void) -> CTextRange;
     fn syntaqlite_parser_traceback(
         p: *mut CParser,
         span: *const c_void,

--- a/syntaqlite-syntax/src/parser/incremental.rs
+++ b/syntaqlite-syntax/src/parser/incremental.rs
@@ -26,7 +26,7 @@ use super::{ParseError, ParsedStatement};
 pub struct TypedIncrementalParseSession<G: TypedDialect> {
     /// Base pointer into the internal source buffer. `feed_token` uses this
     /// to compute the C-side token pointer from byte-offset spans.
-    c_source_ptr: NonNull<u8>,
+    c_text_ptr: NonNull<u8>,
     dialect: AnyDialect,
     /// Checked-out parser state. Returned to `slot` on drop.
     inner: Option<ParserInner>,
@@ -46,13 +46,13 @@ impl<G: TypedDialect> Drop for TypedIncrementalParseSession<G> {
 
 impl<G: TypedDialect> TypedIncrementalParseSession<G> {
     pub(crate) fn new(
-        c_source_ptr: NonNull<u8>,
+        c_text_ptr: NonNull<u8>,
         dialect: AnyDialect,
         inner: ParserInner,
         slot: Rc<RefCell<Option<ParserInner>>>,
     ) -> Self {
         TypedIncrementalParseSession {
-            c_source_ptr,
+            c_text_ptr,
             dialect,
             inner: Some(inner),
             slot,
@@ -135,9 +135,9 @@ impl<G: TypedDialect> TypedIncrementalParseSession<G> {
         span: Range<usize>,
     ) -> Option<Result<TypedParsedStatement<'_, G>, TypedParseError<'_, G>>> {
         self.assert_not_finished();
-        // SAFETY: c_source_ptr is valid for the source length; raw is valid.
+        // SAFETY: c_text_ptr is valid for the source length; raw is valid.
         let rc = unsafe {
-            let c_text = self.c_source_ptr.as_ptr().add(span.start);
+            let c_text = self.c_text_ptr.as_ptr().add(span.start);
             let raw_token_type: u32 = token_type.into();
             #[expect(clippy::cast_possible_truncation)]
             (*self.raw_ptr()).feed_token(raw_token_type, c_text as *const _, span.len() as u32)

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -243,10 +243,10 @@ impl<G: TypedDialect> TypedParser<G> {
         // SAFETY: inner.raw is valid (owned via ParserInner); source is
         // copied into source_buf.
         unsafe { reset_parser(inner.raw.as_ptr(), &mut inner.source_buf, source) };
-        let c_source_ptr =
+        let c_text_ptr =
             NonNull::new(inner.source_buf.as_mut_ptr()).expect("source_buf is non-empty");
         TypedIncrementalParseSession::new(
-            c_source_ptr,
+            c_text_ptr,
             self.dialect.clone(),
             inner,
             Rc::clone(&self.inner),
@@ -369,7 +369,7 @@ impl<G: TypedDialect> TypedParseSession<G> {
     /// # Panics
     ///
     /// Panics only if session invariants were violated.
-    pub fn source(&self) -> &str {
+    pub fn text(&self) -> &str {
         let inner = self
             .inner
             .as_ref()
@@ -416,7 +416,7 @@ pub type AnyParseSession = TypedParseSession<AnyDialect>;
 #[derive(Clone)]
 pub struct AnyParsedStatement<'a> {
     pub(crate) raw: NonNull<CParser>,
-    pub(crate) source: &'a str,
+    pub(crate) text: &'a str,
     pub(crate) dialect: AnyDialect,
 }
 
@@ -425,11 +425,11 @@ impl<'a> AnyParsedStatement<'a> {
     ///
     /// # Safety
     /// `raw` must be a valid, non-null parser pointer that remains valid for `'a`.
-    pub(crate) unsafe fn new(raw: *mut CParser, source: &'a str, dialect: AnyDialect) -> Self {
+    pub(crate) unsafe fn new(raw: *mut CParser, text: &'a str, dialect: AnyDialect) -> Self {
         AnyParsedStatement {
             // SAFETY: caller guarantees raw is non-null.
             raw: unsafe { NonNull::new_unchecked(raw) },
-            source,
+            text,
             dialect,
         }
     }
@@ -528,7 +528,7 @@ impl<'a> AnyParsedStatement<'a> {
     /// from the appropriate expansion layer's buffer (e.g. `"a"` for
     /// `$name` expanded with arg `a`).  Always a direct slice — no
     /// allocation.
-    pub(crate) fn span_expanded_text(&self, span: crate::ast::SourceSpan) -> &'a str {
+    pub fn span_expanded_text(&self, span: crate::ast::TextSpan) -> &'a str {
         let mut out_len: u32 = 0;
         // SAFETY: self.raw is valid for 'a; span is a copy of an arena value.
         let ptr = unsafe { self.raw.as_ref().span_expanded_text(span, &raw mut out_len) };
@@ -540,53 +540,43 @@ impl<'a> AnyParsedStatement<'a> {
         unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize)) }
     }
 
-    /// Authored text for an arena span — always a slice of the user's
-    /// input source (the text passed to `reset`).
+    /// Resolve a [`TextSpan`](crate::ast::TextSpan) to `(authored_text,
+    /// source_offset)` where `authored_text` is a direct slice of the
+    /// user's input source and `source_offset` is its byte offset in
+    /// that source.
     ///
-    /// For direct (macro-free) spans, this is the same bytes as
-    /// `span_expanded_text`.  For spans inside a macro expansion, this
-    /// walks the expansion layer chain: if the span was tokenized inside
-    /// a substituted argument, it drills back to the arg's origin text in
-    /// the source; otherwise it collapses to the outermost `name!(...)`
-    /// call site in the source.  Always a direct slice — no allocation.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into FieldValue::Span in Step 12")
-    )]
-    pub(crate) fn span_text(&self, span: crate::ast::SourceSpan) -> &'a str {
+    /// For direct (macro-free) spans, this is the span's own bytes and
+    /// position.  For spans inside a macro expansion, this walks the
+    /// expansion layer chain: if the span was tokenized inside a
+    /// substituted `$param`, it drills back to the arg's origin text in
+    /// the caller's source; otherwise it collapses to the outermost
+    /// `name!(...)` call site.  Always a direct slice — no allocation.
+    /// Returns `("", 0)` for empty or invalid spans.
+    pub fn span_text(&self, span: crate::ast::TextSpan) -> (&'a str, u32) {
         let mut out_len: u32 = 0;
+        let mut out_offset: u32 = 0;
         // SAFETY: self.raw is valid for 'a; span is a copy of an arena value.
-        let ptr = unsafe { self.raw.as_ref().span_text(span, &raw mut out_len) };
+        let ptr = unsafe {
+            self.raw
+                .as_ref()
+                .span_text(span, &raw mut out_len, &raw mut out_offset)
+        };
         if ptr.is_null() || out_len == 0 {
-            return "";
+            return ("", 0);
         }
         // SAFETY: C guarantees ptr points to out_len bytes of valid UTF-8
         // in a parser-owned buffer valid for 'a.
-        unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize)) }
-    }
-
-    /// Byte range of `span_text(span)` in the user's input source.  For
-    /// spans inside a macro expansion, this is the byte range of either
-    /// the outermost call site or the substituted arg's origin text —
-    /// matching the bytes returned by `span_text`.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into FieldValue::Span in Step 12")
-    )]
-    pub(crate) fn span_text_range(&self, span: crate::ast::SourceSpan) -> crate::ast::SourceRange {
-        // SAFETY: self.raw is valid for 'a; span is a copy of an arena value.
-        let r = unsafe { self.raw.as_ref().span_text_range(span) };
-        crate::ast::SourceRange {
-            start: r.start,
-            end: r.end,
-        }
+        let text = unsafe {
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize))
+        };
+        (text, out_offset)
     }
 
     pub(crate) fn field_span(
         &self,
         node_id: AnyNodeId,
         field_idx: u8,
-    ) -> Option<crate::ast::SourceSpan> {
+    ) -> Option<crate::ast::TextSpan> {
         let (ptr, tag) = self.node_ptr(node_id)?;
         let meta = self.dialect.field_meta(tag).nth(field_idx as usize)?;
         if !matches!(meta.kind(), crate::dialect::FieldKind::Span) {
@@ -594,18 +584,18 @@ impl<'a> AnyParsedStatement<'a> {
         }
         // SAFETY: ptr is a valid arena node pointer for 'a; meta describes
         // a Span field at the indicated byte offset within the node struct.
-        // SourceSpan is `#[repr(C)]` Copy with 1-byte alignment; we use
+        // TextSpan is `#[repr(C)]` Copy with 1-byte alignment; we use
         // read_unaligned to avoid alignment assumptions on the raw pointer.
         Some(unsafe {
             ptr.add(meta.offset() as usize)
-                .cast::<crate::ast::SourceSpan>()
+                .cast::<crate::ast::TextSpan>()
                 .read_unaligned()
         })
     }
 
     /// The source text bound to this result.
-    pub fn source(&self) -> &'a str {
-        self.source
+    pub fn text(&self) -> &'a str {
+        self.text
     }
 
     /// Raw token spans `(offset, length)` for all collected tokens.
@@ -635,17 +625,13 @@ impl<'a> AnyParsedStatement<'a> {
     }
 
     /// Extract reflective node data (`tag` + field values) for `id`.
-    pub fn extract_fields(
-        &self,
-        id: AnyNodeId,
-    ) -> Option<(AnyNodeTag, crate::ast::NodeFields<'a>)> {
+    pub fn extract_fields(&self, id: AnyNodeId) -> Option<(AnyNodeTag, crate::ast::NodeFields)> {
         let (ptr, tag) = self.node_ptr(id)?;
         let mut fields = crate::ast::NodeFields::new();
         for meta in self.dialect.field_meta(tag) {
-            // SAFETY: ptr is a valid arena node pointer valid for 'a;
-            // meta describes a field within that node's struct layout.
-            // self.raw is a valid parser pointer for 'a.
-            let val = unsafe { extract_field_value(ptr, &meta, self.raw.as_ref()) };
+            // SAFETY: ptr is a valid arena node pointer; meta describes a
+            // field within that node's struct layout.
+            let val = unsafe { extract_field_value(ptr, &meta) };
             fields.push(val);
         }
         Some((tag, fields))
@@ -775,12 +761,12 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
     ///
     /// # Safety
     /// `raw` must be a valid, non-null parser pointer that remains valid for `'a`.
-    pub(crate) unsafe fn new(raw: *mut CParser, source: &'a str, dialect: AnyDialect) -> Self {
+    pub(crate) unsafe fn new(raw: *mut CParser, text: &'a str, dialect: AnyDialect) -> Self {
         TypedParsedStatement {
             any: AnyParsedStatement {
                 // SAFETY: caller guarantees raw is non-null.
                 raw: unsafe { NonNull::new_unchecked(raw) },
-                source,
+                text,
                 dialect,
             },
             _marker: PhantomData,
@@ -824,8 +810,8 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
     }
 
     /// The source text bound to this result.
-    pub fn source(&self) -> &'a str {
-        self.any.source
+    pub fn text(&self) -> &'a str {
+        self.any.text
     }
 
     /// Macro expansion call-site spans recorded during parsing.
@@ -841,7 +827,7 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
     ///
     /// Requires `collect_tokens: true` and skips unknown token ordinals for `G`.
     pub fn tokens(&self) -> impl Iterator<Item = TypedParserToken<'a, G>> {
-        let source = self.any.source;
+        let source = self.any.text;
         // SAFETY: self.any.raw is valid for 'a; the returned slice lives for 'a.
         let raw: &'a [ffi::CParserToken] = unsafe { self.any.raw.as_ref().result_tokens() };
         raw.iter().filter_map(move |t| {
@@ -861,7 +847,7 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
     ///
     /// Requires `collect_tokens: true` in [`ParserConfig`].
     pub fn comments(&self) -> impl Iterator<Item = Comment<'a>> {
-        let source = self.any.source;
+        let source = self.any.text;
         // SAFETY: self.any.raw is valid for 'a; the returned slice lives for 'a.
         let raw: &'a [ffi::CComment] = unsafe { self.any.raw.as_ref().result_comments() };
         raw.iter().map(move |c| {
@@ -931,16 +917,19 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
 
 /// Extract a single [`crate::ast::FieldValue`] from a raw arena node pointer.
 ///
+/// Just copies raw bytes into the corresponding variant — callers pull
+/// text / offset / expanded-buffer views out via the accessor methods on
+/// [`AnyParsedStatement`] (e.g. [`span_text`](AnyParsedStatement::span_text)).
+///
 /// # Safety
 /// `ptr` must point to a valid arena node struct whose field at `meta.offset()`
-/// has the type indicated by `meta.kind()`, and must be valid for lifetime `'a`.
+/// has the type indicated by `meta.kind()`.
 #[expect(clippy::cast_ptr_alignment)]
-unsafe fn extract_field_value<'a>(
+unsafe fn extract_field_value(
     ptr: *const u8,
     meta: &crate::dialect::FieldMeta<'_>,
-    parser: &'a CParser,
-) -> crate::ast::FieldValue<'a> {
-    use crate::ast::{FieldValue, SourceRange, SourceSpan};
+) -> crate::ast::FieldValue {
+    use crate::ast::{FieldValue, TextSpan};
     use crate::dialect::FieldKind;
     // SAFETY: covered by function-level contract; ptr and meta are consistent.
     unsafe {
@@ -948,61 +937,16 @@ unsafe fn extract_field_value<'a>(
         match meta.kind() {
             FieldKind::NodeId => FieldValue::NodeId(AnyNodeId(*(field_ptr.cast::<u32>()))),
             FieldKind::Span => {
-                // SourceSpan is `#[repr(C)]` Copy with 1-byte alignment;
+                // TextSpan is `#[repr(C)]` Copy with 1-byte alignment;
                 // use read_unaligned to avoid alignment assumptions.
-                let span = field_ptr.cast::<SourceSpan>().read_unaligned();
-                if span.is_empty() {
-                    return FieldValue::Span {
-                        text: "",
-                        quoted: false,
-                        source: SourceRange::default(),
-                    };
-                }
-                // Populate from the new span accessors.  `text` preserves
-                // the pre-rework semantics (post-expansion bytes — what
-                // the tokenizer saw); `source` is the authored byte range
-                // in the user's input, walking through the layer chain
-                // and arg segments as needed.  Step 12 of the
-                // text-expansion-model plan reshapes this variant into
-                // separate `text` / `expanded_text` / `text_range` fields.
-                let text = span_slice(parser, span, CParser::span_expanded_text);
-                let range = parser.span_text_range(span);
-                FieldValue::Span {
-                    text,
-                    quoted: span.is_quoted(),
-                    source: SourceRange {
-                        start: range.start,
-                        end: range.end,
-                    },
-                }
+                let span = field_ptr.cast::<TextSpan>().read_unaligned();
+                FieldValue::Span(span)
             }
             FieldKind::Bool => FieldValue::Bool(*(field_ptr.cast::<u32>()) != 0),
             FieldKind::Flags => FieldValue::Flags(*field_ptr),
             FieldKind::Enum => FieldValue::Enum(*(field_ptr.cast::<u32>())),
         }
     }
-}
-
-/// Call a span text accessor (`span_text` or `span_expanded_text`) and
-/// materialize the returned pointer/length as a `&'a str`.
-///
-/// # Safety
-/// `parser` must be a valid `CParser` for lifetime `'a`; `span` must be a
-/// copy of an arena value with the `SyntaqliteSourceSpan` layout.
-unsafe fn span_slice(
-    parser: &CParser,
-    span: crate::ast::SourceSpan,
-    accessor: unsafe fn(&CParser, crate::ast::SourceSpan, *mut u32) -> *const u8,
-) -> &str {
-    let mut out_len: u32 = 0;
-    // SAFETY: delegated via function-level contract.
-    let ptr = unsafe { accessor(parser, span, &raw mut out_len) };
-    if ptr.is_null() || out_len == 0 {
-        return "";
-    }
-    // SAFETY: C guarantees `ptr` points to `out_len` bytes of valid UTF-8
-    // in a parser-owned buffer valid for `'a`.
-    unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize)) }
 }
 
 /// Parse failure for a single statement in dialect `G`.
@@ -1061,8 +1005,8 @@ impl<'a, G: TypedDialect> TypedParseError<'a, G> {
     }
 
     /// The source text bound to this result.
-    pub fn parse_source(&self) -> &'a str {
-        self.0.source()
+    pub fn text(&self) -> &'a str {
+        self.0.text()
     }
 
     /// Tokens collected during the (partial) parse, if `collect_tokens` was enabled.
@@ -1126,12 +1070,12 @@ pub(crate) unsafe fn reset_parser(raw: *mut CParser, source_buf: &mut Vec<u8>, s
     source_buf.push(0);
 
     // source_buf has at least one byte (the null terminator just pushed).
-    let c_source_ptr = source_buf.as_ptr();
-    // SAFETY: raw is valid (caller owns it); c_source_ptr points to
+    let c_text_ptr = source_buf.as_ptr();
+    // SAFETY: raw is valid (caller owns it); c_text_ptr points to
     // source_buf which is null-terminated.
     #[expect(clippy::cast_possible_truncation)]
     unsafe {
-        (*raw).reset(c_source_ptr.cast(), source.len() as u32);
+        (*raw).reset(c_text_ptr.cast(), source.len() as u32);
     }
 }
 

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -149,8 +149,8 @@ impl ParseSession {
     }
 
     /// Original SQL source bound to this session.
-    pub fn source(&self) -> &str {
-        self.0.source()
+    pub fn text(&self) -> &str {
+        self.0.text()
     }
 
     /// Return a dialect-agnostic view over the current parse arena state.
@@ -286,8 +286,8 @@ impl<'a> ParsedStatement<'a> {
     }
 
     /// The source text bound to this result.
-    pub fn source(&self) -> &'a str {
-        self.0.source()
+    pub fn text(&self) -> &'a str {
+        self.0.text()
     }
 
     /// Statement-local token stream with parser usage flags.
@@ -374,8 +374,8 @@ impl<'a> ParseError<'a> {
     }
 
     /// The source text bound to this result.
-    pub fn parse_source(&self) -> &'a str {
-        self.0.0.source()
+    pub fn text(&self) -> &'a str {
+        self.0.0.text()
     }
 
     /// Tokens collected during the (partial) parse, if `collect_tokens` was enabled.
@@ -649,18 +649,18 @@ mod tests {
         assert!(!parser.deregister_macro("nonexistent"));
     }
 
-    // ── Step 6: span_text / span_expanded_text / span_text_range ────────────
+    // ── span_text / span_expanded_text accessors ────────────────────────────
 
     use super::super::AnyParsedStatement;
 
     // Walk the tree depth-first looking for a non-empty Span field; return
-    // the raw SourceSpan of the first one found.
-    fn first_span_in_tree<'a>(stmt: &'a AnyParsedStatement<'a>) -> Option<crate::ast::SourceSpan> {
+    // the raw TextSpan of the first one found.
+    fn first_span_in_tree<'a>(stmt: &'a AnyParsedStatement<'a>) -> Option<crate::ast::TextSpan> {
         use crate::ast::FieldValue;
         fn walk<'a>(
             stmt: &'a AnyParsedStatement<'a>,
             id: crate::ast::AnyNodeId,
-        ) -> Option<crate::ast::SourceSpan> {
+        ) -> Option<crate::ast::TextSpan> {
             if let Some((_, fields)) = stmt.extract_fields(id) {
                 for i in 0..fields.len() {
                     if matches!(fields[i], FieldValue::Span { .. })
@@ -699,14 +699,12 @@ mod tests {
         let erased = stmt.erase();
         let span = first_span_in_tree(&erased).expect("expected a Span field");
 
-        // Macro-free: span_text == span_expanded_text, range indexes into source.
-        let span_text = erased.span_text(span);
+        // Macro-free: span_text == span_expanded_text, and both are slices of
+        // the original source.
+        let (span_text, _) = erased.span_text(span);
         let span_expanded = erased.span_expanded_text(span);
-        let range = erased.span_text_range(span);
-
         assert_eq!(span_text, span_expanded);
-        let slice = &source[range.start as usize..range.end as usize];
-        assert_eq!(span_text, slice);
+        assert!(source.contains(span_text));
     }
 
     #[test]
@@ -727,20 +725,14 @@ mod tests {
         // The first span in the tree should be "inner" from the expansion.
         let span = first_span_in_tree(&erased).expect("expected a Span field");
 
-        let span_text = erased.span_text(span);
-        let span_expanded = erased.span_expanded_text(span);
-        let range = erased.span_text_range(span);
-
         // span_text: authored slice — the whole macro call "idmac!()".
         assert_eq!(
-            span_text, "idmac!()",
+            erased.span_text(span).0,
+            "idmac!()",
             "span_text should collapse to the call site"
         );
         // span_expanded_text: the literal text the tokenizer saw — "inner".
-        assert_eq!(span_expanded, "inner");
-        // Range points at the call site in source.
-        let slice = &source[range.start as usize..range.end as usize];
-        assert_eq!(slice, "idmac!()");
+        assert_eq!(erased.span_expanded_text(span), "inner");
     }
 
     #[test]
@@ -760,25 +752,19 @@ mod tests {
         let erased = stmt.erase();
         let span = first_span_in_tree(&erased).expect("expected a Span field");
 
-        let span_text = erased.span_text(span);
-        let span_expanded = erased.span_expanded_text(span);
-        let range = erased.span_text_range(span);
-
         // Arg-segment drill: span_text points at the user's authored arg
         // text, not at the whole call site.
         assert_eq!(
-            span_text, "authored",
+            erased.span_text(span).0,
+            "authored",
             "span_text should drill through arg segment to origin"
         );
         // Expanded text (the token the tokenizer actually saw) is also
         // "authored" because the arg was copied verbatim.
-        assert_eq!(span_expanded, "authored");
-        // Range points at the authored arg in source.
-        let slice = &source[range.start as usize..range.end as usize];
-        assert_eq!(slice, "authored");
+        assert_eq!(erased.span_expanded_text(span), "authored");
     }
 
-    // ── Step 7: traceback with arg-segment drilling ─────────────────────────
+    // ── traceback with arg-segment drilling ─────────────────────────────────
 
     // Walk the tree depth-first looking for the first non-empty Span field;
     // return (owning node, field index) for use with `traceback`.

--- a/syntaqlite-syntax/src/sqlite/ffi.rs
+++ b/syntaqlite-syntax/src/sqlite/ffi.rs
@@ -5,7 +5,7 @@
 
 #![allow(clippy::struct_field_names)]
 
-use crate::ast::{AnyNodeId, ArenaNode, SourceSpan};
+use crate::ast::{AnyNodeId, ArenaNode, TextSpan};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
@@ -19,7 +19,7 @@ pub(crate) enum Bool {
 #[repr(C)]
 pub(crate) struct AggregateFunctionCall {
     pub(crate) tag: u32,
-    pub(crate) func_name: SourceSpan,
+    pub(crate) func_name: TextSpan,
     pub(crate) flags: super::ast::AggregateFunctionCallFlags,
     pub(crate) args: AnyNodeId,
     pub(crate) orderby: AnyNodeId,
@@ -31,7 +31,7 @@ pub(crate) struct AggregateFunctionCall {
 #[repr(C)]
 pub(crate) struct OrderedSetFunctionCall {
     pub(crate) tag: u32,
-    pub(crate) func_name: SourceSpan,
+    pub(crate) func_name: TextSpan,
     pub(crate) flags: super::ast::AggregateFunctionCallFlags,
     pub(crate) args: AnyNodeId,
     pub(crate) orderby_expr: AnyNodeId,
@@ -44,16 +44,16 @@ pub(crate) struct OrderedSetFunctionCall {
 pub(crate) struct CastExpr {
     pub(crate) tag: u32,
     pub(crate) expr: AnyNodeId,
-    pub(crate) type_name: SourceSpan,
+    pub(crate) type_name: TextSpan,
 }
 
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub(crate) struct ColumnRef {
     pub(crate) tag: u32,
-    pub(crate) column: SourceSpan,
-    pub(crate) table: SourceSpan,
-    pub(crate) schema: SourceSpan,
+    pub(crate) column: TextSpan,
+    pub(crate) table: TextSpan,
+    pub(crate) schema: TextSpan,
 }
 
 #[derive(Debug, Clone)]
@@ -139,7 +139,7 @@ pub(crate) struct CaseWhen {
 #[repr(C)]
 pub(crate) struct ForeignKeyClause {
     pub(crate) tag: u32,
-    pub(crate) ref_table: SourceSpan,
+    pub(crate) ref_table: TextSpan,
     pub(crate) ref_columns: AnyNodeId,
     pub(crate) on_delete: super::ast::ForeignKeyAction,
     pub(crate) on_update: super::ast::ForeignKeyAction,
@@ -151,11 +151,11 @@ pub(crate) struct ForeignKeyClause {
 pub(crate) struct ColumnConstraint {
     pub(crate) tag: u32,
     pub(crate) kind: super::ast::ColumnConstraintType,
-    pub(crate) constraint_name: SourceSpan,
+    pub(crate) constraint_name: TextSpan,
     pub(crate) onconf: super::ast::ConflictAction,
     pub(crate) sort_order: super::ast::SortOrder,
     pub(crate) is_autoincrement: Bool,
-    pub(crate) collation_name: SourceSpan,
+    pub(crate) collation_name: TextSpan,
     pub(crate) generated_storage: super::ast::GeneratedColumnStorage,
     pub(crate) default_expr: AnyNodeId,
     pub(crate) check_expr: AnyNodeId,
@@ -168,7 +168,7 @@ pub(crate) struct ColumnConstraint {
 pub(crate) struct ColumnDef {
     pub(crate) tag: u32,
     pub(crate) column_name: AnyNodeId,
-    pub(crate) type_name: SourceSpan,
+    pub(crate) type_name: TextSpan,
     pub(crate) constraints: AnyNodeId,
 }
 
@@ -177,7 +177,7 @@ pub(crate) struct ColumnDef {
 pub(crate) struct TableConstraint {
     pub(crate) tag: u32,
     pub(crate) kind: super::ast::TableConstraintType,
-    pub(crate) constraint_name: SourceSpan,
+    pub(crate) constraint_name: TextSpan,
     pub(crate) onconf: super::ast::ConflictAction,
     pub(crate) is_autoincrement: Bool,
     pub(crate) pk_columns: AnyNodeId,
@@ -190,8 +190,8 @@ pub(crate) struct TableConstraint {
 #[repr(C)]
 pub(crate) struct CreateTableStmt {
     pub(crate) tag: u32,
-    pub(crate) table_name: SourceSpan,
-    pub(crate) schema: SourceSpan,
+    pub(crate) table_name: TextSpan,
+    pub(crate) schema: TextSpan,
     pub(crate) is_temp: Bool,
     pub(crate) if_not_exists: Bool,
     pub(crate) flags: super::ast::CreateTableStmtFlags,
@@ -204,7 +204,7 @@ pub(crate) struct CreateTableStmt {
 #[repr(C)]
 pub(crate) struct CteDefinition {
     pub(crate) tag: u32,
-    pub(crate) cte_name: SourceSpan,
+    pub(crate) cte_name: TextSpan,
     pub(crate) materialized: super::ast::Materialized,
     pub(crate) columns: AnyNodeId,
     pub(crate) select: AnyNodeId,
@@ -236,7 +236,7 @@ pub(crate) struct DeleteStmt {
     pub(crate) tag: u32,
     pub(crate) table: AnyNodeId,
     pub(crate) index_hint: super::ast::IndexHint,
-    pub(crate) index_name: SourceSpan,
+    pub(crate) index_name: TextSpan,
     pub(crate) where_clause: AnyNodeId,
     pub(crate) orderby: AnyNodeId,
     pub(crate) limit_clause: AnyNodeId,
@@ -247,7 +247,7 @@ pub(crate) struct DeleteStmt {
 #[repr(C)]
 pub(crate) struct SetClause {
     pub(crate) tag: u32,
-    pub(crate) column: SourceSpan,
+    pub(crate) column: TextSpan,
     pub(crate) columns: AnyNodeId,
     pub(crate) value: AnyNodeId,
 }
@@ -259,7 +259,7 @@ pub(crate) struct UpdateStmt {
     pub(crate) conflict_action: super::ast::ConflictAction,
     pub(crate) table: AnyNodeId,
     pub(crate) index_hint: super::ast::IndexHint,
-    pub(crate) index_name: SourceSpan,
+    pub(crate) index_name: TextSpan,
     pub(crate) setlist: AnyNodeId,
     pub(crate) from_clause: AnyNodeId,
     pub(crate) where_clause: AnyNodeId,
@@ -302,28 +302,28 @@ pub(crate) struct UnaryExpr {
 pub(crate) struct Literal {
     pub(crate) tag: u32,
     pub(crate) literal_type: super::ast::LiteralType,
-    pub(crate) source: SourceSpan,
+    pub(crate) source: TextSpan,
 }
 
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub(crate) struct IdentName {
     pub(crate) tag: u32,
-    pub(crate) source: SourceSpan,
+    pub(crate) source: TextSpan,
 }
 
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub(crate) struct Error {
     pub(crate) tag: u32,
-    pub(crate) source: SourceSpan,
+    pub(crate) source: TextSpan,
 }
 
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub(crate) struct FunctionCall {
     pub(crate) tag: u32,
-    pub(crate) func_name: SourceSpan,
+    pub(crate) func_name: TextSpan,
     pub(crate) flags: super::ast::FunctionCallFlags,
     pub(crate) args: AnyNodeId,
     pub(crate) filter_clause: AnyNodeId,
@@ -334,7 +334,7 @@ pub(crate) struct FunctionCall {
 #[repr(C)]
 pub(crate) struct Variable {
     pub(crate) tag: u32,
-    pub(crate) source: SourceSpan,
+    pub(crate) source: TextSpan,
 }
 
 #[derive(Debug, Clone)]
@@ -342,7 +342,7 @@ pub(crate) struct Variable {
 pub(crate) struct CollateExpr {
     pub(crate) tag: u32,
     pub(crate) expr: AnyNodeId,
-    pub(crate) collation: SourceSpan,
+    pub(crate) collation: TextSpan,
 }
 
 #[derive(Debug, Clone)]
@@ -441,8 +441,8 @@ pub(crate) struct LimitClause {
 #[repr(C)]
 pub(crate) struct TableRef {
     pub(crate) tag: u32,
-    pub(crate) table_name: SourceSpan,
-    pub(crate) schema: SourceSpan,
+    pub(crate) table_name: TextSpan,
+    pub(crate) schema: TextSpan,
     pub(crate) alias: AnyNodeId,
     pub(crate) args: AnyNodeId,
 }
@@ -486,8 +486,8 @@ pub(crate) struct TriggerEvent {
 #[repr(C)]
 pub(crate) struct CreateTriggerStmt {
     pub(crate) tag: u32,
-    pub(crate) trigger_name: SourceSpan,
-    pub(crate) schema: SourceSpan,
+    pub(crate) trigger_name: TextSpan,
+    pub(crate) schema: TextSpan,
     pub(crate) is_temp: Bool,
     pub(crate) if_not_exists: Bool,
     pub(crate) timing: super::ast::TriggerTiming,
@@ -501,20 +501,20 @@ pub(crate) struct CreateTriggerStmt {
 #[repr(C)]
 pub(crate) struct CreateVirtualTableStmt {
     pub(crate) tag: u32,
-    pub(crate) table_name: SourceSpan,
-    pub(crate) schema: SourceSpan,
-    pub(crate) module_name: SourceSpan,
+    pub(crate) table_name: TextSpan,
+    pub(crate) schema: TextSpan,
+    pub(crate) module_name: TextSpan,
     pub(crate) if_not_exists: Bool,
-    pub(crate) module_args: SourceSpan,
+    pub(crate) module_args: TextSpan,
 }
 
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub(crate) struct PragmaStmt {
     pub(crate) tag: u32,
-    pub(crate) pragma_name: SourceSpan,
-    pub(crate) schema: SourceSpan,
-    pub(crate) value: SourceSpan,
+    pub(crate) pragma_name: TextSpan,
+    pub(crate) schema: TextSpan,
+    pub(crate) value: TextSpan,
     pub(crate) pragma_form: super::ast::PragmaForm,
 }
 
@@ -522,8 +522,8 @@ pub(crate) struct PragmaStmt {
 #[repr(C)]
 pub(crate) struct AnalyzeOrReindexStmt {
     pub(crate) tag: u32,
-    pub(crate) target_name: SourceSpan,
-    pub(crate) schema: SourceSpan,
+    pub(crate) target_name: TextSpan,
+    pub(crate) schema: TextSpan,
     pub(crate) kind: super::ast::AnalyzeOrReindexOp,
 }
 
@@ -547,7 +547,7 @@ pub(crate) struct DetachStmt {
 #[repr(C)]
 pub(crate) struct VacuumStmt {
     pub(crate) tag: u32,
-    pub(crate) schema: SourceSpan,
+    pub(crate) schema: TextSpan,
     pub(crate) filename: AnyNodeId,
 }
 
@@ -563,9 +563,9 @@ pub(crate) struct ExplainStmt {
 #[repr(C)]
 pub(crate) struct CreateIndexStmt {
     pub(crate) tag: u32,
-    pub(crate) index_name: SourceSpan,
-    pub(crate) schema: SourceSpan,
-    pub(crate) table_name: SourceSpan,
+    pub(crate) index_name: TextSpan,
+    pub(crate) schema: TextSpan,
+    pub(crate) table_name: TextSpan,
     pub(crate) is_unique: Bool,
     pub(crate) if_not_exists: Bool,
     pub(crate) columns: AnyNodeId,
@@ -576,8 +576,8 @@ pub(crate) struct CreateIndexStmt {
 #[repr(C)]
 pub(crate) struct CreateViewStmt {
     pub(crate) tag: u32,
-    pub(crate) view_name: SourceSpan,
-    pub(crate) schema: SourceSpan,
+    pub(crate) view_name: TextSpan,
+    pub(crate) schema: TextSpan,
     pub(crate) is_temp: Bool,
     pub(crate) if_not_exists: Bool,
     pub(crate) column_names: AnyNodeId,
@@ -613,7 +613,7 @@ pub(crate) struct FrameSpec {
 #[repr(C)]
 pub(crate) struct WindowDef {
     pub(crate) tag: u32,
-    pub(crate) base_window_name: SourceSpan,
+    pub(crate) base_window_name: TextSpan,
     pub(crate) partition_by: AnyNodeId,
     pub(crate) orderby: AnyNodeId,
     pub(crate) frame: AnyNodeId,
@@ -623,7 +623,7 @@ pub(crate) struct WindowDef {
 #[repr(C)]
 pub(crate) struct NamedWindowDef {
     pub(crate) tag: u32,
-    pub(crate) window_name: SourceSpan,
+    pub(crate) window_name: TextSpan,
     pub(crate) window_def: AnyNodeId,
 }
 
@@ -633,7 +633,7 @@ pub(crate) struct FilterOver {
     pub(crate) tag: u32,
     pub(crate) filter_expr: AnyNodeId,
     pub(crate) over_def: AnyNodeId,
-    pub(crate) over_name: SourceSpan,
+    pub(crate) over_name: TextSpan,
 }
 
 // SAFETY: TAG matches the value the C parser writes into the `tag` field.

--- a/syntaqlite-syntax/src/tokenizer.rs
+++ b/syntaqlite-syntax/src/tokenizer.rs
@@ -201,14 +201,14 @@ impl<G: TypedDialect> TypedTokenizer<G> {
         inner.source_buf.push(0);
 
         // source_buf has at least one byte (the null terminator just pushed).
-        let c_source_ptr =
+        let c_text_ptr =
             NonNull::new(inner.source_buf.as_mut_ptr()).expect("source_buf is non-empty");
-        // SAFETY: inner.raw is valid; c_source_ptr points to source_buf which
+        // SAFETY: inner.raw is valid; c_text_ptr points to source_buf which
         // is null-terminated. source_buf lives inside inner which will be owned
         // by the cursor.
         unsafe {
             inner.raw.as_mut().reset(
-                c_source_ptr.as_ptr() as *const _,
+                c_text_ptr.as_ptr() as *const _,
                 #[expect(clippy::cast_possible_truncation)]
                 {
                     source.len() as u32
@@ -218,7 +218,7 @@ impl<G: TypedDialect> TypedTokenizer<G> {
         TypedTokenCursor {
             raw: inner.raw,
             source,
-            c_source_base: c_source_ptr,
+            c_text_base: c_text_ptr,
             inner: Some(inner),
             slot: Rc::clone(&self.inner),
             _marker: PhantomData,
@@ -273,7 +273,7 @@ impl<G: TypedDialect> TypedTokenizer<G> {
         TypedTokenCursor {
             raw: inner.raw,
             source: source_str,
-            c_source_base: NonNull::new(source.as_ptr() as *mut u8).expect("CStr is non-null"),
+            c_text_base: NonNull::new(source.as_ptr() as *mut u8).expect("CStr is non-null"),
             inner: Some(inner),
             slot: Rc::clone(&self.inner),
             _marker: PhantomData,
@@ -324,7 +324,7 @@ struct TypedTokenCursor<'a, G: TypedDialect> {
     source: &'a str,
     /// Base pointer of the C source buffer. Used to compute byte offsets back
     /// into the Rust `source` slice.
-    c_source_base: NonNull<u8>,
+    c_text_base: NonNull<u8>,
     inner: Option<TokenizerInner>,
     slot: Rc<RefCell<Option<TokenizerInner>>>,
     _marker: PhantomData<G>,
@@ -357,7 +357,7 @@ impl<'a, G: TypedDialect> Iterator for TypedTokenCursor<'a, G> {
 
             if let Some(token_type) = G::Token::from_token_type(AnyTokenType(token.type_)) {
                 // Compute offset into the source string from the C pointer.
-                let offset = token.text as usize - self.c_source_base.as_ptr() as usize;
+                let offset = token.text as usize - self.c_text_base.as_ptr() as usize;
                 let text = &self.source[offset..offset + token.length as usize];
                 return Some(TypedToken { token_type, text });
             }

--- a/syntaqlite/src/fmt/formatter.rs
+++ b/syntaqlite/src/fmt/formatter.rs
@@ -186,7 +186,7 @@ impl Formatter {
 
             let erased = stmt.erase();
             self.collect_side_channels(&erased);
-            let stmt_source = erased.source();
+            let stmt_source = erased.text();
 
             let root_id = erased.root_id();
             let prev_has_root = last_has_root;
@@ -448,7 +448,7 @@ impl Formatter {
             let mut arena = DocArena::recycle(prev_arena);
             self.parts.clear();
 
-            let stmt_source = erased.source();
+            let stmt_source = erased.text();
             if stmt_num > 0 {
                 emit_stmt_separator(
                     comment_ctx.as_ref(),
@@ -615,7 +615,7 @@ pub(crate) fn try_macro_verbatim<'a>(
 ) -> Option<DocId> {
     let cctx = ctx.comment_ctx.as_ref()?;
     let (tok_offset, _) = cctx.peek_next_token()?;
-    let source = ctx.source();
+    let source = ctx.text();
 
     for (i, r) in regions.iter().enumerate() {
         let r_start = r.call_offset();

--- a/syntaqlite/src/fmt/interpret.rs
+++ b/syntaqlite/src/fmt/interpret.rs
@@ -19,8 +19,8 @@ pub(crate) struct FmtCtx<'a> {
 }
 
 impl<'a> FmtCtx<'a> {
-    pub(crate) fn source(&self) -> &'a str {
-        self.reader.source()
+    pub(crate) fn text(&self) -> &'a str {
+        self.reader.text()
     }
 }
 
@@ -79,7 +79,7 @@ impl Formatter {
             return NIL_DOC;
         }
 
-        let source = ctx.source();
+        let source = ctx.text();
         let Some((tag, fields)) = ctx.reader.extract_fields(root_id) else {
             return NIL_DOC;
         };
@@ -212,26 +212,20 @@ impl Formatter {
                 }
                 FmtOp::Span(idx) => {
                     // INVARIANT: Span ops only target Span fields.
-                    let FieldValue::Span {
-                        text: s,
-                        quoted,
-                        source: span_src,
-                    } = fields[idx as usize]
-                    else {
+                    let FieldValue::Span(span) = fields[idx as usize] else {
                         panic!("Span: field {idx} is not a Span");
                     };
 
+                    let (s, span_start) = ctx.reader.span_text(span);
                     if !s.is_empty() {
+                        let quoted = span.is_quoted();
                         if let Some(ref cctx) = ctx.comment_ctx {
                             // For quoted spans, the original token in source
                             // starts one byte earlier (the opening quote) and
                             // extends one byte past (the closing quote).
-                            let drain_offset = if quoted {
-                                span_src.start - 1
-                            } else {
-                                span_src.start
-                            };
-                            let token_len = span_src.len() + if quoted { 2 } else { 0 };
+                            let span_len = u32::try_from(s.len()).unwrap_or(u32::MAX);
+                            let drain_offset = if quoted { span_start - 1 } else { span_start };
+                            let token_len = span_len + if quoted { 2 } else { 0 };
                             let drain = cctx.drain_before(drain_offset, source, arena);
                             flush_drain(&drain, &mut pending, &mut running, arena);
                             cctx.advance_past(drain_offset + token_len);
@@ -500,10 +494,10 @@ impl Formatter {
                 }
                 FmtOp::IfSpan(idx, skip) => {
                     // INVARIANT: IfSpan ops only target Span fields.
-                    let FieldValue::Span { text: s, .. } = fields[idx as usize] else {
+                    let FieldValue::Span(span) = fields[idx as usize] else {
                         panic!("IfSpan: field {idx} is not a Span");
                     };
-                    if s.is_empty() {
+                    if span.is_empty() {
                         ip += skip as usize;
                     }
                 }

--- a/syntaqlite/src/semantic/analyzer.rs
+++ b/syntaqlite/src/semantic/analyzer.rs
@@ -6,32 +6,31 @@
 use std::collections::{HashMap, HashSet};
 
 use syntaqlite_syntax::ParserConfig;
-use syntaqlite_syntax::any::{
-    AnyNodeId, AnyParseError, AnyParsedStatement, AnyParser, FieldValue, NodeFields, ParseOutcome,
-    SourceRange,
-};
-#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-use syntaqlite_syntax::any::TokenCategory;
 #[cfg(feature = "lsp")]
 use syntaqlite_syntax::any::AnyTokenType;
+#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
+use syntaqlite_syntax::any::TokenCategory;
+use syntaqlite_syntax::any::{
+    AnyNodeId, AnyParseError, AnyParsedStatement, AnyParser, FieldValue, NodeFields, ParseOutcome,
+};
 
 use crate::dialect::AnyDialect;
 use crate::dialect::{FIELD_ABSENT, MacroDef, SemanticRole};
 
+#[cfg(feature = "lsp")]
+use super::catalog::{AritySpec, FunctionCategory};
 use super::catalog::{
     Catalog, CatalogLayer, ColumnResolution, FunctionCheckResult, columns_from_select,
 };
-#[cfg(feature = "lsp")]
-use super::catalog::{AritySpec, FunctionCategory};
 use super::diagnostics::{Diagnostic, DiagnosticMessage, Help};
 use super::fuzzy::best_suggestion;
-use super::model::{DefinedRelation, SemanticModel, StatementModel};
-#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-use super::model::{SemanticToken, StoredComment, StoredToken};
 #[cfg(feature = "lsp")]
 use super::model::{
     CompletionContext, CompletionInfo, DefinitionLocation, Resolution, ResolvedSymbol,
 };
+use super::model::{DefinedRelation, SemanticModel, StatementModel};
+#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
+use super::model::{SemanticToken, StoredComment, StoredToken};
 use super::{AnalysisMode, CheckConfig, CheckLevel, ValidationConfig};
 
 /// Long-lived semantic analysis engine.
@@ -470,7 +469,7 @@ impl SemanticAnalyzer {
 
         // Extract the module name text.
         let module_name = match fields[module as usize] {
-            FieldValue::Span { text, .. } if !text.is_empty() => text.to_string(),
+            FieldValue::Span(sp) if !sp.is_empty() => erased.span_expanded_text(sp).to_string(),
             _ => return,
         };
 
@@ -483,9 +482,9 @@ impl SemanticAnalyzer {
         let Some(source) = self.resolver.as_ref().and_then(|r| r.resolve(&module_name)) else {
             // Emit diagnostic for unresolvable module.
             let (start, end) = match fields[module as usize] {
-                FieldValue::Span { text, .. } => {
-                    let offset = erased.source().find(text).unwrap_or(0);
-                    (offset, offset + text.len())
+                FieldValue::Span(sp) => {
+                    let (authored, off) = erased.span_text(sp);
+                    (off as usize, off as usize + authored.len())
                 }
                 _ => (0, 0),
             };
@@ -514,7 +513,7 @@ impl Default for SemanticAnalyzer {
 
 /// Extract the source text for a single parsed statement from its token spans.
 fn statement_source(stmt: &AnyParsedStatement<'_>) -> String {
-    let source = stmt.source();
+    let source = stmt.text();
     let mut start = usize::MAX;
     let mut end = 0usize;
     for (offset, length) in stmt.token_spans() {
@@ -552,11 +551,11 @@ fn extract_defined_relations(
         SemanticRole::DefineView { name, .. } => (name, true),
         _ => return Vec::new(),
     };
-    if let FieldValue::Span { text, .. } = fields[name_field as usize]
-        && !text.is_empty()
+    if let FieldValue::Span(sp) = fields[name_field as usize]
+        && !sp.is_empty()
     {
         vec![DefinedRelation {
-            name: text.to_string(),
+            name: stmt.span_expanded_text(sp).to_string(),
             is_view,
         }]
     } else {
@@ -917,19 +916,17 @@ fn ddl_name_offset(
         SemanticRole::DefineTable { name, .. } | SemanticRole::DefineView { name, .. } => *name,
         _ => return None,
     };
-    let FieldValue::Span {
-        text: s, source, ..
-    } = fields[name_idx as usize]
-    else {
+    let FieldValue::Span(sp) = fields[name_idx as usize] else {
         return None;
     };
-    if s.is_empty() {
+    if sp.is_empty() {
         return None;
     }
-    Some((
-        s.to_ascii_lowercase(),
-        (source.start as usize, source.end as usize),
-    ))
+    let name = stmt.span_expanded_text(sp);
+    let (authored, off) = stmt.span_text(sp);
+    let start = off as usize;
+    let end = start + authored.len();
+    Some((name.to_ascii_lowercase(), (start, end)))
 }
 
 /// Check if the root node of a statement defines a template macro and, if so,
@@ -957,13 +954,13 @@ fn extract_macro_registration(
 
     // Extract the macro name.
     let name = match fields[def.name_field as usize] {
-        FieldValue::Span { text, .. } if !text.is_empty() => text.to_string(),
+        FieldValue::Span(sp) if !sp.is_empty() => stmt.span_text(sp).0.to_string(),
         _ => return None,
     };
 
     // Extract the macro body.
     let body = match fields[def.body_field as usize] {
-        FieldValue::Span { text, .. } if !text.is_empty() => text.to_string(),
+        FieldValue::Span(sp) if !sp.is_empty() => stmt.span_expanded_text(sp).to_string(),
         _ => return None,
     };
 
@@ -983,8 +980,8 @@ fn extract_macro_registration(
             }
             let (_, child_fields) = stmt.extract_fields(child_id)?;
             match child_fields[def.arg_name_field as usize] {
-                FieldValue::Span { text, .. } if !text.is_empty() => {
-                    param_names.push(text.to_string());
+                FieldValue::Span(sp) if !sp.is_empty() => {
+                    param_names.push(stmt.span_text(sp).0.to_string());
                 }
                 _ => return None,
             }
@@ -1045,16 +1042,17 @@ impl CheckConfig {
 }
 
 impl<'a> ValidationPass<'a> {
-    /// Push a diagnostic anchored to a span field of a node.  `source` is the
-    /// pre-extracted `SourceRange` from the field; `node_id` + `field_idx` are
-    /// used to build the macro expansion traceback (if any).  Severity is
-    /// determined entirely by the check level — callers do not specify it.
+    /// Push a diagnostic anchored to a span field of a node.  `text_range`
+    /// is `(start, end)` authored byte offsets from the field; `node_id` +
+    /// `field_idx` are used to build the macro expansion traceback (if
+    /// any).  Severity is determined entirely by the check level —
+    /// callers do not specify it.
     fn emit(
         &mut self,
         stmt: &mut AnyParsedStatement<'_>,
         node_id: AnyNodeId,
         field_idx: u8,
-        source: SourceRange,
+        text_range: (usize, usize),
         message: DiagnosticMessage,
         help: Option<Help>,
     ) {
@@ -1072,8 +1070,8 @@ impl<'a> ValidationPass<'a> {
         // Only attach if there's actual expansion (more than 1 frame).
         let expansion_frames = if frames.len() > 1 { frames } else { Vec::new() };
         self.diagnostics.push(Diagnostic {
-            start_offset: source.start as usize,
-            end_offset: source.end as usize,
+            start_offset: text_range.0,
+            end_offset: text_range.1,
             message,
             severity,
             help,
@@ -1237,7 +1235,7 @@ impl<'a> ValidationPass<'a> {
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    fn field_node_id(fields: &NodeFields<'_>, idx: u8) -> Option<AnyNodeId> {
+    fn field_node_id(fields: &NodeFields, idx: u8) -> Option<AnyNodeId> {
         match fields[idx as usize] {
             FieldValue::NodeId(id) if !id.is_null() => Some(id),
             _ => None,
@@ -1268,8 +1266,13 @@ impl<'a> ValidationPass<'a> {
             return ("", 0, 0);
         }
         match fields[0] {
-            FieldValue::Span { text, source, .. } => {
-                (text, source.start as usize, source.end as usize)
+            FieldValue::Span(sp) => {
+                // Identifier spelling uses the post-expansion bytes;
+                // source position uses the authored byte range.
+                let name = stmt.span_expanded_text(sp);
+                let (authored, off) = stmt.span_text(sp);
+                let start = off as usize;
+                (name, start, start + authored.len())
             }
             _ => ("", 0, 0),
         }
@@ -1277,27 +1280,31 @@ impl<'a> ValidationPass<'a> {
 
     // ── Role handlers ─────────────────────────────────────────────────────────
 
-    fn visit_source_ref<'b>(
+    fn visit_source_ref(
         &mut self,
-        stmt: &mut AnyParsedStatement<'b>,
+        stmt: &mut AnyParsedStatement<'_>,
         node_id: AnyNodeId,
-        fields: &NodeFields<'b>,
+        fields: &NodeFields,
         name_idx: u8,
         alias_idx: u8,
     ) {
-        let FieldValue::Span {
-            text: name, source, ..
-        } = fields[name_idx as usize]
-        else {
+        let FieldValue::Span(sp) = fields[name_idx as usize] else {
             return;
         };
-        if name.is_empty() {
+        if sp.is_empty() {
             return;
         }
-        #[cfg(feature = "lsp")]
-        let start = source.start as usize;
-        #[cfg(feature = "lsp")]
-        let end = source.end as usize;
+        // Identifier spelling comes from the post-expansion bytes (what
+        // the tokenizer saw), so a reference produced from a macro body
+        // resolves against the catalog by its expanded name.  Source
+        // position comes from `span_text`, which walks the expansion
+        // chain back to the authored byte range in the user's input —
+        // so diagnostics anchor at the macro call site when the token
+        // lives inside a macro body.
+        let name = stmt.span_expanded_text(sp);
+        let (authored, off) = stmt.span_text(sp);
+        let start = off as usize;
+        let end = start + authored.len();
 
         let is_known =
             self.catalog.resolve_relation(name) || self.catalog.resolve_table_function(name);
@@ -1309,7 +1316,7 @@ impl<'a> ValidationPass<'a> {
                 stmt,
                 node_id,
                 name_idx,
-                source,
+                (start, end),
                 DiagnosticMessage::UnknownTable {
                     name: name.to_string(),
                 },
@@ -1355,23 +1362,24 @@ impl<'a> ValidationPass<'a> {
             .add_table(scope_name, columns, without_rowid.into());
     }
 
-    fn visit_call<'b>(
+    fn visit_call(
         &mut self,
-        stmt: &mut AnyParsedStatement<'b>,
+        stmt: &mut AnyParsedStatement<'_>,
         node_id: AnyNodeId,
-        fields: &NodeFields<'b>,
+        fields: &NodeFields,
         name_idx: u8,
         args_idx: u8,
     ) {
-        if let FieldValue::Span {
-            text: name, source, ..
-        } = fields[name_idx as usize]
-            && !name.is_empty()
+        if let FieldValue::Span(sp) = fields[name_idx as usize]
+            && !sp.is_empty()
         {
-            #[cfg(feature = "lsp")]
-            let start = source.start as usize;
-            #[cfg(feature = "lsp")]
-            let end = source.end as usize;
+            // Identifier spelling from post-expansion bytes; source
+            // position from `span_text` (walks expansion chain back to
+            // authored byte range).
+            let name = stmt.span_expanded_text(sp);
+            let (authored, off) = stmt.span_text(sp);
+            let start = off as usize;
+            let end = start + authored.len();
             let args_id = Self::field_node_id(fields, args_idx);
             let arg_count = args_id
                 .and_then(|id| stmt.list_children(id))
@@ -1405,7 +1413,7 @@ impl<'a> ValidationPass<'a> {
                         stmt,
                         node_id,
                         name_idx,
-                        source,
+                        (start, end),
                         DiagnosticMessage::UnknownFunction {
                             name: name.to_string(),
                         },
@@ -1417,7 +1425,7 @@ impl<'a> ValidationPass<'a> {
                         stmt,
                         node_id,
                         name_idx,
-                        source,
+                        (start, end),
                         DiagnosticMessage::FunctionArity {
                             name: name.to_string(),
                             expected,
@@ -1431,11 +1439,11 @@ impl<'a> ValidationPass<'a> {
         self.visit_children(stmt, node_id);
     }
 
-    fn visit_column_ref<'b>(
+    fn visit_column_ref(
         &mut self,
-        stmt: &mut AnyParsedStatement<'b>,
+        stmt: &mut AnyParsedStatement<'_>,
         node_id: AnyNodeId,
-        fields: &NodeFields<'b>,
+        fields: &NodeFields,
         column_idx: u8,
         table_idx: u8,
     ) {
@@ -1444,21 +1452,23 @@ impl<'a> ValidationPass<'a> {
         if !self.scope.has_frames() {
             return;
         }
-        let FieldValue::Span {
-            text: column,
-            source,
-            ..
-        } = fields[column_idx as usize]
-        else {
+        let FieldValue::Span(col_sp) = fields[column_idx as usize] else {
             return;
         };
-        if column.is_empty() {
+        if col_sp.is_empty() {
             return;
         }
+        // Identifier spelling comes from post-expansion bytes; source
+        // position from `span_text` (walks expansion chain back to
+        // authored byte range for diagnostic placement).
+        let column = stmt.span_expanded_text(col_sp);
         let table = match fields[table_idx as usize] {
-            FieldValue::Span { text: s, .. } if !s.is_empty() => Some(s),
+            FieldValue::Span(sp) if !sp.is_empty() => Some(stmt.span_expanded_text(sp)),
             _ => None,
         };
+        let (authored, col_off) = stmt.span_text(col_sp);
+        let start = col_off as usize;
+        let end = start + authored.len();
 
         match self.scope.resolve_column(table, column) {
             ColumnResolution::Found {
@@ -1466,7 +1476,7 @@ impl<'a> ValidationPass<'a> {
                 all_columns,
             } => {
                 #[cfg(feature = "lsp")]
-                self.record_column_resolution(source, column, resolved_table, all_columns);
+                self.record_column_resolution(start, end, column, resolved_table, all_columns);
                 #[cfg(not(feature = "lsp"))]
                 let _ = (resolved_table, all_columns);
             }
@@ -1480,7 +1490,7 @@ impl<'a> ValidationPass<'a> {
                     stmt,
                     node_id,
                     column_idx,
-                    source,
+                    (start, end),
                     DiagnosticMessage::UnknownColumn {
                         column: column.to_string(),
                         table: Some(tbl.to_string()),
@@ -1502,7 +1512,7 @@ impl<'a> ValidationPass<'a> {
                     stmt,
                     node_id,
                     column_idx,
-                    source,
+                    (start, end),
                     DiagnosticMessage::UnknownColumn {
                         column: column.to_string(),
                         table: None,
@@ -1518,7 +1528,8 @@ impl<'a> ValidationPass<'a> {
     #[cfg(feature = "lsp")]
     fn record_column_resolution(
         &mut self,
-        source: SourceRange,
+        start: usize,
+        end: usize,
         column: &str,
         resolved_table: String,
         all_columns: Vec<String>,
@@ -1549,8 +1560,8 @@ impl<'a> ValidationPass<'a> {
                     })
             });
         self.resolutions.push(Resolution {
-            start: source.start as usize,
-            end: source.end as usize,
+            start,
+            end,
             symbol: ResolvedSymbol::Column {
                 column: column.to_string(),
                 table: resolved_table,
@@ -1560,10 +1571,10 @@ impl<'a> ValidationPass<'a> {
         });
     }
 
-    fn visit_scoped_source<'b>(
+    fn visit_scoped_source(
         &mut self,
-        stmt: &mut AnyParsedStatement<'b>,
-        fields: &NodeFields<'b>,
+        stmt: &mut AnyParsedStatement<'_>,
+        fields: &NodeFields,
         body_idx: u8,
         alias_idx: u8,
     ) {
@@ -1582,10 +1593,10 @@ impl<'a> ValidationPass<'a> {
     }
 
     #[expect(clippy::too_many_arguments)]
-    fn visit_query<'b>(
+    fn visit_query(
         &mut self,
-        stmt: &mut AnyParsedStatement<'b>,
-        fields: &NodeFields<'b>,
+        stmt: &mut AnyParsedStatement<'_>,
+        fields: &NodeFields,
         from: u8,
         columns: u8,
         where_clause: u8,
@@ -1618,10 +1629,10 @@ impl<'a> ValidationPass<'a> {
     }
 
     /// Extract alias names from the SELECT result column list.
-    fn collect_select_aliases<'b>(
+    fn collect_select_aliases(
         &self,
-        stmt: &mut AnyParsedStatement<'b>,
-        fields: &NodeFields<'b>,
+        stmt: &mut AnyParsedStatement<'_>,
+        fields: &NodeFields,
         columns_idx: u8,
     ) -> Vec<String> {
         let mut aliases = Vec::new();
@@ -1658,10 +1669,10 @@ impl<'a> ValidationPass<'a> {
         aliases
     }
 
-    fn visit_cte_scope<'b>(
+    fn visit_cte_scope(
         &mut self,
-        stmt: &mut AnyParsedStatement<'b>,
-        fields: &NodeFields<'b>,
+        stmt: &mut AnyParsedStatement<'_>,
+        fields: &NodeFields,
         recursive_idx: u8,
         bindings_idx: u8,
         body_idx: u8,
@@ -1819,8 +1830,11 @@ impl<'a> ValidationPass<'a> {
         };
 
         let (name, name_range) = match fields[name_idx as usize] {
-            FieldValue::Span { text, source, .. } => {
-                (text, (source.start as usize, source.end as usize))
+            FieldValue::Span(sp) => {
+                let name = stmt.span_expanded_text(sp);
+                let (authored, off) = stmt.span_text(sp);
+                let start = off as usize;
+                (name, (start, start + authored.len()))
             }
             _ => ("", (0, 0)),
         };
@@ -1837,7 +1851,7 @@ impl<'a> ValidationPass<'a> {
     /// Extract declared CTE column names from the column list field.
     fn extract_declared_cols<'b>(
         stmt: &mut AnyParsedStatement<'b>,
-        fields: &NodeFields<'b>,
+        fields: &NodeFields,
         cols_idx: u8,
     ) -> Option<Vec<(&'b str, usize, usize)>> {
         if cols_idx == FIELD_ABSENT {
@@ -1940,10 +1954,10 @@ impl<'a> ValidationPass<'a> {
         Some(count)
     }
 
-    fn visit_trigger_scope<'b>(
+    fn visit_trigger_scope(
         &mut self,
-        stmt: &mut AnyParsedStatement<'b>,
-        fields: &NodeFields<'b>,
+        stmt: &mut AnyParsedStatement<'_>,
+        fields: &NodeFields,
         when_idx: u8,
         body_idx: u8,
     ) {

--- a/syntaqlite/src/semantic/catalog.rs
+++ b/syntaqlite/src/semantic/catalog.rs
@@ -651,7 +651,9 @@ impl Catalog {
                 without_rowid,
             } => {
                 let name_val = match fields[name as usize] {
-                    FieldValue::Span { text: s, .. } if !s.is_empty() => s.to_string(),
+                    FieldValue::Span(sp) if !sp.is_empty() => {
+                        stmt.span_expanded_text(sp).to_string()
+                    }
                     _ => return,
                 };
                 let cols = extract_columns(
@@ -674,7 +676,9 @@ impl Catalog {
                 select,
             } => {
                 let name_val = match fields[name as usize] {
-                    FieldValue::Span { text: s, .. } if !s.is_empty() => s.to_string(),
+                    FieldValue::Span(sp) if !sp.is_empty() => {
+                        stmt.span_expanded_text(sp).to_string()
+                    }
                     _ => return,
                 };
                 let cols = extract_columns(
@@ -693,7 +697,9 @@ impl Catalog {
                 ..
             } => {
                 let name_val = match fields[name as usize] {
-                    FieldValue::Span { text: s, .. } if !s.is_empty() => s.to_string(),
+                    FieldValue::Span(sp) if !sp.is_empty() => {
+                        stmt.span_expanded_text(sp).to_string()
+                    }
                     _ => return,
                 };
                 let arity = extract_function_arity(stmt, &fields, opt_field(args));
@@ -989,13 +995,14 @@ fn ddl_name_span(
         SemanticRole::DefineTable { name, .. } | SemanticRole::DefineView { name, .. } => *name,
         _ => return None,
     };
-    let FieldValue::Span { text: s, .. } = fields[name_idx as usize] else {
+    let FieldValue::Span(sp) = fields[name_idx as usize] else {
         return None;
     };
-    if s.is_empty() {
+    if sp.is_empty() {
         return None;
     }
-    let off = s.as_ptr() as usize - stmt.source().as_ptr() as usize;
+    let (s, off_u32) = stmt.span_text(sp);
+    let off = off_u32 as usize;
     Some((s.to_ascii_lowercase(), off, off + s.len()))
 }
 
@@ -1058,12 +1065,12 @@ fn column_def_name_span<'a>(
     }
     let (_, name_fields) = stmt.extract_fields(name_id)?;
     for j in 0..name_fields.len() {
-        if let FieldValue::Span {
-            text: s, source, ..
-        } = name_fields[j]
-            && !s.is_empty()
+        if let FieldValue::Span(sp) = name_fields[j]
+            && !sp.is_empty()
         {
-            return Some((s, source.start as usize, source.end as usize));
+            let (s, off) = stmt.span_text(sp);
+            let start = off as usize;
+            return Some((s, start, start + s.len()));
         }
     }
     None
@@ -1075,9 +1082,9 @@ fn column_def_name_span<'a>(
 /// the result columns of the AS-SELECT body. Returns `None` only when
 /// inference is impossible (e.g. `SELECT *`), which tells the catalog to
 /// accept any column reference conservatively.
-fn extract_columns<'a>(
-    stmt: &AnyParsedStatement<'a>,
-    fields: &NodeFields<'a>,
+fn extract_columns(
+    stmt: &AnyParsedStatement<'_>,
+    fields: &NodeFields,
     columns_field: Option<u8>,
     select_field: Option<u8>,
     roles: &'static [SemanticRole],
@@ -1106,9 +1113,9 @@ fn extract_columns<'a>(
 }
 
 /// Check whether a DDL function returns a table.
-fn is_table_returning<'a>(
-    stmt: &AnyParsedStatement<'a>,
-    fields: &NodeFields<'a>,
+fn is_table_returning(
+    stmt: &AnyParsedStatement<'_>,
+    fields: &NodeFields,
     return_type_field: Option<u8>,
     roles: &'static [SemanticRole],
 ) -> bool {
@@ -1135,9 +1142,9 @@ fn is_table_returning<'a>(
 }
 
 /// Extract argument count for a function DDL contribution.
-fn extract_function_arity<'a>(
-    stmt: &AnyParsedStatement<'a>,
-    fields: &NodeFields<'a>,
+fn extract_function_arity(
+    stmt: &AnyParsedStatement<'_>,
+    fields: &NodeFields,
     args_field: Option<u8>,
 ) -> AritySpec {
     let Some(args_idx) = args_field else {
@@ -1190,10 +1197,10 @@ fn columns_from_column_list(
         };
         // The first non-empty Span inside the name node is the identifier text.
         for j in 0..name_fields.len() {
-            if let FieldValue::Span { text: s, .. } = name_fields[j]
-                && !s.is_empty()
+            if let FieldValue::Span(sp) = name_fields[j]
+                && !sp.is_empty()
             {
-                out.push(s.to_ascii_lowercase());
+                out.push(stmt.span_expanded_text(sp).to_ascii_lowercase());
                 break;
             }
         }
@@ -1279,9 +1286,9 @@ pub(super) fn columns_from_select(
 ///    expression node (`SQLite` calls this `ENAME_SPAN`, stored by
 ///    `sqlite3ExprListSetSpan`). For `SELECT 1` this gives `"1"`;
 ///    for `SELECT 1+2` it gives `"1+2"`; etc.
-fn infer_result_col_name<'a>(
-    stmt: &AnyParsedStatement<'a>,
-    child_fields: &NodeFields<'a>,
+fn infer_result_col_name(
+    stmt: &AnyParsedStatement<'_>,
+    child_fields: &NodeFields,
     alias_idx: u8,
     expr_idx: u8,
     roles: &[SemanticRole],
@@ -1292,10 +1299,10 @@ fn infer_result_col_name<'a>(
         && let Some((_, alias_fields)) = stmt.extract_fields(alias_id)
     {
         for j in 0..alias_fields.len() {
-            if let FieldValue::Span { text: s, .. } = alias_fields[j]
-                && !s.is_empty()
+            if let FieldValue::Span(sp) = alias_fields[j]
+                && !sp.is_empty()
             {
-                return Some(s.to_ascii_lowercase());
+                return Some(stmt.span_expanded_text(sp).to_ascii_lowercase());
             }
         }
     }
@@ -1316,10 +1323,10 @@ fn infer_result_col_name<'a>(
     if let SemanticRole::ColumnRef {
         column: col_idx, ..
     } = expr_role
-        && let FieldValue::Span { text: col_span, .. } = expr_fields[col_idx as usize]
-        && !col_span.is_empty()
+        && let FieldValue::Span(sp) = expr_fields[col_idx as usize]
+        && !sp.is_empty()
     {
-        return Some(col_span.to_ascii_lowercase());
+        return Some(stmt.span_expanded_text(sp).to_ascii_lowercase());
     }
 
     // Fallback: use the raw source text spanned by the expression node
@@ -1336,11 +1343,10 @@ pub(super) fn expr_source_text<'a>(
     stmt: &AnyParsedStatement<'a>,
     id: AnyNodeId,
 ) -> Option<&'a str> {
-    let source = stmt.source();
-    let base = source.as_ptr() as usize;
+    let source = stmt.text();
     let mut min = usize::MAX;
     let mut max = 0usize;
-    collect_spans(stmt, id, base, &mut min, &mut max);
+    collect_spans(stmt, id, &mut min, &mut max);
     if min < max {
         Some(&source[min..max])
     } else {
@@ -1349,22 +1355,17 @@ pub(super) fn expr_source_text<'a>(
 }
 
 /// Walk `id` and all its descendants, updating `[min, max)` with every `Span`.
-fn collect_spans(
-    stmt: &AnyParsedStatement<'_>,
-    id: AnyNodeId,
-    base: usize,
-    min: &mut usize,
-    max: &mut usize,
-) {
+fn collect_spans(stmt: &AnyParsedStatement<'_>, id: AnyNodeId, min: &mut usize, max: &mut usize) {
     if id.is_null() {
         return;
     }
     if let Some((_, fields)) = stmt.extract_fields(id) {
         for i in 0..fields.len() {
             match fields[i] {
-                FieldValue::Span { text: s, .. } if !s.is_empty() => {
-                    let start = s.as_ptr() as usize - base;
-                    let end = start + s.len();
+                FieldValue::Span(sp) if !sp.is_empty() => {
+                    let (text, off) = stmt.span_text(sp);
+                    let start = off as usize;
+                    let end = start + text.len();
                     if start < *min {
                         *min = start;
                     }
@@ -1373,7 +1374,7 @@ fn collect_spans(
                     }
                 }
                 FieldValue::NodeId(child) if !child.is_null() => {
-                    collect_spans(stmt, child, base, min, max);
+                    collect_spans(stmt, child, min, max);
                 }
                 _ => {}
             }
@@ -1382,7 +1383,7 @@ fn collect_spans(
     // Also descend into list children (e.g. ExprList inside a FunctionCall).
     if let Some(children) = stmt.list_children(id) {
         for &child in children {
-            collect_spans(stmt, child, base, min, max);
+            collect_spans(stmt, child, min, max);
         }
     }
 }

--- a/syntaqlite/src/semantic/lineage/resolver.rs
+++ b/syntaqlite/src/semantic/lineage/resolver.rs
@@ -136,7 +136,9 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
 
         if let SemanticRole::CteBinding { name, body, .. } = role {
             let cte_name = match fields[name as usize] {
-                FieldValue::Span { text: s, .. } if !s.is_empty() => Some(s.to_ascii_lowercase()),
+                FieldValue::Span(sp) if !sp.is_empty() => {
+                    Some(self.stmt.span_expanded_text(sp).to_ascii_lowercase())
+                }
                 FieldValue::NodeId(id) if !id.is_null() => {
                     self.span_text(id).map(|s| s.to_ascii_lowercase())
                 }
@@ -514,7 +516,7 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
 
     fn trace_expr_origin(
         &mut self,
-        child_fields: &syntaqlite_syntax::any::NodeFields<'_>,
+        child_fields: &syntaqlite_syntax::any::NodeFields,
         expr_idx: u8,
         sources: &HashMap<String, SourceInfo>,
     ) -> Option<ColumnOrigin> {
@@ -535,14 +537,16 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
         };
 
         let col_name = match expr_fields[col_idx as usize] {
-            FieldValue::Span { text: s, .. } if !s.is_empty() => s.to_ascii_lowercase(),
+            FieldValue::Span(sp) if !sp.is_empty() => {
+                self.stmt.span_expanded_text(sp).to_ascii_lowercase()
+            }
             _ => return None,
         };
 
-        let source_name = if let FieldValue::Span { text: s, .. } = expr_fields[tbl_idx as usize]
-            && !s.is_empty()
+        let source_name = if let FieldValue::Span(sp) = expr_fields[tbl_idx as usize]
+            && !sp.is_empty()
         {
-            s.to_ascii_lowercase()
+            self.stmt.span_expanded_text(sp).to_ascii_lowercase()
         } else {
             find_source_for_column(sources, &col_name)?
         };
@@ -580,7 +584,7 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
 
     fn infer_column_name(
         &self,
-        child_fields: &syntaqlite_syntax::any::NodeFields<'_>,
+        child_fields: &syntaqlite_syntax::any::NodeFields,
         alias_idx: u8,
         expr_idx: u8,
     ) -> Option<String> {
@@ -590,10 +594,10 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
             && let Some((_, alias_fields)) = self.stmt.extract_fields(alias_id)
         {
             for j in 0..alias_fields.len() {
-                if let FieldValue::Span { text: s, .. } = alias_fields[j]
-                    && !s.is_empty()
+                if let FieldValue::Span(sp) = alias_fields[j]
+                    && !sp.is_empty()
                 {
-                    return Some(s.to_ascii_lowercase());
+                    return Some(self.stmt.span_expanded_text(sp).to_ascii_lowercase());
                 }
             }
         }
@@ -605,10 +609,10 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
             && let SemanticRole::ColumnRef {
                 column: col_idx, ..
             } = self.role_for(expr_tag)
-            && let FieldValue::Span { text: col_span, .. } = expr_fields[col_idx as usize]
-            && !col_span.is_empty()
+            && let FieldValue::Span(sp) = expr_fields[col_idx as usize]
+            && !sp.is_empty()
         {
-            return Some(col_span.to_ascii_lowercase());
+            return Some(self.stmt.span_expanded_text(sp).to_ascii_lowercase());
         }
 
         // Fallback: use expression source text.
@@ -635,10 +639,10 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
         }
         let (_, fields) = self.stmt.extract_fields(node_id)?;
         for i in 0..fields.len() {
-            if let FieldValue::Span { text: s, .. } = fields[i]
-                && !s.is_empty()
+            if let FieldValue::Span(sp) = fields[i]
+                && !sp.is_empty()
             {
-                return Some(s.to_owned());
+                return Some(self.stmt.span_expanded_text(sp).to_owned());
             }
         }
         None
@@ -646,14 +650,16 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
 
     fn span_text_from_field(
         &self,
-        fields: &syntaqlite_syntax::any::NodeFields<'_>,
+        fields: &syntaqlite_syntax::any::NodeFields,
         field_idx: u8,
     ) -> Option<String> {
         if field_idx == crate::dialect::FIELD_ABSENT {
             return None;
         }
         match fields[field_idx as usize] {
-            FieldValue::Span { text: s, .. } if !s.is_empty() => Some(s.to_owned()),
+            FieldValue::Span(sp) if !sp.is_empty() => {
+                Some(self.stmt.span_expanded_text(sp).to_owned())
+            }
             FieldValue::NodeId(id) if !id.is_null() => self.span_text(id),
             _ => None,
         }

--- a/syntaqlite/src/semantic/model.rs
+++ b/syntaqlite/src/semantic/model.rs
@@ -335,7 +335,6 @@ impl SemanticModel {
             .rev()
             .find_map(StatementModel::lineage)
     }
-
 }
 
 #[cfg(feature = "lsp")]

--- a/syntaqlite/tests/generated.rs
+++ b/syntaqlite/tests/generated.rs
@@ -187,7 +187,7 @@ fn debug_multi_stmt_comments() {
                 ParseOutcome::Err(e) => panic!("parse error: {e:?}"),
             };
             let comments: Vec<_> = stmt.comments().collect();
-            eprintln!("stmt {stmt_num}: source={:?}", stmt.source());
+            eprintln!("stmt {stmt_num}: source={:?}", stmt.text());
             eprintln!("  {} comment(s):", comments.len());
             for c in &comments {
                 let text = &source[c.offset() as usize..(c.offset() + c.length()) as usize];

--- a/syntaqlite/tests/low_level.rs
+++ b/syntaqlite/tests/low_level.rs
@@ -543,8 +543,10 @@ fn collect_span_ranges(
         for idx in 0..fields.len() {
             let field_idx = u8::try_from(idx).expect("field index fits in u8");
             match fields[idx] {
-                FieldValue::Span { source, .. } => {
-                    spans.push((field_idx, source.start as usize, source.end as usize));
+                FieldValue::Span(sp) => {
+                    let (text, off) = erased.span_text(sp);
+                    let start = off as usize;
+                    spans.push((field_idx, start, start + text.len()));
                 }
                 FieldValue::NodeId(child) if !child.is_null() => {
                     collect_span_ranges(erased, child, spans);

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -1,4 +1,5 @@
 #[non_exhaustive] pub enum syntaqlite_syntax::util::SqliteVersion
+#[repr(C)] pub struct syntaqlite_syntax::any::TextSpan
 #[repr(transparent)] pub struct syntaqlite_syntax::any::AnyNodeId(_)
 #[repr(transparent)] pub struct syntaqlite_syntax::any::AnyNodeTag(_)
 #[repr(transparent)] pub struct syntaqlite_syntax::any::AnyTokenType(_)
@@ -50,7 +51,6 @@ impl core::convert::From<syntaqlite_syntax::TokenType> for u32
 impl core::convert::From<syntaqlite_syntax::any::AnyNodeId> for syntaqlite_syntax::nodes::NodeId
 impl core::convert::From<syntaqlite_syntax::any::AnyNodeTag> for u32
 impl core::convert::From<syntaqlite_syntax::any::AnyTokenType> for u32
-impl core::convert::From<syntaqlite_syntax::any::SourceRange> for core::ops::range::Range<usize>
 impl core::convert::From<syntaqlite_syntax::nodes::AggregateFunctionCallId> for syntaqlite_syntax::any::AnyNodeId
 impl core::convert::From<syntaqlite_syntax::nodes::AlterTableStmtId> for syntaqlite_syntax::any::AnyNodeId
 impl core::convert::From<syntaqlite_syntax::nodes::AnalyzeOrReindexStmtId> for syntaqlite_syntax::any::AnyNodeId
@@ -141,7 +141,7 @@ impl core::convert::From<syntaqlite_syntax::typed::Dialect> for syntaqlite_synta
 impl core::convert::From<syntaqlite_syntax::typed::TypedIncrementalParseSession<syntaqlite_syntax::typed::Dialect>> for syntaqlite_syntax::IncrementalParseSession
 impl core::fmt::Debug for syntaqlite_syntax::ParserToken<'_>
 impl core::fmt::Debug for syntaqlite_syntax::any::AnyNode<'_>
-impl core::fmt::Debug for syntaqlite_syntax::any::NodeFields<'_>
+impl core::fmt::Debug for syntaqlite_syntax::any::NodeFields
 impl core::fmt::Debug for syntaqlite_syntax::nodes::AggregateFunctionCall<'_>
 impl core::fmt::Debug for syntaqlite_syntax::nodes::AlterTableStmt<'_>
 impl core::fmt::Debug for syntaqlite_syntax::nodes::AnalyzeOrReindexStmt<'_>
@@ -273,6 +273,7 @@ impl core::fmt::Display for syntaqlite_syntax::nodes::WindowDef<'_>
 impl core::fmt::Display for syntaqlite_syntax::nodes::WithClause<'_>
 impl core::marker::Send for syntaqlite_syntax::any::AnyDialect
 impl core::marker::Sync for syntaqlite_syntax::any::AnyDialect
+impl core::ops::index::Index<usize> for syntaqlite_syntax::any::NodeFields
 impl syntaqlite_syntax::CommentSpan
 impl syntaqlite_syntax::CompletionContext
 impl syntaqlite_syntax::IncrementalParseSession
@@ -285,7 +286,8 @@ impl syntaqlite_syntax::any::AnyTokenType
 impl syntaqlite_syntax::any::FieldMeta<'_>
 impl syntaqlite_syntax::any::KeywordEntry
 impl syntaqlite_syntax::any::MacroRegion
-impl syntaqlite_syntax::any::SourceRange
+impl syntaqlite_syntax::any::NodeFields
+impl syntaqlite_syntax::any::TextSpan
 impl syntaqlite_syntax::nodes::AggregateFunctionCallFlags
 impl syntaqlite_syntax::nodes::AggregateFunctionCallId
 impl syntaqlite_syntax::nodes::AlterOp
@@ -591,11 +593,9 @@ impl<'a> core::convert::From<syntaqlite_syntax::typed::TypedNodeList<'a, syntaql
 impl<'a> core::convert::From<syntaqlite_syntax::typed::TypedNodeList<'a, syntaqlite_syntax::typed::Dialect, syntaqlite_syntax::nodes::UpsertClause<'a>>> for syntaqlite_syntax::nodes::UpsertClauseListId
 impl<'a> core::convert::From<syntaqlite_syntax::typed::TypedNodeList<'a, syntaqlite_syntax::typed::Dialect, syntaqlite_syntax::nodes::WindowDef<'a>>> for syntaqlite_syntax::nodes::WindowDefListId
 impl<'a> core::convert::From<syntaqlite_syntax::typed::TypedNodeList<'a, syntaqlite_syntax::typed::Dialect, syntaqlite_syntax::typed::TypedNodeList<'a, syntaqlite_syntax::typed::Dialect, syntaqlite_syntax::nodes::Expr<'a>>>> for syntaqlite_syntax::nodes::ValuesRowListId
-impl<'a> core::ops::index::Index<usize> for syntaqlite_syntax::any::NodeFields<'a>
 impl<'a> syntaqlite_syntax::Comment<'a>
 impl<'a> syntaqlite_syntax::ParserToken<'a>
 impl<'a> syntaqlite_syntax::any::AnyParsedStatement<'a>
-impl<'a> syntaqlite_syntax::any::NodeFields<'a>
 impl<'a> syntaqlite_syntax::nodes::AggregateFunctionCall<'a>
 impl<'a> syntaqlite_syntax::nodes::AlterTableStmt<'a>
 impl<'a> syntaqlite_syntax::nodes::AnalyzeOrReindexStmt<'a>
@@ -754,7 +754,7 @@ impl<G: syntaqlite_syntax::typed::TypedDialect> syntaqlite_syntax::typed::TypedT
 impl<T, E> syntaqlite_syntax::ParseOutcome<T, E>
 pub enum syntaqlite_syntax::CommentKind
 pub enum syntaqlite_syntax::ParseOutcome<T, E>
-pub enum syntaqlite_syntax::any::FieldValue<'a>
+pub enum syntaqlite_syntax::any::FieldValue
 pub enum syntaqlite_syntax::any::ParseOutcome<T, E>
 pub enum syntaqlite_syntax::any::TokenCategory
 pub enum syntaqlite_syntax::nodes::Expr<'a>
@@ -765,7 +765,6 @@ pub enum syntaqlite_syntax::nodes::Select<'a>
 pub enum syntaqlite_syntax::nodes::Stmt<'a>
 pub enum syntaqlite_syntax::nodes::TableSource<'a>
 pub enum syntaqlite_syntax::typed::ParseOutcome<T, E>
-pub fn core::ops::range::Range<usize>::from(r: syntaqlite_syntax::any::SourceRange) -> core::ops::range::Range<usize>
 pub fn syntaqlite_syntax::Comment<'a>::kind(&self) -> syntaqlite_syntax::CommentKind
 pub fn syntaqlite_syntax::Comment<'a>::length(&self) -> u32
 pub fn syntaqlite_syntax::Comment<'a>::offset(&self) -> u32
@@ -905,14 +904,16 @@ pub fn syntaqlite_syntax::any::AnyNodeId::from(id: syntaqlite_syntax::nodes::Wit
 pub fn syntaqlite_syntax::any::AnyNodeId::is_null(&self) -> bool
 pub fn syntaqlite_syntax::any::AnyNodeTag::from(t: syntaqlite_syntax::nodes::NodeTag) -> syntaqlite_syntax::any::AnyNodeTag
 pub fn syntaqlite_syntax::any::AnyNodeTag::from_raw(v: u32) -> Self
-pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::child_node_ids(&self, id: syntaqlite_syntax::any::AnyNodeId) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::AnyNodeId> + '_
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::child_node_ids(&self, id: syntaqlite_syntax::any::AnyNodeId) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::AnyNodeId> + use<>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::comment_spans(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::CommentSpan> + use<'_>
-pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::extract_fields(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(syntaqlite_syntax::any::AnyNodeTag, syntaqlite_syntax::any::NodeFields<'a>)>
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::extract_fields(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(syntaqlite_syntax::any::AnyNodeTag, syntaqlite_syntax::any::NodeFields)>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::list_children(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a [syntaqlite_syntax::any::AnyNodeId]>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::macro_regions(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRegion> + use<'_>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_id(&self) -> syntaqlite_syntax::any::AnyNodeId
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_node(&self) -> core::option::Option<syntaqlite_syntax::any::AnyNode<'_>>
-pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::source(&self) -> &'a str
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_expanded_text(&self, span: syntaqlite_syntax::any::TextSpan) -> &'a str
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_text(&self, span: syntaqlite_syntax::any::TextSpan) -> (&'a str, u32)
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::text(&self) -> &'a str
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::token_spans(&self) -> impl core::iter::traits::iterator::Iterator<Item = (u32, u32)> + use<'_>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::traceback(&mut self, node_id: syntaqlite_syntax::any::AnyNodeId, field_idx: u8) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::TracebackFrame<'a>> + use<'_, 'a>
 pub fn syntaqlite_syntax::any::AnyTokenType::from(t: syntaqlite_syntax::TokenType) -> syntaqlite_syntax::any::AnyTokenType
@@ -927,12 +928,12 @@ pub fn syntaqlite_syntax::any::KeywordEntry::keyword(&self) -> &'static str
 pub fn syntaqlite_syntax::any::KeywordEntry::token_type(&self) -> syntaqlite_syntax::any::AnyTokenType
 pub fn syntaqlite_syntax::any::MacroRegion::call_length(&self) -> u32
 pub fn syntaqlite_syntax::any::MacroRegion::call_offset(&self) -> u32
-pub fn syntaqlite_syntax::any::NodeFields<'_>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn syntaqlite_syntax::any::NodeFields<'a>::index(&self, idx: usize) -> &syntaqlite_syntax::any::FieldValue<'a>
-pub fn syntaqlite_syntax::any::NodeFields<'a>::is_empty(&self) -> bool
-pub fn syntaqlite_syntax::any::NodeFields<'a>::len(&self) -> usize
-pub fn syntaqlite_syntax::any::SourceRange::is_empty(self) -> bool
-pub fn syntaqlite_syntax::any::SourceRange::len(self) -> u32
+pub fn syntaqlite_syntax::any::NodeFields::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::any::NodeFields::index(&self, idx: usize) -> &syntaqlite_syntax::any::FieldValue
+pub fn syntaqlite_syntax::any::NodeFields::is_empty(&self) -> bool
+pub fn syntaqlite_syntax::any::NodeFields::len(&self) -> usize
+pub fn syntaqlite_syntax::any::TextSpan::is_empty(self) -> bool
+pub fn syntaqlite_syntax::any::TextSpan::is_quoted(self) -> bool
 pub fn syntaqlite_syntax::nodes::AggregateFunctionCall<'_>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn syntaqlite_syntax::nodes::AggregateFunctionCall<'a>::args(&self) -> core::option::Option<syntaqlite_syntax::nodes::ExprList<'a>>
 pub fn syntaqlite_syntax::nodes::AggregateFunctionCall<'a>::filter_clause(&self) -> core::option::Option<syntaqlite_syntax::nodes::Expr<'a>>
@@ -1620,20 +1621,20 @@ pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::kind(&self) -> syntaqli
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::length(&self) -> core::option::Option<usize>
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::message(&self) -> &str
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::offset(&self) -> core::option::Option<usize>
-pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::parse_source(&self) -> &'a str
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::recovery_root(&'a self) -> core::option::Option<<G as syntaqlite_syntax::typed::TypedDialect>::Node>
+pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::text(&self) -> &'a str
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::typed::TypedParserToken<'a, G>>
 pub fn syntaqlite_syntax::typed::TypedParseSession<G>::arena_result(&self) -> syntaqlite_syntax::any::AnyParsedStatement<'_>
 pub fn syntaqlite_syntax::typed::TypedParseSession<G>::drop(&mut self)
 pub fn syntaqlite_syntax::typed::TypedParseSession<G>::next(&mut self) -> syntaqlite_syntax::ParseOutcome<syntaqlite_syntax::typed::TypedParsedStatement<'_, G>, syntaqlite_syntax::typed::TypedParseError<'_, G>>
 pub fn syntaqlite_syntax::typed::TypedParseSession<G>::register_macro(&mut self, name: &str, params: &[&str], body: &str)
-pub fn syntaqlite_syntax::typed::TypedParseSession<G>::source(&self) -> &str
+pub fn syntaqlite_syntax::typed::TypedParseSession<G>::text(&self) -> &str
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::comments(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::dump(&self, out: &mut alloc::string::String, indent: usize)
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::erase(self) -> syntaqlite_syntax::any::AnyParsedStatement<'a>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::macro_regions(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRegion> + use<'_, 'a, G>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::root(&'a self) -> core::option::Option<<G as syntaqlite_syntax::typed::TypedDialect>::Node>
-pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::source(&self) -> &'a str
+pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::text(&self) -> &'a str
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::typed::TypedParserToken<'a, G>>
 pub fn syntaqlite_syntax::typed::TypedParser<G>::deregister_macro(&mut self, name: &str) -> bool
 pub fn syntaqlite_syntax::typed::TypedParser<G>::incremental_parse(&self, source: &str) -> syntaqlite_syntax::typed::TypedIncrementalParseSession<G>
@@ -1682,8 +1683,7 @@ pub struct syntaqlite_syntax::any::AnyParsedStatement<'a>
 pub struct syntaqlite_syntax::any::FieldMeta<'a>(_)
 pub struct syntaqlite_syntax::any::KeywordEntry
 pub struct syntaqlite_syntax::any::MacroRegion
-pub struct syntaqlite_syntax::any::NodeFields<'a>
-pub struct syntaqlite_syntax::any::SourceRange
+pub struct syntaqlite_syntax::any::NodeFields
 pub struct syntaqlite_syntax::any::TracebackFrame<'a>
 pub struct syntaqlite_syntax::nodes::AggregateFunctionCall<'a>
 pub struct syntaqlite_syntax::nodes::AggregateFunctionCallId(_)
@@ -2052,15 +2052,10 @@ pub syntaqlite_syntax::any::FieldValue::Bool(bool)
 pub syntaqlite_syntax::any::FieldValue::Enum(u32)
 pub syntaqlite_syntax::any::FieldValue::Flags(u8)
 pub syntaqlite_syntax::any::FieldValue::NodeId(syntaqlite_syntax::any::AnyNodeId)
-pub syntaqlite_syntax::any::FieldValue::Span
-pub syntaqlite_syntax::any::FieldValue::Span::quoted: bool
-pub syntaqlite_syntax::any::FieldValue::Span::source: syntaqlite_syntax::any::SourceRange
-pub syntaqlite_syntax::any::FieldValue::Span::text: &'a str
+pub syntaqlite_syntax::any::FieldValue::Span(syntaqlite_syntax::any::TextSpan)
 pub syntaqlite_syntax::any::ParseOutcome::Done
 pub syntaqlite_syntax::any::ParseOutcome::Err(E)
 pub syntaqlite_syntax::any::ParseOutcome::Ok(T)
-pub syntaqlite_syntax::any::SourceRange::end: u32
-pub syntaqlite_syntax::any::SourceRange::start: u32
 pub syntaqlite_syntax::any::TokenCategory::Comment
 pub syntaqlite_syntax::any::TokenCategory::Function
 pub syntaqlite_syntax::any::TokenCategory::Identifier
@@ -2517,7 +2512,7 @@ pub type syntaqlite_syntax::any::AnyParser = syntaqlite_syntax::typed::TypedPars
 pub type syntaqlite_syntax::any::AnyParserToken<'a> = syntaqlite_syntax::typed::TypedParserToken<'a, syntaqlite_syntax::any::AnyDialect>
 pub type syntaqlite_syntax::any::AnyToken<'a> = syntaqlite_syntax::typed::TypedToken<'a, syntaqlite_syntax::any::AnyDialect>
 pub type syntaqlite_syntax::any::AnyTokenizer = syntaqlite_syntax::typed::TypedTokenizer<syntaqlite_syntax::any::AnyDialect>
-pub type syntaqlite_syntax::any::NodeFields<'a>::Output = syntaqlite_syntax::any::FieldValue<'a>
+pub type syntaqlite_syntax::any::NodeFields::Output = syntaqlite_syntax::any::FieldValue
 pub type syntaqlite_syntax::nodes::AggregateFunctionCallId::Node<'a> = syntaqlite_syntax::nodes::AggregateFunctionCall<'a>
 pub type syntaqlite_syntax::nodes::AlterTableStmtId::Node<'a> = syntaqlite_syntax::nodes::AlterTableStmt<'a>
 pub type syntaqlite_syntax::nodes::AnalyzeOrReindexStmtId::Node<'a> = syntaqlite_syntax::nodes::AnalyzeOrReindexStmt<'a>

--- a/web/docs/content/reference/c-api.md
+++ b/web/docs/content/reference/c-api.md
@@ -78,8 +78,8 @@ typedef struct {
 | Function | Description |
 |----------|-------------|
 | `syntaqlite_parser_node(p, node_id)` | Pointer to node data in the arena |
-| `syntaqlite_parser_source(p)` | Pointer to the source text |
-| `syntaqlite_parser_source_length(p)` | Length of the source text |
+| `syntaqlite_parser_text(p)` | Pointer to the source text |
+| `syntaqlite_parser_text_length(p)` | Length of the source text |
 | `syntaqlite_parser_node_count(p)` | Number of nodes in the arena |
 | `syntaqlite_dump_node(p, node_id, indent)` | Pretty-print a node subtree. **Caller must `free()` the result** |
 


### PR DESCRIPTION
## Motivation

The Rust span-handling surface had drifted from the C API and accumulated
avoidable confusion:

- `FieldValue::Span` was a struct variant with eagerly-computed `text` /
  `quoted` / `source` fields — populated by calling two accessors per
  field in `extract_field_value`. Consumers couldn't tell which of
  `text` (expansion-layer bytes) vs `source` (authored byte range) mapped
  to which C accessor, and the formatter latently used the wrong view.
- Rust type `SourceSpan` mirrored C `SyntaqliteSourceSpan` but both names
  conflicted with the unrelated `SourceRange` type and `source` field names,
  so "source" was overloaded to mean three different things.
- `SourceRange` existed only because `FieldValue::Span.source` needed a
  `(start, end)` pair — no C equivalent, and deleting it turned out to be
  the cleanest path.
- `syntaqlite_parser_span_text_range` existed as a separate C API just to
  return what `span_text` already computed internally.
- `AnyParsedStatement::source()` / `source: &'a str` field were named
  inconsistently with `syntaqlite_parser_source()` which was itself badly
  named (the user text is not a "source" in any parser sense — it is the
  authored input text).

## Changes

Rename and reshape the whole chain so the Rust API mirrors C exactly.

**Type renames (C → Rust mirror):**

| C | Rust |
|---|---|
| `SyntaqliteSourceSpan` | `SyntaqliteTextSpan` / `TextSpan` |
| `syntaqlite_parser_source` | `syntaqlite_parser_text` |
| `AnyParsedStatement::source()` | `text()` |

Parallel typed-wrapper `source()` methods (`TypedParseSession`,
`ParseSession`, `ParsedStatement`, `TypedParsedStatement`) and local vars
(`c_source_ptr` / `c_source_base` in tokenizer / parser / incremental)
renamed for consistency.

**Removed (no C equivalent):**

- `SourceRange` Rust type + the already-deleted `SyntaqliteTextRange`
- `syntaqlite_parser_span_text_range` C function (+ wrapper)
- `AnyParsedStatement::span_text_range` pub(crate) wrapper
- `FieldValue::Span.source` / `.text` / `.quoted` struct-variant fields
- Eager accessor calls inside `extract_field_value`

**New shape:**

- `FieldValue::Span(TextSpan)` — newtype variant, 1:1 with the C struct.
  Consumers pull `text` / `expanded_text` / `offset` via the accessor
  methods on `AnyParsedStatement`, matching how a C consumer would
  compose the primitive accessors.
- `syntaqlite_parser_span_text(p, &span, &out_len, &out_offset)` — the
  existing C function gained an optional offset out-param so callers get
  authored bytes *and* their source position in a single call (replaces
  the deleted `span_text_range`).
- `AnyParsedStatement::span_text(span) -> (&'a str, u32)` — tuple return
  of `(authored_text, source_offset)`, derived from the single C call.
  Tuple (not a struct) because a named `SpanText` type next to `TextSpan`
  was confusing.
- `AnyParsedStatement::span_expanded_text(span) -> &'a str` — now `pub`
  (part of the 1:1 accessor set).
- `TextSpan::is_empty()` / `is_quoted()` are now `pub` methods.
- `extract_field_value` no longer needs `&CParser` — just copies raw
  field bytes into the variant.
- `NodeFields` and `FieldValue` lose their `'a` lifetime parameter since
  spans no longer borrow any strings.

**Consumer migration:**

- **Semantic analyzer / catalog / lineage resolver:** identifier
  *spelling* uses `span_expanded_text` (what the tokenizer saw, so a
  column ref produced from inside a macro body resolves by its expanded
  name); *source positions* use `span_text` (walks the expansion chain
  back to authored bytes so diagnostics anchor at the macro call site).
  **This fixes a latent regression** where macro-body column names would
  otherwise report the call site text as the unknown column.
- **Formatter (`fmt/interpret.rs`, `fmt/formatter.rs`):** now uses
  `span_text` for authored bytes and comment-drain positioning. Fixes a
  latent correctness issue where expanded-layer bytes could have been
  emitted verbatim for macro-body spans instead of the user's authored
  token.
- **`ValidationPass::emit` signature:** `SourceRange` → `(usize, usize)`
  tuple.
- **Tests:** `low_level.rs` and `session.rs` test helpers updated to the
  new tuple / newtype shape.

**Side cleanup:** design-doc leaks removed from source code (`parser_internal.h`,
`session.rs`, `mod.rs`) — "Step 4" / "Step 7" / "Step 12" /
`text-expansion-model plan` references replaced with descriptive comments.

Rebased on top of `origin/main` #97 (LSP feature-gating); the conflict
in `visit_source_ref` / `visit_call` / `visit_column_ref` /
`record_column_resolution` resolved by moving `start`/`end` computation
out from under the `#[cfg(feature = "lsp")]` gate, since `emit` now
needs them unconditionally.

## Test plan

- [x] `tools/pre-push --all` green: fmt, clippy (default + all-features),
      dead-code (default + no-default), C format, C deps, public-API
      snapshot, cargo build, unit tests, 7 integration suites (ast, fmt,
      amalg, perfetto-fmt, perfetto-val, grammar, web playground)
- [x] `cargo check -p syntaqlite` (default features) clean
- [x] `cargo check -p syntaqlite --features lsp` clean
- [ ] CI green