### PR TITLE
synq: fix OOB read in macro expansion when body is not NUL-terminated

### DIFF
--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -148,6 +148,7 @@ SYNTAQLITE_API SyntaqliteParser* syntaqlite_parser_create_with_dialect(
   syntaqlite_vec_init(&p->node_expanded_buf);
   // macro_lookup_fn, macro_result_*, expansion state already zeroed by memset
   syntaqlite_vec_init(&p->macro_expand_buf);
+  syntaqlite_vec_init(&p->macro_body_buf);
   return p;
 }
 
@@ -213,6 +214,7 @@ SYNTAQLITE_API void syntaqlite_parser_destroy(SyntaqliteParser* p) {
     syntaqlite_vec_free(&p->traceback_buf, p->mem);
     syntaqlite_vec_free(&p->node_expanded_buf, p->mem);
     syntaqlite_vec_free(&p->macro_expand_buf, p->mem);
+    syntaqlite_vec_free(&p->macro_body_buf, p->mem);
     p->mem.xFree(p);
   }
 }
@@ -913,9 +915,8 @@ SYNTAQLITE_API const char* syntaqlite_parser_node_expanded_text(
   SynqNodeExpandedExtent e =
       syntaqlite_vec_at(&p->ctx.node_expanded_extents, node_id);
   if (e.length > 0) {
-    const char* buf = e.layer_id == 0
-                          ? p->source
-                          : p->layers.data[e.layer_id].expansion_data;
+    const char* buf =
+        e.layer_id == 0 ? p->source : p->layers.data[e.layer_id].expansion_data;
     if (out_len) {
       *out_len = e.length;
     }

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -144,6 +144,11 @@ struct SyntaqliteParser {
   // Reused across invocations to avoid repeated allocation.
   SYNQ_VEC(uint8_t) macro_expand_buf;
 
+  // NUL-terminated staging buffer for the macro body before tokenization.
+  // The tokenizer reads until NUL, but callers may pass non-NUL-terminated
+  // buffers (e.g. Rust &str), so we stage the body here first.
+  SYNQ_VEC(uint8_t) macro_body_buf;
+
   // ── Expansion state ───────────────────────────────────────────────────
   // Blue-paint recursion detection: names of macros currently being expanded.
   const char* expansion_names[SYNQ_MAX_MACRO_DEPTH];

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -695,7 +695,7 @@ SYNTAQLITE_API int syntaqlite_macro_expansion_expand_and_set_result(
   p->macro_body_buf.count = 0;
   syntaqlite_vec_push_n(&p->macro_body_buf, (const uint8_t*)body, body_len,
                         p->mem);
-  syntaqlite_vec_push_n(&p->macro_body_buf, (const uint8_t*)"", 1, p->mem);
+  syntaqlite_vec_push(&p->macro_body_buf, 0, p->mem);
 
   // Collect arg mappings on the stack (max 64 params).
   SyntaqliteArgMapping mappings[64];

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -747,7 +747,7 @@ SYNTAQLITE_API int syntaqlite_macro_expansion_expand_and_set_result(
 
   // Steal the scratch vec's buffer directly into the layer (no copy).
   // Null-terminate for safety.
-  syntaqlite_vec_push_n(&p->macro_expand_buf, (const uint8_t*)"", 1, p->mem);
+  syntaqlite_vec_push(&p->macro_expand_buf, 0, p->mem);
   SynqExpansionLayer* lyr = &p->layers.data[p->macro_pending_layer];
   layer_free_data(p, lyr);
   lyr->expansion_data = (const char*)p->macro_expand_buf.data;

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -689,11 +689,20 @@ SYNTAQLITE_API int syntaqlite_macro_expansion_expand_and_set_result(
   // Reuse the parser's scratch vec — reset count but keep the allocation.
   p->macro_expand_buf.count = 0;
 
+  // Stage the body into a NUL-terminated buffer before tokenizing.
+  // The tokenizer reads until NUL, but callers may pass non-NUL-terminated
+  // buffers (e.g. Rust &str), so we must ensure the NUL sentinel exists.
+  p->macro_body_buf.count = 0;
+  syntaqlite_vec_push_n(&p->macro_body_buf, (const uint8_t*)body, body_len,
+                        p->mem);
+  syntaqlite_vec_push_n(&p->macro_body_buf, (const uint8_t*)"", 1, p->mem);
+
   // Collect arg mappings on the stack (max 64 params).
   SyntaqliteArgMapping mappings[64];
   uint32_t mapping_count = 0;
 
-  const unsigned char* z = (const unsigned char*)body;
+  const unsigned char* z = (const unsigned char*)p->macro_body_buf.data;
+  const char* zbody = (const char*)p->macro_body_buf.data;
   uint32_t pos = 0;
   while (pos < body_len) {
     uint32_t ttype = 0;
@@ -702,8 +711,8 @@ SYNTAQLITE_API int syntaqlite_macro_expansion_expand_and_set_result(
     if (tlen <= 0)
       break;
 
-    if (ttype == SYNTAQLITE_TK_VARIABLE && body[pos] == '$' && tlen > 1) {
-      const char* pname = body + pos + 1;
+    if (ttype == SYNTAQLITE_TK_VARIABLE && zbody[pos] == '$' && tlen > 1) {
+      const char* pname = zbody + pos + 1;
       uint32_t pname_len = (uint32_t)tlen - 1;
 
       int found = -1;
@@ -729,7 +738,7 @@ SYNTAQLITE_API int syntaqlite_macro_expansion_expand_and_set_result(
                               args[found].length, p->mem);
       }
     } else {
-      syntaqlite_vec_push_n(&p->macro_expand_buf, (const uint8_t*)(body + pos),
+      syntaqlite_vec_push_n(&p->macro_expand_buf, (const uint8_t*)(zbody + pos),
                             (uint32_t)tlen, p->mem);
     }
 


### PR DESCRIPTION
## Motivation

`syntaqlite_macro_expansion_expand_and_set_result` tokenizes the macro body in-place, but the SQLite tokenizer reads until it hits a NUL byte. Callers across the FFI boundary (Rust `&str`) can pass non-NUL-terminated buffers, causing a heap OOB read past `body_len`. This produces flaky behavior: intermittent parse failures, spurious `memcmp` matches, and SIGABRT under ASan.

Fixes #127.

## Changes

Add a parser-owned `macro_body_buf` scratch buffer that stages the macro body with a NUL sentinel before tokenizing. This mirrors the pattern already used by the main parse loop (`source_buf` in `reset_parser`). The fix is entirely on the C side — zero Rust-side changes needed.