### PR TITLE
synq: fix node_expanded_text fast path for nested macros (#120)

### DIFF
--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -908,29 +908,18 @@ SYNTAQLITE_API const char* syntaqlite_parser_node_expanded_text(
   }
 
   // Fast path: node's tokens all live in one layer → return a direct
-  // slice of that layer's buffer, no allocation.
+  // slice of that layer's buffer, no allocation.  Cross-layer nodes
+  // have layer_id == SYNQ_CROSS_LAYER and fall through to the slow path.
   SynqNodeExpandedExtent e =
       syntaqlite_vec_at(&p->ctx.node_expanded_extents, node_id);
   if (e.length > 0) {
-    if (e.layer_id == 0) {
-      if (e.offset + e.length > p->source_len) {
-        return NULL;
-      }
-      if (out_len) {
-        *out_len = e.length;
-      }
-      return p->source + e.offset;
+    const char* buf = e.layer_id == 0
+                          ? p->source
+                          : p->layers.data[e.layer_id].expansion_data;
+    if (out_len) {
+      *out_len = e.length;
     }
-    if (e.layer_id < syntaqlite_vec_len(&p->layers)) {
-      const SynqExpansionLayer* lyr = &p->layers.data[e.layer_id];
-      if (lyr->expansion_data && e.offset + e.length <= lyr->expansion_len) {
-        if (out_len) {
-          *out_len = e.length;
-        }
-        return lyr->expansion_data + e.offset;
-      }
-    }
-    return NULL;
+    return buf + e.offset;
   }
 
   // Slow path: the node's tokens cross layers.  Materialize the

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -100,20 +100,24 @@ void synq_extent_on_reduce(SynqParseCtx* pCtx, unsigned int nrhs) {
   syntaqlite_vec_push(&pCtx->extent_stack, merged, pCtx->mem);
 
   // Merge expanded-layer spans: all same layer → merge in that layer;
-  // empty entries are neutral; any cross-layer or pre-existing sentinel
-  // collapses the result to the sentinel (length = 0).
+  // epsilon entries ({0,0,0}) are neutral; cross-layer poison
+  // (layer_id == SYNQ_CROSS_LAYER) propagates upward unconditionally.
   SynqNodeExpandedExtent exp_merged = {0, 0, 0};
   for (uint32_t i = len - nrhs; i < len; i++) {
     SynqNodeExpandedExtent e = syntaqlite_vec_at(&pCtx->expanded_stack, i);
+    if (e.layer_id == SYNQ_CROSS_LAYER) {
+      exp_merged = e;  // propagate poison
+      break;
+    }
     if (e.length == 0) {
-      continue;
+      continue;  // skip epsilon
     }
     if (exp_merged.length == 0) {
       exp_merged = e;
       continue;
     }
     if (exp_merged.layer_id != e.layer_id) {
-      exp_merged.length = 0;  // cross-layer → sentinel
+      exp_merged = (SynqNodeExpandedExtent){0, 0, SYNQ_CROSS_LAYER};
       break;
     }
     uint32_t start =

--- a/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
@@ -47,9 +47,14 @@ typedef struct SynqExtentRange {
 
 // Layer-local byte range used by per-node *expanded*-text tracking —
 // the bytes the tokenizer saw for a node, in whichever layer buffer
-// they live.  `length == 0` is the sentinel: either an epsilon
-// reduction (no tokens) or a node whose tokens span multiple layers
-// (no contiguous expansion slice can represent it).
+// they live.
+//
+// Sentinel states:
+//   {0, 0, 0}                  — epsilon (no tokens); neutral in merges.
+//   {_, 0, SYNQ_CROSS_LAYER}   — cross-layer poison; propagates through
+//                                parent merges so the fast path falls
+//                                through to the slow path.
+#define SYNQ_CROSS_LAYER UINT32_MAX
 typedef struct SynqNodeExpandedExtent {
   uint32_t offset;
   uint32_t length;

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -602,6 +602,47 @@ mod tests {
     }
 
     #[test]
+    fn parser_collect_node_extents_cross_layer_sentinel_not_absorbed_by_parent_reduce() {
+        // Regression test for #120: when a macro call is nested inside a
+        // compound expression (e.g. CASE), the cross-layer sentinel from the
+        // inner reduce was absorbed by the parent reduce's merge loop (both
+        // epsilon and cross-layer used length==0).  The parent then gets a
+        // non-sentinel extent and the fast path returns un-expanded source.
+        let mut parser = Parser::with_config(
+            &ParserConfig::default()
+                .with_collect_node_extents(true)
+                .with_macro_fallback(true),
+        );
+        let mut reg = TestMacroRegistry::new();
+        reg.register("cast_string", &["value"], "CAST($value AS TEXT)");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "SELECT CASE WHEN 1 THEN cast_string!(y) END;";
+        let mut session = parser.parse(source);
+        let statement = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("statement is missing"),
+            ParseOutcome::Err(err) => panic!("statement should parse: {err}"),
+        };
+
+        let root_id = statement.erase().root_id();
+        // The root SELECT node crosses layers (SELECT/CASE/WHEN/THEN/END in
+        // layer 0, CAST(y AS TEXT) in layer 1).  node_expanded_text must
+        // return the post-expansion view, NOT the raw authored source.
+        let expanded = statement
+            .node_expanded_text(root_id)
+            .expect("cross-layer node should produce expanded text");
+        assert!(
+            expanded.contains("CAST(y AS TEXT)"),
+            "expected expanded macro in output, got: {expanded:?}",
+        );
+        assert!(
+            !expanded.contains("cast_string!(y)"),
+            "expanded text should not contain raw macro call, got: {expanded:?}",
+        );
+    }
+
+    #[test]
     fn parser_collect_node_extents_expanded_text_is_source_for_root_nodes() {
         // For nodes built entirely from root-layer tokens,
         // `node_expanded_text` and `node_text` both return slices of


### PR DESCRIPTION
## Motivation

`syntaqlite_parser_node_expanded_text` uses a fast path that returns a direct slice of the source buffer for single-layer nodes. However, `synq_extent_on_reduce` used `length == 0` as a sentinel for **both** epsilon reductions and cross-layer collapses. When a macro call is nested inside a compound expression (e.g. `SELECT CASE WHEN 1 THEN cast_string!(y) END`), the cross-layer sentinel gets absorbed by a parent reduce's merge loop as if it were epsilon, producing a bogus non-zero layer-0 extent. The fast path then returns the raw un-expanded source.

Fixes #120.

## Changes

- Introduce `SYNQ_CROSS_LAYER` sentinel (`UINT32_MAX`) in `layer_id` to distinguish cross-layer collapse from epsilon — the merge loop now propagates this poison upward instead of silently absorbing it
- The fast path goes back to a clean `if (e.length > 0)` check with no workarounds
- Add regression test reproducing the exact scenario from the issue