### PR TITLE
synq: trim whitespace and comments from macro arg ranges

### DIFF
--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -74,6 +74,7 @@ uint32_t synq_parser_scan_macro_args(SyntaqliteParser* p,
   uint32_t arg_count = 0;
   uint32_t depth = 1;
   uint32_t arg_start = pos;
+  uint32_t arg_end = pos;  // end of last significant token in current arg
 
   while (pos < source_len && depth > 0) {
     ttype = 0;
@@ -82,6 +83,9 @@ uint32_t synq_parser_scan_macro_args(SyntaqliteParser* p,
     if (tlen <= 0)
       return 0;
 
+    int is_skip =
+        (ttype == SYNTAQLITE_TK_SPACE || ttype == SYNTAQLITE_TK_COMMENT);
+
     if (ttype == SYNTAQLITE_TK_LP) {
       depth++;
     } else if (ttype == SYNTAQLITE_TK_RP) {
@@ -89,7 +93,7 @@ uint32_t synq_parser_scan_macro_args(SyntaqliteParser* p,
       if (depth == 0) {
         if (arg_count < max_args) {
           out_args[arg_count].offset = arg_start;
-          out_args[arg_count].length = pos - arg_start;
+          out_args[arg_count].length = arg_end - arg_start;
         }
         arg_count++;
         *out_end_offset = pos + (uint32_t)tlen;
@@ -98,12 +102,22 @@ uint32_t synq_parser_scan_macro_args(SyntaqliteParser* p,
     } else if (depth == 1 && ttype == SYNTAQLITE_TK_COMMA) {
       if (arg_count < max_args) {
         out_args[arg_count].offset = arg_start;
-        out_args[arg_count].length = pos - arg_start;
+        out_args[arg_count].length = arg_end - arg_start;
       }
       arg_count++;
       arg_start = pos + (uint32_t)tlen;
+      arg_end = arg_start;
     } else if (ttype == SYNTAQLITE_TK_SEMI) {
       return 0;
+    }
+
+    // Trim leading whitespace/comments by advancing arg_start.
+    // Trim trailing implicitly: arg_end only advances past significant tokens.
+    if (depth >= 1 && is_skip && pos == arg_start) {
+      arg_start = pos + (uint32_t)tlen;
+      arg_end = arg_start;
+    } else if (!is_skip) {
+      arg_end = pos + (uint32_t)tlen;
     }
 
     pos += (uint32_t)tlen;

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -940,6 +940,85 @@ mod tests {
     }
 
     #[test]
+    fn macro_arg_trailing_comment_does_not_corrupt_nested_expansion() {
+        // Regression: scan_macro_args captured trailing whitespace/comments in
+        // arg text.  When substituted into a nested expansion, a `-- comment`
+        // consumed the rest of the line in the expansion buffer, corrupting
+        // sibling tokens (e.g. commas, closing parens).
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let mut reg = TestMacroRegistry::new();
+        reg.register("mpass", &["x"], "$x");
+        reg.register("mwrap", &["x"], "(mpass!($x), mpass!($x))");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let sql = "SELECT mwrap!(\n  foo  -- a stray inline comment\n);";
+        let mut session = parser.parse(sql);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(err) => panic!("unexpected error: {}", err.message()),
+        };
+
+        // If the comment was trimmed correctly, the mwrap expansion produces
+        // "(mpass!(foo), mpass!(foo))" which further expands to "(foo, foo)".
+        // That parses as a parenthesized expression list — no syntax error.
+        let mut dump = String::new();
+        stmt.dump(&mut dump, 0);
+        assert!(
+            !dump.contains("error"),
+            "expansion should not produce errors, got:\n{dump}"
+        );
+    }
+
+    #[test]
+    fn macro_nested_expansion_basic() {
+        // Verify nested expansion works at all.
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let mut reg = TestMacroRegistry::new();
+        reg.register("mpass", &["x"], "$x");
+        reg.register("mwrap", &["x"], "mpass!($x)");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let sql = "SELECT mwrap!(42);";
+        let mut session = parser.parse(sql);
+        match session.next() {
+            ParseOutcome::Ok(stmt) => {
+                let mut dump = String::new();
+                stmt.dump(&mut dump, 0);
+                assert!(
+                    stmt.root().is_some(),
+                    "nested expansion should work, got:\n{dump}"
+                );
+            }
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(err) => panic!("unexpected error: {}", err.message()),
+        }
+    }
+
+    #[test]
+    fn macro_arg_leading_whitespace_trimmed() {
+        // Args like `macro!(  x  )` should have leading/trailing whitespace
+        // trimmed so the substituted text is just `x`.
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let mut reg = TestMacroRegistry::new();
+        reg.register("mpass", &["x"], "$x");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let sql = "SELECT mpass!(  42  );";
+        let mut session = parser.parse(sql);
+        match session.next() {
+            ParseOutcome::Ok(stmt) => {
+                let mut dump = String::new();
+                stmt.dump(&mut dump, 0);
+                // Should parse as SELECT 42 — no errors.
+                assert!(stmt.root().is_some());
+            }
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(err) => panic!("unexpected error: {}", err.message()),
+        }
+    }
+
+    #[test]
     fn macro_deregister_falls_back_to_legacy() {
         let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
         let reg = Rc::new(RefCell::new(TestMacroRegistry::new()));


### PR DESCRIPTION
## Motivation

`synq_parser_scan_macro_args` included leading/trailing whitespace and SQL line comments (`-- ...`) in each captured argument's text range. When that arg text was substituted as a `$param` in a nested expansion, an embedded `-- comment` consumed the rest of the line in the *expansion buffer*, swallowing sibling tokens (commas, closing parens) and producing garbage parse states.

Closes #131.

## Changes

- Track `arg_end` separately from `pos` in `scan_macro_args` so it only advances past significant (non-whitespace, non-comment) tokens. Leading whitespace/comments are trimmed by advancing `arg_start` when a skip token sits at the arg boundary. Trailing trim is implicit since `arg_end` stops at the last significant token.
- Add three tests: trailing comment with nested expansion (the regression), basic nested expansion, and leading/trailing whitespace trimming.