### PR TITLE
synq: use // comments instead of # in .synq files

### DIFF
--- a/syntaqlite-buildtools/src/util/synq_parser.rs
+++ b/syntaqlite-buildtools/src/util/synq_parser.rs
@@ -300,13 +300,13 @@ fn tokenize(input: &str) -> Result<Vec<Token>, String> {
 
     let mut tokens = Vec::new();
     loop {
-        // skip whitespace and # comments
+        // skip whitespace and // comments
         loop {
             match b.get(i) {
                 Some(b' ' | b'\t' | b'\n' | b'\r') => {
                     advance(&mut i, &mut line, &mut col);
                 }
-                Some(b'#') => {
+                Some(b'/') if b.get(i + 1) == Some(&b'/') => {
                     while let Some(ch) = advance(&mut i, &mut line, &mut col) {
                         if ch == b'\n' {
                             break;


### PR DESCRIPTION
## Motivation

.synq files used `#` for line comments, but Lemon (the parser generator we use) uses `//` style comments. Aligning comment syntax makes the toolchain more consistent.

## Changes

Replace `#` line comment support with `//` line comments in the .synq tokenizer.