### PR TITLE
synq: skip whitespace/comments in expand_and_feed nested-macro lookahead

### DIFF
--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -290,13 +290,28 @@ static int expand_and_feed(SyntaqliteParser* p,
     }
 
     // Check for nested macro call: ID followed by '!'.
+    // Skip whitespace/comments between ID and '!' to mirror the main parse
+    // loop's next_token() behaviour (issue #130).
     // Skip when inside a macro definition body — body should be verbatim.
-    uint32_t next_pos = pos + (uint32_t)tlen;
-    if (ttype == SYNTAQLITE_TK_ID && next_pos < buf_len && z[next_pos] == '!' &&
+    uint32_t bang_pos = pos + (uint32_t)tlen;
+    if (ttype == SYNTAQLITE_TK_ID && p->ctx.in_macro_def_body == 0) {
+      // Scan past whitespace/comments to find the next significant byte.
+      while (bang_pos < buf_len) {
+        uint32_t la_type = 0;
+        int64_t la_len = SynqSqliteGetTokenVersionWrapped(
+            &p->dialect, p->macro.macro_fallback, z + bang_pos, &la_type);
+        if (la_len <= 0)
+          break;
+        if (la_type != SYNTAQLITE_TK_SPACE && la_type != SYNTAQLITE_TK_COMMENT)
+          break;
+        bang_pos += (uint32_t)la_len;
+      }
+    }
+    if (ttype == SYNTAQLITE_TK_ID && bang_pos < buf_len && z[bang_pos] == '!' &&
         p->ctx.in_macro_def_body == 0) {
       uint32_t nested_end = 0;
       int erc = synq_parser_expand_and_feed_macro(p, buf, buf_len, pos,
-                                                  (uint32_t)tlen, next_pos,
+                                                  (uint32_t)tlen, bang_pos,
                                                   depth + 1, &nested_end);
       if (erc == 0) {
         pos = nested_end;

--- a/syntaqlite/tests/low_level.rs
+++ b/syntaqlite/tests/low_level.rs
@@ -507,6 +507,55 @@ fn collect_all_spans(
     }
 }
 
+/// Nested macro calls inside an expansion buffer must be detected even when
+/// whitespace or comments separate the ID from '!'. Regression test for
+/// <https://github.com/LalitMaganti/syntaqlite/issues/130>.
+#[test]
+fn nested_macro_with_whitespace_before_bang() {
+    struct TwoMacros;
+    impl MacroLookup for TwoMacros {
+        fn lookup(&mut self, name: &str, _args: &[MacroArg<'_>], out: &mut MacroOutput) -> bool {
+            match name {
+                // omacro!() expands to "imacro\n  !(42)" — newline+spaces before "!".
+                "omacro" => {
+                    out.write("imacro\n  !(42)");
+                    true
+                }
+                // cmacro!() expands to "imacro/* comment */!(42)" — comment before "!".
+                "cmacro" => {
+                    out.write("imacro/* comment */!(42)");
+                    true
+                }
+                "imacro" => {
+                    out.write("100");
+                    true
+                }
+                _ => false,
+            }
+        }
+    }
+
+    let config = ParserConfig::default()
+        .with_collect_tokens(true)
+        .with_macro_fallback(true);
+
+    // Test whitespace (newline + spaces) between ID and '!'.
+    let mut parser = Parser::with_config(&config);
+    parser.set_macro_lookup(Some(Box::new(TwoMacros)));
+    let mut session = parser.parse("SELECT omacro!();");
+    let ParseOutcome::Ok(_) = session.next() else {
+        panic!("nested macro with whitespace before '!' should parse")
+    };
+
+    // Test comment between ID and '!'.
+    let mut parser = Parser::with_config(&config);
+    parser.set_macro_lookup(Some(Box::new(TwoMacros)));
+    let mut session = parser.parse("SELECT cmacro!();");
+    let ParseOutcome::Ok(_) = session.next() else {
+        panic!("nested macro with comment before '!' should parse")
+    };
+}
+
 /// When a single statement has more than 255 macro expansions, the parser
 /// must not wrap `_layer_id` at 256 (`uint8_t` overflow). Regression test
 /// for <https://github.com/LalitMaganti/syntaqlite/issues/128>.


### PR DESCRIPTION
## Motivation

`expand_and_feed` in `parser_macros.c` detects nested macro calls by checking the byte immediately after an ID token for `!`. This requires the bang to be adjacent — any whitespace or comments between the ID and `!` cause the detection to fail, feeding the bare ID to Lemon which then errors on the stray `!`.

The main parse loop in `parser.c` handles this correctly via `next_token()`, which skips `SPACE`/`COMMENT` tokens before returning the lookahead type. So `m\n  !(x)` works at the top level but fails inside an expansion buffer.

Fixes #130.

## Changes

- In `expand_and_feed`, after tokenizing an ID, scan past any `SPACE`/`COMMENT` tokens using the tokenizer before checking for `!` — mirroring what `next_token()` does in the main parse loop.
- Add regression test covering both whitespace and comment separators between ID and `!` in nested macro expansions.