### PR TITLE
synq: emit hard parse error for unknown macro calls

### DIFF
--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -504,9 +504,18 @@ int synq_parser_try_macro_call(SyntaqliteParser* p,
     // Not found or error — if had_error was set, propagate.
     if (p->had_error)
       return -1;
+
+    // Lookup callback is registered but the macro was not found.
+    // This is a hard error — the user likely misspelled the macro name
+    // or forgot to define it.
+    snprintf(p->error_msg, sizeof(p->error_msg),
+             "unknown macro '%.*s'", (int)id_len,
+             (const char*)z + id_offset);
+    p->had_error = 1;
+    return -1;
   }
 
-  // No callback, or macro not found — fall through to TK_ID fallback.
+  // No callback — fall through to TK_ID fallback.
   // (We already checked macro_style/macro_fallback at the top.)
 
   // Scan balanced parens to find the end of name!(args).

--- a/syntaqlite-syntax/src/dialect.rs
+++ b/syntaqlite-syntax/src/dialect.rs
@@ -216,6 +216,14 @@ pub struct AnyDialect {
     _keep_alive: Option<std::sync::Arc<dyn Send + Sync>>,
 }
 
+impl std::fmt::Debug for AnyDialect {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnyDialect")
+            .field("inner", &self.inner)
+            .finish_non_exhaustive()
+    }
+}
+
 // SAFETY: The dialect wraps an immutable reference to static C data.
 unsafe impl Send for AnyDialect {}
 // SAFETY: AnyDialect wraps a *const CDialect to a static C dialect object; it is safe to share across threads.

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -1086,6 +1086,54 @@ mod tests {
     }
 
     #[test]
+    fn unknown_macro_with_lookup_fn_emits_error_message() {
+        // When a lookup callback is registered but the macro is not found,
+        // the parser should produce a hard error with "unknown macro 'name'".
+        // We need macro_fallback to enable macro syntax for SQLite dialect.
+        let mut parser = Parser::with_config(
+            &ParserConfig::default().with_macro_fallback(true),
+        );
+        // Lookup callback that always returns false (nothing registered).
+        parser.set_macro_lookup(Some(Box::new(TestLookup::prefix("__never__"))));
+
+        let mut session = parser.parse("SELECT foo!(1, 2);");
+        match session.next() {
+            crate::ParseOutcome::Err(e) => {
+                let msg = e.message();
+                assert!(
+                    msg.contains("unknown macro") && msg.contains("foo"),
+                    "expected 'unknown macro' error mentioning 'foo', got: '{msg}'"
+                );
+            }
+            crate::ParseOutcome::Ok(_) => {
+                panic!("expected parse error for unknown macro, got Ok");
+            }
+            crate::ParseOutcome::Done => {
+                panic!("expected parse error, got Done");
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_macro_without_lookup_fn_falls_through() {
+        // When macro_fallback is enabled but NO lookup callback is
+        // registered, unknown macro calls should fall through to TK_ID.
+        let mut parser = Parser::with_config(
+            &ParserConfig::default().with_macro_fallback(true),
+        );
+        // No set_macro_lookup — no callback.
+
+        let mut session = parser.parse("SELECT foo!(1, 2);");
+        match session.next() {
+            crate::ParseOutcome::Ok(_) => {} // Expected — no lookup, fallback mode.
+            crate::ParseOutcome::Err(e) => {
+                panic!("expected Ok without lookup_fn, got error: {}", e.message());
+            }
+            crate::ParseOutcome::Done => panic!("expected Ok, got Done"),
+        }
+    }
+
+    #[test]
     fn macro_fallback_records_macro_region() {
         let mut handle = ParserHandle::new();
         let parser = handle.parser_mut();

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -544,7 +544,7 @@ pub type AnyParseSession = TypedParseSession<AnyDialect>;
 /// Cheap to borrow — holds a raw parser pointer and dialect handle.  Nodes
 /// and lists store `&'a AnyParsedStatement<'a>` rather than an owned copy,
 /// making them `Copy` and eliminating dialect-handle clones.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct AnyParsedStatement<'a> {
     pub(crate) raw: NonNull<CParser>,
     pub(crate) dialect: AnyDialect,
@@ -949,7 +949,7 @@ impl<'a> AnyParsedStatement<'a> {
 /// - AST traversal (`root()`).
 /// - Token/comment-aware tooling (`tokens()`, `comments()`).
 /// - Dialect-agnostic pipelines (`erase()`).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TypedParsedStatement<'a, G: TypedDialect> {
     pub(crate) any: AnyParsedStatement<'a>,
     _marker: PhantomData<G>,

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -272,6 +272,7 @@ impl std::fmt::Debug for ParserToken<'_> {
 /// - Original source slice (`source()`).
 #[cfg(feature = "sqlite")]
 #[doc(hidden)]
+#[derive(Debug)]
 pub struct ParsedStatement<'a>(
     pub(super) TypedParsedStatement<'a, crate::sqlite::dialect::Dialect>,
 );

--- a/syntaqlite-syntax/src/sqlite/dialect.rs
+++ b/syntaqlite-syntax/src/sqlite/dialect.rs
@@ -11,7 +11,7 @@ use crate::util::{SqliteSyntaxFlags, SqliteVersion};
 ///
 /// Wraps an [`AnyDialect`] and implements [`TypedDialect`]. Obtain via [`dialect()`];
 /// configure with [`with_version`](Self::with_version) and [`with_cflags`](Self::with_cflags).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Dialect {
     raw: AnyDialect,
 }

--- a/syntaqlite/src/semantic/analyzer.rs
+++ b/syntaqlite/src/semantic/analyzer.rs
@@ -322,9 +322,17 @@ impl SemanticAnalyzer {
 
         // Macro registry shared between the lookup callback and the
         // analysis loop.  The callback borrows it via Rc<RefCell<…>>.
+        //
+        // Only install the lookup callback for dialects with native macro
+        // support (macro_style).  For dialects without it (e.g. SQLite
+        // with macro_fallback for embedded SQL holes), unresolved macro
+        // calls fall through to TK_ID without hitting the lookup path.
+        // When a lookup IS installed, unresolved names are hard parse errors.
         let registry: Rc<RefCell<MacroRegistry>> = Rc::new(RefCell::new(HashMap::new()));
-        let registry_for_cb = Rc::clone(&registry);
-        parser.set_macro_lookup(Some(Box::new(SharedRegistryLookup(registry_for_cb))));
+        if self.dialect.has_macro_style() {
+            let registry_for_cb = Rc::clone(&registry);
+            parser.set_macro_lookup(Some(Box::new(SharedRegistryLookup(registry_for_cb))));
+        }
 
         let mut session = parser.parse(source);
 


### PR DESCRIPTION
## Motivation

When a macro name is not found during lookup, the parser silently passes `name!(args)` through as a single `TK_ID` token. This is terrible UX — typos and undefined macros produce confusing downstream errors (or worse, silently wrong results) instead of a clear "unknown macro" message.

## Changes

- **C parser** (`parser_macros.c`): When `lookup_fn` is registered and returns "not found", emit a hard parse error `"unknown macro 'name'"` instead of falling through to TK_ID fallback.
- **Analyzer** (`analyzer.rs`): Only install the macro lookup callback for dialects with native macro support (`has_macro_style()`). SQLite + `macro_fallback` (embedded SQL) skips the callback, so hole placeholders (`__h__!()`) continue working via fallback.
- **Debug derives**: Add `Debug` impls for `AnyDialect`, `AnyParsedStatement`, `TypedParsedStatement`, `ParsedStatement`, and SQLite `Dialect` (+ codegen template).
- **Tests**: Two new parser tests verifying unknown-macro error emission and fallback-without-callback behavior.