### PR TITLE
synq: add SYNTAQLITE_OMIT_MACROS compile-time guard

### DIFF
--- a/python/dev/diff_tests/amalg_executor.py
+++ b/python/dev/diff_tests/amalg_executor.py
@@ -37,11 +37,14 @@ class DialectConfig:
     mode: AmalgMode = AmalgMode.FULL
     actions_dir: Optional[str] = None
     nodes_dir: Optional[str] = None
+    extra_cflags: tuple[str, ...] = ()
 
     @property
     def key(self) -> str:
         """Unique build-cache key."""
-        return f"{self.name}_{self.mode.value}"
+        suffix = "_".join(f.lstrip("-D").lower() for f in self.extra_cflags)
+        base = f"{self.name}_{self.mode.value}"
+        return f"{base}_{suffix}" if suffix else base
 
 
 # ---------------------------------------------------------------------------
@@ -93,7 +96,8 @@ def _build_runtime_only(cli_binary: Path, output_dir: Path) -> None:
 # ---------------------------------------------------------------------------
 
 def _compile_full_binary(
-    test_c: Path, amalg_dir: Path, dialect_name: str, output_binary: Path
+    test_c: Path, amalg_dir: Path, dialect_name: str, output_binary: Path,
+    extra_cflags: tuple[str, ...] = (),
 ) -> None:
     """Compile test_ast.c against a self-contained full amalgamation."""
     grammar_header = f'"syntaqlite_{dialect_name}.h"'
@@ -106,6 +110,7 @@ def _compile_full_binary(
         f"-DGRAMMAR_HEADER={grammar_header}",
         f"-DGRAMMAR_FN={grammar_fn}",
         "-Werror",
+        *extra_cflags,
     ]
     proc = subprocess.run(cmd, capture_output=True, text=True)
     if proc.returncode != 0:
@@ -285,7 +290,8 @@ class AmalgTestContext:
         if dialect.mode == AmalgMode.FULL:
             _build_full(self.cli_binary, dialect, amalg_dir)
             binary = temp / f"test_{key}"
-            _compile_full_binary(self.test_c, amalg_dir, dialect.name, binary)
+            _compile_full_binary(self.test_c, amalg_dir, dialect.name, binary,
+                                extra_cflags=dialect.extra_cflags)
 
         elif dialect.mode == AmalgMode.DIALECT_ONLY:
             _build_dialect_only(self.cli_binary, dialect, amalg_dir)

--- a/python/dev/integration_tests/suites/amalg.py
+++ b/python/dev/integration_tests/suites/amalg.py
@@ -39,6 +39,10 @@ def _dialect_configs(root_dir: Path) -> dict[str, DialectConfig]:
     perfetto_nodes = str(root_dir / "dialects/perfetto/nodes")
     return {
         "sqliteamalgfull": DialectConfig(name="sqlite", mode=AmalgMode.FULL),
+        "sqliteamalgomitmacros": DialectConfig(
+            name="sqlite", mode=AmalgMode.FULL,
+            extra_cflags=("-DSYNTAQLITE_OMIT_MACROS",),
+        ),
         "sqliteamalgruntimeonly": DialectConfig(name="sqlite", mode=AmalgMode.DIALECT_ONLY),
         "perfettoamalgfull": DialectConfig(
             name="perfetto", mode=AmalgMode.FULL,

--- a/syntaqlite-buildtools/src/main.rs
+++ b/syntaqlite-buildtools/src/main.rs
@@ -168,6 +168,10 @@ struct AmalgamateSyntaxArgs {
     /// Output directory for the amalgamated .h and .c files.
     #[arg(long, required = true)]
     output_dir: String,
+    /// Compile out macro expansion support (`SYNTAQLITE_OMIT_MACROS`).
+    /// Use for dialects that do not use macro calls.
+    #[arg(long, default_value_t = false)]
+    omit_macros: bool,
 }
 
 // ── amalgamate ────────────────────────────────────────────────────────────────
@@ -228,6 +232,7 @@ fn main() {
                 &args.dialect,
                 runtime,
                 dialect,
+                args.omit_macros,
             )?;
             std::fs::create_dir_all(output).map_err(|e| format!("creating output dir: {e}"))?;
             let h_path = output.join(format!("syntaqlite_{}.h", args.dialect));

--- a/syntaqlite-buildtools/src/parser_tools/amalgamate.rs
+++ b/syntaqlite-buildtools/src/parser_tools/amalgamate.rs
@@ -111,9 +111,20 @@ pub struct AmalgamateOutput {
 /// # Errors
 ///
 /// Returns an error if reading source files from `runtime_dir` fails.
+/// Emit `#ifndef / #define / #endif` for a compile-time omit flag.
+fn emit_omit_define(out: &mut String, name: &str) {
+    let _ = write!(out, "#ifndef {name}\n#define {name}\n#endif\n\n");
+}
+
+/// Produce the runtime-only amalgamation: `syntaqlite_runtime.{h,c}` +
+/// `syntaqlite_dialect.h`.
+///
+/// # Errors
+///
+/// Returns an error if reading source files from `runtime_dir` fails.
 pub fn amalgamate_runtime(runtime_dir: &Path) -> Result<AmalgamateOutput, String> {
     let files = collect_files(&[&runtime_dir.join("csrc"), &runtime_dir.join("include")])?;
-    Ok(emit(&files, EmitMode::RuntimeOnly))
+    Ok(emit(&files, EmitMode::RuntimeOnly, false))
 }
 
 /// Produce `syntaqlite_<dialect>.{h,c}` that references `syntaqlite_runtime.h`
@@ -145,10 +156,15 @@ pub fn amalgamate_dialect(
             runtime_header: runtime_header.unwrap_or("syntaqlite_runtime.h"),
             ext_header: ext_header.unwrap_or("syntaqlite_dialect.h"),
         },
+        false,
     ))
 }
 
 /// Produce `syntaqlite_<dialect>.{h,c}` with the runtime inlined.
+///
+/// When `omit_macros` is true, `SYNTAQLITE_OMIT_MACROS` is injected into
+/// the amalgamation header and source, compiling out all macro expansion
+/// code.
 ///
 /// # Errors
 ///
@@ -157,6 +173,7 @@ pub fn amalgamate_full(
     dialect: &str,
     runtime_dir: &Path,
     dialect_dir: &Path,
+    omit_macros: bool,
 ) -> Result<AmalgamateOutput, String> {
     let files = collect_files(&[
         &runtime_dir.join("csrc"),
@@ -164,7 +181,7 @@ pub fn amalgamate_full(
         &dialect_dir.join("csrc"),
         &dialect_dir.join("include"),
     ])?;
-    Ok(emit(&files, EmitMode::Full(dialect)))
+    Ok(emit(&files, EmitMode::Full(dialect), omit_macros))
 }
 
 // ---------------------------------------------------------------------------
@@ -534,7 +551,7 @@ fn detect_include_guard(content: &str) -> Option<String> {
     clippy::too_many_lines,
     reason = "large emit function; splitting would harm readability"
 )]
-fn emit(files: &FileMap, mode: EmitMode) -> AmalgamateOutput {
+fn emit(files: &FileMap, mode: EmitMode, omit_macros: bool) -> AmalgamateOutput {
     let (guard, header_filename) = match &mode {
         EmitMode::DialectOnly { dialect: d, .. } | EmitMode::Full(d) => (
             format!("SYNTAQLITE_{}_H", d.to_uppercase()),
@@ -561,9 +578,10 @@ fn emit(files: &FileMap, mode: EmitMode) -> AmalgamateOutput {
             ..
         } => {
             if *dialect != "sqlite" {
-                header.push_str("#ifndef SYNTAQLITE_OMIT_SQLITE_API\n");
-                header.push_str("#define SYNTAQLITE_OMIT_SQLITE_API\n");
-                header.push_str("#endif\n\n");
+                emit_omit_define(&mut header, "SYNTAQLITE_OMIT_SQLITE_API");
+            }
+            if omit_macros {
+                emit_omit_define(&mut header, "SYNTAQLITE_OMIT_MACROS");
             }
             header.push_str("#ifndef SYNTAQLITE_RUNTIME_HEADER\n");
             let _ = writeln!(
@@ -574,9 +592,13 @@ fn emit(files: &FileMap, mode: EmitMode) -> AmalgamateOutput {
             header.push_str("#include SYNTAQLITE_RUNTIME_HEADER\n\n");
         }
         EmitMode::Full(dialect) if *dialect != "sqlite" => {
-            header.push_str("#ifndef SYNTAQLITE_OMIT_SQLITE_API\n");
-            header.push_str("#define SYNTAQLITE_OMIT_SQLITE_API\n");
-            header.push_str("#endif\n\n");
+            emit_omit_define(&mut header, "SYNTAQLITE_OMIT_SQLITE_API");
+            if omit_macros {
+                emit_omit_define(&mut header, "SYNTAQLITE_OMIT_MACROS");
+            }
+        }
+        EmitMode::Full(_) if omit_macros => {
+            emit_omit_define(&mut header, "SYNTAQLITE_OMIT_MACROS");
         }
         _ => {}
     }
@@ -629,9 +651,10 @@ fn emit(files: &FileMap, mode: EmitMode) -> AmalgamateOutput {
     } = &mode
     {
         if *dialect != "sqlite" {
-            source.push_str("#ifndef SYNTAQLITE_OMIT_SQLITE_API\n");
-            source.push_str("#define SYNTAQLITE_OMIT_SQLITE_API\n");
-            source.push_str("#endif\n\n");
+            emit_omit_define(&mut source, "SYNTAQLITE_OMIT_SQLITE_API");
+        }
+        if omit_macros {
+            emit_omit_define(&mut source, "SYNTAQLITE_OMIT_MACROS");
         }
         source.push_str("#ifndef SYNTAQLITE_RUNTIME_HEADER\n");
         let _ = writeln!(
@@ -647,9 +670,12 @@ fn emit(files: &FileMap, mode: EmitMode) -> AmalgamateOutput {
     } else if let EmitMode::Full(dialect) = &mode
         && *dialect != "sqlite"
     {
-        source.push_str("#ifndef SYNTAQLITE_OMIT_SQLITE_API\n");
-        source.push_str("#define SYNTAQLITE_OMIT_SQLITE_API\n");
-        source.push_str("#endif\n\n");
+        emit_omit_define(&mut source, "SYNTAQLITE_OMIT_SQLITE_API");
+        if omit_macros {
+            emit_omit_define(&mut source, "SYNTAQLITE_OMIT_MACROS");
+        }
+    } else if omit_macros {
+        emit_omit_define(&mut source, "SYNTAQLITE_OMIT_MACROS");
     }
     let _ = write!(source, "#include \"{header_filename}\"\n\n");
 

--- a/syntaqlite-cli/src/codegen.rs
+++ b/syntaqlite-cli/src/codegen.rs
@@ -195,7 +195,8 @@ fn cmd_generate_dialect_full(
 
     let out = Path::new(output_dir);
     ensure_dir(out, "output dir")?;
-    let result = amalgamate::amalgamate_full(dialect, runtime_temp.path(), dialect_temp.path())?;
+    let result =
+        amalgamate::amalgamate_full(dialect, runtime_temp.path(), dialect_temp.path(), false)?;
     write_file(&out.join(format!("syntaqlite_{dialect}.h")), &result.header)?;
     write_file(&out.join(format!("syntaqlite_{dialect}.c")), &result.source)?;
     eprintln!(

--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -63,17 +63,16 @@ static void reset_stmt(SyntaqliteParser* p) {
   synq_parse_ctx_clear(&p->ctx);
   syntaqlite_vec_clear(&p->comments);
   syntaqlite_vec_clear(&p->tokens);
+#ifndef SYNTAQLITE_OMIT_MACROS
   syntaqlite_vec_clear(&p->macro.traceback_buf);
   syntaqlite_vec_clear(&p->macro.node_expanded_buf);
   synq_layers_free_owned(&p->macro.layers, p->mem);
   syntaqlite_vec_clear(&p->macro.layers);
-  // Push sentinel at index 0 (source layer).  p->source may be NULL on
-  // the very first reset_stmt call (before syntaqlite_parser_reset sets it),
-  // which is fine — syntaqlite_parser_reset re-clears and re-pushes.
   if (p->source)
     synq_layers_push_sentinel(&p->macro.layers, p->source, p->source_len,
                               p->mem);
   p->macro.expansion_depth = 0;
+#endif
   p->ctx.layer_id = 0;
   p->ctx.cur_shift_start = 0;
   p->ctx.last_shifted_end = 0;
@@ -103,8 +102,10 @@ static int32_t stmt_boundary(SyntaqliteParser* p) {
   if (p->ctx.root == SYNTAQLITE_NULL_NODE && !p->had_error)
     return SYNTAQLITE_PARSE_DONE;
 
+#ifndef SYNTAQLITE_OMIT_MACROS
   if (synq_parser_check_macro_straddle(p) < 0)
     return SYNTAQLITE_PARSE_ERROR;
+#endif
 
   if (p->had_error) {
     p->had_error = 0;  // consumed for this result
@@ -129,9 +130,9 @@ SYNTAQLITE_API SyntaqliteParser* syntaqlite_parser_create_with_dialect(
   synq_parse_ctx_init(&p->ctx, m);
   syntaqlite_vec_init(&p->comments);
   syntaqlite_vec_init(&p->tokens);
-  // All macro-related vecs (layers, traceback_buf, node_expanded_buf,
-  // expand_buf, body_buf) initialized inside synq_macro_state_init.
+#ifndef SYNTAQLITE_OMIT_MACROS
   synq_macro_state_init(&p->macro);
+#endif
   return p;
 }
 
@@ -158,12 +159,11 @@ SYNTAQLITE_API void syntaqlite_parser_reset(SyntaqliteParser* p,
   p->finished = 0;
   p->pending_reset = 0;
   p->last_status = SYNTAQLITE_PARSE_DONE;
+#ifndef SYNTAQLITE_OMIT_MACROS
   p->macro.depth = 0;
-
-  // Re-push the sentinel with the correct source pointer (reset_stmt may
-  // have pushed one with the old source, or none if source was NULL).
   syntaqlite_vec_clear(&p->macro.layers);
   synq_layers_push_sentinel(&p->macro.layers, source, len, p->mem);
+#endif
 
   p->ctx.source = source;
   p->ctx.env = &p->dialect;
@@ -175,7 +175,9 @@ SYNTAQLITE_API void syntaqlite_parser_destroy(SyntaqliteParser* p) {
     synq_parse_ctx_free(&p->ctx);
     syntaqlite_vec_free(&p->comments, p->mem);
     syntaqlite_vec_free(&p->tokens, p->mem);
+#ifndef SYNTAQLITE_OMIT_MACROS
     synq_macro_state_free(&p->macro, p->mem);
+#endif
     p->mem.xFree(p);
   }
 }
@@ -288,8 +290,10 @@ static int finish_input(SyntaqliteParser* p) {
   }
 
   if (p->ctx.root != SYNTAQLITE_NULL_NODE) {
+#ifndef SYNTAQLITE_OMIT_MACROS
     if (synq_parser_check_macro_straddle(p) < 0)
       return set_result_status(p, SYNTAQLITE_PARSE_ERROR);
+#endif
     return set_result_status(
         p, p->had_error ? SYNTAQLITE_PARSE_ERROR : SYNTAQLITE_PARSE_OK);
   }
@@ -363,8 +367,13 @@ static int64_t next_token(SyntaqliteParser* p,
                           uint32_t* out_type) {
   while (pos < p->source_len && z[pos] != '\0') {
     uint32_t type = 0;
+#ifdef SYNTAQLITE_OMIT_MACROS
+    int64_t len =
+        SynqSqliteGetTokenVersionWrapped(&p->dialect, 0, z + pos, &type);
+#else
     int64_t len = SynqSqliteGetTokenVersionWrapped(
         &p->dialect, p->macro.macro_fallback, z + pos, &type);
+#endif
     if (len <= 0)
       return 0;
     if (type == SYNTAQLITE_TK_SPACE) {
@@ -493,6 +502,7 @@ SYNTAQLITE_API int32_t syntaqlite_parser_next(SyntaqliteParser* p) {
     uint32_t la_type = 0;
     int64_t la_len = next_token(p, z, p->offset, &la_offset, &la_type);
 
+#ifndef SYNTAQLITE_OMIT_MACROS
     // Macro detection: ID followed by TK_BANG ('!').  The token wrapper
     // produces TK_BANG for any dialect that may have macro calls (Rust-style
     // dialects or any dialect with macro_fallback enabled).
@@ -507,6 +517,7 @@ SYNTAQLITE_API int32_t syntaqlite_parser_next(SyntaqliteParser* p) {
         continue;
       }
     }
+#endif
 
     // Normal token (or macro fallthrough): record + feed to Lemon.
     if (synq_parser_record_and_feed(p, cur_type, cur_offset, (uint32_t)cur_len))
@@ -566,12 +577,23 @@ SYNTAQLITE_API const SyntaqliteParserToken* syntaqlite_result_tokens(
   return p->tokens.data;
 }
 
+#ifdef SYNTAQLITE_OMIT_MACROS
+SYNTAQLITE_API uint32_t syntaqlite_result_macro_count(SyntaqliteParser* p) {
+  (void)p;
+  return 0;
+}
+SYNTAQLITE_API SyntaqliteMacroRegion
+syntaqlite_result_macro_at(SyntaqliteParser* p, uint32_t idx) {
+  (void)p;
+  (void)idx;
+  return (SyntaqliteMacroRegion){0, 0};
+}
+#else
 SYNTAQLITE_API uint32_t syntaqlite_result_macro_count(SyntaqliteParser* p) {
   uint32_t total = syntaqlite_vec_len(&p->macro.layers);
   // Entry 0 is the source sentinel; real expansion layers start at 1.
   return total <= 1 ? 0 : total - 1;
 }
-
 SYNTAQLITE_API SyntaqliteMacroRegion
 syntaqlite_result_macro_at(SyntaqliteParser* p, uint32_t idx) {
   // +1 to skip the source sentinel at index 0.
@@ -582,6 +604,7 @@ syntaqlite_result_macro_at(SyntaqliteParser* p, uint32_t idx) {
   const SynqExpansionLayer* lyr = &p->macro.layers.data[layer_idx];
   return (SyntaqliteMacroRegion){lyr->call_offset, lyr->call_length};
 }
+#endif
 
 // ---------------------------------------------------------------------------
 // Arena accessors
@@ -596,12 +619,14 @@ SYNTAQLITE_API uint32_t syntaqlite_parser_node_count(SyntaqliteParser* p) {
   return syntaqlite_vec_len(&p->ctx.ast.offsets);
 }
 
+#ifndef SYNTAQLITE_OMIT_MACROS
 static void append_expanded_range(SyntaqliteParser* p,
                                   uint32_t layer_id,
                                   const char* buf,
                                   uint32_t buf_len,
                                   uint32_t start,
                                   uint32_t end);
+#endif
 
 SYNTAQLITE_API const char* syntaqlite_parser_text(SyntaqliteParser* p,
                                                   uint32_t* out_len) {
@@ -613,21 +638,20 @@ SYNTAQLITE_API const char* syntaqlite_parser_text(SyntaqliteParser* p,
 
 SYNTAQLITE_API const char* syntaqlite_parser_expanded_text(SyntaqliteParser* p,
                                                            uint32_t* out_len) {
+#ifdef SYNTAQLITE_OMIT_MACROS
+  // Without macros, expanded text == source text.
+  return syntaqlite_parser_text(p, out_len);
+#else
   if (out_len) {
     *out_len = 0;
   }
-  // Materialize the whole input with every currently-active macro
-  // call replaced by its expansion buffer.  Walks the full source
-  // range `[0, source_len)` using the same recursive inliner as
-  // `syntaqlite_parser_node_expanded_text` and writes the result into
-  // the parser's scratch buffer.  Returned pointer is valid until the
-  // next call or `reset_stmt`.
   syntaqlite_vec_clear(&p->macro.node_expanded_buf);
   append_expanded_range(p, 0, p->source, p->source_len, 0, p->source_len);
   if (out_len) {
     *out_len = syntaqlite_vec_len(&p->macro.node_expanded_buf);
   }
   return (const char*)p->macro.node_expanded_buf.data;
+#endif
 }
 
 // ---------------------------------------------------------------------------
@@ -759,8 +783,13 @@ SYNTAQLITE_API int32_t syntaqlite_parser_set_macro_fallback(SyntaqliteParser* p,
                                                             uint32_t enable) {
   if (p->sealed)
     return -1;
+#ifdef SYNTAQLITE_OMIT_MACROS
+  (void)enable;
+  return -1;
+#else
   p->macro.macro_fallback = enable;
   return 0;
+#endif
 }
 
 SYNTAQLITE_API int32_t
@@ -802,11 +831,7 @@ SYNTAQLITE_API const char* syntaqlite_parser_node_text(SyntaqliteParser* p,
   return p->source + r.root_start;
 }
 
-// Recursively append `buf[start..end]` to `out`, inlining any child
-// expansion layers whose parent is `layer_id` and whose call site
-// falls within `[start, end)`.  For each child found, writes the bytes
-// up to its call site, then recurses into the child's expansion data.
-// This materializes the post-expansion view of a byte range.
+#ifndef SYNTAQLITE_OMIT_MACROS
 static void append_expanded_range(SyntaqliteParser* p,
                                   uint32_t layer_id,
                                   const char* buf,
@@ -854,11 +879,16 @@ static void append_expanded_range(SyntaqliteParser* p,
     syntaqlite_vec_push_n(&p->macro.node_expanded_buf, buf + cursor, n, p->mem);
   }
 }
+#endif  // !SYNTAQLITE_OMIT_MACROS
 
 SYNTAQLITE_API const char* syntaqlite_parser_node_expanded_text(
     SyntaqliteParser* p,
     uint32_t node_id,
     uint32_t* out_len) {
+#ifdef SYNTAQLITE_OMIT_MACROS
+  // Without macros, expanded text == authored text.
+  return syntaqlite_parser_node_text(p, node_id, out_len, NULL);
+#else
   if (out_len) {
     *out_len = 0;
   }
@@ -869,9 +899,6 @@ SYNTAQLITE_API const char* syntaqlite_parser_node_expanded_text(
     return NULL;
   }
 
-  // Fast path: node's tokens all live in one layer → return a direct
-  // slice of that layer's buffer, no allocation.  Cross-layer nodes
-  // have layer_id == SYNQ_CROSS_LAYER and fall through to the slow path.
   SynqNodeExpandedExtent e =
       syntaqlite_vec_at(&p->ctx.node_expanded_extents, node_id);
   if (e.length > 0) {
@@ -884,11 +911,6 @@ SYNTAQLITE_API const char* syntaqlite_parser_node_expanded_text(
     return buf + e.offset;
   }
 
-  // Slow path: the node's tokens cross layers.  Materialize the
-  // post-expansion text by walking the node's root range and inlining
-  // each enclosed macro call's expansion buffer.  The result is
-  // written into the parser's scratch buffer and the returned pointer
-  // is valid until the next call or `reset_stmt`.
   if (node_id >= syntaqlite_vec_len(&p->ctx.node_extents)) {
     return NULL;
   }
@@ -903,10 +925,16 @@ SYNTAQLITE_API const char* syntaqlite_parser_node_expanded_text(
     *out_len = syntaqlite_vec_len(&p->macro.node_expanded_buf);
   }
   return (const char*)p->macro.node_expanded_buf.data;
+#endif
 }
 
 SYNTAQLITE_API int syntaqlite_node_is_macro_free(SyntaqliteParser* p,
                                                  uint32_t node_id) {
+#ifdef SYNTAQLITE_OMIT_MACROS
+  (void)p;
+  (void)node_id;
+  return 1;  // No macros → all nodes are macro-free.
+#else
   if (!p->ctx.collect_node_extents) {
     return 0;
   }
@@ -917,4 +945,67 @@ SYNTAQLITE_API int syntaqlite_node_is_macro_free(SyntaqliteParser* p,
       syntaqlite_vec_at(&p->ctx.node_expanded_extents, node_id);
   // length == 0 is the sentinel for epsilon or multi-layer nodes.
   return e.length > 0 && e.layer_id == 0;
+#endif
 }
+
+// ---------------------------------------------------------------------------
+// SYNTAQLITE_OMIT_MACROS stubs for span/traceback APIs
+// ---------------------------------------------------------------------------
+//
+// When macros are compiled out, parser_spans.c is empty.  These stubs
+// provide the same public API with trivial implementations: all spans
+// are in layer 0 (source), so span_text is a direct source slice and
+// traceback returns NULL (no expansion frames to report).
+
+#ifdef SYNTAQLITE_OMIT_MACROS
+
+SYNTAQLITE_API const char* syntaqlite_parser_span_text(
+    SyntaqliteParser* p,
+    const SyntaqliteTextSpan* span,
+    uint32_t* out_len,
+    uint32_t* out_offset) {
+  if (out_offset)
+    *out_offset = 0;
+  if (!span || span->length == 0) {
+    *out_len = 0;
+    return NULL;
+  }
+  if (span->offset + span->length > p->source_len) {
+    *out_len = 0;
+    return NULL;
+  }
+  *out_len = span->length;
+  if (out_offset)
+    *out_offset = span->offset;
+  return p->source + span->offset;
+}
+
+SYNTAQLITE_API const char* syntaqlite_parser_span_expanded_text(
+    SyntaqliteParser* p,
+    const SyntaqliteTextSpan* span,
+    uint32_t* out_len) {
+  return syntaqlite_parser_span_text(p, span, out_len, NULL);
+}
+
+SYNTAQLITE_API const SyntaqliteTracebackFrame* syntaqlite_parser_traceback(
+    SyntaqliteParser* p,
+    const SyntaqliteTextSpan* sp,
+    uint32_t* out_count) {
+  (void)p;
+  (void)sp;
+  if (out_count)
+    *out_count = 0;
+  return NULL;
+}
+
+SYNTAQLITE_API int32_t
+syntaqlite_parser_set_macro_lookup(SyntaqliteParser* p,
+                                   SyntaqliteMacroLookupFn fn,
+                                   void* user_data) {
+  (void)p;
+  (void)fn;
+  (void)user_data;
+  return -1;
+}
+
+#endif  // SYNTAQLITE_OMIT_MACROS

--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -63,15 +63,16 @@ static void reset_stmt(SyntaqliteParser* p) {
   synq_parse_ctx_clear(&p->ctx);
   syntaqlite_vec_clear(&p->comments);
   syntaqlite_vec_clear(&p->tokens);
-  syntaqlite_vec_clear(&p->traceback_buf);
-  syntaqlite_vec_clear(&p->node_expanded_buf);
-  synq_layers_free_owned(&p->layers, p->mem);
-  syntaqlite_vec_clear(&p->layers);
+  syntaqlite_vec_clear(&p->macro.traceback_buf);
+  syntaqlite_vec_clear(&p->macro.node_expanded_buf);
+  synq_layers_free_owned(&p->macro.layers, p->mem);
+  syntaqlite_vec_clear(&p->macro.layers);
   // Push sentinel at index 0 (source layer).  p->source may be NULL on
   // the very first reset_stmt call (before syntaqlite_parser_reset sets it),
   // which is fine — syntaqlite_parser_reset re-clears and re-pushes.
   if (p->source)
-    synq_layers_push_sentinel(&p->layers, p->source, p->source_len, p->mem);
+    synq_layers_push_sentinel(&p->macro.layers, p->source, p->source_len,
+                              p->mem);
   p->macro.expansion_depth = 0;
   p->ctx.layer_id = 0;
   p->ctx.cur_shift_start = 0;
@@ -128,10 +129,8 @@ SYNTAQLITE_API SyntaqliteParser* syntaqlite_parser_create_with_dialect(
   synq_parse_ctx_init(&p->ctx, m);
   syntaqlite_vec_init(&p->comments);
   syntaqlite_vec_init(&p->tokens);
-  syntaqlite_vec_init(&p->layers);
-  syntaqlite_vec_init(&p->traceback_buf);
-  syntaqlite_vec_init(&p->node_expanded_buf);
-  // macro callback/expansion fields already zeroed by memset.
+  // All macro-related vecs (layers, traceback_buf, node_expanded_buf,
+  // expand_buf, body_buf) initialized inside synq_macro_state_init.
   synq_macro_state_init(&p->macro);
   return p;
 }
@@ -163,8 +162,8 @@ SYNTAQLITE_API void syntaqlite_parser_reset(SyntaqliteParser* p,
 
   // Re-push the sentinel with the correct source pointer (reset_stmt may
   // have pushed one with the old source, or none if source was NULL).
-  syntaqlite_vec_clear(&p->layers);
-  synq_layers_push_sentinel(&p->layers, source, len, p->mem);
+  syntaqlite_vec_clear(&p->macro.layers);
+  synq_layers_push_sentinel(&p->macro.layers, source, len, p->mem);
 
   p->ctx.source = source;
   p->ctx.env = &p->dialect;
@@ -176,10 +175,6 @@ SYNTAQLITE_API void syntaqlite_parser_destroy(SyntaqliteParser* p) {
     synq_parse_ctx_free(&p->ctx);
     syntaqlite_vec_free(&p->comments, p->mem);
     syntaqlite_vec_free(&p->tokens, p->mem);
-    synq_layers_free_owned(&p->layers, p->mem);
-    syntaqlite_vec_free(&p->layers, p->mem);
-    syntaqlite_vec_free(&p->traceback_buf, p->mem);
-    syntaqlite_vec_free(&p->node_expanded_buf, p->mem);
     synq_macro_state_free(&p->macro, p->mem);
     p->mem.xFree(p);
   }
@@ -369,7 +364,7 @@ static int64_t next_token(SyntaqliteParser* p,
   while (pos < p->source_len && z[pos] != '\0') {
     uint32_t type = 0;
     int64_t len = SynqSqliteGetTokenVersionWrapped(
-        &p->dialect, p->macro_fallback, z + pos, &type);
+        &p->dialect, p->macro.macro_fallback, z + pos, &type);
     if (len <= 0)
       return 0;
     if (type == SYNTAQLITE_TK_SPACE) {
@@ -572,7 +567,7 @@ SYNTAQLITE_API const SyntaqliteParserToken* syntaqlite_result_tokens(
 }
 
 SYNTAQLITE_API uint32_t syntaqlite_result_macro_count(SyntaqliteParser* p) {
-  uint32_t total = syntaqlite_vec_len(&p->layers);
+  uint32_t total = syntaqlite_vec_len(&p->macro.layers);
   // Entry 0 is the source sentinel; real expansion layers start at 1.
   return total <= 1 ? 0 : total - 1;
 }
@@ -581,10 +576,10 @@ SYNTAQLITE_API SyntaqliteMacroRegion
 syntaqlite_result_macro_at(SyntaqliteParser* p, uint32_t idx) {
   // +1 to skip the source sentinel at index 0.
   uint32_t layer_idx = idx + 1;
-  if (layer_idx >= syntaqlite_vec_len(&p->layers)) {
+  if (layer_idx >= syntaqlite_vec_len(&p->macro.layers)) {
     return (SyntaqliteMacroRegion){0, 0};
   }
-  const SynqExpansionLayer* lyr = &p->layers.data[layer_idx];
+  const SynqExpansionLayer* lyr = &p->macro.layers.data[layer_idx];
   return (SyntaqliteMacroRegion){lyr->call_offset, lyr->call_length};
 }
 
@@ -627,12 +622,12 @@ SYNTAQLITE_API const char* syntaqlite_parser_expanded_text(SyntaqliteParser* p,
   // `syntaqlite_parser_node_expanded_text` and writes the result into
   // the parser's scratch buffer.  Returned pointer is valid until the
   // next call or `reset_stmt`.
-  syntaqlite_vec_clear(&p->node_expanded_buf);
+  syntaqlite_vec_clear(&p->macro.node_expanded_buf);
   append_expanded_range(p, 0, p->source, p->source_len, 0, p->source_len);
   if (out_len) {
-    *out_len = syntaqlite_vec_len(&p->node_expanded_buf);
+    *out_len = syntaqlite_vec_len(&p->macro.node_expanded_buf);
   }
-  return (const char*)p->node_expanded_buf.data;
+  return (const char*)p->macro.node_expanded_buf.data;
 }
 
 // ---------------------------------------------------------------------------
@@ -764,7 +759,7 @@ SYNTAQLITE_API int32_t syntaqlite_parser_set_macro_fallback(SyntaqliteParser* p,
                                                             uint32_t enable) {
   if (p->sealed)
     return -1;
-  p->macro_fallback = enable;
+  p->macro.macro_fallback = enable;
   return 0;
 }
 
@@ -823,14 +818,14 @@ static void append_expanded_range(SyntaqliteParser* p,
   if (end > buf_len)
     end = buf_len;
   uint32_t cursor = start;
-  uint32_t nlayers = syntaqlite_vec_len(&p->layers);
+  uint32_t nlayers = syntaqlite_vec_len(&p->macro.layers);
   for (;;) {
     // Find the next child layer (parent == layer_id) whose call site
     // begins at or after `cursor` and lies fully within `[start, end)`.
     uint32_t best_child = 0;
     uint32_t best_offset = UINT32_MAX;
     for (uint32_t i = 1; i < nlayers; i++) {
-      const SynqExpansionLayer* lyr = &p->layers.data[i];
+      const SynqExpansionLayer* lyr = &p->macro.layers.data[i];
       if (lyr->parent_layer_id != layer_id)
         continue;
       if (lyr->call_offset < cursor)
@@ -844,10 +839,11 @@ static void append_expanded_range(SyntaqliteParser* p,
     }
     if (best_child == 0)
       break;
-    const SynqExpansionLayer* child = &p->layers.data[best_child];
+    const SynqExpansionLayer* child = &p->macro.layers.data[best_child];
     if (best_offset > cursor) {
       uint32_t n = best_offset - cursor;
-      syntaqlite_vec_push_n(&p->node_expanded_buf, buf + cursor, n, p->mem);
+      syntaqlite_vec_push_n(&p->macro.node_expanded_buf, buf + cursor, n,
+                            p->mem);
     }
     append_expanded_range(p, best_child, child->expansion_data,
                           child->expansion_len, 0, child->expansion_len);
@@ -855,7 +851,7 @@ static void append_expanded_range(SyntaqliteParser* p,
   }
   if (end > cursor) {
     uint32_t n = end - cursor;
-    syntaqlite_vec_push_n(&p->node_expanded_buf, buf + cursor, n, p->mem);
+    syntaqlite_vec_push_n(&p->macro.node_expanded_buf, buf + cursor, n, p->mem);
   }
 }
 
@@ -879,8 +875,9 @@ SYNTAQLITE_API const char* syntaqlite_parser_node_expanded_text(
   SynqNodeExpandedExtent e =
       syntaqlite_vec_at(&p->ctx.node_expanded_extents, node_id);
   if (e.length > 0) {
-    const char* buf =
-        e.layer_id == 0 ? p->source : p->layers.data[e.layer_id].expansion_data;
+    const char* buf = e.layer_id == 0
+                          ? p->source
+                          : p->macro.layers.data[e.layer_id].expansion_data;
     if (out_len) {
       *out_len = e.length;
     }
@@ -899,13 +896,13 @@ SYNTAQLITE_API const char* syntaqlite_parser_node_expanded_text(
   if (r.root_start > r.root_end || r.root_end > p->source_len) {
     return NULL;
   }
-  syntaqlite_vec_clear(&p->node_expanded_buf);
+  syntaqlite_vec_clear(&p->macro.node_expanded_buf);
   append_expanded_range(p, 0, p->source, p->source_len, r.root_start,
                         r.root_end);
   if (out_len) {
-    *out_len = syntaqlite_vec_len(&p->node_expanded_buf);
+    *out_len = syntaqlite_vec_len(&p->macro.node_expanded_buf);
   }
-  return (const char*)p->node_expanded_buf.data;
+  return (const char*)p->macro.node_expanded_buf.data;
 }
 
 SYNTAQLITE_API int syntaqlite_node_is_macro_free(SyntaqliteParser* p,

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -34,7 +34,15 @@ extern "C" {
 #define SYNQ_PRINTF(fmt_idx, va_idx)
 #endif
 
-// ── Macro expansion types ────────────────────────────────────────────────
+// ── Macro expansion (compiled out with -DSYNTAQLITE_OMIT_MACROS) ─────────
+//
+// All macro-related types, struct fields, and helper declarations live
+// inside this guard.  When SYNTAQLITE_OMIT_MACROS is defined, the parser
+// struct shrinks and parser_macros.c / parser_spans.c compile to empty
+// translation units.  Public APIs that reference macro state (span_text,
+// traceback, expanded_text, etc.) are stubbed in parser.c.
+
+#ifndef SYNTAQLITE_OMIT_MACROS
 
 // A comma-separated argument extracted from a macro call site.
 typedef struct SynqMacroArg {
@@ -89,51 +97,64 @@ typedef struct SynqExpansionLayer {
 
 typedef SYNQ_VEC(SynqExpansionLayer) SynqExpansionLayerVec;
 
-// ── Macro expansion state ────────────────────────────────────────────────
-//
-// Groups callback registration, per-invocation state, scratch buffers,
-// and recursion detection.  Accessed almost exclusively from
-// parser_macros.c; parser.c only touches init/free/reset.
-
+// All macro-related parser state, including layer tree and scratch buffers.
+// Factored into a single sub-struct so the parser struct has one guarded
+// field: `SynqMacroState macro;`.
 typedef struct SynqMacroState {
-  // Callback registration.
+  // ── Configuration ──────────────────────────────────────────────────────
+  uint32_t macro_fallback;  // 1 = unregistered name!(args) becomes TK_ID.
+
+  // ── Callback registration ──────────────────────────────────────────────
   SyntaqliteMacroLookupFn lookup_fn;
   void* lookup_user_data;
 
-  // Per-invocation state (set before callback, cleared after).
-  // `pending_layer` indexes into p->layers for the layer the callback
+  // ── Per-invocation state (set before callback, cleared after) ──────────
+  // `pending_layer` indexes into layers for the layer the callback
   // should write into via set_result / expand_and_set_result.
   uint32_t pending_layer;
   const SyntaqliteToken* expansion_args;
   uint32_t expansion_arg_count;
 
-  // Scratch buffers (reused across invocations, freed in destroy).
+  // ── Scratch buffers (reused across invocations, freed in destroy) ──────
   SYNQ_VEC(uint8_t) expand_buf;  // Template expansion output.
   SYNQ_VEC(uint8_t) body_buf;    // NUL-terminated body staging.
 
-  // Blue-paint recursion detection: names of macros currently being expanded.
+  // ── Blue-paint recursion detection ─────────────────────────────────────
   const char* expansion_names[SYNQ_MAX_MACRO_DEPTH];
   uint32_t expansion_name_lens[SYNQ_MAX_MACRO_DEPTH];
   uint32_t expansion_depth;
 
-  // Nesting depth (0 = not in macro).
+  // ── Nesting depth (0 = not in macro) ───────────────────────────────────
   uint32_t depth;
+
+  // ── Layer tree ─────────────────────────────────────────────────────────
+  // Entry 0 is a sentinel representing the original source; actual
+  // expansions start at index 1.  `_layer_id` on AST spans indexes
+  // directly into this vector.
+  SynqExpansionLayerVec layers;
+
+  // ── Scratch buffers for span/text APIs ─────────────────────────────────
+  // Scratch for `syntaqlite_parser_traceback`.
+  SYNQ_VEC(SyntaqliteTracebackFrame) traceback_buf;
+  // Scratch for `syntaqlite_parser_node_expanded_text`.
+  SYNQ_VEC(uint8_t) node_expanded_buf;
 } SynqMacroState;
+
+#endif  // !SYNTAQLITE_OMIT_MACROS
 
 // ── Parser struct ───────────────────────────────────────────────────────────
 
 struct SyntaqliteParser {
-  // ── Core (shared by parser.c, parser_macros.c, parser_dump.c) ──────────
+  // ── Core ───────────────────────────────────────────────────────────────
   SyntaqliteMemMethods mem;
   SyntaqliteDialect dialect;
   void* lemon;
   SynqParseCtx ctx;
   const char* source;
   uint32_t source_len;
-  uint32_t offset;          // Tokenizer cursor into source.
-  uint32_t had_error;       // Sticky error flag for current result.
-  char error_msg[256];      // Error message buffer.
-  uint32_t macro_fallback;  // 1 = unregistered name!(args) becomes TK_ID.
+  uint32_t offset;      // Tokenizer cursor into source.
+  uint32_t had_error;   // Sticky error flag for current result.
+  char error_msg[256];  // Error message buffer.
 
   // ── Parser-only state (only parser.c) ──────────────────────────────────
   uint32_t last_token_type;  // Last non-whitespace token fed to Lemon.
@@ -148,24 +169,10 @@ struct SyntaqliteParser {
   SYNQ_VEC(SyntaqliteComment) comments;
   SYNQ_VEC(SyntaqliteParserToken) tokens;
 
-  // Scratch buffer for materializing the expanded text of mixed-layer
-  // nodes in `syntaqlite_parser_node_expanded_text`.  Rewritten on every
-  // call, invalidated by the next call / `reset_stmt`.
-  SYNQ_VEC(uint8_t) node_expanded_buf;
-
-  // ── Layer tree (shared — parser.c + parser_macros.c) ───────────────────
-  // Entry 0 is a sentinel representing the original source; actual
-  // expansions start at index 1.  `_layer_id` on AST spans indexes
-  // directly into this vector.
-  SynqExpansionLayerVec layers;
-
-  // Scratch buffer for `syntaqlite_parser_traceback`.  Rewritten on every
-  // call; pointers returned from one call are invalidated by the next
-  // (and by `reset_stmt`).
-  SYNQ_VEC(SyntaqliteTracebackFrame) traceback_buf;
-
-  // ── Macro expansion state (mostly parser_macros.c) ─────────────────────
+  // ── Macro expansion state (compiled out with SYNTAQLITE_OMIT_MACROS) ───
+#ifndef SYNTAQLITE_OMIT_MACROS
   SynqMacroState macro;
+#endif
 };
 
 // ── Cross-file helpers ──────────────────────────────────────────────────────
@@ -186,6 +193,8 @@ int synq_parser_record_and_feed(SyntaqliteParser* p,
                                 uint32_t cur_type,
                                 uint32_t cur_offset,
                                 uint32_t cur_len);
+
+#ifndef SYNTAQLITE_OMIT_MACROS
 
 // Scan balanced parens for macro args.  Defined in parser_macros.c.
 uint32_t synq_parser_scan_macro_args(SyntaqliteParser* p,
@@ -215,19 +224,14 @@ int synq_parser_try_macro_call(SyntaqliteParser* p,
                                uint32_t id_len,
                                uint32_t bang_offset);
 
-// Diagnose macro expansions that straddle AST node boundaries.  Defined in
-// parser_macros.c.
+// Diagnose macro expansions that straddle AST node boundaries.
 int synq_parser_check_macro_straddle(SyntaqliteParser* p);
-
-// ── Macro state lifecycle ───────────────────────────────────────────────────
 
 // Initialize macro state vecs (callback/expansion fields zeroed by memset).
 void synq_macro_state_init(SynqMacroState* m);
 
-// Free macro state scratch buffers.
+// Free all macro state buffers.
 void synq_macro_state_free(SynqMacroState* m, SyntaqliteMemMethods mem);
-
-// ── Layer helpers ───────────────────────────────────────────────────────────
 
 // Free owned expansion data and arg segments on layers 1..N (skip sentinel).
 void synq_layers_free_owned(SynqExpansionLayerVec* layers,
@@ -238,6 +242,8 @@ void synq_layers_push_sentinel(SynqExpansionLayerVec* layers,
                                const char* source,
                                uint32_t source_len,
                                SyntaqliteMemMethods mem);
+
+#endif  // !SYNTAQLITE_OMIT_MACROS
 
 #ifdef __cplusplus
 }

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -53,14 +53,14 @@ uint32_t synq_parser_scan_macro_args(SyntaqliteParser* p,
   // Expect LP.
   uint32_t ttype = 0;
   int64_t tlen = SynqSqliteGetTokenVersionWrapped(
-      &p->dialect, p->macro_fallback, z + pos, &ttype);
+      &p->dialect, p->macro.macro_fallback, z + pos, &ttype);
   if (tlen <= 0 || ttype != SYNTAQLITE_TK_LP)
     return 0;
   pos += (uint32_t)tlen;
 
   // Check for empty args: macro!()
   ttype = 0;
-  tlen = SynqSqliteGetTokenVersionWrapped(&p->dialect, p->macro_fallback,
+  tlen = SynqSqliteGetTokenVersionWrapped(&p->dialect, p->macro.macro_fallback,
                                           z + pos, &ttype);
   if (tlen > 0 && ttype == SYNTAQLITE_TK_RP) {
     *out_end_offset = pos + (uint32_t)tlen;
@@ -73,8 +73,8 @@ uint32_t synq_parser_scan_macro_args(SyntaqliteParser* p,
 
   while (pos < source_len && depth > 0) {
     ttype = 0;
-    tlen = SynqSqliteGetTokenVersionWrapped(&p->dialect, p->macro_fallback,
-                                            z + pos, &ttype);
+    tlen = SynqSqliteGetTokenVersionWrapped(
+        &p->dialect, p->macro.macro_fallback, z + pos, &ttype);
     if (tlen <= 0)
       return 0;
 
@@ -115,11 +115,18 @@ uint32_t synq_parser_scan_macro_args(SyntaqliteParser* p,
 void synq_macro_state_init(SynqMacroState* m) {
   syntaqlite_vec_init(&m->expand_buf);
   syntaqlite_vec_init(&m->body_buf);
+  syntaqlite_vec_init(&m->layers);
+  syntaqlite_vec_init(&m->traceback_buf);
+  syntaqlite_vec_init(&m->node_expanded_buf);
 }
 
 void synq_macro_state_free(SynqMacroState* m, SyntaqliteMemMethods mem) {
   syntaqlite_vec_free(&m->expand_buf, mem);
   syntaqlite_vec_free(&m->body_buf, mem);
+  synq_layers_free_owned(&m->layers, mem);
+  syntaqlite_vec_free(&m->layers, mem);
+  syntaqlite_vec_free(&m->traceback_buf, mem);
+  syntaqlite_vec_free(&m->node_expanded_buf, mem);
 }
 
 void synq_layers_free_owned(SynqExpansionLayerVec* layers,
@@ -168,7 +175,7 @@ SYNTAQLITE_API void syntaqlite_macro_expansion_set_result(SyntaqliteParser* p,
                                                           uint32_t body_len,
                                                           uint32_t def_line,
                                                           uint32_t def_col) {
-  SynqExpansionLayer* lyr = &p->layers.data[p->macro.pending_layer];
+  SynqExpansionLayer* lyr = &p->macro.layers.data[p->macro.pending_layer];
   layer_free_data(p, lyr);
   char* d = p->mem.xMalloc(body_len + 1);
   memcpy(d, body, body_len);
@@ -193,15 +200,16 @@ SYNTAQLITE_API void syntaqlite_macro_expansion_set_result_with_arg_map(
     return;
 
   // Build resolved SynqArgSegment array from the caller's mappings.
-  SynqExpansionLayer* lyr = &p->layers.data[p->macro.pending_layer];
+  SynqExpansionLayer* lyr = &p->macro.layers.data[p->macro.pending_layer];
   const SyntaqliteToken* args = p->macro.expansion_args;
   uint32_t arg_count = p->macro.expansion_arg_count;
   uint32_t origin_layer_id = lyr->parent_layer_id;
   // For layer 0, arg text lives in source; for nested layers, in
   // expansion_data.  Both are pointed to by args[i].text.
   const char* origin_base =
-      origin_layer_id == 0 ? p->source
-                           : p->layers.data[origin_layer_id].expansion_data;
+      origin_layer_id == 0
+          ? p->source
+          : p->macro.layers.data[origin_layer_id].expansion_data;
 
   SynqArgSegment* segs = p->mem.xMalloc(mapping_count * sizeof(SynqArgSegment));
   uint32_t seg_count = 0;
@@ -254,7 +262,7 @@ static int expand_and_feed(SyntaqliteParser* p,
   while (pos < buf_len) {
     uint32_t ttype = 0;
     int64_t tlen = SynqSqliteGetTokenVersionWrapped(
-        &p->dialect, p->macro_fallback, z + pos, &ttype);
+        &p->dialect, p->macro.macro_fallback, z + pos, &ttype);
     if (tlen <= 0)
       break;
 
@@ -368,7 +376,7 @@ int synq_parser_expand_and_feed_macro(SyntaqliteParser* p,
   uint32_t call_length = end_offset - id_offset;
   begin_macro_expansion(p, id_offset, call_length, buf + id_offset, id_len);
 
-  uint32_t new_layer_idx = syntaqlite_vec_len(&p->layers) - 1;
+  uint32_t new_layer_idx = syntaqlite_vec_len(&p->macro.layers) - 1;
   p->macro.pending_layer = new_layer_idx;
   p->macro.expansion_args = token_args;
   p->macro.expansion_arg_count = token_arg_count;
@@ -382,7 +390,7 @@ int synq_parser_expand_and_feed_macro(SyntaqliteParser* p,
     // Callback failed — tear down the layer we pushed.
     synq_end_macro(p);
     // Free any data the callback may have written before failing.
-    SynqExpansionLayer* lyr = &p->layers.data[new_layer_idx];
+    SynqExpansionLayer* lyr = &p->macro.layers.data[new_layer_idx];
     if (lyr->expansion_data)
       p->mem.xFree((void*)lyr->expansion_data);
     lyr->expansion_data = NULL;
@@ -393,7 +401,7 @@ int synq_parser_expand_and_feed_macro(SyntaqliteParser* p,
   }
 
   // The callback wrote expansion_data/len/def_line/def_col onto the layer.
-  SynqExpansionLayer* lyr = &p->layers.data[new_layer_idx];
+  SynqExpansionLayer* lyr = &p->macro.layers.data[new_layer_idx];
   const char* data = lyr->expansion_data;
   uint32_t data_len = lyr->expansion_len;
 
@@ -447,7 +455,7 @@ static void begin_macro_expansion(SyntaqliteParser* p,
       .name_len = name_len,
       .parent_layer_id = p->ctx.layer_id,
   };
-  syntaqlite_vec_push(&p->layers, layer, p->mem);
+  syntaqlite_vec_push(&p->macro.layers, layer, p->mem);
   p->macro.depth++;
 }
 
@@ -461,8 +469,8 @@ static void synq_end_macro(SyntaqliteParser* p) {
     } else {
       // Walk back to find the still-active parent layer.
       uint32_t cur = p->ctx.layer_id;
-      if (cur > 0 && cur < syntaqlite_vec_len(&p->layers)) {
-        p->ctx.layer_id = p->layers.data[cur].parent_layer_id;
+      if (cur > 0 && cur < syntaqlite_vec_len(&p->macro.layers)) {
+        p->ctx.layer_id = p->macro.layers.data[cur].parent_layer_id;
       }
     }
   }
@@ -485,7 +493,7 @@ int synq_parser_try_macro_call(SyntaqliteParser* p,
   if (z[bang_offset] != '!')
     return -1;
   if (p->dialect.tmpl->macro_style != SYNQ_MACRO_STYLE_RUST &&
-      !p->macro_fallback)
+      !p->macro.macro_fallback)
     return -1;
   // Don't expand macros while parsing a macro definition body — the body
   // should be captured verbatim, with nested macro calls preserved as text.
@@ -520,7 +528,7 @@ int synq_parser_try_macro_call(SyntaqliteParser* p,
 
   // Record macro region so formatter emits verbatim (no expansion data).
   begin_macro_expansion(p, id_offset, call_length, NULL, 0);
-  p->ctx.layer_id = syntaqlite_vec_len(&p->layers) - 1;
+  p->ctx.layer_id = syntaqlite_vec_len(&p->macro.layers) - 1;
   synq_end_macro(p);
 
   // Feed the whole name!(args) span as a single TK_ID to Lemon.
@@ -535,7 +543,7 @@ int synq_parser_try_macro_call(SyntaqliteParser* p,
 // ---------------------------------------------------------------------------
 
 int synq_parser_check_macro_straddle(SyntaqliteParser* p) {
-  uint32_t layer_count = syntaqlite_vec_len(&p->layers);
+  uint32_t layer_count = syntaqlite_vec_len(&p->macro.layers);
   // Sentinel occupies index 0; real expansion layers start at 1.
   if (layer_count <= 1)
     return 0;
@@ -547,7 +555,7 @@ int synq_parser_check_macro_straddle(SyntaqliteParser* p) {
   }
 
   uint32_t node_count = syntaqlite_vec_len(&p->ctx.ast.offsets);
-  const SynqExpansionLayer* layers = p->layers.data;
+  const SynqExpansionLayer* layers = p->macro.layers.data;
 
   for (uint32_t nid = 0; nid < node_count; nid++) {
     const uint8_t* raw = synq_arena_cptr(&p->ctx.ast, nid);
@@ -687,7 +695,7 @@ SYNTAQLITE_API int syntaqlite_macro_expansion_expand_and_set_result(
   // Steal the scratch vec's buffer directly into the layer (no copy).
   // Null-terminate for safety.
   syntaqlite_vec_push(&p->macro.expand_buf, 0, p->mem);
-  SynqExpansionLayer* lyr = &p->layers.data[p->macro.pending_layer];
+  SynqExpansionLayer* lyr = &p->macro.layers.data[p->macro.pending_layer];
   layer_free_data(p, lyr);
   lyr->expansion_data = (const char*)p->macro.expand_buf.data;
   lyr->expansion_len = p->macro.expand_buf.count - 1;  // exclude NUL
@@ -702,8 +710,9 @@ SYNTAQLITE_API int syntaqlite_macro_expansion_expand_and_set_result(
   if (mapping_count > 0) {
     uint32_t origin_layer_id = lyr->parent_layer_id;
     const char* origin_base =
-        origin_layer_id == 0 ? p->source
-                             : p->layers.data[origin_layer_id].expansion_data;
+        origin_layer_id == 0
+            ? p->source
+            : p->macro.layers.data[origin_layer_id].expansion_data;
 
     SynqArgSegment* segs =
         p->mem.xMalloc(mapping_count * sizeof(SynqArgSegment));

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -4,9 +4,13 @@
 // Macro expansion pipeline: arg scanning, lookup callback dispatch,
 // template expansion, layer lifecycle, and straddle diagnostics.
 //
+// Compiled out entirely when SYNTAQLITE_OMIT_MACROS is defined.
+//
 // Span resolution and traceback live in parser_spans.c.
 // Per-node extent tracking hooks live in parser_extents.c.
 // Cross-file helpers are declared in csrc/parser_internal.h.
+
+#ifndef SYNTAQLITE_OMIT_MACROS
 
 #include <stdio.h>
 #include <string.h>
@@ -608,12 +612,13 @@ int synq_parser_check_macro_straddle(SyntaqliteParser* p) {
 // Macro lookup callback API
 // ---------------------------------------------------------------------------
 
-SYNTAQLITE_API void syntaqlite_parser_set_macro_lookup(
-    SyntaqliteParser* p,
-    SyntaqliteMacroLookupFn fn,
-    void* user_data) {
+SYNTAQLITE_API int32_t
+syntaqlite_parser_set_macro_lookup(SyntaqliteParser* p,
+                                   SyntaqliteMacroLookupFn fn,
+                                   void* user_data) {
   p->macro.lookup_fn = fn;
   p->macro.lookup_user_data = user_data;
+  return 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -732,3 +737,5 @@ SYNTAQLITE_API int syntaqlite_macro_expansion_expand_and_set_result(
 
   return 0;
 }
+
+#endif  // !SYNTAQLITE_OMIT_MACROS

--- a/syntaqlite-syntax/csrc/parser_spans.c
+++ b/syntaqlite-syntax/csrc/parser_spans.c
@@ -52,14 +52,14 @@ static void span_walk_to_source(SyntaqliteParser* p,
   uint32_t off = offset;
   uint32_t len = length;
   uint32_t layer = layer_id;
-  uint32_t layers_count = syntaqlite_vec_len(&p->layers);
+  uint32_t layers_count = syntaqlite_vec_len(&p->macro.layers);
   // Each iteration either drills into an arg origin layer or moves up
   // to a parent layer; cap defensively at twice the max depth.
   for (uint32_t step = 0; step < 2 * (SYNQ_MAX_MACRO_DEPTH + 1); step++) {
     if (layer == 0 || layer >= layers_count) {
       break;
     }
-    const SynqExpansionLayer* cur = &p->layers.data[layer];
+    const SynqExpansionLayer* cur = &p->macro.layers.data[layer];
 
     // Arg-segment drill: if the span lies fully inside a substituted arg,
     // the authored bytes live in the segment's origin layer, not via the
@@ -85,11 +85,11 @@ SYNTAQLITE_API const char* syntaqlite_parser_span_expanded_text(
     return NULL;
   }
   uint32_t layer = span->_layer_id;
-  if (layer >= syntaqlite_vec_len(&p->layers)) {
+  if (layer >= syntaqlite_vec_len(&p->macro.layers)) {
     *out_len = 0;
     return NULL;
   }
-  const SynqExpansionLayer* lyr = &p->layers.data[layer];
+  const SynqExpansionLayer* lyr = &p->macro.layers.data[layer];
   if (!lyr->expansion_data ||
       span->offset + span->length > lyr->expansion_len) {
     *out_len = 0;
@@ -175,7 +175,7 @@ SYNTAQLITE_API const SyntaqliteTracebackFrame* syntaqlite_parser_traceback(
     *out_count = 0;
   // Clear the scratch buffer from any previous call.  Keeps the
   // allocation so repeat calls reuse the same heap block.
-  syntaqlite_vec_clear(&p->traceback_buf);
+  syntaqlite_vec_clear(&p->macro.traceback_buf);
   if (!sp || sp->length == 0)
     return NULL;
 
@@ -187,14 +187,14 @@ SYNTAQLITE_API const SyntaqliteTracebackFrame* syntaqlite_parser_traceback(
   uint32_t off = sp->offset;
   uint32_t len = sp->length;
   uint32_t layer_id = sp->_layer_id;
-  uint32_t layers_count = syntaqlite_vec_len(&p->layers);
+  uint32_t layers_count = syntaqlite_vec_len(&p->macro.layers);
 
   for (uint32_t step = 0; step < 2 * (SYNQ_MAX_MACRO_DEPTH + 1) &&
                           count < SYNQ_MAX_MACRO_DEPTH + 2;
        step++) {
     if (layer_id >= layers_count)
       break;
-    const SynqExpansionLayer* lyr = &p->layers.data[layer_id];
+    const SynqExpansionLayer* lyr = &p->macro.layers.data[layer_id];
 
     if (layer_id == 0) {
       // Root (sentinel) — emit final frame and terminate.
@@ -239,12 +239,12 @@ SYNTAQLITE_API const SyntaqliteTracebackFrame* syntaqlite_parser_traceback(
     return NULL;
 
   // Reverse into the parser's owned buffer so frame[0] is outermost.
-  syntaqlite_vec_ensure(&p->traceback_buf, count, p->mem);
+  syntaqlite_vec_ensure(&p->macro.traceback_buf, count, p->mem);
   for (uint32_t i = 0; i < count; i++) {
-    p->traceback_buf.data[i] = tmp[count - 1 - i];
+    p->macro.traceback_buf.data[i] = tmp[count - 1 - i];
   }
-  p->traceback_buf.count = count;
+  p->macro.traceback_buf.count = count;
   if (out_count)
     *out_count = count;
-  return p->traceback_buf.data;
+  return p->macro.traceback_buf.data;
 }

--- a/syntaqlite-syntax/csrc/parser_spans.c
+++ b/syntaqlite-syntax/csrc/parser_spans.c
@@ -4,9 +4,11 @@
 // Span resolution and traceback.
 //
 // Navigates the expansion layer tree to resolve AST span coordinates
-// back to authored source positions.  Split out of parser_macros.c so
-// the macro expansion pipeline and the layer navigation / public span
-// API can evolve independently.
+// back to authored source positions.  Compiled out when
+// SYNTAQLITE_OMIT_MACROS is defined — without macro expansion, span_text
+// and traceback are stubbed in parser.c.
+
+#ifndef SYNTAQLITE_OMIT_MACROS
 
 #include <string.h>
 
@@ -248,3 +250,5 @@ SYNTAQLITE_API const SyntaqliteTracebackFrame* syntaqlite_parser_traceback(
     *out_count = count;
   return p->macro.traceback_buf.data;
 }
+
+#endif  // !SYNTAQLITE_OMIT_MACROS

--- a/syntaqlite-syntax/csrc/token_wrapped.c
+++ b/syntaqlite-syntax/csrc/token_wrapped.c
@@ -21,15 +21,13 @@ int64_t SynqSqliteGetTokenVersionWrapped(const SyntaqliteDialect* g,
   int64_t len = SYNQ_GET_TOKEN(g, z, &token_type_int);
   *tokenType = (uint32_t)token_type_int;
 
-  // Reclassify a lone '!' as TK_BANG when the caller can have macro calls.
-  // Check the cheap conditions first (token type / length / character)
-  // before consulting macro_style or macro_fallback — the common case is
-  // that the token isn't '!' at all.
+#ifndef SYNTAQLITE_OMIT_MACROS
   if (*tokenType == SYNTAQLITE_TK_ILLEGAL && len == 1 && z[0] == '!' &&
       (g->tmpl->macro_style == SYNQ_MACRO_STYLE_RUST || macro_fallback)) {
     *tokenType = SYNTAQLITE_TK_BANG;
     return 1;
   }
+#endif
 
   if (SYNQ_VER_LT(g, 3038000) && *tokenType == SYNTAQLITE_TK_PTR) {
     /* -> and ->> operators added in 3.38.

--- a/syntaqlite-syntax/include/syntaqlite/incremental.h
+++ b/syntaqlite-syntax/include/syntaqlite/incremental.h
@@ -104,10 +104,11 @@ typedef int (*SyntaqliteMacroLookupFn)(void* user_data,
                                        const SyntaqliteToken* args,
                                        uint32_t arg_count);
 
-SYNTAQLITE_API void syntaqlite_parser_set_macro_lookup(
-    SyntaqliteParser* p,
-    SyntaqliteMacroLookupFn fn,
-    void* user_data);
+// Returns 0 on success, -1 if macros are compiled out (SYNTAQLITE_OMIT_MACROS).
+SYNTAQLITE_API int32_t
+syntaqlite_parser_set_macro_lookup(SyntaqliteParser* p,
+                                   SyntaqliteMacroLookupFn fn,
+                                   void* user_data);
 
 // ---------------------------------------------------------------------------
 // Macro expansion result (called from inside the lookup callback)

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -477,7 +477,7 @@ impl CParser {
             ) -> i32,
         >,
         user_data: *mut c_void,
-    ) {
+    ) -> i32 {
         // SAFETY: self is a valid, non-null CParser pointer.
         unsafe { syntaqlite_parser_set_macro_lookup(self, func, user_data) }
     }
@@ -595,7 +595,7 @@ unsafe extern "C" {
             ) -> i32,
         >,
         user_data: *mut c_void,
-    );
+    ) -> i32;
 }
 
 #[cfg(all(test, feature = "sqlite"))]

--- a/tests/amalg_tests/sqlite_omit_macros.py
+++ b/tests/amalg_tests/sqlite_omit_macros.py
@@ -1,0 +1,126 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Amalgamation tests with SYNTAQLITE_OMIT_MACROS defined.
+
+Verifies that the parser works correctly when macro support is compiled
+out — all macro-related code is absent, and basic SQL parsing still
+produces the expected AST.
+"""
+
+from python.dev.diff_tests.testing import DiffTestBlueprint, TestSuite
+
+
+class SqliteAmalgOmitMacros(TestSuite):
+    """Parsing through amalgamated sqlite dialect with macros omitted."""
+
+    def test_select_literal(self):
+        return DiffTestBlueprint(
+            sql="SELECT 1",
+            out="""\
+            SelectStmt
+              flags: (none)
+              columns:
+                ResultColumnList [1 items]
+                  ResultColumn
+                    flags: (none)
+                    alias: (none)
+                    expr:
+                      Literal
+                        literal_type: INTEGER
+                        source: "1"
+              from_clause: (none)
+              where_clause: (none)
+              groupby: (none)
+              having: (none)
+              orderby: (none)
+              limit_clause: (none)
+              window_clause: (none)
+""",
+        )
+
+    def test_select_from_where(self):
+        return DiffTestBlueprint(
+            sql="SELECT a FROM t WHERE x = 1",
+            out="""\
+            SelectStmt
+              flags: (none)
+              columns:
+                ResultColumnList [1 items]
+                  ResultColumn
+                    flags: (none)
+                    alias: (none)
+                    expr:
+                      ColumnRef
+                        column: "a"
+                        table: (none)
+                        schema: (none)
+              from_clause:
+                TableRef
+                  table_name: "t"
+                  schema: (none)
+                  alias: (none)
+                  args: (none)
+              where_clause:
+                BinaryExpr
+                  op: EQ
+                  left:
+                    ColumnRef
+                      column: "x"
+                      table: (none)
+                      schema: (none)
+                  right:
+                    Literal
+                      literal_type: INTEGER
+                      source: "1"
+              groupby: (none)
+              having: (none)
+              orderby: (none)
+              limit_clause: (none)
+              window_clause: (none)
+""",
+        )
+
+    def test_multiple_statements(self):
+        return DiffTestBlueprint(
+            sql="SELECT 1; SELECT 2",
+            out="""\
+            SelectStmt
+              flags: (none)
+              columns:
+                ResultColumnList [1 items]
+                  ResultColumn
+                    flags: (none)
+                    alias: (none)
+                    expr:
+                      Literal
+                        literal_type: INTEGER
+                        source: "1"
+              from_clause: (none)
+              where_clause: (none)
+              groupby: (none)
+              having: (none)
+              orderby: (none)
+              limit_clause: (none)
+              window_clause: (none)
+            ----
+            SelectStmt
+              flags: (none)
+              columns:
+                ResultColumnList [1 items]
+                  ResultColumn
+                    flags: (none)
+                    alias: (none)
+                    expr:
+                      Literal
+                        literal_type: INTEGER
+                        source: "2"
+              from_clause: (none)
+              where_clause: (none)
+              groupby: (none)
+              having: (none)
+              orderby: (none)
+              limit_clause: (none)
+              window_clause: (none)
+""",
+        )

--- a/tests/public-api/syntaqlite-buildtools.txt
+++ b/tests/public-api/syntaqlite-buildtools.txt
@@ -17,7 +17,7 @@ pub const fn syntaqlite_buildtools::codegen_api::DialectCodegenJob<'a>::with_pyt
 pub enum syntaqlite_buildtools::codegen_api::MacroStyle
 pub fn alloc::string::String::from(v: syntaqlite_buildtools::version_analysis::SqliteVersion) -> Self
 pub fn syntaqlite_buildtools::amalgamate::amalgamate_dialect(dialect: &str, dialect_dir: &std::path::Path, runtime_header: core::option::Option<&str>, ext_header: core::option::Option<&str>) -> core::result::Result<syntaqlite_buildtools::amalgamate::AmalgamateOutput, alloc::string::String>
-pub fn syntaqlite_buildtools::amalgamate::amalgamate_full(dialect: &str, runtime_dir: &std::path::Path, dialect_dir: &std::path::Path) -> core::result::Result<syntaqlite_buildtools::amalgamate::AmalgamateOutput, alloc::string::String>
+pub fn syntaqlite_buildtools::amalgamate::amalgamate_full(dialect: &str, runtime_dir: &std::path::Path, dialect_dir: &std::path::Path, omit_macros: bool) -> core::result::Result<syntaqlite_buildtools::amalgamate::AmalgamateOutput, alloc::string::String>
 pub fn syntaqlite_buildtools::amalgamate::amalgamate_header(syntax_dir: &std::path::Path, lib_dir: &std::path::Path) -> core::result::Result<alloc::string::String, alloc::string::String>
 pub fn syntaqlite_buildtools::amalgamate::amalgamate_runtime(runtime_dir: &std::path::Path) -> core::result::Result<syntaqlite_buildtools::amalgamate::AmalgamateOutput, alloc::string::String>
 pub fn syntaqlite_buildtools::base_files::merge_file_sets(base: &[(&str, &str)], extensions: &[(alloc::string::String, alloc::string::String)]) -> alloc::vec::Vec<(alloc::string::String, alloc::string::String)>


### PR DESCRIPTION
## Motivation

Macros are a dialect-level feature. Dialects that don't use macro expansion (e.g. plain SQLite) still compile all the macro machinery — arg scanning, template expansion, layer management, span resolution through layers, traceback, etc. There's no way to compile it out for size/simplicity when building an amalgamation for a macro-free dialect.

## Changes

**Field consolidation** — move `macro_fallback`, `layers`, `node_expanded_buf`, and `traceback_buf` into `SynqMacroState`. The parser struct now has a single `#ifndef SYNTAQLITE_OMIT_MACROS` around one field.

**Compile-time guard** — when `-DSYNTAQLITE_OMIT_MACROS` is defined:
- `parser_macros.c` and `parser_spans.c` compile to empty translation units
- `token_wrapped.c` skips TK_BANG reclassification
- `parser.c` stubs public APIs: `span_text` returns a direct source slice, `traceback` returns NULL, `expanded_text` returns source text, `node_is_macro_free` returns 1, `set_macro_fallback`/`set_macro_lookup` return -1
- `SynqMacroState` and all layer/expansion types are absent from the struct

**Amalgamation support** — `amalgamate_full()` accepts `omit_macros: bool`; `amalgamate-syntax` CLI gains `--omit-macros` flag. When set, `#define SYNTAQLITE_OMIT_MACROS` is injected into the amalgamation output.

**API change** — `syntaqlite_parser_set_macro_lookup` return type changed from `void` to `int32_t` (returns -1 when macros are compiled out).

**Tests** — new `SqliteAmalgOmitMacros` amalgamation test suite compiles with the flag and verifies parsing works correctly.