### PR TITLE
synq: wire real synq_on_shift / synq_on_reduce hook calls

### DIFF
--- a/python/dev/diff_tests/perfetto_common.py
+++ b/python/dev/diff_tests/perfetto_common.py
@@ -63,6 +63,7 @@ def _write_runtime_shims(csrc_dir: Path) -> None:
 #include \"syntaqlite_dialect/arena.h\"
 #include \"syntaqlite_dialect/vec.h\"
 #include \"syntaqlite_dialect/ast_builder.h\"
+#include \"syntaqlite_dialect/extent_hooks.h\"
 #endif
 """,
         encoding="utf-8",

--- a/python/tools/build_web_playground.py
+++ b/python/tools/build_web_playground.py
@@ -270,6 +270,7 @@ def main() -> int:
                 "#include \"syntaqlite_dialect/vec.h\"\n#include \"syntaqlite_dialect/dialect_types.h\"\n"
                 "#include \"syntaqlite_dialect/dialect_macros.h\"\n"
                 "#include \"syntaqlite_dialect/ast_builder.h\"\n"
+                "#include \"syntaqlite_dialect/extent_hooks.h\"\n"
                 "#endif\n")
 
     out_perfetto = os.path.join(ROOT_DIR, "web/playground", "public", "syntaqlite-perfetto.wasm")

--- a/syntaqlite-buildtools/src/parser_tools/parser_pipeline.rs
+++ b/syntaqlite-buildtools/src/parser_tools/parser_pipeline.rs
@@ -118,11 +118,12 @@ fn patch_generated_parser_files(
     }
     let c_patched = transformer
         .insert_after_includes("#include \"syntaqlite_dialect/dialect_macros.h\"")
-        // Inject per-node extent tracking hook sites into Lemon's
-        // `yy_shift` and `yy_reduce` functions.  These are currently
-        // compile-time no-op C comments; a follow-up change will
-        // replace them with real `synq_on_shift` / `synq_on_reduce`
-        // calls once the runtime helpers land.  The anchor lines
+        .insert_after_includes("#include \"syntaqlite_dialect/extent_hooks.h\"")
+        // Inject per-node extent tracking hook calls into Lemon's
+        // `yy_shift` and `yy_reduce` functions.  The hook macros
+        // (declared in `extent_hooks.h`) bridge `yypParser` — Lemon's
+        // internal parser struct — to the `SynqParseCtx*` the
+        // underlying hook functions expect.  The anchor lines
         // (`yytos->minor.yy0 = yyMinor;` and `yymsp = yypParser->yytos;`)
         // are stable Lemon internals and have been unchanged for
         // years; the hardened `CTransformer` will fail loudly if
@@ -131,12 +132,12 @@ fn patch_generated_parser_files(
         .replace_in_function(
             "yy_shift",
             "yytos->minor.yy0 = yyMinor;",
-            "yytos->minor.yy0 = yyMinor;\n  /* synq_on_shift hook site */",
+            "yytos->minor.yy0 = yyMinor;\n  synq_on_shift(yypParser, yyMajor, &yyMinor);",
         )
         .replace_in_function(
             "yy_reduce",
             "yymsp = yypParser->yytos;",
-            "yymsp = yypParser->yytos;\n  /* synq_on_reduce hook site */",
+            "yymsp = yypParser->yytos;\n  synq_on_reduce(yypParser, yyruleno);",
         )
         .append(&expected_tokens_c_snippet(parser_name))
         .append(&nonterminal_defines_snippet(&nts))
@@ -467,20 +468,26 @@ mod tests {
     }
 
     #[test]
-    fn patch_generated_parser_files_injects_extent_hook_sites() {
-        // The per-node extent tracking work (follow-up PRs) needs to call
-        // a shadow-stack helper on every terminal shift and every rule
-        // reduction.  Lemon's `yy_shift` and `yy_reduce` functions are
-        // the natural hook points, and we inject our calls via the
-        // existing `patch_generated_parser_files` post-lemon patching
-        // step.  This test pins the anchor-based injection: if Lemon
-        // ever reorders or renames the lines we key off, the patch
-        // step (and therefore this test) will fail loudly.
+    fn patch_generated_parser_files_injects_extent_hook_calls() {
+        // The per-node extent tracking work needs to call a shadow-stack
+        // helper on every terminal shift and every rule reduction.
+        // Lemon's `yy_shift` and `yy_reduce` functions are the natural
+        // hook points, and we inject our calls via the existing
+        // `patch_generated_parser_files` post-lemon patching step.
         //
-        // At this point in the stack the hook sites are intentionally
-        // compile-time no-op C comments — a later change will replace
-        // them with the real `synq_on_shift` / `synq_on_reduce` calls
-        // once the runtime helpers land.
+        // This test pins the anchor-based injection:
+        // 1. A `#include "syntaqlite_dialect/extent_hooks.h"` is
+        //    injected after the existing includes so the generated
+        //    parse.c can resolve the hook macros.
+        // 2. `synq_on_shift(yypParser, yyMajor, &yyMinor)` is injected
+        //    after the stable `yytos->minor.yy0 = yyMinor;` anchor.
+        // 3. `synq_on_reduce(yypParser, yyruleno)` is injected after
+        //    the stable `yymsp = yypParser->yytos;` anchor, before
+        //    `switch(yyruleno)`.
+        //
+        // If Lemon ever reorders or renames the lines we key off,
+        // the hardened `CTransformer` will fail loudly instead of
+        // silently dropping the hooks.
         let dir = tempfile::TempDir::new().expect("temp dir");
         let parse_c = dir.path().join("parse.c");
         let parse_h = dir.path().join("parse.h");
@@ -493,18 +500,24 @@ mod tests {
 
         let parse_c_out = fs::read_to_string(&parse_c).expect("read parse.c");
 
-        // yy_shift hook site injected after the stable
-        // `yytos->minor.yy0 = yyMinor;` anchor.
+        // Header for the hook macros is included.
         assert!(
-            parse_c_out.contains("synq_on_shift hook site"),
-            "expected yy_shift extent hook marker in generated parse.c\n\n{parse_c_out}"
+            parse_c_out.contains("#include \"syntaqlite_dialect/extent_hooks.h\""),
+            "expected extent_hooks.h include in generated parse.c\n\n{parse_c_out}"
         );
 
-        // yy_reduce hook site injected after the stable
+        // yy_shift hook call injected after the stable
+        // `yytos->minor.yy0 = yyMinor;` anchor.
+        assert!(
+            parse_c_out.contains("synq_on_shift(yypParser, yyMajor, &yyMinor);"),
+            "expected yy_shift hook call in generated parse.c\n\n{parse_c_out}"
+        );
+
+        // yy_reduce hook call injected after the stable
         // `yymsp = yypParser->yytos;` anchor, before `switch(yyruleno)`.
         assert!(
-            parse_c_out.contains("synq_on_reduce hook site"),
-            "expected yy_reduce extent hook marker in generated parse.c\n\n{parse_c_out}"
+            parse_c_out.contains("synq_on_reduce(yypParser, yyruleno);"),
+            "expected yy_reduce hook call in generated parse.c\n\n{parse_c_out}"
         );
     }
 

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -19,8 +19,34 @@
 #include "syntaqlite/parser.h"
 #include "syntaqlite_dialect/ast_builder.h"
 #include "syntaqlite_dialect/dialect_types.h"
+#include "syntaqlite_dialect/extent_hooks.h"
 
 #include "csrc/parser_internal.h"
+
+// ---------------------------------------------------------------------------
+// Per-node extent tracking hooks
+// ---------------------------------------------------------------------------
+//
+// These are invoked from the Lemon-generated `yy_shift` and `yy_reduce`
+// via the macros in `extent_hooks.h`, which the post-lemon patching
+// step injects at the two stable anchor lines.
+//
+// The bodies are intentionally no-ops at this point in the stack —
+// they exist only so the injected calls link.  A follow-up change
+// will add the shadow stack, the `collect_node_extents` flag on
+// `SynqParseCtx`, and the actual extent-recording logic.
+void synq_extent_on_shift(SynqParseCtx* pCtx,
+                          unsigned int major,
+                          const SynqParseToken* token) {
+  (void)pCtx;
+  (void)major;
+  (void)token;
+}
+
+void synq_extent_on_reduce(SynqParseCtx* pCtx, unsigned int ruleno) {
+  (void)pCtx;
+  (void)ruleno;
+}
 
 // ---------------------------------------------------------------------------
 // Macro argument scanning

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
@@ -4971,6 +4971,8 @@ typedef struct yyParser yyParser;
 #include "syntaqlite_sqlite/sqlite_tokens.h"
 
 #include "syntaqlite_dialect/dialect_macros.h"
+
+#include "syntaqlite_dialect/extent_hooks.h"
 static FILE* yyTraceFILE = 0;
 static char* yyTracePrompt = 0;
 #endif /* NDEBUG */
@@ -6220,7 +6222,7 @@ static void yy_shift(
   yytos->stateno = yyNewState;
   yytos->major = yyMajor;
   yytos->minor.yy0 = yyMinor;
-  /* synq_on_shift hook site */
+  synq_on_shift(yypParser, yyMajor, &yyMinor);
   yyTraceShift(yypParser, yyNewState, "Shift");
 }
 
@@ -7141,7 +7143,7 @@ static YYACTIONTYPE yy_reduce(
   SynqSqliteParseARG_FETCH(void) yyLookahead;
   (void)yyLookaheadToken;
   yymsp = yypParser->yytos;
-  /* synq_on_reduce hook site */
+  synq_on_reduce(yypParser, yyruleno);
 
   switch (yyruleno) {
     /* Beginning here are the reduction cases.  A typical example

--- a/syntaqlite-syntax/include/syntaqlite_dialect/extent_hooks.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/extent_hooks.h
@@ -1,0 +1,65 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+// Per-node extent tracking hooks called from the Lemon-generated
+// parser.
+//
+// These hooks run on every terminal shift and every rule reduction
+// inside `yy_shift` / `yy_reduce`.  They are injected by
+// `syntaqlite-buildtools` via the post-lemon patching step in
+// `parser_pipeline::patch_generated_parser_files`.
+//
+// The macros `synq_on_shift` / `synq_on_reduce` are invoked from
+// the generated parser where `yypParser` (Lemon's internal parser
+// struct) is in scope; they extract `pCtx` (the `%extra_context`
+// field) and delegate to the underlying `synq_extent_on_*`
+// functions.  Keeping the macros here rather than declaring them
+// inline in the parse.c patch keeps the call-site compact and
+// centralizes the `yyParser` → `SynqParseCtx*` bridge.
+//
+// At this point in the stack the underlying functions are
+// intentionally no-ops — a follow-up change will add the shadow
+// stack, the `collect_node_extents` flag, and the actual extent
+// recording logic.  Landing the hook plumbing in its own small
+// PR isolates the Lemon-patch mechanics from the extent-tracking
+// semantics.
+
+#ifndef SYNTAQLITE_INTERNAL_EXTENT_HOOKS_H
+#define SYNTAQLITE_INTERNAL_EXTENT_HOOKS_H
+
+#include "syntaqlite_dialect/ast_builder.h"  // for SynqParseCtx, SynqParseToken
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Called from the top of Lemon's `yy_shift` for every terminal shift.
+// Will push a `(root_start, root_end)` byte range onto the shadow
+// stack when per-node extent tracking is enabled; currently a no-op.
+void synq_extent_on_shift(SynqParseCtx* pCtx,
+                          unsigned int major,
+                          const SynqParseToken* token);
+
+// Called from the top of Lemon's `yy_reduce` for every rule reduction,
+// before the user action switch.  Will pop `-yyRuleInfoNRhs[ruleno]`
+// entries from the shadow stack, compute the merged range, and push
+// the result back so the user action can read its own extent;
+// currently a no-op.
+void synq_extent_on_reduce(SynqParseCtx* pCtx, unsigned int ruleno);
+
+// Convenience macros invoked from the patched Lemon template.  At the
+// call site `yyParser` is Lemon's generated parser struct, carrying
+// the `%extra_context` field `pCtx` directly (see `_common.y`:
+// `%extra_context {SynqParseCtx* pCtx}`).
+#define synq_on_shift(yypParser, yyMajor, yyMinor_ptr)             \
+  synq_extent_on_shift((yypParser)->pCtx, (unsigned int)(yyMajor), \
+                       (yyMinor_ptr))
+
+#define synq_on_reduce(yypParser, yyruleno) \
+  synq_extent_on_reduce((yypParser)->pCtx, (yyruleno))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // SYNTAQLITE_INTERNAL_EXTENT_HOOKS_H

--- a/syntaqlite-syntax/src/embedded_sources.rs
+++ b/syntaqlite-syntax/src/embedded_sources.rs
@@ -95,6 +95,10 @@ pub const DIALECT_EXT_HEADERS: &[(&str, &str)] = &[
         include_str!("../include/syntaqlite_dialect/dialect_types.h"),
     ),
     (
+        "extent_hooks.h",
+        include_str!("../include/syntaqlite_dialect/extent_hooks.h"),
+    ),
+    (
         "sqlite_compat.h",
         include_str!("../include/syntaqlite_dialect/sqlite_compat.h"),
     ),


### PR DESCRIPTION
## Motivation

The previous PR (#101) added no-op C comment markers inside Lemon's `yy_shift` / `yy_reduce` to prove the anchor-based injection works. This PR is the next tiny step: replace the comment markers with real function calls, add the declarations they resolve against, and stub-define those declarations so the build links.

Splitting "scaffolding" from "plumbing" from "runtime semantics" keeps each step reviewable in isolation:

- **PR #101 (scaffolding)** — prove `replace_in_function` lands at the right places in the real generated `sqlite_parse.c`.
- **This PR (plumbing)** — bridge `yyParser` (Lemon internal) to `SynqParseCtx*` (our side) via macros, declare the underlying hook functions, stub them as no-ops, and verify the whole chain compiles and links.
- **Next PR (runtime)** — add the shadow stack, `collect_node_extents` flag, and actual extent-recording logic inside those stubs.

The plumbing step has real risk of its own: the macro has to `yyParser->pCtx` where `yyParser` is an opaque Lemon-internal struct — if Lemon ever stopped exposing the `%extra_context` field at that exact name, our patched parse.c wouldn't compile. Landing it standalone gives us a loud early warning if that ever happens.

## Changes

- **`syntaqlite-syntax/include/syntaqlite_dialect/extent_hooks.h`** (new): declares `synq_extent_on_shift(SynqParseCtx*, unsigned int, const SynqParseToken*)` and `synq_extent_on_reduce(SynqParseCtx*, unsigned int)`, plus two convenience macros `synq_on_shift` / `synq_on_reduce` that extract `(yypParser)->pCtx` at the call site and delegate to the friendly-argument functions. Keeps the `yyParser` → `SynqParseCtx*` bridge centralized rather than reimplementing it inside every patched parse.c.
- **`syntaqlite-syntax/csrc/parser_macros.c`**: stub definitions of both functions. Bodies are intentionally no-op `(void)` casts for now — the shadow stack comes in the next PR. Includes the new `extent_hooks.h` so the declarations and definitions line up.
- **`syntaqlite-buildtools/src/parser_tools/parser_pipeline.rs`**:
  - `insert_after_includes` now also injects `#include \"syntaqlite_dialect/extent_hooks.h\"` so the generated parse.c can resolve the macros.
  - The two `replace_in_function` calls now inject the real `synq_on_shift(yypParser, yyMajor, &yyMinor);` and `synq_on_reduce(yypParser, yyruleno);` calls instead of the no-op comment markers.
  - Test updated: `patch_generated_parser_files_injects_extent_hook_calls` (renamed from `_sites`) now asserts the actual function call expansions plus the new include.
- **`syntaqlite-syntax/src/embedded_sources.rs`**: register the new header in `DIALECT_EXT_HEADERS` so amalgamation consumers pick it up.
- **`syntaqlite-syntax/csrc/sqlite/sqlite_parse.c`**: regenerated — three and only three lines change (the header include and the two call sites).

### Red-green development

Built test-first:

1. **RED** — updated the hook-site test to assert the new header include and real function call expansions (was asserting comment substrings). Ran `cargo test`: 2 passed, 1 failed (the new assertions).
2. **GREEN** — added `extent_hooks.h`, stubs in `parser_macros.c`, updated `patch_generated_parser_files`, wired into `embedded_sources.rs`. Ran `cargo test`: 3 passed.
3. **VERIFY** — `cargo check --all-features --all-targets`, `cargo clippy -D warnings`, full `cargo test -p syntaqlite-buildtools` (139 passed), `tools/run-codegen` (regenerates `sqlite_parse.c` with real calls + new include, no other drift), `tools/run-bootstrap-test` (PASS: all 28 files regen identically).

The bootstrap test is the strongest validation: it confirms the full compile chain works when you rebuild from scratch — the C linker successfully resolves `synq_on_shift` / `synq_on_reduce` calls in the regenerated `sqlite_parse.c` against the stub definitions in `parser_macros.c` through the new header.

## Stacked on

- #99 (fix-bootstrap-tokens-h)
- #100 (harden-ctransformer)
- #101 (lempar-hook-scaffolding) — this PR replaces the no-op markers introduced there with real calls.