### PR TITLE
synq: widen SyntaqliteTextSpan.length to uint32_t

### DIFF
--- a/dialects/perfetto/actions/perfetto.y
+++ b/dialects/perfetto/actions/perfetto.y
@@ -147,10 +147,8 @@ select_body_end(A) ::= . { A = pCtx->last_shifted_end; }
 cmd(A) ::= CREATE perfetto_or_replace(R) PERFETTO TABLE nm(N)
            perfetto_table_schema(S) AS select_body_start(BS) select(E) select_body_end(BE). {
     SyntaqliteTextSpan select_span = {
-        BS,
-        (uint16_t)(BE - BS),
-        0,
-        /*layer_id=*/0,
+        .offset = BS,
+        .length = BE - BS,
     };
     A = synq_parse_create_perfetto_table_stmt(pCtx,
         synq_span(pCtx, N),
@@ -163,10 +161,8 @@ cmd(A) ::= CREATE perfetto_or_replace(R) PERFETTO TABLE nm(N)
 cmd(A) ::= CREATE perfetto_or_replace(R) PERFETTO VIEW nm(N)
            perfetto_table_schema(S) AS select_body_start(BS) select(E) select_body_end(BE). {
     SyntaqliteTextSpan select_span = {
-        BS,
-        (uint16_t)(BE - BS),
-        0,
-        /*layer_id=*/0,
+        .offset = BS,
+        .length = BE - BS,
     };
     A = synq_parse_create_perfetto_view_stmt(pCtx,
         synq_span(pCtx, N),
@@ -180,10 +176,8 @@ cmd(A) ::= CREATE perfetto_or_replace(R) PERFETTO FUNCTION nm(N) LP
            perfetto_arg_def_list(ARGS) RP RETURNS perfetto_return_type(RT)
            AS select_body_start(BS) select(E) select_body_end(BE). {
     SyntaqliteTextSpan select_span = {
-        BS,
-        (uint16_t)(BE - BS),
-        0,
-        /*layer_id=*/0,
+        .offset = BS,
+        .length = BE - BS,
     };
     A = synq_parse_create_perfetto_function_stmt(pCtx,
         synq_span(pCtx, N),

--- a/syntaqlite-buildtools/parser-actions/_common.y
+++ b/syntaqlite-buildtools/parser-actions/_common.y
@@ -93,13 +93,9 @@ static inline SyntaqliteTextSpan synq_error_span(SynqParseCtx* pCtx) {
   if (pCtx->error_offset == 0xFFFFFFFF || pCtx->error_length == 0) {
     return SYNQ_NO_SPAN;
   }
-  uint32_t len = pCtx->error_length;
-  if (len > UINT16_MAX) {
-    len = UINT16_MAX;
-  }
   return (SyntaqliteTextSpan){
       .offset = pCtx->error_offset,
-      .length = (uint16_t)len,
+      .length = pCtx->error_length,
       .flags = 0,
   };
 }

--- a/syntaqlite-buildtools/parser-actions/virtual_table.y
+++ b/syntaqlite-buildtools/parser-actions/virtual_table.y
@@ -32,7 +32,7 @@ cmd(A) ::= create_vtab(X) LP(L) vtabarglist RP(R). {
     uint32_t args_end = R.offset;
     vtab->create_virtual_table_stmt.module_args = (SyntaqliteTextSpan){
         .offset = args_start,
-        .length = (uint16_t)(args_end - args_start),
+        .length = args_end - args_start,
         .flags = 0,
         ._layer_id = L.layer_id,
     };

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_keyword.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_keyword.c
@@ -242,8 +242,8 @@ const unsigned char synq_sqlite_aKWLen[149] = {
     8, 6,  4,  9, 5, 8, 4,  3,  9,  5, 5, 6, 4, 6, 2, 2,  7,
 };
 /* synq_sqlite_aKWOffset[i] is the index into synq_sqlite_zKWText[] of the start
-*of
-** the text for the i-th keyword. */
+ *of
+ ** the text for the i-th keyword. */
 const unsigned short int synq_sqlite_aKWOffset[149] = {
     0,   0,   2,   2,   8,   9,   14,  16,  20,  23,  25,  25,  29,  33,  36,
     41,  46,  48,  53,  54,  59,  62,  65,  67,  69,  78,  81,  86,  90,  90,

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
@@ -94,13 +94,9 @@ static inline SyntaqliteTextSpan synq_error_span(SynqParseCtx* pCtx) {
   if (pCtx->error_offset == 0xFFFFFFFF || pCtx->error_length == 0) {
     return SYNQ_NO_SPAN;
   }
-  uint32_t len = pCtx->error_length;
-  if (len > UINT16_MAX) {
-    len = UINT16_MAX;
-  }
   return (SyntaqliteTextSpan){
       .offset = pCtx->error_offset,
-      .length = (uint16_t)len,
+      .length = pCtx->error_length,
       .flags = 0,
   };
 }
@@ -9781,7 +9777,7 @@ static YYACTIONTYPE yy_reduce(
       uint32_t args_end = yymsp[0].minor.yy0.offset;
       vtab->create_virtual_table_stmt.module_args = (SyntaqliteTextSpan){
           .offset = args_start,
-          .length = (uint16_t)(args_end - args_start),
+          .length = args_end - args_start,
           .flags = 0,
           ._layer_id = yymsp[-2].minor.yy0.layer_id,
       };
@@ -10056,7 +10052,7 @@ static void yy_syntax_error(
   SynqSqliteParseARG_FETCH SynqSqliteParseCTX_FETCH
 #define TOKEN yyminor
       /************ Begin %syntax_error code
-         ****************************************/
+       ****************************************/
 
       (void) yymajor;
   (void)TOKEN;

--- a/syntaqlite-syntax/include/syntaqlite/types.h
+++ b/syntaqlite-syntax/include/syntaqlite/types.h
@@ -38,9 +38,10 @@ typedef uint32_t SyntaqliteCompletionContext;
 //     drill-through fidelity for spans inside substituted macro args.
 typedef struct SyntaqliteTextSpan {
   uint32_t offset;
-  uint16_t length;
+  uint32_t length;
   uint8_t flags;
   uint8_t _layer_id;  // Internal: 0 = source, >0 = macro expansion layer.
+  uint8_t _pad[2];
 } SyntaqliteTextSpan;
 
 // ── Span flags ───────────────────────────────────────────────────────────────

--- a/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
@@ -322,10 +322,10 @@ static inline SyntaqliteTextSpan synq_span(SynqParseCtx* ctx,
                                            SynqParseToken tok) {
   (void)ctx;
   if (tok.z == NULL)
-    return (SyntaqliteTextSpan){0, 0, 0, 0};
+    return (SyntaqliteTextSpan){0};
   return (SyntaqliteTextSpan){
       .offset = tok.offset,
-      .length = (uint16_t)tok.n,
+      .length = tok.n,
       .flags = 0,
       ._layer_id = tok.layer_id,
   };
@@ -340,21 +340,28 @@ static inline SyntaqliteTextSpan synq_span_dequote(SynqParseCtx* ctx,
                                                    SynqParseToken tok) {
   (void)ctx;
   if (tok.z == NULL)
-    return (SyntaqliteTextSpan){0, 0, 0, 0};
+    return (SyntaqliteTextSpan){0};
   if (tok.n >= 2) {
     char open = tok.z[0];
     char close = tok.z[tok.n - 1];
     if ((open == '"' && close == '"') || (open == '`' && close == '`') ||
         (open == '[' && close == ']')) {
-      SyntaqliteTextSpan sp = {tok.offset + 1, (uint16_t)(tok.n - 2), 0,
-                               tok.layer_id};
+      SyntaqliteTextSpan sp = {
+          .offset = tok.offset + 1,
+          .length = tok.n - 2,
+          ._layer_id = tok.layer_id,
+      };
       return synq_span_set_quoted(sp);
     }
   }
-  return (SyntaqliteTextSpan){tok.offset, (uint16_t)tok.n, 0, tok.layer_id};
+  return (SyntaqliteTextSpan){
+      .offset = tok.offset,
+      .length = tok.n,
+      ._layer_id = tok.layer_id,
+  };
 }
 
-#define SYNQ_NO_SPAN ((SyntaqliteTextSpan){0, 0, 0, 0})
+#define SYNQ_NO_SPAN ((SyntaqliteTextSpan){0})
 
 // Mark a token as "used as identifier" (fallback from keyword).
 // O(1) — uses the token_idx stored in SynqParseToken at collection time.

--- a/syntaqlite-syntax/src/ast.rs
+++ b/syntaqlite-syntax/src/ast.rs
@@ -445,12 +445,13 @@ mod ffi {
     #[repr(C)]
     pub struct CTextSpan {
         pub(crate) offset: u32,
-        pub(crate) length: u16,
+        pub(crate) length: u32,
         pub(crate) flags: u8,
         /// Internal: 0 = original source, >0 = macro expansion layer id.
         /// Read by the C-side span accessors; the Rust side passes the
         /// whole struct across the FFI boundary without inspecting it.
         pub(crate) _layer_id: u8,
+        pub(crate) _pad: [u8; 2],
     }
 
     /// Mirror of C `SYNTAQLITE_SPAN_FLAG_QUOTED` from `types.h`.

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -155,9 +155,7 @@ impl CParser {
         }
         // SAFETY: C guarantees `ptr` points to `out_len` bytes of valid
         // UTF-8 within the parser's source buffer.
-        unsafe {
-            std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize))
-        }
+        unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize)) }
     }
 
     /// Post-expansion source text — the bound source with every
@@ -183,9 +181,7 @@ impl CParser {
         }
         // SAFETY: C guarantees `ptr` points to `out_len` bytes of valid
         // UTF-8 within the parser's scratch buffer.
-        unsafe {
-            std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize))
-        }
+        unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize)) }
     }
 
     /// Source text of AST node `node_id`, returned as `(slice, offset)`

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -615,9 +615,7 @@ mod tests {
         // `session.expanded_text()` materializes the whole input with
         // every currently-active macro call replaced by its expansion,
         // mirroring `syntaqlite_parser_expanded_text` at the C level.
-        let mut parser = Parser::with_config(
-            &ParserConfig::default().with_macro_fallback(true),
-        );
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
         parser.register_macro("id", &["x"], "$x");
 
         let source = "SELECT id!(42);";


### PR DESCRIPTION
## Motivation

`SyntaqliteTextSpan.length` was `uint16_t` (max 65,535 bytes). When a dialect extension grammar constructs a span from marker rules (e.g. Perfetto's `select_body_start`/`select_body_end`), the cast `(uint16_t)(end - start)` silently truncates if the spanned region exceeds ~64KB. This produces incorrect parse results with no error.

Fixes #106.

## Changes

- Widen `SyntaqliteTextSpan.length` from `uint16_t` to `uint32_t` (C) / `u16` to `u32` (Rust), adding a 2-byte `_pad` field to maintain alignment (struct grows from 8 → 12 bytes)
- Remove all `(uint16_t)` truncating casts in span construction sites (`synq_span`, `synq_span_dequote`, virtual table module args, Perfetto select spans)
- Remove the `UINT16_MAX` clamp in `synq_error_span` — no longer needed
- Switch Perfetto action initializers from positional to designated initializers
- Regenerate codegen outputs