### PR TITLE
synq: fix spurious straddle on 3+ deep nested macros

### DIFF
--- a/syntaqlite-syntax/csrc/parser_extents.c
+++ b/syntaqlite-syntax/csrc/parser_extents.c
@@ -13,13 +13,14 @@
 // Per-node extent tracking hooks
 // ---------------------------------------------------------------------------
 //
-// When enabled, two parallel shadow stacks mirror Lemon's symbol stack:
+// Two parallel shadow stacks mirror Lemon's symbol stack:
 //
 //   * `extent_stack` tracks the merged *authored* range in root-source
 //     coordinates — used by `syntaqlite_parser_node_text`.  Macro
 //     tokens push the outermost call-site range stashed in
 //     `begin_macro_expansion`.  Epsilon pushes the sentinel
 //     `(UINT32_MAX, 0)`, which is neutral under min/max merging.
+//     Only maintained when `collect_node_extents` is enabled.
 //
 //   * `expanded_stack` tracks the merged *expanded* range in the
 //     tokens' own layer — used by
@@ -27,11 +28,25 @@
 //     the layer; mixed-layer merges collapse to the sentinel
 //     `(length=0)`, since no contiguous expansion slice can represent
 //     a node whose tokens cross layers.
+//     Always maintained — also carries `macro_root` and `from_shift`
+//     for O(1) macro straddle detection.
 
 void synq_extent_on_shift(SynqParseCtx* pCtx,
                           unsigned int major,
                           const SynqParseToken* token) {
   (void)major;
+
+  uint32_t macro_root =
+      (token->layer_id != 0) ? pCtx->macro_root_layer : 0;
+  SynqNodeExpandedExtent e = {
+      .offset = token->offset,
+      .length = token->n,
+      .layer_id = token->layer_id,
+      .macro_root = macro_root,
+      .from_shift = 1,
+  };
+  syntaqlite_vec_push(&pCtx->expanded_stack, e, pCtx->mem);
+
   if (!pCtx->collect_node_extents) {
     return;
   }
@@ -40,22 +55,80 @@ void synq_extent_on_shift(SynqParseCtx* pCtx,
     r.root_start = token->offset;
     r.root_end = token->offset + token->n;
   } else {
-    // Attribute tokens from inside a macro expansion to the outermost
-    // call-site range stashed in `begin_macro_expansion`.
     r.root_start = pCtx->macro_root_start;
     r.root_end = pCtx->macro_root_end;
   }
   syntaqlite_vec_push(&pCtx->extent_stack, r, pCtx->mem);
-
-  SynqNodeExpandedExtent e = {
-      .offset = token->offset,
-      .length = token->n,
-      .layer_id = token->layer_id,
-  };
-  syntaqlite_vec_push(&pCtx->expanded_stack, e, pCtx->mem);
 }
 
 void synq_extent_on_reduce(SynqParseCtx* pCtx, unsigned int nrhs) {
+  uint32_t exp_len = syntaqlite_vec_len(&pCtx->expanded_stack);
+
+  // Straddle detection: if any two terminal (from_shift=1) entries
+  // have different macro_root values, the expansion boundary cuts
+  // through this grammar production.
+  if (!pCtx->has_macro_straddle) {
+    uint32_t first_term_root = SYNQ_MACRO_ROOT_NEUTRAL;
+    for (uint32_t i = exp_len - nrhs; i < exp_len; i++) {
+      SynqNodeExpandedExtent e =
+          syntaqlite_vec_at(&pCtx->expanded_stack, i);
+      if (!e.from_shift)
+        continue;
+      if (first_term_root == SYNQ_MACRO_ROOT_NEUTRAL) {
+        first_term_root = e.macro_root;
+      } else if (e.macro_root != first_term_root) {
+        pCtx->has_macro_straddle = 1;
+        break;
+      }
+    }
+  }
+
+  // Merge expanded-layer spans.
+  SynqNodeExpandedExtent exp_merged = {
+      0, 0, 0, SYNQ_MACRO_ROOT_NEUTRAL, 0};
+  for (uint32_t i = exp_len - nrhs; i < exp_len; i++) {
+    SynqNodeExpandedExtent e = syntaqlite_vec_at(&pCtx->expanded_stack, i);
+
+    if (exp_merged.macro_root == SYNQ_MACRO_ROOT_NEUTRAL &&
+        e.macro_root != SYNQ_MACRO_ROOT_NEUTRAL) {
+      exp_merged.macro_root = e.macro_root;
+    }
+
+    if (e.layer_id == SYNQ_CROSS_LAYER) {
+      uint32_t saved_mr = exp_merged.macro_root;
+      exp_merged = e;
+      exp_merged.macro_root = saved_mr;
+      exp_merged.from_shift = 0;
+      break;
+    }
+    if (e.length == 0) {
+      continue;
+    }
+    if (exp_merged.length == 0) {
+      exp_merged.layer_id = e.layer_id;
+      exp_merged.offset = e.offset;
+      exp_merged.length = e.length;
+      continue;
+    }
+    if (exp_merged.layer_id != e.layer_id) {
+      uint32_t saved_mr = exp_merged.macro_root;
+      exp_merged =
+          (SynqNodeExpandedExtent){0, 0, SYNQ_CROSS_LAYER, 0, 0};
+      exp_merged.macro_root = saved_mr;
+      break;
+    }
+    uint32_t start =
+        exp_merged.offset < e.offset ? exp_merged.offset : e.offset;
+    uint32_t end_a = exp_merged.offset + exp_merged.length;
+    uint32_t end_b = e.offset + e.length;
+    uint32_t end = end_a > end_b ? end_a : end_b;
+    exp_merged.offset = start;
+    exp_merged.length = end - start;
+  }
+  exp_merged.from_shift = 0;
+  syntaqlite_vec_truncate(&pCtx->expanded_stack, exp_len - nrhs);
+  syntaqlite_vec_push(&pCtx->expanded_stack, exp_merged, pCtx->mem);
+
   if (!pCtx->collect_node_extents) {
     return;
   }
@@ -73,36 +146,4 @@ void synq_extent_on_reduce(SynqParseCtx* pCtx, unsigned int nrhs) {
   }
   syntaqlite_vec_truncate(&pCtx->extent_stack, len - nrhs);
   syntaqlite_vec_push(&pCtx->extent_stack, merged, pCtx->mem);
-
-  // Merge expanded-layer spans: all same layer → merge in that layer;
-  // epsilon entries ({0,0,0}) are neutral; cross-layer poison
-  // (layer_id == SYNQ_CROSS_LAYER) propagates upward unconditionally.
-  SynqNodeExpandedExtent exp_merged = {0, 0, 0};
-  for (uint32_t i = len - nrhs; i < len; i++) {
-    SynqNodeExpandedExtent e = syntaqlite_vec_at(&pCtx->expanded_stack, i);
-    if (e.layer_id == SYNQ_CROSS_LAYER) {
-      exp_merged = e;  // propagate poison
-      break;
-    }
-    if (e.length == 0) {
-      continue;  // skip epsilon
-    }
-    if (exp_merged.length == 0) {
-      exp_merged = e;
-      continue;
-    }
-    if (exp_merged.layer_id != e.layer_id) {
-      exp_merged = (SynqNodeExpandedExtent){0, 0, SYNQ_CROSS_LAYER};
-      break;
-    }
-    uint32_t start =
-        exp_merged.offset < e.offset ? exp_merged.offset : e.offset;
-    uint32_t end_a = exp_merged.offset + exp_merged.length;
-    uint32_t end_b = e.offset + e.length;
-    uint32_t end = end_a > end_b ? end_a : end_b;
-    exp_merged.offset = start;
-    exp_merged.length = end - start;
-  }
-  syntaqlite_vec_truncate(&pCtx->expanded_stack, len - nrhs);
-  syntaqlite_vec_push(&pCtx->expanded_stack, exp_merged, pCtx->mem);
 }

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -438,7 +438,6 @@ int synq_parser_expand_and_feed_macro(SyntaqliteParser* p,
   const char* data = lyr->expansion_data;
   uint32_t data_len = lyr->expansion_len;
 
-  uint32_t saved_layer_id = p->ctx.layer_id;
   p->ctx.layer_id = new_layer_idx;
 
   // Push blue-paint for recursion detection.
@@ -449,9 +448,7 @@ int synq_parser_expand_and_feed_macro(SyntaqliteParser* p,
   // Feed expanded tokens (may trigger nested macro expansions).
   int frc = expand_and_feed(p, data, data_len, depth);
 
-  // Pop blue-paint.
   p->macro.expansion_depth--;
-  p->ctx.layer_id = saved_layer_id;
   synq_end_macro(p);
 
   if (frc < 0)
@@ -479,6 +476,7 @@ static void begin_macro_expansion(SyntaqliteParser* p,
   if (p->ctx.layer_id == 0) {
     p->ctx.macro_root_start = call_offset;
     p->ctx.macro_root_end = call_offset + call_length;
+    p->ctx.macro_root_layer = syntaqlite_vec_len(&p->macro.layers);
   }
 
   SynqExpansionLayer layer = {
@@ -576,65 +574,12 @@ int synq_parser_try_macro_call(SyntaqliteParser* p,
 // ---------------------------------------------------------------------------
 
 int synq_parser_check_macro_straddle(SyntaqliteParser* p) {
-  uint32_t layer_count = syntaqlite_vec_len(&p->macro.layers);
-  // Sentinel occupies index 0; real expansion layers start at 1.
-  if (layer_count <= 1)
+  if (!p->ctx.has_macro_straddle)
     return 0;
-  if (!p->dialect.tmpl->range_meta) {
-    snprintf(p->error_msg, sizeof(p->error_msg),
-             "internal error: grammar has no range_meta but macros were used");
-    p->had_error = 1;
-    return -1;
-  }
-
-  uint32_t node_count = syntaqlite_vec_len(&p->ctx.ast.offsets);
-  const SynqExpansionLayer* layers = p->macro.layers.data;
-
-  for (uint32_t nid = 0; nid < node_count; nid++) {
-    const uint8_t* raw = synq_arena_cptr(&p->ctx.ast, nid);
-    uint32_t tag;
-    memcpy(&tag, raw, sizeof(tag));
-    if (tag == 0 || tag >= p->dialect.tmpl->node_count)
-      continue;
-
-    const SyntaqliteRangeMetaEntry* entry = &p->dialect.tmpl->range_meta[tag];
-    if (entry->fields == NULL || entry->count == 0)
-      continue;
-
-    for (uint32_t mi = 1; mi < layer_count; mi++) {
-      uint32_t r_start = layers[mi].call_offset;
-      uint32_t r_end = r_start + layers[mi].call_length;
-
-      int has_inside = 0;
-      int has_outside = 0;
-
-      for (uint8_t fi = 0; fi < entry->count; fi++) {
-        if (entry->fields[fi].kind != 1)
-          continue;  // Not a TextSpan.
-        const SyntaqliteTextSpan* sp =
-            (const SyntaqliteTextSpan*)(raw + entry->fields[fi].offset);
-        if (sp->length == 0)
-          continue;
-
-        uint32_t s_start = sp->offset;
-        uint32_t s_end = sp->offset + sp->length;
-
-        if (s_start >= r_start && s_end <= r_end) {
-          has_inside = 1;
-        } else {
-          has_outside = 1;
-        }
-      }
-
-      if (has_inside && has_outside) {
-        snprintf(p->error_msg, sizeof(p->error_msg),
-                 "macro expansion straddles node boundary");
-        p->had_error = 1;
-        return -1;
-      }
-    }
-  }
-  return 0;
+  snprintf(p->error_msg, sizeof(p->error_msg),
+           "macro expansion straddles node boundary");
+  p->had_error = 1;
+  return -1;
 }
 
 // ---------------------------------------------------------------------------

--- a/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
@@ -50,15 +50,23 @@ typedef struct SynqExtentRange {
 // they live.
 //
 // Sentinel states:
-//   {0, 0, 0}                  — epsilon (no tokens); neutral in merges.
-//   {_, 0, SYNQ_CROSS_LAYER}   — cross-layer poison; propagates through
-//                                parent merges so the fast path falls
-//                                through to the slow path.
+//   {0, 0, 0, *, 0}            — epsilon (no tokens); neutral in merges.
+//   {_, 0, SYNQ_CROSS_LAYER, *, 0}
+//                               — cross-layer poison; propagates through
+//                                 parent merges so the fast path falls
+//                                 through to the slow path.
+//
+// The `macro_root` and `from_shift` fields support O(1) straddle
+// detection during reduce (see parser_extents.c).
 #define SYNQ_CROSS_LAYER UINT32_MAX
+#define SYNQ_MACRO_ROOT_NEUTRAL UINT32_MAX
 typedef struct SynqNodeExpandedExtent {
   uint32_t offset;
   uint32_t length;
   uint32_t layer_id;
+  uint32_t macro_root;  // 0 = source, >0 = outermost expansion layer idx,
+                         // SYNQ_MACRO_ROOT_NEUTRAL = epsilon / neutral.
+  uint32_t from_shift;  // 1 = terminal (pushed at shift), 0 = non-terminal.
 } SynqNodeExpandedExtent;
 
 // ---------------------------------------------------------------------------
@@ -138,6 +146,8 @@ typedef struct SynqParseCtx {
   uint32_t collect_node_extents;
   uint32_t macro_root_start;
   uint32_t macro_root_end;
+  uint32_t macro_root_layer;    // Outermost expansion layer idx (set on entry).
+  uint32_t has_macro_straddle;  // Sticky flag set during reduce.
 } SynqParseCtx;
 
 // Common header for all list nodes in the arena.
@@ -193,6 +203,8 @@ static inline void synq_parse_ctx_init(SynqParseCtx* ctx,
   ctx->collect_node_extents = 0;
   ctx->macro_root_start = 0;
   ctx->macro_root_end = 0;
+  ctx->macro_root_layer = 0;
+  ctx->has_macro_straddle = 0;
 }
 
 static inline void synq_parse_ctx_free(SynqParseCtx* ctx) {
@@ -216,6 +228,8 @@ static inline void synq_parse_ctx_clear(SynqParseCtx* ctx) {
   synq_arena_clear(&ctx->ast);
   ctx->macro_root_start = 0;
   ctx->macro_root_end = 0;
+  ctx->macro_root_layer = 0;
+  ctx->has_macro_straddle = 0;
 }
 
 // Record the current shadow-stack tops (authored + expanded) as the

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -1397,6 +1397,36 @@ mod tests {
     }
 
     #[test]
+    fn three_deep_nested_no_arg_macros_no_spurious_straddle() {
+        // Regression test for #125: check_macro_straddle fired a false
+        // positive on 3-deep nested no-arg macros because it compared
+        // span offsets across different expansion layers without
+        // accounting for _layer_id.
+        let mut parser = Parser::with_config(
+            &ParserConfig::default().with_macro_fallback(true),
+        );
+        let mut reg = TestMacroRegistry::new();
+        reg.register("_dfs", &[], "(SELECT node_id AS id)");
+        reg.register("_tree_reach", &[], "(SELECT node_id FROM _dfs!())");
+        reg.register(
+            "_for_stack",
+            &[],
+            "(SELECT f.id, f.parent_id, f.name FROM _tree_reach!())",
+        );
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let mut session = parser.parse("SELECT * FROM _for_stack!();");
+        match session.next() {
+            ParseOutcome::Ok(_) => {} // expected
+            ParseOutcome::Done => panic!("expected a statement"),
+            ParseOutcome::Err(e) => panic!(
+                "should parse without straddle error: {}",
+                e.message()
+            ),
+        }
+    }
+
+    #[test]
     fn node_is_macro_free_false_without_extent_tracking() {
         let parser = Parser::new(); // no extent tracking
         let source = "SELECT 1";


### PR DESCRIPTION
## Motivation

Fixes #125. `check_macro_straddle` fired a false positive on 3-deep nested
no-arg macros because:

1. `synq_end_macro` was called *after* restoring `layer_id` in
   `synq_parser_expand_and_feed_macro`, so it walked the parent chain from the
   caller's layer instead of the expansion layer — clobbering `layer_id` to the
   grandparent. Tokens after a nested expansion were shifted with the wrong
   `layer_id`.

2. The straddle check compared span offsets across different expansion layers
   without accounting for `_layer_id` — a category error that fired spuriously
   when offsets happened to overlap numerically.

## Changes

- **Fix layer_id clobbering**: swap the call order so `synq_end_macro` runs
  while `layer_id` still points at the expansion layer.
- **O(1) straddle detection**: replace the O(nodes×layers×fields) post-parse
  scan with reduce-time detection. The `expanded_stack` (now always maintained)
  carries `macro_root` and `from_shift` per entry. At reduce time, if any two
  terminal entries have different `macro_root` values, a sticky flag is set.
  `check_macro_straddle` returns the flag in O(1).
- **Regression test**: 3-deep nested no-arg macros (`_dfs` → `_tree_reach` →
  `_for_stack`) that previously triggered the false positive.