### PR TITLE
synq: widen _layer_id to uint32_t to fix overflow at 256 layers

### DIFF
--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -207,8 +207,7 @@ int synq_parser_feed_one_token(SyntaqliteParser* p,
       .type = token_type,
       .token_idx = token_idx,
       .offset = tok_offset,
-      .layer_id = (uint8_t)p->ctx.layer_id,
-      ._pad = {0, 0, 0},
+      .layer_id = p->ctx.layer_id,
   };
   SYNQ_PARSER_FEED(p->dialect.tmpl, p->lemon, (int)token_type, minor);
   p->last_token_type = token_type;
@@ -278,8 +277,7 @@ static int finish_input(SyntaqliteParser* p) {
                         .type = 0,
                         .token_idx = 0xFFFFFFFF,
                         .offset = 0,
-                        .layer_id = 0,
-                        ._pad = {0, 0, 0}};
+                        .layer_id = 0};
   SYNQ_PARSER_FEED(p->dialect.tmpl, p->lemon, 0, eof);
   p->finished = 1;
 
@@ -319,8 +317,8 @@ int synq_parser_record_and_feed(SyntaqliteParser* p,
                                 uint32_t cur_len) {
   uint32_t tidx = 0xFFFFFFFF;
   if (p->collect_tokens) {
-    SyntaqliteParserToken tp = {
-        cur_offset, cur_len, cur_type, 0, (uint8_t)p->ctx.layer_id, {0, 0, 0}};
+    SyntaqliteParserToken tp = {cur_offset, cur_len, cur_type, 0,
+                                p->ctx.layer_id};
     syntaqlite_vec_push(&p->tokens, tp, p->mem);
     tidx = syntaqlite_vec_len(&p->tokens) - 1;
   }
@@ -673,8 +671,8 @@ SYNTAQLITE_API int32_t syntaqlite_parser_feed_token(SyntaqliteParser* p,
   uint32_t tidx = 0xFFFFFFFF;
   if (p->collect_tokens && text) {
     uint32_t tok_offset = (uint32_t)(text - p->source);
-    SyntaqliteParserToken tp = {
-        tok_offset, len, token_type, 0, (uint8_t)p->ctx.layer_id, {0, 0, 0}};
+    SyntaqliteParserToken tp = {tok_offset, len, token_type, 0,
+                                p->ctx.layer_id};
     syntaqlite_vec_push(&p->tokens, tp, p->mem);
     tidx = syntaqlite_vec_len(&p->tokens) - 1;
   }

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -84,7 +84,7 @@ typedef struct SynqExpansionLayer {
   SynqArgSegment* arg_segments;
   uint32_t arg_segment_count;
 
-  uint8_t parent_layer_id;  // Layer containing the call (0 = source).
+  uint32_t parent_layer_id;  // Layer containing the call (0 = source).
 } SynqExpansionLayer;
 
 typedef SYNQ_VEC(SynqExpansionLayer) SynqExpansionLayerVec;

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -291,8 +291,7 @@ static int expand_and_feed(SyntaqliteParser* p,
                             .type = ttype,
                             .token_idx = 0xFFFFFFFF,
                             .offset = pos,
-                            .layer_id = (uint8_t)p->ctx.layer_id,
-                            ._pad = {0, 0, 0}};
+                            .layer_id = p->ctx.layer_id};
     SYNQ_PARSER_FEED(p->dialect.tmpl, p->lemon, (int)ttype, minor);
     p->last_token_type = ttype;
 
@@ -446,7 +445,7 @@ static void begin_macro_expansion(SyntaqliteParser* p,
       .call_length = call_length,
       .name = name,
       .name_len = name_len,
-      .parent_layer_id = (uint8_t)p->ctx.layer_id,
+      .parent_layer_id = p->ctx.layer_id,
   };
   syntaqlite_vec_push(&p->layers, layer, p->mem);
   p->macro.depth++;

--- a/syntaqlite-syntax/csrc/parser_spans.c
+++ b/syntaqlite-syntax/csrc/parser_spans.c
@@ -84,7 +84,7 @@ SYNTAQLITE_API const char* syntaqlite_parser_span_expanded_text(
     *out_len = 0;
     return NULL;
   }
-  uint8_t layer = span->_layer_id;
+  uint32_t layer = span->_layer_id;
   if (layer >= syntaqlite_vec_len(&p->layers)) {
     *out_len = 0;
     return NULL;
@@ -186,7 +186,7 @@ SYNTAQLITE_API const SyntaqliteTracebackFrame* syntaqlite_parser_traceback(
   uint32_t count = 0;
   uint32_t off = sp->offset;
   uint32_t len = sp->length;
-  uint8_t layer_id = sp->_layer_id;
+  uint32_t layer_id = sp->_layer_id;
   uint32_t layers_count = syntaqlite_vec_len(&p->layers);
 
   for (uint32_t step = 0; step < 2 * (SYNQ_MAX_MACRO_DEPTH + 1) &&

--- a/syntaqlite-syntax/include/syntaqlite/dialect.h
+++ b/syntaqlite-syntax/include/syntaqlite/dialect.h
@@ -81,8 +81,7 @@ typedef struct SynqParseToken {
                        // shift time so reductions don't depend on
                        // ctx->source which may have been swapped back
                        // after a macro expansion
-  uint8_t layer_id;    // 0 = original source, 1+ = expansion layer index
-  uint8_t _pad[3];
+  uint32_t layer_id;   // 0 = original source, 1+ = expansion layer index
 } SynqParseToken;
 
 typedef struct SyntaqliteFieldRangeMeta SyntaqliteFieldRangeMeta;

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -194,8 +194,7 @@ typedef struct SyntaqliteParserToken {
   uint32_t length;  // Byte length.
   uint32_t type;    // Original token type from tokenizer (pre-fallback).
   SyntaqliteParserTokenFlags flags;  // Bitmask of SYNQ_TOKEN_FLAG_* values.
-  uint8_t _layer_id;  // Internal: 0 = original source, >0 = expansion layer.
-  uint8_t _pad[3];
+  uint32_t _layer_id;  // Internal: 0 = original source, >0 = expansion layer.
 } SyntaqliteParserToken;
 
 // Per-statement token/comment arrays.

--- a/syntaqlite-syntax/include/syntaqlite/types.h
+++ b/syntaqlite-syntax/include/syntaqlite/types.h
@@ -39,9 +39,8 @@ typedef uint32_t SyntaqliteCompletionContext;
 typedef struct SyntaqliteTextSpan {
   uint32_t offset;
   uint32_t length;
-  uint8_t flags;
-  uint8_t _layer_id;  // Internal: 0 = source, >0 = macro expansion layer.
-  uint8_t _pad[2];
+  uint32_t flags;
+  uint32_t _layer_id;  // Internal: 0 = source, >0 = macro expansion layer.
 } SyntaqliteTextSpan;
 
 // ── Span flags ───────────────────────────────────────────────────────────────
@@ -49,7 +48,7 @@ typedef struct SyntaqliteTextSpan {
 // Identifier was quoted in source (`"..."`, `` `...` ``, or `[...]`).
 // The span points to the dequoted inner text; the formatter re-wraps in
 // `"..."`.
-#define SYNTAQLITE_SPAN_FLAG_QUOTED ((uint8_t)1u)
+#define SYNTAQLITE_SPAN_FLAG_QUOTED ((uint32_t)1u)
 
 static inline int synq_span_is_quoted(SyntaqliteTextSpan sp) {
   return (sp.flags & SYNTAQLITE_SPAN_FLAG_QUOTED) != 0;

--- a/syntaqlite-syntax/src/ast.rs
+++ b/syntaqlite-syntax/src/ast.rs
@@ -446,16 +446,15 @@ mod ffi {
     pub struct CTextSpan {
         pub(crate) offset: u32,
         pub(crate) length: u32,
-        pub(crate) flags: u8,
+        pub(crate) flags: u32,
         /// Internal: 0 = original source, >0 = macro expansion layer id.
         /// Read by the C-side span accessors; the Rust side passes the
         /// whole struct across the FFI boundary without inspecting it.
-        pub(crate) _layer_id: u8,
-        pub(crate) _pad: [u8; 2],
+        pub(crate) _layer_id: u32,
     }
 
     /// Mirror of C `SYNTAQLITE_SPAN_FLAG_QUOTED` from `types.h`.
-    const SPAN_FLAG_QUOTED: u8 = 1;
+    const SPAN_FLAG_QUOTED: u32 = 1;
 
     impl CTextSpan {
         /// Returns `true` if the span covers zero bytes.

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -65,8 +65,7 @@ pub(crate) struct CParserToken {
     /// Internal: 0 = original source, >0 = expansion layer id.
     /// Read only by C-side span accessors; the Rust side does not
     /// inspect it directly.
-    pub _layer_id: u8,
-    pub _pad: [u8; 3],
+    pub _layer_id: u32,
 }
 
 /// Mirrors C `SyntaqliteToken` from `include/syntaqlite/tokenizer.h`.

--- a/syntaqlite/tests/low_level.rs
+++ b/syntaqlite/tests/low_level.rs
@@ -7,6 +7,7 @@ use syntaqlite::nodes::Stmt;
 use syntaqlite::parse::ParserConfig;
 use syntaqlite::parse::TokenType;
 use syntaqlite::{ParseOutcome, Parser};
+use syntaqlite_syntax::{MacroArg, MacroLookup, MacroOutput};
 
 /// Feed tokens for "SELECT 1" via the low-level API and verify same AST
 /// as the high-level parse.
@@ -475,5 +476,100 @@ fn field_source_range_direct_span() {
     assert!(
         spans.iter().any(|&(_, start, end)| start == 7 && end == 8),
         "expected to find span at range 7..8, got: {spans:?}"
+    );
+}
+
+/// Walk an AST collecting all non-empty `TextSpan` fields recursively.
+fn collect_all_spans(
+    stmt: &syntaqlite_syntax::any::AnyParsedStatement<'_>,
+    node_id: syntaqlite_syntax::any::AnyNodeId,
+    out: &mut Vec<syntaqlite_syntax::any::TextSpan>,
+) {
+    use syntaqlite_syntax::any::FieldValue;
+    if node_id.is_null() {
+        return;
+    }
+    if let Some((_, fields)) = stmt.extract_fields(node_id) {
+        for idx in 0..fields.len() {
+            match fields[idx] {
+                FieldValue::Span(sp) if !sp.is_empty() => out.push(sp),
+                FieldValue::NodeId(child) if !child.is_null() => {
+                    collect_all_spans(stmt, child, out);
+                }
+                _ => {}
+            }
+        }
+    }
+    if let Some(children) = stmt.list_children(node_id) {
+        for &child in children {
+            collect_all_spans(stmt, child, out);
+        }
+    }
+}
+
+/// When a single statement has more than 255 macro expansions, the parser
+/// must not wrap `_layer_id` at 256 (`uint8_t` overflow). Regression test
+/// for <https://github.com/LalitMaganti/syntaqlite/issues/128>.
+#[test]
+fn layer_id_no_overflow_at_256_expansions() {
+    struct ConstMacro;
+    impl MacroLookup for ConstMacro {
+        fn lookup(&mut self, _name: &str, _args: &[MacroArg<'_>], out: &mut MacroOutput) -> bool {
+            out.write("42");
+            true
+        }
+    }
+
+    // Build a SELECT with 260 macro calls: SELECT mm!(), mm!(), ..., mm!();
+    // Each call creates one expansion layer, pushing well past 255.
+    let mut sql = String::from("SELECT ");
+    for i in 0..260 {
+        if i > 0 {
+            sql.push_str(", ");
+        }
+        sql.push_str("mm!()");
+    }
+    sql.push(';');
+
+    let config = ParserConfig::default()
+        .with_collect_tokens(true)
+        .with_collect_node_extents(true)
+        .with_macro_fallback(true);
+    let mut parser = Parser::with_config(&config);
+    parser.set_macro_lookup(Some(Box::new(ConstMacro)));
+    let mut session = parser.parse(&sql);
+
+    let ParseOutcome::Ok(stmt) = session.next() else {
+        panic!("expected successful parse with 260 macro calls")
+    };
+    let erased = stmt.erase();
+
+    // Walk the AST collecting all Span fields, then check span_expanded_text.
+    // Each mm!() expansion produces a span whose expanded text is "42".
+    // If _layer_id wraps at 256, span_expanded_text reads from the source
+    // buffer instead, returning garbage like "SE".
+    let mut spans = Vec::new();
+    collect_all_spans(&erased, erased.root_id(), &mut spans);
+
+    // Every span_expanded_text must be a valid SQL fragment: either a
+    // source token ("SELECT", ",") or the macro body ("42"). If _layer_id
+    // wraps, we get source bytes at wrong offsets.
+    let mut bad = Vec::new();
+    for (i, &span) in spans.iter().enumerate() {
+        let expanded = erased.span_expanded_text(span);
+        // Source-layer tokens and correct macro expansions produce
+        // recognizable text. The wrapped case returns "SE" (source[0..2])
+        // for spans that should contain "42".
+        if expanded == "42" || expanded == "SELECT" || expanded == "," {
+            continue;
+        }
+        bad.push((i, expanded.to_string()));
+    }
+    assert!(
+        bad.is_empty(),
+        "span_expanded_text returned unexpected text for {} spans \
+         (_layer_id likely wrapped at 256): {:?}",
+        bad.len(),
+        &bad[..5.min(bad.len())]
     );
 }


### PR DESCRIPTION
## Motivation

`SyntaqliteTextSpan._layer_id` and related fields (`SynqExpansionLayer.parent_layer_id`, `SynqParseToken.layer_id`, `SyntaqliteParserToken._layer_id`) are `uint8_t`. When a single statement produces more than 255 expansion layers (e.g. 256+ macro calls in a VALUES table), the layer id wraps to 0 — the sentinel for the original source buffer. The span machinery then believes macro-produced spans came from the source, causing `node_text` / `span_expanded_text` to return wrong bytes (e.g. `"SE"` instead of `"42"`).

Fixes #128.

## Changes

- Widen `_layer_id`, `parent_layer_id`, and `layer_id` from `uint8_t`/`u8` to `uint32_t`/`u32` across all C structs and Rust FFI mirrors
- Widen `flags` field in `SyntaqliteTextSpan` to `uint32_t` to eliminate padding
- Remove truncating `(uint8_t)` casts in `parser.c` and `parser_macros.c`
- Remove `_pad` fields that are no longer needed
- Add regression test with 260 macro expansions verifying `span_expanded_text` correctness