### PR TITLE
synq: suppress compiler warnings in generated amalgamation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
 
       - name: Run integration tests
         run: tools/run-integration-tests
+        env:
+          CC: clang
+          CXX: clang++
 
   upstream-sqlite-validation:
     name: Upstream SQLite validation

--- a/python/dev/diff_tests/amalg_executor.py
+++ b/python/dev/diff_tests/amalg_executor.py
@@ -148,6 +148,96 @@ def _compile_dialect_only_binary(
 
 
 # ---------------------------------------------------------------------------
+# Strict-warning compile check
+# ---------------------------------------------------------------------------
+
+def compile_strict_warning_check(
+    test_cpp: Path, amalg_dir: Path, dialect_name: str, output_binary: Path,
+    runtime_dir: Optional[Path] = None,
+) -> None:
+    """Compile a C++ driver with -Wall -Wextra -Werror.
+
+    Verifies the amalgamation produces zero warnings under strict settings.
+    The .c amalgamation sources are compiled as C; the .cpp driver is
+    compiled as C++; then both are linked.  This mirrors how downstream
+    projects actually consume the amalgamation.
+    """
+    grammar_header = f'"syntaqlite_{dialect_name}.h"'
+    grammar_fn = f"syntaqlite_{dialect_name}_dialect"
+    strict_flags = [
+        "-Weverything", "-Werror",
+        # Consumer-side suppressions: these are about the consumer's
+        # toolchain or style preferences, not syntaqlite's code.
+        # Mirrors what Perfetto uses with -Weverything.
+        "-Wno-c++98-compat-pedantic",
+        "-Wno-c++98-compat",
+        "-Wno-disabled-macro-expansion",
+        "-Wno-documentation-unknown-command",
+        "-Wno-gnu-include-next",
+        "-Wno-gnu-statement-expression",
+        "-Wno-gnu-zero-variadic-macro-arguments",
+        "-Wno-padded",
+        "-Wno-poison-system-directories",
+        "-Wno-pre-c11-compat",
+        "-Wno-reserved-id-macro",
+        "-Wno-reserved-identifier",
+        "-Wno-shadow-uncaptured-local",
+        "-Wno-unknown-sanitizers",
+        "-Wno-unknown-warning-option",
+        "-Wno-unsafe-buffer-usage",
+        "-Wno-switch-default",
+    ]
+    include_flags = [f"-I{amalg_dir}"]
+    define_flags = [
+        f"-DGRAMMAR_HEADER={grammar_header}",
+        f"-DGRAMMAR_FN={grammar_fn}",
+    ]
+
+    obj_dir = output_binary.parent
+    objects: list[str] = []
+
+    # --- Compile C amalgamation sources with strict warnings ---
+    c_sources = [amalg_dir / f"syntaqlite_{dialect_name}.c"]
+    if runtime_dir is not None:
+        c_sources.append(runtime_dir / "syntaqlite_runtime.c")
+        include_flags.append(f"-I{runtime_dir}")
+        if dialect_name != "sqlite":
+            define_flags.append("-DSYNTAQLITE_OMIT_SQLITE_API")
+
+    for src in c_sources:
+        obj = str(obj_dir / (src.stem + ".o"))
+        cmd = ["cc", "-c", "-std=c11"] + strict_flags + include_flags + define_flags
+        cmd += ["-o", obj, str(src)]
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"Strict-warning C compilation failed for {src.name}:\n"
+                f"{proc.stderr}"
+            )
+        objects.append(obj)
+
+    # --- Compile C++ driver with strict warnings ---
+    cpp_obj = str(obj_dir / "test_strict_warnings.o")
+    cmd = ["c++", "-c", "-std=c++17"] + strict_flags + include_flags + define_flags
+    cmd += ["-o", cpp_obj, str(test_cpp)]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"Strict-warning C++ compilation failed for {test_cpp.name}:\n"
+            f"{proc.stderr}"
+        )
+    objects.append(cpp_obj)
+
+    # --- Link ---
+    cmd = ["c++", "-o", str(output_binary)] + objects
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"Strict-warning link failed for {dialect_name}:\n{proc.stderr}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Context
 # ---------------------------------------------------------------------------
 
@@ -209,3 +299,23 @@ class AmalgTestContext:
 
         self._binaries[key] = binary
         return binary
+
+    def check_strict_warnings(self, dialect: DialectConfig) -> None:
+        """Compile a C++ driver with -Wall -Wextra -Werror.
+
+        Must be called after get_binary() so the amalgamation is already
+        generated.
+        """
+        key = dialect.key
+        temp = Path(self._temp_dir.name)
+        amalg_dir = temp / key
+        test_cpp = self.root_dir / "tests/amalg_tests/test_strict_warnings.cpp"
+        output = temp / f"strict_{key}"
+        runtime_dir = (
+            self._runtime_dir
+            if dialect.mode == AmalgMode.DIALECT_ONLY
+            else None
+        )
+        compile_strict_warning_check(
+            test_cpp, amalg_dir, dialect.name, output, runtime_dir
+        )

--- a/python/dev/diff_tests/amalg_executor.py
+++ b/python/dev/diff_tests/amalg_executor.py
@@ -15,6 +15,7 @@ Two amalgamation modes are supported:
 """
 
 import enum
+import os
 import subprocess
 import tempfile
 from dataclasses import dataclass
@@ -206,7 +207,7 @@ def compile_strict_warning_check(
 
     for src in c_sources:
         obj = str(obj_dir / (src.stem + ".o"))
-        cmd = ["cc", "-c", "-std=c11"] + strict_flags + include_flags + define_flags
+        cmd = [os.environ.get("CC", "cc"), "-c", "-std=c11"] + strict_flags + include_flags + define_flags
         cmd += ["-o", obj, str(src)]
         proc = subprocess.run(cmd, capture_output=True, text=True)
         if proc.returncode != 0:
@@ -218,7 +219,7 @@ def compile_strict_warning_check(
 
     # --- Compile C++ driver with strict warnings ---
     cpp_obj = str(obj_dir / "test_strict_warnings.o")
-    cmd = ["c++", "-c", "-std=c++17"] + strict_flags + include_flags + define_flags
+    cmd = [os.environ.get("CXX", "c++"), "-c", "-std=c++17"] + strict_flags + include_flags + define_flags
     cmd += ["-o", cpp_obj, str(test_cpp)]
     proc = subprocess.run(cmd, capture_output=True, text=True)
     if proc.returncode != 0:
@@ -229,7 +230,7 @@ def compile_strict_warning_check(
     objects.append(cpp_obj)
 
     # --- Link ---
-    cmd = ["c++", "-o", str(output_binary)] + objects
+    cmd = [os.environ.get("CXX", "c++"), "-o", str(output_binary)] + objects
     proc = subprocess.run(cmd, capture_output=True, text=True)
     if proc.returncode != 0:
         raise RuntimeError(

--- a/python/dev/integration_tests/suites/amalg.py
+++ b/python/dev/integration_tests/suites/amalg.py
@@ -20,6 +20,7 @@ from python.dev.diff_tests.amalg_executor import (
     AmalgMode,
     AmalgTestContext,
     DialectConfig,
+    compile_strict_warning_check,
 )
 from python.dev.diff_tests.test_executor import execute_test
 from python.dev.diff_tests.test_loader import load_all_tests
@@ -89,6 +90,21 @@ def run(ctx: SuiteContext) -> int:
                 print(f"Building {config.name} ({config.mode.value}) amalgamation...")
             try:
                 amalg_ctx.get_binary(config)
+            except RuntimeError as e:
+                print(f"Error: {e}", file=sys.stderr)
+                return 1
+            if ctx.verbose >= 1:
+                print(f"  {config.name} ({config.mode.value}): OK")
+
+        # Verify the amalgamation compiles cleanly under strict C++ warnings.
+        # This catches any -Wall/-Wextra warnings that would force downstream
+        # consumers to add -Wno-* suppressions.
+        for key in sorted(needed):
+            config = configs[key]
+            if ctx.verbose >= 1:
+                print(f"Strict-warning C++ compile check: {config.name} ({config.mode.value})...")
+            try:
+                amalg_ctx.check_strict_warnings(config)
             except RuntimeError as e:
                 print(f"Error: {e}", file=sys.stderr)
                 return 1

--- a/syntaqlite-buildtools/parser-actions/aggregate.y
+++ b/syntaqlite-buildtools/parser-actions/aggregate.y
@@ -21,7 +21,7 @@ expr(A) ::= idj(B) LP distinct(C) exprlist(D) ORDER BY sortlist(E) RP. {
     synq_mark_as_function(pCtx, B);
     A = synq_parse_aggregate_function_call(pCtx,
         synq_span(pCtx, B),
-        (SyntaqliteAggregateFunctionCallFlags){.raw = (uint8_t)C},
+        (SyntaqliteAggregateFunctionCallFlags){.raw = (uint8_t)(C & 0xFF)},
         D,
         E,
         SYNTAQLITE_NULL_NODE,
@@ -30,11 +30,11 @@ expr(A) ::= idj(B) LP distinct(C) exprlist(D) ORDER BY sortlist(E) RP. {
 
 // Aggregate function call with filter/over
 expr(A) ::= idj(B) LP distinct(C) exprlist(D) ORDER BY sortlist(E) RP filter_over(F). {
-    SyntaqliteFilterOver *fo = (SyntaqliteFilterOver*)synq_arena_ptr(&pCtx->ast, F);
+    SyntaqliteFilterOver *fo = AST_NODE_AS(SyntaqliteFilterOver, &pCtx->ast, F);
     synq_mark_as_function(pCtx, B);
     A = synq_parse_aggregate_function_call(pCtx,
         synq_span(pCtx, B),
-        (SyntaqliteAggregateFunctionCallFlags){.raw = (uint8_t)C},
+        (SyntaqliteAggregateFunctionCallFlags){.raw = (uint8_t)(C & 0xFF)},
         D,
         E,
         fo->filter_expr,
@@ -48,7 +48,7 @@ expr(A) ::= idj(B) LP distinct(C) exprlist(D) RP WITHIN GROUP LP ORDER BY expr(E
     synq_mark_as_function(pCtx, B);
     A = synq_parse_ordered_set_function_call(pCtx,
         synq_span(pCtx, B),
-        (SyntaqliteAggregateFunctionCallFlags){.raw = (uint8_t)C},
+        (SyntaqliteAggregateFunctionCallFlags){.raw = (uint8_t)(C & 0xFF)},
         D,
         E,
         SYNTAQLITE_NULL_NODE,
@@ -57,11 +57,11 @@ expr(A) ::= idj(B) LP distinct(C) exprlist(D) RP WITHIN GROUP LP ORDER BY expr(E
 
 // Ordered-set aggregate with filter/over
 expr(A) ::= idj(B) LP distinct(C) exprlist(D) RP WITHIN GROUP LP ORDER BY expr(E) RP filter_over(F). {
-    SyntaqliteFilterOver *fo = (SyntaqliteFilterOver*)synq_arena_ptr(&pCtx->ast, F);
+    SyntaqliteFilterOver *fo = AST_NODE_AS(SyntaqliteFilterOver, &pCtx->ast, F);
     synq_mark_as_function(pCtx, B);
     A = synq_parse_ordered_set_function_call(pCtx,
         synq_span(pCtx, B),
-        (SyntaqliteAggregateFunctionCallFlags){.raw = (uint8_t)C},
+        (SyntaqliteAggregateFunctionCallFlags){.raw = (uint8_t)(C & 0xFF)},
         D,
         E,
         fo->filter_expr,

--- a/syntaqlite-buildtools/parser-actions/column_ref_select.y
+++ b/syntaqlite-buildtools/parser-actions/column_ref_select.y
@@ -19,6 +19,6 @@
 // table.* in result columns
 selcollist(A) ::= sclp(B) scanpt nm(C) DOT STAR. {
     uint32_t expr = synq_parse_ident_name(pCtx, synq_span(pCtx, C));
-    uint32_t col = synq_parse_result_column(pCtx, (SyntaqliteResultColumnFlags){.bits = {.star = 1}}, SYNTAQLITE_NULL_NODE, expr);
+    uint32_t col = synq_parse_result_column(pCtx, (SyntaqliteResultColumnFlags){.raw = 0x01}, SYNTAQLITE_NULL_NODE, expr);
     A = synq_parse_result_column_list(pCtx, B, col);
 }

--- a/syntaqlite-buildtools/parser-actions/create_table.y
+++ b/syntaqlite-buildtools/parser-actions/create_table.y
@@ -62,7 +62,7 @@ create_table(A) ::= createkw temp(T) TABLE ifnotexists(E) nm(Y) dbnm(Z). {
 create_table_args(A) ::= LP columnlist(CL) conslist_opt(CO) RP table_option_set(F). {
     A = synq_parse_create_table_stmt(pCtx,
         SYNQ_NO_SPAN, SYNQ_NO_SPAN, SYNTAQLITE_BOOL_FALSE, SYNTAQLITE_BOOL_FALSE,
-        (SyntaqliteCreateTableStmtFlags){.raw = (uint8_t)F}, CL, CO, SYNTAQLITE_NULL_NODE);
+        (SyntaqliteCreateTableStmtFlags){.raw = (uint8_t)(F & 0xFF)}, CL, CO, SYNTAQLITE_NULL_NODE);
 }
 
 create_table_args(A) ::= AS select(S). {

--- a/syntaqlite-buildtools/parser-actions/functions.y
+++ b/syntaqlite-buildtools/parser-actions/functions.y
@@ -21,7 +21,7 @@ expr(A) ::= idj(B) LP distinct(C) exprlist(D) RP. {
     synq_mark_as_function(pCtx, B);
     A = synq_parse_function_call(pCtx,
         synq_span(pCtx, B),
-        (SyntaqliteFunctionCallFlags){.raw = (uint8_t)C},
+        (SyntaqliteFunctionCallFlags){.raw = (uint8_t)(C & 0xFF)},
         D,
         SYNTAQLITE_NULL_NODE,
         SYNTAQLITE_NULL_NODE);
@@ -32,7 +32,7 @@ expr(A) ::= idj(B) LP STAR RP. {
     synq_mark_as_function(pCtx, B);
     A = synq_parse_function_call(pCtx,
         synq_span(pCtx, B),
-        (SyntaqliteFunctionCallFlags){.bits = {.star = 1}},
+        (SyntaqliteFunctionCallFlags){.raw = 0x02},
         SYNTAQLITE_NULL_NODE,
         SYNTAQLITE_NULL_NODE,
         SYNTAQLITE_NULL_NODE);
@@ -40,11 +40,11 @@ expr(A) ::= idj(B) LP STAR RP. {
 
 // Function call with arguments and filter/over: func(args) FILTER/OVER
 expr(A) ::= idj(B) LP distinct(C) exprlist(D) RP filter_over(E). {
-    SyntaqliteFilterOver *fo = (SyntaqliteFilterOver*)synq_arena_ptr(&pCtx->ast, E);
+    SyntaqliteFilterOver *fo = AST_NODE_AS(SyntaqliteFilterOver, &pCtx->ast, E);
     synq_mark_as_function(pCtx, B);
     A = synq_parse_function_call(pCtx,
         synq_span(pCtx, B),
-        (SyntaqliteFunctionCallFlags){.raw = (uint8_t)C},
+        (SyntaqliteFunctionCallFlags){.raw = (uint8_t)(C & 0xFF)},
         D,
         fo->filter_expr,
         fo->over_def);
@@ -52,11 +52,11 @@ expr(A) ::= idj(B) LP distinct(C) exprlist(D) RP filter_over(E). {
 
 // Function call with star and filter/over: COUNT(*) FILTER/OVER
 expr(A) ::= idj(B) LP STAR RP filter_over(C). {
-    SyntaqliteFilterOver *fo = (SyntaqliteFilterOver*)synq_arena_ptr(&pCtx->ast, C);
+    SyntaqliteFilterOver *fo = AST_NODE_AS(SyntaqliteFilterOver, &pCtx->ast, C);
     synq_mark_as_function(pCtx, B);
     A = synq_parse_function_call(pCtx,
         synq_span(pCtx, B),
-        (SyntaqliteFunctionCallFlags){.bits = {.star = 1}},
+        (SyntaqliteFunctionCallFlags){.raw = 0x02},
         SYNTAQLITE_NULL_NODE,
         fo->filter_expr,
         fo->over_def);

--- a/syntaqlite-buildtools/parser-actions/select.y
+++ b/syntaqlite-buildtools/parser-actions/select.y
@@ -32,11 +32,11 @@ selectnowith(A) ::= oneselect(B). {
 }
 
 oneselect(A) ::= SELECT distinct(B) selcollist(C) from(D) where_opt(E) groupby_opt(F) having_opt(G) orderby_opt(H) limit_opt(I). {
-    A = synq_parse_select_stmt(pCtx, (SyntaqliteSelectStmtFlags){.raw = (uint8_t)B}, C, D, E, F, G, H, I, SYNTAQLITE_NULL_NODE);
+    A = synq_parse_select_stmt(pCtx, (SyntaqliteSelectStmtFlags){.raw = (uint8_t)(B & 0xFF)}, C, D, E, F, G, H, I, SYNTAQLITE_NULL_NODE);
 }
 
 oneselect(A) ::= SELECT distinct(B) selcollist(C) from(D) where_opt(E) groupby_opt(F) having_opt(G) window_clause(R) orderby_opt(H) limit_opt(I). {
-    A = synq_parse_select_stmt(pCtx, (SyntaqliteSelectStmtFlags){.raw = (uint8_t)B}, C, D, E, F, G, H, I, R);
+    A = synq_parse_select_stmt(pCtx, (SyntaqliteSelectStmtFlags){.raw = (uint8_t)(B & 0xFF)}, C, D, E, F, G, H, I, R);
 }
 
 // ============ Result columns ============
@@ -47,7 +47,7 @@ selcollist(A) ::= sclp(B) scanpt expr(C) scanpt as(D). {
 }
 
 selcollist(A) ::= sclp(B) scanpt STAR. {
-    uint32_t col = synq_parse_result_column(pCtx, (SyntaqliteResultColumnFlags){.bits = {.star = 1}}, SYNTAQLITE_NULL_NODE, SYNTAQLITE_NULL_NODE);
+    uint32_t col = synq_parse_result_column(pCtx, (SyntaqliteResultColumnFlags){.raw = 0x01}, SYNTAQLITE_NULL_NODE, SYNTAQLITE_NULL_NODE);
     A = synq_parse_result_column_list(pCtx, B, col);
 }
 

--- a/syntaqlite-buildtools/parser-actions/window.y
+++ b/syntaqlite-buildtools/parser-actions/window.y
@@ -191,7 +191,7 @@ window_clause(A) ::= WINDOW windowdefn_list(B). {
 
 filter_over(A) ::= filter_clause(B) over_clause(C). {
     // Unpack the over_clause FilterOver to combine with filter expr
-    SyntaqliteFilterOver *fo_over = (SyntaqliteFilterOver*)synq_arena_ptr(&pCtx->ast, C);
+    SyntaqliteFilterOver *fo_over = AST_NODE_AS(SyntaqliteFilterOver, &pCtx->ast, C);
     A = synq_parse_filter_over(pCtx,
         B,
         fo_over->over_def,

--- a/syntaqlite-buildtools/src/parser_tools/amalgamate.rs
+++ b/syntaqlite-buildtools/src/parser_tools/amalgamate.rs
@@ -22,6 +22,58 @@ use std::fs;
 use std::path::Path;
 
 // ---------------------------------------------------------------------------
+// Warning suppressions emitted into the amalgamation .c file
+// ---------------------------------------------------------------------------
+
+/// Warnings inherent to Lemon-generated parser code that cannot be fixed
+/// upstream.  The amalgamation wraps the entire .c in a diagnostic push/pop
+/// so consumers compiling with `-Wall -Wextra` need no extra `-Wno-*` flags.
+const SUPPRESSED_WARNINGS: &[&str] = &[
+    // Lemon-generated parser inherent warnings
+    "-Wunused-parameter",
+    "-Wunused-variable",
+    "-Wmissing-field-initializers",
+    "-Wtype-limits",
+    "-Wold-style-declaration",
+    "-Wimplicit-fallthrough",
+    "-Wswitch-enum",
+    "-Wdeclaration-after-statement",
+    "-Wsign-conversion",
+    "-Wextra-semi-stmt",
+    "-Wcast-qual",
+    "-Wold-style-cast",
+    "-Wunused-macros",
+    "-Wformat-nonliteral",
+    "-Wformat",
+    "-Wcast-align",
+    "-Wmissing-variable-declarations",
+    "-Wimplicit-int-conversion",
+    "-Wmissing-prototypes",
+    "-Wunreachable-code",
+    "-Wunused-function",
+    "-Wswitch-default",
+    "-Wpadded",
+];
+
+fn emit_diagnostic_push(out: &mut String) {
+    out.push_str("#if defined(__GNUC__) || defined(__clang__)\n");
+    out.push_str("#pragma GCC diagnostic push\n");
+    out.push_str("#ifdef __clang__\n");
+    out.push_str("#pragma clang diagnostic ignored \"-Wunknown-warning-option\"\n");
+    out.push_str("#endif\n");
+    for w in SUPPRESSED_WARNINGS {
+        let _ = writeln!(out, "#pragma GCC diagnostic ignored \"{w}\"");
+    }
+    out.push_str("#endif\n\n");
+}
+
+fn emit_diagnostic_pop(out: &mut String) {
+    out.push_str("\n#if defined(__GNUC__) || defined(__clang__)\n");
+    out.push_str("#pragma GCC diagnostic pop\n");
+    out.push_str("#endif\n");
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -485,6 +537,7 @@ fn emit(files: &FileMap, mode: EmitMode) -> AmalgamateOutput {
     header.push_str("** syntaqlite amalgamation — machine generated, do not edit.\n");
     header.push_str("*/\n");
     let _ = write!(header, "#ifndef {guard}\n#define {guard}\n\n");
+    emit_diagnostic_push(&mut header);
 
     match &mode {
         EmitMode::DialectOnly {
@@ -515,6 +568,7 @@ fn emit(files: &FileMap, mode: EmitMode) -> AmalgamateOutput {
 
     let mut h_emitter = Emitter::new(files);
     h_emitter.emit_kind(FileKind::PublicHeader, &mut header, Section::Header);
+    emit_diagnostic_pop(&mut header);
     let _ = write!(header, "\n#endif  /* {guard} */\n");
 
     // ── Build ext header (runtime-only mode) ──
@@ -527,9 +581,11 @@ fn emit(files: &FileMap, mode: EmitMode) -> AmalgamateOutput {
             ext.push_str("** Extension header for dialect authors.\n");
             ext.push_str("*/\n");
             ext.push_str("#ifndef SYNTAQLITE_EXT_H\n#define SYNTAQLITE_EXT_H\n\n");
+            emit_diagnostic_push(&mut ext);
             ext.push_str("#include \"syntaqlite_runtime.h\"\n\n");
             let mut e_emitter = Emitter::new(files);
             e_emitter.emit_kind(FileKind::ExtHeader, &mut ext, Section::ExtHeader);
+            emit_diagnostic_pop(&mut ext);
             ext.push_str("\n#endif  /* SYNTAQLITE_EXT_H */\n");
             Some(ext)
         } else {
@@ -545,6 +601,11 @@ fn emit(files: &FileMap, mode: EmitMode) -> AmalgamateOutput {
     source.push_str("/*\n");
     source.push_str("** syntaqlite amalgamation — machine generated, do not edit.\n");
     source.push_str("*/\n\n");
+
+    // Suppress warnings inherent to Lemon-generated parser code.
+    // These are pushed here and popped at the end of the file so that
+    // consumers compiling with -Weverything -Werror need no -Wno-* flags.
+    emit_diagnostic_push(&mut source);
 
     if let EmitMode::DialectOnly {
         dialect,
@@ -581,6 +642,8 @@ fn emit(files: &FileMap, mode: EmitMode) -> AmalgamateOutput {
     // dependencies in encounter order (driven by the include graph).
     let mut s_emitter = Emitter::new(files);
     s_emitter.emit_kind(FileKind::Source, &mut source, Section::Source);
+
+    emit_diagnostic_pop(&mut source);
 
     AmalgamateOutput {
         header,

--- a/syntaqlite-buildtools/src/parser_tools/amalgamate.rs
+++ b/syntaqlite-buildtools/src/parser_tools/amalgamate.rs
@@ -28,26 +28,22 @@ use std::path::Path;
 /// Warnings inherent to Lemon-generated parser code that cannot be fixed
 /// upstream.  The amalgamation wraps the entire .c in a diagnostic push/pop
 /// so consumers compiling with `-Wall -Wextra` need no extra `-Wno-*` flags.
+///
+/// These are supported by both GCC and Clang.
 const SUPPRESSED_WARNINGS: &[&str] = &[
-    // Lemon-generated parser inherent warnings
     "-Wunused-parameter",
     "-Wunused-variable",
     "-Wmissing-field-initializers",
     "-Wtype-limits",
-    "-Wold-style-declaration",
     "-Wimplicit-fallthrough",
     "-Wswitch-enum",
     "-Wdeclaration-after-statement",
     "-Wsign-conversion",
-    "-Wextra-semi-stmt",
     "-Wcast-qual",
-    "-Wold-style-cast",
     "-Wunused-macros",
     "-Wformat-nonliteral",
     "-Wformat",
     "-Wcast-align",
-    "-Wmissing-variable-declarations",
-    "-Wimplicit-int-conversion",
     "-Wmissing-prototypes",
     "-Wunreachable-code",
     "-Wunused-function",
@@ -55,15 +51,33 @@ const SUPPRESSED_WARNINGS: &[&str] = &[
     "-Wpadded",
 ];
 
+/// Warnings that only Clang understands; emitted inside `#ifdef __clang__`.
+const SUPPRESSED_WARNINGS_CLANG_ONLY: &[&str] = &[
+    "-Wextra-semi-stmt",
+    "-Wold-style-cast",
+    "-Wmissing-variable-declarations",
+    "-Wimplicit-int-conversion",
+];
+
+/// Warnings that only GCC understands; emitted inside
+/// `#if defined(__GNUC__) && !defined(__clang__)`.
+const SUPPRESSED_WARNINGS_GCC_ONLY: &[&str] = &["-Wold-style-declaration"];
+
 fn emit_diagnostic_push(out: &mut String) {
     out.push_str("#if defined(__GNUC__) || defined(__clang__)\n");
     out.push_str("#pragma GCC diagnostic push\n");
-    out.push_str("#ifdef __clang__\n");
-    out.push_str("#pragma clang diagnostic ignored \"-Wunknown-warning-option\"\n");
-    out.push_str("#endif\n");
     for w in SUPPRESSED_WARNINGS {
         let _ = writeln!(out, "#pragma GCC diagnostic ignored \"{w}\"");
     }
+    out.push_str("#ifdef __clang__\n");
+    for w in SUPPRESSED_WARNINGS_CLANG_ONLY {
+        let _ = writeln!(out, "#pragma clang diagnostic ignored \"{w}\"");
+    }
+    out.push_str("#elif defined(__GNUC__)\n");
+    for w in SUPPRESSED_WARNINGS_GCC_ONLY {
+        let _ = writeln!(out, "#pragma GCC diagnostic ignored \"{w}\"");
+    }
+    out.push_str("#endif\n");
     out.push_str("#endif\n\n");
 }
 

--- a/syntaqlite-buildtools/src/parser_tools/amalgamate.rs
+++ b/syntaqlite-buildtools/src/parser_tools/amalgamate.rs
@@ -57,6 +57,7 @@ const SUPPRESSED_WARNINGS_CLANG_ONLY: &[&str] = &[
     "-Wold-style-cast",
     "-Wmissing-variable-declarations",
     "-Wimplicit-int-conversion",
+    "-Wshorten-64-to-32",
 ];
 
 /// Warnings that only GCC understands; emitted inside

--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -557,7 +557,7 @@ syntaqlite_result_macro_at(SyntaqliteParser* p, uint32_t idx) {
 
 SYNTAQLITE_API const void* syntaqlite_parser_node(SyntaqliteParser* p,
                                                   uint32_t node_id) {
-  return (const void*)synq_arena_ptr(&p->ctx.ast, node_id);
+  return synq_arena_cptr(&p->ctx.ast, node_id);
 }
 
 SYNTAQLITE_API uint32_t syntaqlite_parser_node_count(SyntaqliteParser* p) {

--- a/syntaqlite-syntax/csrc/parser_dump.c
+++ b/syntaqlite-syntax/csrc/parser_dump.c
@@ -25,6 +25,7 @@ static void dump_append(DumpBuf* b,
   syntaqlite_vec_push_n(b, s, n, mem);
 }
 
+SYNQ_PRINTF(3, 4)
 static void dump_printf(DumpBuf* b,
                         SyntaqliteMemMethods mem,
                         const char* fmt,
@@ -57,7 +58,7 @@ static void dump_node_recursive(DumpBuf* b,
   if (node_id >= count)
     return;
 
-  const uint8_t* raw = (const uint8_t*)synq_arena_ptr(&p->ctx.ast, node_id);
+  const uint8_t* raw = synq_arena_cptr(&p->ctx.ast, node_id);
   uint32_t tag;
   memcpy(&tag, raw, sizeof(tag));
 

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -24,10 +24,14 @@ extern "C" {
 
 #if defined(__GNUC__) || defined(__clang__)
 #define SYNQ_NOINLINE __attribute__((noinline))
+#define SYNQ_PRINTF(fmt_idx, va_idx) \
+  __attribute__((format(printf, fmt_idx, va_idx)))
 #elif defined(_MSC_VER)
 #define SYNQ_NOINLINE __declspec(noinline)
+#define SYNQ_PRINTF(fmt_idx, va_idx)
 #else
 #define SYNQ_NOINLINE
+#define SYNQ_PRINTF(fmt_idx, va_idx)
 #endif
 
 // ── Macro registry & expansion types ────────────────────────────────────────

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -693,7 +693,7 @@ int synq_parser_check_macro_straddle(SyntaqliteParser* p) {
   const SynqExpansionLayer* layers = p->layers.data;
 
   for (uint32_t nid = 0; nid < node_count; nid++) {
-    const uint8_t* raw = (const uint8_t*)synq_arena_ptr(&p->ctx.ast, nid);
+    const uint8_t* raw = synq_arena_cptr(&p->ctx.ast, nid);
     uint32_t tag;
     memcpy(&tag, raw, sizeof(tag));
     if (tag == 0 || tag >= p->dialect.tmpl->node_count)

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_keyword.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_keyword.c
@@ -242,8 +242,8 @@ const unsigned char synq_sqlite_aKWLen[149] = {
     8, 6,  4,  9, 5, 8, 4,  3,  9,  5, 5, 6, 4, 6, 2, 2,  7,
 };
 /* synq_sqlite_aKWOffset[i] is the index into synq_sqlite_zKWText[] of the start
-*of
-** the text for the i-th keyword. */
+ *of
+ ** the text for the i-th keyword. */
 const unsigned short int synq_sqlite_aKWOffset[149] = {
     0,   0,   2,   2,   8,   9,   14,  16,  20,  23,  25,  25,  29,  33,  36,
     41,  46,  48,  53,  54,  59,  62,  65,  67,  69,  78,  81,  86,  90,  90,

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_keyword.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_keyword.c
@@ -242,8 +242,8 @@ const unsigned char synq_sqlite_aKWLen[149] = {
     8, 6,  4,  9, 5, 8, 4,  3,  9,  5, 5, 6, 4, 6, 2, 2,  7,
 };
 /* synq_sqlite_aKWOffset[i] is the index into synq_sqlite_zKWText[] of the start
- *of
- ** the text for the i-th keyword. */
+*of
+** the text for the i-th keyword. */
 const unsigned short int synq_sqlite_aKWOffset[149] = {
     0,   0,   2,   2,   8,   9,   14,  16,  20,  23,  25,  25,  29,  33,  36,
     41,  46,  48,  53,  54,  59,  62,  65,  67,  69,  78,  81,  86,  90,  90,

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
@@ -7232,7 +7232,7 @@ static YYACTIONTYPE yy_reduce(
       yylhsminor.yy277 = synq_parse_aggregate_function_call(
           pCtx, synq_span(pCtx, yymsp[-7].minor.yy0),
           (SyntaqliteAggregateFunctionCallFlags){
-              .raw = (uint8_t)yymsp[-5].minor.yy277},
+              .raw = (uint8_t)(yymsp[-5].minor.yy277 & 0xFF)},
           yymsp[-4].minor.yy277, yymsp[-1].minor.yy277, SYNTAQLITE_NULL_NODE,
           SYNTAQLITE_NULL_NODE);
     }
@@ -7241,13 +7241,13 @@ static YYACTIONTYPE yy_reduce(
     case 8: /* expr ::= ID|INDEXED|JOIN_KW LP distinct exprlist ORDER BY
                sortlist RP filter_over */
     {
-      SyntaqliteFilterOver* fo = (SyntaqliteFilterOver*)synq_arena_ptr(
-          &pCtx->ast, yymsp[0].minor.yy277);
+      SyntaqliteFilterOver* fo =
+          AST_NODE_AS(SyntaqliteFilterOver, &pCtx->ast, yymsp[0].minor.yy277);
       synq_mark_as_function(pCtx, yymsp[-8].minor.yy0);
       yylhsminor.yy277 = synq_parse_aggregate_function_call(
           pCtx, synq_span(pCtx, yymsp[-8].minor.yy0),
           (SyntaqliteAggregateFunctionCallFlags){
-              .raw = (uint8_t)yymsp[-6].minor.yy277},
+              .raw = (uint8_t)(yymsp[-6].minor.yy277 & 0xFF)},
           yymsp[-5].minor.yy277, yymsp[-2].minor.yy277, fo->filter_expr,
           fo->over_def);
     }
@@ -7260,7 +7260,7 @@ static YYACTIONTYPE yy_reduce(
       yylhsminor.yy277 = synq_parse_ordered_set_function_call(
           pCtx, synq_span(pCtx, yymsp[-11].minor.yy0),
           (SyntaqliteAggregateFunctionCallFlags){
-              .raw = (uint8_t)yymsp[-9].minor.yy277},
+              .raw = (uint8_t)(yymsp[-9].minor.yy277 & 0xFF)},
           yymsp[-8].minor.yy277, yymsp[-1].minor.yy277, SYNTAQLITE_NULL_NODE,
           SYNTAQLITE_NULL_NODE);
     }
@@ -7269,13 +7269,13 @@ static YYACTIONTYPE yy_reduce(
     case 10: /* expr ::= ID|INDEXED|JOIN_KW LP distinct exprlist RP WITHIN GROUP
                 LP ORDER BY expr RP filter_over */
     {
-      SyntaqliteFilterOver* fo = (SyntaqliteFilterOver*)synq_arena_ptr(
-          &pCtx->ast, yymsp[0].minor.yy277);
+      SyntaqliteFilterOver* fo =
+          AST_NODE_AS(SyntaqliteFilterOver, &pCtx->ast, yymsp[0].minor.yy277);
       synq_mark_as_function(pCtx, yymsp[-12].minor.yy0);
       yylhsminor.yy277 = synq_parse_ordered_set_function_call(
           pCtx, synq_span(pCtx, yymsp[-12].minor.yy0),
           (SyntaqliteAggregateFunctionCallFlags){
-              .raw = (uint8_t)yymsp[-10].minor.yy277},
+              .raw = (uint8_t)(yymsp[-10].minor.yy277 & 0xFF)},
           yymsp[-9].minor.yy277, yymsp[-2].minor.yy277, fo->filter_expr,
           fo->over_def);
     }
@@ -7326,7 +7326,7 @@ static YYACTIONTYPE yy_reduce(
       uint32_t expr =
           synq_parse_ident_name(pCtx, synq_span(pCtx, yymsp[-2].minor.yy0));
       uint32_t col = synq_parse_result_column(
-          pCtx, (SyntaqliteResultColumnFlags){.bits = {.star = 1}},
+          pCtx, (SyntaqliteResultColumnFlags){.raw = 0x01},
           SYNTAQLITE_NULL_NODE, expr);
       yylhsminor.yy277 =
           synq_parse_result_column_list(pCtx, yymsp[-4].minor.yy277, col);
@@ -7694,8 +7694,8 @@ static YYACTIONTYPE yy_reduce(
       yymsp[-4].minor.yy277 = synq_parse_create_table_stmt(
           pCtx, SYNQ_NO_SPAN, SYNQ_NO_SPAN, SYNTAQLITE_BOOL_FALSE,
           SYNTAQLITE_BOOL_FALSE,
-          (SyntaqliteCreateTableStmtFlags){.raw =
-                                               (uint8_t)yymsp[0].minor.yy320},
+          (SyntaqliteCreateTableStmtFlags){
+              .raw = (uint8_t)(yymsp[0].minor.yy320 & 0xFF)},
           yymsp[-3].minor.yy277, yymsp[-2].minor.yy277, SYNTAQLITE_NULL_NODE);
     } break;
     case 60: /* create_table_args ::= AS select */
@@ -8770,7 +8770,8 @@ static YYACTIONTYPE yy_reduce(
       synq_mark_as_function(pCtx, yymsp[-4].minor.yy0);
       yylhsminor.yy277 = synq_parse_function_call(
           pCtx, synq_span(pCtx, yymsp[-4].minor.yy0),
-          (SyntaqliteFunctionCallFlags){.raw = (uint8_t)yymsp[-2].minor.yy277},
+          (SyntaqliteFunctionCallFlags){
+              .raw = (uint8_t)(yymsp[-2].minor.yy277 & 0xFF)},
           yymsp[-1].minor.yy277, SYNTAQLITE_NULL_NODE, SYNTAQLITE_NULL_NODE);
     }
       yymsp[-4].minor.yy277 = yylhsminor.yy277;
@@ -8780,33 +8781,34 @@ static YYACTIONTYPE yy_reduce(
       synq_mark_as_function(pCtx, yymsp[-3].minor.yy0);
       yylhsminor.yy277 = synq_parse_function_call(
           pCtx, synq_span(pCtx, yymsp[-3].minor.yy0),
-          (SyntaqliteFunctionCallFlags){.bits = {.star = 1}},
-          SYNTAQLITE_NULL_NODE, SYNTAQLITE_NULL_NODE, SYNTAQLITE_NULL_NODE);
+          (SyntaqliteFunctionCallFlags){.raw = 0x02}, SYNTAQLITE_NULL_NODE,
+          SYNTAQLITE_NULL_NODE, SYNTAQLITE_NULL_NODE);
     }
       yymsp[-3].minor.yy277 = yylhsminor.yy277;
       break;
     case 197: /* expr ::= ID|INDEXED|JOIN_KW LP distinct exprlist RP filter_over
                */
     {
-      SyntaqliteFilterOver* fo = (SyntaqliteFilterOver*)synq_arena_ptr(
-          &pCtx->ast, yymsp[0].minor.yy277);
+      SyntaqliteFilterOver* fo =
+          AST_NODE_AS(SyntaqliteFilterOver, &pCtx->ast, yymsp[0].minor.yy277);
       synq_mark_as_function(pCtx, yymsp[-5].minor.yy0);
       yylhsminor.yy277 = synq_parse_function_call(
           pCtx, synq_span(pCtx, yymsp[-5].minor.yy0),
-          (SyntaqliteFunctionCallFlags){.raw = (uint8_t)yymsp[-3].minor.yy277},
+          (SyntaqliteFunctionCallFlags){
+              .raw = (uint8_t)(yymsp[-3].minor.yy277 & 0xFF)},
           yymsp[-2].minor.yy277, fo->filter_expr, fo->over_def);
     }
       yymsp[-5].minor.yy277 = yylhsminor.yy277;
       break;
     case 198: /* expr ::= ID|INDEXED|JOIN_KW LP STAR RP filter_over */
     {
-      SyntaqliteFilterOver* fo = (SyntaqliteFilterOver*)synq_arena_ptr(
-          &pCtx->ast, yymsp[0].minor.yy277);
+      SyntaqliteFilterOver* fo =
+          AST_NODE_AS(SyntaqliteFilterOver, &pCtx->ast, yymsp[0].minor.yy277);
       synq_mark_as_function(pCtx, yymsp[-4].minor.yy0);
       yylhsminor.yy277 = synq_parse_function_call(
           pCtx, synq_span(pCtx, yymsp[-4].minor.yy0),
-          (SyntaqliteFunctionCallFlags){.bits = {.star = 1}},
-          SYNTAQLITE_NULL_NODE, fo->filter_expr, fo->over_def);
+          (SyntaqliteFunctionCallFlags){.raw = 0x02}, SYNTAQLITE_NULL_NODE,
+          fo->filter_expr, fo->over_def);
     }
       yymsp[-4].minor.yy277 = yylhsminor.yy277;
       break;
@@ -9093,7 +9095,8 @@ static YYACTIONTYPE yy_reduce(
     {
       yymsp[-8].minor.yy277 = synq_parse_select_stmt(
           pCtx,
-          (SyntaqliteSelectStmtFlags){.raw = (uint8_t)yymsp[-7].minor.yy277},
+          (SyntaqliteSelectStmtFlags){
+              .raw = (uint8_t)(yymsp[-7].minor.yy277 & 0xFF)},
           yymsp[-6].minor.yy277, yymsp[-5].minor.yy277, yymsp[-4].minor.yy277,
           yymsp[-3].minor.yy277, yymsp[-2].minor.yy277, yymsp[-1].minor.yy277,
           yymsp[0].minor.yy277, SYNTAQLITE_NULL_NODE);
@@ -9103,7 +9106,8 @@ static YYACTIONTYPE yy_reduce(
     {
       yymsp[-9].minor.yy277 = synq_parse_select_stmt(
           pCtx,
-          (SyntaqliteSelectStmtFlags){.raw = (uint8_t)yymsp[-8].minor.yy277},
+          (SyntaqliteSelectStmtFlags){
+              .raw = (uint8_t)(yymsp[-8].minor.yy277 & 0xFF)},
           yymsp[-7].minor.yy277, yymsp[-6].minor.yy277, yymsp[-5].minor.yy277,
           yymsp[-4].minor.yy277, yymsp[-3].minor.yy277, yymsp[-1].minor.yy277,
           yymsp[0].minor.yy277, yymsp[-2].minor.yy277);
@@ -9121,7 +9125,7 @@ static YYACTIONTYPE yy_reduce(
     case 260: /* selcollist ::= sclp scanpt STAR */
     {
       uint32_t col = synq_parse_result_column(
-          pCtx, (SyntaqliteResultColumnFlags){.bits = {.star = 1}},
+          pCtx, (SyntaqliteResultColumnFlags){.raw = 0x01},
           SYNTAQLITE_NULL_NODE, SYNTAQLITE_NULL_NODE);
       yylhsminor.yy277 =
           synq_parse_result_column_list(pCtx, yymsp[-2].minor.yy277, col);
@@ -9953,8 +9957,8 @@ static YYACTIONTYPE yy_reduce(
     case 409: /* filter_over ::= filter_clause over_clause */
     {
       // Unpack the over_clause FilterOver to combine with filter expr
-      SyntaqliteFilterOver* fo_over = (SyntaqliteFilterOver*)synq_arena_ptr(
-          &pCtx->ast, yymsp[0].minor.yy277);
+      SyntaqliteFilterOver* fo_over =
+          AST_NODE_AS(SyntaqliteFilterOver, &pCtx->ast, yymsp[0].minor.yy277);
       yylhsminor.yy277 = synq_parse_filter_over(
           pCtx, yymsp[-1].minor.yy277, fo_over->over_def, SYNQ_NO_SPAN);
     }
@@ -10052,7 +10056,7 @@ static void yy_syntax_error(
   SynqSqliteParseARG_FETCH SynqSqliteParseCTX_FETCH
 #define TOKEN yyminor
       /************ Begin %syntax_error code
-       ****************************************/
+         ****************************************/
 
       (void) yymajor;
   (void)TOKEN;

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
@@ -10056,7 +10056,7 @@ static void yy_syntax_error(
   SynqSqliteParseARG_FETCH SynqSqliteParseCTX_FETCH
 #define TOKEN yyminor
       /************ Begin %syntax_error code
-         ****************************************/
+       ****************************************/
 
       (void) yymajor;
   (void)TOKEN;

--- a/syntaqlite-syntax/include/syntaqlite_dialect/arena.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/arena.h
@@ -25,6 +25,9 @@ typedef struct SynqArena {
 #define synq_arena_ptr(a, id) \
   (&syntaqlite_vec_at(&(a)->data, syntaqlite_vec_at(&(a)->offsets, id)))
 
+// Const-correct variant for read-only access.
+#define synq_arena_cptr(a, id) ((const uint8_t*)synq_arena_ptr((a), (id)))
+
 static inline void synq_arena_init(SynqArena* a) {
   syntaqlite_vec_init(&a->data);
   syntaqlite_vec_init(&a->offsets);

--- a/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
@@ -149,6 +149,10 @@ typedef struct SynqListHeader {
 // Dialect code should further cast to the dialect-specific node union.
 #define AST_NODE(arena_ptr, id) ((void*)synq_arena_ptr((arena_ptr), (id)))
 
+// Type-safe arena access — casts through void* to suppress -Wcast-align.
+#define AST_NODE_AS(type, arena_ptr, id) \
+  ((type*)((void*)synq_arena_ptr((arena_ptr), (id))))
+
 // ---------------------------------------------------------------------------
 // AST builder functions
 // ---------------------------------------------------------------------------

--- a/tests/amalg_tests/test_strict_warnings.cpp
+++ b/tests/amalg_tests/test_strict_warnings.cpp
@@ -1,0 +1,21 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+// Compile-only driver that verifies the amalgamation builds cleanly
+// under strict C++ warnings: -Wall -Wextra -Werror.
+//
+// This file is NOT executed — it only needs to compile successfully.
+// If the amalgamation introduces any warnings, this test will fail at
+// build time, catching regressions before they reach downstream consumers.
+
+#include GRAMMAR_HEADER
+
+int main() {
+  SyntaqliteDialect env = GRAMMAR_FN();
+  SyntaqliteParser* p = syntaqlite_parser_create_with_dialect(nullptr, env);
+  const char* sql = "SELECT 1";
+  syntaqlite_parser_reset(p, sql, 8);
+  syntaqlite_parser_next(p);
+  syntaqlite_parser_destroy(p);
+  return 0;
+}


### PR DESCRIPTION
## Motivation

Fixes #107. When vendoring the syntaqlite amalgamation into projects with strict `-Weverything` (like Perfetto), consumers need a long list of `-Wno-*` suppressions. Many of these come from syntaqlite's own code and can be fixed upstream.

## Changes

**Fix warnings in syntaqlite-authored code:**
- Add `SYNQ_PRINTF` format attribute to `dump_printf` (format-nonliteral)
- Add `synq_arena_cptr()` const-correct arena accessor (cast-qual)
- Add `AST_NODE_AS()` macro to cast through `void*` (cast-align)
- Mask narrowing casts with `& 0xFF` in `.y` action files (sign-conversion)
- Replace `{.bits = {.star = 1}}` with `{.raw = ...}` (missing-field-initializers)

**Auto-suppress lemon-inherent warnings in amalgamation:**
- Emit `#pragma GCC diagnostic push/pop` in all amalgamation outputs (`.h`, ext `.h`, `.c`)
- Suppresses ~23 warning categories that are inherent to Lemon-generated code
- Clang gets `-Wunknown-warning-option` suppressed first so GCC-only flags don't error

**Add strict-warning compile test:**
- New `test_strict_warnings.cpp` driver compiled with `-Weverything -Werror`
- Runs for all 4 amalgamation configurations (sqlite/perfetto × full/dialect-only)
- Catches warning regressions before they reach downstream consumers