### PR TITLE
synq: add public API to detect macro-free spans, nodes, and statements

### DIFF
--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -942,3 +942,17 @@ SYNTAQLITE_API const char* syntaqlite_parser_node_expanded_text(
   }
   return (const char*)p->node_expanded_buf.data;
 }
+
+SYNTAQLITE_API int syntaqlite_node_is_macro_free(SyntaqliteParser* p,
+                                                 uint32_t node_id) {
+  if (!p->ctx.collect_node_extents) {
+    return 0;
+  }
+  if (node_id >= syntaqlite_vec_len(&p->ctx.node_expanded_extents)) {
+    return 0;
+  }
+  SynqNodeExpandedExtent e =
+      syntaqlite_vec_at(&p->ctx.node_expanded_extents, node_id);
+  // length == 0 is the sentinel for epsilon or multi-layer nodes.
+  return e.length > 0 && e.layer_id == 0;
+}

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -380,6 +380,26 @@ SYNTAQLITE_API const char* syntaqlite_parser_node_expanded_text(
     uint32_t* out_len);
 
 // ---------------------------------------------------------------------------
+// Macro-expansion queries
+// ---------------------------------------------------------------------------
+
+// Returns 1 if `span` was tokenized from the original source (layer 0),
+// 0 if it was produced by a macro expansion.  Returns 0 for empty spans.
+static inline int syntaqlite_span_is_macro_free(
+    const SyntaqliteTextSpan* span) {
+  return span->length > 0 && span->_layer_id == 0;
+}
+
+// Returns 1 if all tokens of AST node `node_id` live in layer 0 (original
+// source), 0 otherwise.  Returns 0 when extent tracking is disabled, the
+// node id is unknown, or no extent was recorded.
+//
+// Requires `syntaqlite_parser_set_collect_node_extents(p, 1)` before the
+// first `reset()`.
+SYNTAQLITE_API int syntaqlite_node_is_macro_free(SyntaqliteParser* p,
+                                                 uint32_t node_id);
+
+// ---------------------------------------------------------------------------
 // Node and list helpers
 // ---------------------------------------------------------------------------
 

--- a/syntaqlite-syntax/src/ast.rs
+++ b/syntaqlite-syntax/src/ast.rs
@@ -470,6 +470,14 @@ mod ffi {
         pub fn is_quoted(self) -> bool {
             (self.flags & SPAN_FLAG_QUOTED) != 0
         }
+
+        /// Returns `true` if the span was tokenized from the original
+        /// source (layer 0), `false` if it was produced by a macro
+        /// expansion.  Returns `false` for empty spans.
+        #[expect(clippy::used_underscore_binding)]
+        pub fn is_macro_free(self) -> bool {
+            self.length > 0 && self._layer_id == 0
+        }
     }
 
     /// List node header — `tag` + `count`, followed by `count` child [`AnyNodeId`]s

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -248,6 +248,15 @@ impl CParser {
         Some(text)
     }
 
+    /// Returns `true` if all tokens of AST node `node_id` live in
+    /// layer 0 (original source).  Requires extent tracking.
+    pub(crate) unsafe fn node_is_macro_free(&self, node_id: u32) -> bool {
+        // SAFETY: self is a valid, non-null CParser pointer owned by the caller.
+        unsafe {
+            syntaqlite_node_is_macro_free(std::ptr::from_ref::<Self>(self).cast_mut(), node_id) != 0
+        }
+    }
+
     pub(crate) unsafe fn reset(&mut self, source: *const c_char, len: u32) {
         // SAFETY: self is a valid, non-null CParser pointer; source is a
         // null-terminated C string of at least `len` bytes.
@@ -535,6 +544,8 @@ unsafe extern "C" {
         node_id: u32,
         out_len: *mut u32,
     ) -> *const u8;
+
+    fn syntaqlite_node_is_macro_free(p: *mut CParser, node_id: u32) -> i32;
 
     // AST dump
     fn syntaqlite_dump_node(p: *mut CParser, node_id: u32, indent: u32) -> *mut c_char;

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -604,6 +604,20 @@ impl<'a> AnyParsedStatement<'a> {
         unsafe { self.raw.as_ref().node_expanded_text(id.0) }
     }
 
+    /// Returns `true` if all tokens of AST node `id` live in layer 0
+    /// (the original source), `false` if any came from a macro
+    /// expansion.  Returns `false` when extent tracking is disabled,
+    /// the node id is unknown, or the node is null.
+    ///
+    /// Requires [`ParserConfig::with_collect_node_extents`].
+    pub fn node_is_macro_free(&self, id: AnyNodeId) -> bool {
+        if id.is_null() {
+            return false;
+        }
+        // SAFETY: self.raw is valid for 'a.
+        unsafe { self.raw.as_ref().node_is_macro_free(id.0) }
+    }
+
     /// Post-expansion text for the whole bound source — the
     /// parser-level analogue of [`Self::node_expanded_text`].
     /// Materializes the source with every currently-active macro call
@@ -614,6 +628,13 @@ impl<'a> AnyParsedStatement<'a> {
         // SAFETY: self.raw is valid for 'a; the returned slice borrows
         // from the parser's scratch buffer which outlives 'a.
         unsafe { self.raw.as_ref().expanded_text() }
+    }
+
+    /// Returns `true` if the statement contains no macro expansions —
+    /// all tokens came from the original source text.
+    pub fn is_macro_free(&self) -> bool {
+        // SAFETY: self.raw is valid for 'a.
+        unsafe { self.raw.as_ref().result_macro_count() == 0 }
     }
 
     /// Macro expansion call-site spans recorded during parsing.

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -322,6 +322,13 @@ impl<'a> ParsedStatement<'a> {
         self.0.clone().erase()
     }
 
+    /// Returns `true` if all tokens of AST node `id` live in layer 0.
+    /// See [`AnyParsedStatement::node_is_macro_free`](
+    /// super::AnyParsedStatement::node_is_macro_free).
+    pub fn node_is_macro_free(&self, id: super::AnyNodeId) -> bool {
+        self.0.any.node_is_macro_free(id)
+    }
+
     /// Source text of AST node `id` as `(text, offset)`.  See
     /// [`AnyParsedStatement::node_text`](super::AnyParsedStatement::node_text).
     pub fn node_text(&self, id: super::AnyNodeId) -> Option<(&'a str, u32)> {
@@ -333,6 +340,13 @@ impl<'a> ParsedStatement<'a> {
     /// super::AnyParsedStatement::node_expanded_text).
     pub fn node_expanded_text(&self, id: super::AnyNodeId) -> Option<&'a str> {
         self.0.any.node_expanded_text(id)
+    }
+
+    /// Returns `true` if the statement contains no macro expansions.
+    /// See [`AnyParsedStatement::is_macro_free`](
+    /// super::AnyParsedStatement::is_macro_free).
+    pub fn is_macro_free(&self) -> bool {
+        self.0.any.is_macro_free()
     }
 
     /// Macro expansion call-site spans recorded during parsing.
@@ -1185,5 +1199,138 @@ mod tests {
         let off = frames[0].offset_in_snippet;
         let end = off + "authored".len();
         assert_eq!(&source[off..end], "authored");
+    }
+
+    #[test]
+    fn statement_is_macro_free_true_for_plain_sql() {
+        let parser = Parser::new();
+        let source = "SELECT foo FROM bar";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+        assert!(
+            stmt.is_macro_free(),
+            "plain SQL statement should be macro-free"
+        );
+    }
+
+    #[test]
+    fn statement_is_macro_free_false_for_expansion() {
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let mut reg = TestMacroRegistry::new();
+        reg.register("idmac", &[], "inner");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "SELECT idmac!()";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+        assert!(
+            !stmt.is_macro_free(),
+            "statement with macro expansion should not be macro-free"
+        );
+    }
+
+    #[test]
+    fn span_is_macro_free_true_for_plain_sql() {
+        let parser = Parser::new();
+        let source = "SELECT foo FROM bar";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+        let erased = stmt.erase();
+        let span = first_span_in_tree(&erased).expect("expected a Span field");
+        assert!(span.is_macro_free(), "plain SQL span should be macro-free");
+    }
+
+    #[test]
+    fn span_is_macro_free_false_for_expansion() {
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let mut reg = TestMacroRegistry::new();
+        reg.register("idmac", &[], "inner");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "SELECT idmac!()";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+        let erased = stmt.erase();
+        let span = first_span_in_tree(&erased).expect("expected a Span field");
+        assert!(
+            !span.is_macro_free(),
+            "span from macro expansion should not be macro-free"
+        );
+    }
+
+    #[test]
+    fn node_is_macro_free_true_for_plain_sql() {
+        let parser = Parser::with_config(&ParserConfig::default().with_collect_node_extents(true));
+        let source = "SELECT foo FROM bar";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+        let erased = stmt.erase();
+        assert!(
+            erased.node_is_macro_free(erased.root_id()),
+            "root node in plain SQL should be macro-free"
+        );
+    }
+
+    #[test]
+    fn node_is_macro_free_false_for_expansion() {
+        let mut parser = Parser::with_config(
+            &ParserConfig::default()
+                .with_macro_fallback(true)
+                .with_collect_node_extents(true),
+        );
+        let mut reg = TestMacroRegistry::new();
+        reg.register("idmac", &["x"], "$x");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "SELECT idmac!(col1) FROM t";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+        let erased = stmt.erase();
+        // Root spans multiple layers (SELECT from source, col1 from expansion).
+        assert!(
+            !erased.node_is_macro_free(erased.root_id()),
+            "root node with macro expansion should not be macro-free"
+        );
+    }
+
+    #[test]
+    fn node_is_macro_free_false_without_extent_tracking() {
+        let parser = Parser::new(); // no extent tracking
+        let source = "SELECT 1";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+        let erased = stmt.erase();
+        assert!(
+            !erased.node_is_macro_free(erased.root_id()),
+            "should return false when extent tracking is disabled"
+        );
     }
 }

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -913,9 +913,11 @@ pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::child_node_ids(&self, id:
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::comment_spans(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::CommentSpan> + use<'_>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::expanded_text(&self) -> &'a str
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::extract_fields(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(syntaqlite_syntax::any::AnyNodeTag, syntaqlite_syntax::any::NodeFields)>
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::is_macro_free(&self) -> bool
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::list_children(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a [syntaqlite_syntax::any::AnyNodeId]>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::macro_regions(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRegion> + use<'_>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_expanded_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a str>
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_is_macro_free(&self, id: syntaqlite_syntax::any::AnyNodeId) -> bool
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(&'a str, u32)>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_id(&self) -> syntaqlite_syntax::any::AnyNodeId
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_node(&self) -> core::option::Option<syntaqlite_syntax::any::AnyNode<'_>>
@@ -941,6 +943,7 @@ pub fn syntaqlite_syntax::any::NodeFields::index(&self, idx: usize) -> &syntaqli
 pub fn syntaqlite_syntax::any::NodeFields::is_empty(&self) -> bool
 pub fn syntaqlite_syntax::any::NodeFields::len(&self) -> usize
 pub fn syntaqlite_syntax::any::TextSpan::is_empty(self) -> bool
+pub fn syntaqlite_syntax::any::TextSpan::is_macro_free(self) -> bool
 pub fn syntaqlite_syntax::any::TextSpan::is_quoted(self) -> bool
 pub fn syntaqlite_syntax::nodes::AggregateFunctionCall<'_>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn syntaqlite_syntax::nodes::AggregateFunctionCall<'a>::args(&self) -> core::option::Option<syntaqlite_syntax::nodes::ExprList<'a>>


### PR DESCRIPTION
## Motivation

Downstream consumers that want to route expanded text to a second parser (e.g. SQLite for passthrough statements) need to decide, for each statement, whether the parsed tokens came entirely from the root source or involved macro expansion. Today the only discriminator is the internal `_layer_id` field on `SyntaqliteTextSpan` / `SyntaqliteParserToken`, which violates the "internal" annotation and couples callers to layout.

Closes #119

## Changes

Adds three levels of macro-free detection:

**Span level** — cheapest, no FFI call:
- C: `syntaqlite_span_is_macro_free(span)` (static inline)
- Rust: `TextSpan::is_macro_free()`

**Node level** — checks expanded extents (requires extent tracking):
- C: `syntaqlite_node_is_macro_free(p, node_id)`
- Rust: `AnyParsedStatement::node_is_macro_free(id)` + `ParsedStatement` delegate

**Statement level** — checks macro region count (no extent tracking needed):
- Rust: `AnyParsedStatement::is_macro_free()` + `ParsedStatement` delegate

Includes 7 new tests covering all three levels for both macro-free and macro-expanded cases, plus the extent-tracking-disabled edge case.