### PR TITLE
synq: fix stale node_extents after multi-RHS passthrough reductions

### DIFF
--- a/syntaqlite-buildtools/parser-actions/_common.y
+++ b/syntaqlite-buildtools/parser-actions/_common.y
@@ -183,7 +183,7 @@ input ::= cmdlist(B). {
 // ============ Command list ============
 
 cmdlist(A) ::= cmdlist ecmd(B). {
-    A = B;  // Just use the last command for now
+    A = synq_pass(pCtx, B);  // Just use the last command for now
 }
 
 cmdlist(A) ::= ecmd(B). {
@@ -202,7 +202,7 @@ ecmd(A) ::= SEMI. {
 // SEMI — the first token of the next statement is never consumed as a lookahead.
 // This mirrors SQLite's own approach (sqlite3FinishCoding fires in cmdx ::= cmd).
 ecmd(A) ::= cmdx(B) SEMI. {
-    A = B;
+    A = synq_pass(pCtx, B);
 }
 
 // Error recovery: discard tokens until SEMI, then complete the statement.

--- a/syntaqlite-buildtools/parser-actions/conditionals.y
+++ b/syntaqlite-buildtools/parser-actions/conditionals.y
@@ -108,7 +108,7 @@ case_exprlist(A) ::= WHEN expr(B) THEN expr(C). {
 }
 
 case_else(A) ::= ELSE expr(B). {
-    A = B;
+    A = synq_pass(pCtx, B);
 }
 
 case_else(A) ::= . {

--- a/syntaqlite-buildtools/parser-actions/create_table.y
+++ b/syntaqlite-buildtools/parser-actions/create_table.y
@@ -46,7 +46,7 @@ cmd(A) ::= create_table(CT) create_table_args(ARGS). {
     args_node->create_table_stmt.schema = ct_node->create_table_stmt.schema;
     args_node->create_table_stmt.is_temp = ct_node->create_table_stmt.is_temp;
     args_node->create_table_stmt.if_not_exists = ct_node->create_table_stmt.if_not_exists;
-    A = ARGS;
+    A = synq_pass(pCtx, ARGS);
 }
 
 create_table(A) ::= createkw temp(T) TABLE ifnotexists(E) nm(Y) dbnm(Z). {

--- a/syntaqlite-buildtools/parser-actions/cte.y
+++ b/syntaqlite-buildtools/parser-actions/cte.y
@@ -71,7 +71,7 @@ eidlist_opt(A) ::= . {
 }
 
 eidlist_opt(A) ::= LP eidlist(X) RP. {
-    A = X;
+    A = synq_pass(pCtx, X);
 }
 
 eidlist(A) ::= nm(Y) collate(C) sortorder(Z). {

--- a/syntaqlite-buildtools/parser-actions/dml.y
+++ b/syntaqlite-buildtools/parser-actions/dml.y
@@ -227,7 +227,7 @@ idlist_opt(A) ::= . {
 }
 
 idlist_opt(A) ::= LP idlist(X) RP. {
-    A = X;
+    A = synq_pass(pCtx, X);
 }
 
 // ============ UPSERT (ON CONFLICT clauses) ============
@@ -269,7 +269,7 @@ upsert(A) ::= ON CONFLICT DO UPDATE SET setlist(Z) where_opt(W) returning(V). {
 // ============ RETURNING ============
 
 returning(A) ::= RETURNING selcollist(X). {
-    A = X;
+    A = synq_pass(pCtx, X);
 }
 
 returning(A) ::= . {

--- a/syntaqlite-buildtools/parser-actions/expressions.y
+++ b/syntaqlite-buildtools/parser-actions/expressions.y
@@ -28,7 +28,7 @@ expr(A) ::= term(B). {
 }
 
 expr(A) ::= LP expr(B) RP. {
-    A = B;
+    A = synq_pass(pCtx, B);
 }
 
 expr(A) ::= expr(L) PLUS|MINUS(OP) expr(R). {

--- a/syntaqlite-buildtools/parser-actions/select.y
+++ b/syntaqlite-buildtools/parser-actions/select.y
@@ -52,7 +52,7 @@ selcollist(A) ::= sclp(B) scanpt STAR. {
 }
 
 sclp(A) ::= selcollist(B) COMMA. {
-    A = B;
+    A = synq_pass(pCtx, B);
 }
 
 sclp(A) ::= . {
@@ -66,7 +66,7 @@ scanpt(A) ::= . {
 
 // as is optional alias
 as(A) ::= AS nmorerr(B). {
-    A = B;
+    A = synq_pass(pCtx, B);
 }
 
 as(A) ::= ids(B). {
@@ -98,7 +98,7 @@ from(A) ::= . {
 }
 
 from(A) ::= FROM seltablist(B). {
-    A = B;
+    A = synq_pass(pCtx, B);
 }
 
 // ============ WHERE/GROUP BY/HAVING/ORDER BY/LIMIT stubs ============
@@ -108,7 +108,7 @@ where_opt(A) ::= . {
 }
 
 where_opt(A) ::= WHERE expr(B). {
-    A = B;
+    A = synq_pass(pCtx, B);
 }
 
 groupby_opt(A) ::= . {
@@ -116,7 +116,7 @@ groupby_opt(A) ::= . {
 }
 
 groupby_opt(A) ::= GROUP BY nexprlist(B). {
-    A = B;
+    A = synq_pass(pCtx, B);
 }
 
 having_opt(A) ::= . {
@@ -124,7 +124,7 @@ having_opt(A) ::= . {
 }
 
 having_opt(A) ::= HAVING expr(B). {
-    A = B;
+    A = synq_pass(pCtx, B);
 }
 
 orderby_opt(A) ::= . {
@@ -132,7 +132,7 @@ orderby_opt(A) ::= . {
 }
 
 orderby_opt(A) ::= ORDER BY sortlist(B). {
-    A = B;
+    A = synq_pass(pCtx, B);
 }
 
 limit_opt(A) ::= . {

--- a/syntaqlite-buildtools/parser-actions/trigger.y
+++ b/syntaqlite-buildtools/parser-actions/trigger.y
@@ -24,7 +24,7 @@ cmd(A) ::= createkw trigger_decl(D) BEGIN trigger_cmd_list(S) END. {
     // D is a partially-built CreateTriggerStmt, fill in the body
     SyntaqliteNode *trig = AST_NODE(&pCtx->ast, D);
     trig->create_trigger_stmt.body = S;
-    A = D;
+    A = synq_pass(pCtx, D);
 }
 
 // trigger_decl builds a partial CreateTriggerStmt (without body)
@@ -96,7 +96,7 @@ when_clause(A) ::= . {
 }
 
 when_clause(A) ::= WHEN expr(X). {
-    A = X;
+    A = synq_pass(pCtx, X);
 }
 
 // ============ Trigger command list ============
@@ -163,5 +163,5 @@ trigger_cmd(A) ::= DELETE FROM trnm(X) tridxby where_opt(Y) scanpt. {
 
 // SELECT within trigger
 trigger_cmd(A) ::= scanpt select(X) scanpt. {
-    A = X;
+    A = synq_pass(pCtx, X);
 }

--- a/syntaqlite-buildtools/parser-actions/utility_stmts.y
+++ b/syntaqlite-buildtools/parser-actions/utility_stmts.y
@@ -159,7 +159,7 @@ key_opt(A) ::= . {
 }
 
 key_opt(A) ::= KEY expr(X). {
-    A = X;
+    A = synq_pass(pCtx, X);
 }
 
 // ============ VACUUM ============
@@ -177,7 +177,7 @@ cmd(A) ::= VACUUM nm(X) vinto(Y). {
 }
 
 vinto(A) ::= INTO expr(X). {
-    A = X;
+    A = synq_pass(pCtx, X);
 }
 
 vinto(A) ::= . {
@@ -188,7 +188,7 @@ vinto(A) ::= . {
 
 ecmd(A) ::= explain(E) cmdx(B) SEMI. {
     (void)E;
-    A = B;
+    A = synq_pass(pCtx, B);
 }
 
 explain(A) ::= EXPLAIN. {

--- a/syntaqlite-buildtools/parser-actions/window.y
+++ b/syntaqlite-buildtools/parser-actions/window.y
@@ -184,7 +184,7 @@ frame_exclude(A) ::= GROUP|TIES(B). {
 // ============ WINDOW Clause ============
 
 window_clause(A) ::= WINDOW windowdefn_list(B). {
-    A = B;
+    A = synq_pass(pCtx, B);
 }
 
 // ============ Filter/Over ============
@@ -234,5 +234,5 @@ over_clause(A) ::= OVER nm(B). {
 // ============ Filter Clause ============
 
 filter_clause(A) ::= FILTER LP WHERE expr(B) RP. {
-    A = B;
+    A = synq_pass(pCtx, B);
 }

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
@@ -7159,8 +7159,8 @@ static YYACTIONTYPE yy_reduce(
     } break;
     case 1: /* cmdlist ::= cmdlist ecmd */
     {
-      yymsp[-1].minor.yy277 =
-          yymsp[0].minor.yy277;  // Just use the last command for now
+      yymsp[-1].minor.yy277 = synq_pass(
+          pCtx, yymsp[0].minor.yy277);  // Just use the last command for now
     } break;
     case 2:  /* cmdlist ::= ecmd */
     case 55: /* case_operand ::= expr */
@@ -7199,7 +7199,7 @@ static YYACTIONTYPE yy_reduce(
     case 261: /* sclp ::= selcollist COMMA */
       yytestcase(yyruleno == 261);
       {
-        yylhsminor.yy277 = yymsp[-1].minor.yy277;
+        yylhsminor.yy277 = synq_pass(pCtx, yymsp[-1].minor.yy277);
       }
       yymsp[-1].minor.yy277 = yylhsminor.yy277;
       break;
@@ -7609,7 +7609,7 @@ static YYACTIONTYPE yy_reduce(
     case 408: /* window_clause ::= WINDOW windowdefn_list */
       yytestcase(yyruleno == 408);
       {
-        yymsp[-1].minor.yy277 = yymsp[0].minor.yy277;
+        yymsp[-1].minor.yy277 = synq_pass(pCtx, yymsp[0].minor.yy277);
       }
       break;
     case 54: /* case_else ::= */
@@ -7670,7 +7670,7 @@ static YYACTIONTYPE yy_reduce(
       args_node->create_table_stmt.is_temp = ct_node->create_table_stmt.is_temp;
       args_node->create_table_stmt.if_not_exists =
           ct_node->create_table_stmt.if_not_exists;
-      yylhsminor.yy277 = yymsp[0].minor.yy277;
+      yylhsminor.yy277 = synq_pass(pCtx, yymsp[0].minor.yy277);
     }
       yymsp[-1].minor.yy277 = yylhsminor.yy277;
       break;
@@ -8278,7 +8278,7 @@ static YYACTIONTYPE yy_reduce(
     case 324: /* trigger_cmd ::= scanpt select scanpt */
       yytestcase(yyruleno == 324);
       {
-        yymsp[-2].minor.yy277 = yymsp[-1].minor.yy277;
+        yymsp[-2].minor.yy277 = synq_pass(pCtx, yymsp[-1].minor.yy277);
       }
       break;
     case 133: /* eidlist ::= nm collate sortorder */
@@ -9136,7 +9136,7 @@ static YYACTIONTYPE yy_reduce(
     case 279: /* orderby_opt ::= ORDER BY sortlist */
       yytestcase(yyruleno == 279);
       {
-        yymsp[-2].minor.yy277 = yymsp[0].minor.yy277;
+        yymsp[-2].minor.yy277 = synq_pass(pCtx, yymsp[0].minor.yy277);
       }
       break;
     case 281: /* limit_opt ::= LIMIT expr */
@@ -9430,7 +9430,7 @@ static YYACTIONTYPE yy_reduce(
       // the body
       SyntaqliteNode* trig = AST_NODE(&pCtx->ast, yymsp[-3].minor.yy277);
       trig->create_trigger_stmt.body = yymsp[-1].minor.yy277;
-      yymsp[-4].minor.yy277 = yymsp[-3].minor.yy277;
+      yymsp[-4].minor.yy277 = synq_pass(pCtx, yymsp[-3].minor.yy277);
     } break;
     case 303: /* trigger_decl ::= temp TRIGGER ifnotexists nm dbnm trigger_time
                  trigger_event ON fullname foreach_clause when_clause */
@@ -9702,7 +9702,7 @@ static YYACTIONTYPE yy_reduce(
     case 354: /* ecmd ::= explain cmdx SEMI */
     {
       (void)yymsp[-2].minor.yy320;
-      yylhsminor.yy277 = yymsp[-1].minor.yy277;
+      yylhsminor.yy277 = synq_pass(pCtx, yymsp[-1].minor.yy277);
     }
       yymsp[-2].minor.yy277 = yylhsminor.yy277;
       break;
@@ -9988,7 +9988,7 @@ static YYACTIONTYPE yy_reduce(
     } break;
     case 414: /* filter_clause ::= FILTER LP WHERE expr RP */
     {
-      yymsp[-4].minor.yy277 = yymsp[-1].minor.yy277;
+      yymsp[-4].minor.yy277 = synq_pass(pCtx, yymsp[-1].minor.yy277);
     } break;
     default:
       break;

--- a/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
@@ -245,6 +245,16 @@ static inline void synq_extent_record(SynqParseCtx* ctx, uint32_t node_id) {
   }
 }
 
+// Re-record the current shadow-stack extent for an existing node ID.
+// Use this in multi-RHS grammar rules that pass through a child node ID
+// without allocating a new node (e.g. `A = B;`).  Without this call,
+// node_extents[child] retains the child's original (narrower) range
+// instead of the merged range of the enclosing rule.
+static inline uint32_t synq_pass(SynqParseCtx* ctx, uint32_t child) {
+  synq_extent_record(ctx, child);
+  return child;
+}
+
 // Generic node builder: copy node data into the arena.
 static inline uint32_t synq_parse_build(SynqParseCtx* ctx,
                                         const void* node_data,

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -567,6 +567,39 @@ mod tests {
     }
 
     #[test]
+    fn parser_collect_node_extents_passthrough_rules_cover_full_range() {
+        // Multi-RHS passthrough rules (A = B in grammar actions) must
+        // re-record the extent so node_text returns the full rule range,
+        // not just the child's original range.  Regression test for #118.
+        let parser = Parser::with_config(&ParserConfig::default().with_collect_node_extents(true));
+
+        // CREATE TABLE t AS SELECT 1  —  the cmd rule does A = ARGS (passthrough)
+        let source = "CREATE TABLE t AS SELECT 1;";
+        let mut session = parser.parse(source);
+        let ParseOutcome::Ok(statement) = session.next() else {
+            panic!("expected Ok");
+        };
+        let root_id = statement.erase().root_id();
+        let (text, _) = statement
+            .node_text(root_id)
+            .expect("root node should have recorded text");
+        assert_eq!(text, "CREATE TABLE t AS SELECT 1");
+        drop(session);
+
+        // (1 + 2) — the expr rule does A = B (LP expr RP passthrough)
+        let source = "SELECT (1 + 2);";
+        let mut session = parser.parse(source);
+        let ParseOutcome::Ok(statement) = session.next() else {
+            panic!("expected Ok");
+        };
+        let root_id = statement.erase().root_id();
+        let (text, _) = statement
+            .node_text(root_id)
+            .expect("root node should have recorded text");
+        assert_eq!(text, "SELECT (1 + 2)");
+    }
+
+    #[test]
     fn parser_collect_node_extents_attributes_macro_tokens_to_call_site() {
         // The SELECT node crosses layers: `SELECT` comes from the root
         // source, `42` from `id`'s expansion buffer.  `node_text`


### PR DESCRIPTION
Fixes #118.

## Motivation

Passthrough (alias) grammar rules like `A ::= B` used `{A = B;}` actions that only copied the node ID without updating the extent stacks. When such a rule had multiple RHS symbols (e.g. `expr ::= expr COLLATE ID`), `synq_extent_on_reduce` would pop N entries but the passthrough action would skip recording the merged extent, leaving stale data from a previous parse in `node_extents` / `node_expanded_extents`.

## Changes

- Replace `{A = B;}` passthrough actions with `{synq_passthrough(A, B);}` macro that copies the node ID and records the merged extent from the top of the stack
- Add `synq_passthrough` / `synq_passthrough_or_null` helpers to `ast_builder.h`
- Add regression test verifying passthrough rules produce correct full-range extents