### PR TITLE
synq: zero-cost straddle detection when no macros are used

### DIFF
--- a/syntaqlite-syntax/csrc/parser_extents.c
+++ b/syntaqlite-syntax/csrc/parser_extents.c
@@ -13,14 +13,13 @@
 // Per-node extent tracking hooks
 // ---------------------------------------------------------------------------
 //
-// Two parallel shadow stacks mirror Lemon's symbol stack:
+// When enabled, two parallel shadow stacks mirror Lemon's symbol stack:
 //
 //   * `extent_stack` tracks the merged *authored* range in root-source
 //     coordinates — used by `syntaqlite_parser_node_text`.  Macro
 //     tokens push the outermost call-site range stashed in
 //     `begin_macro_expansion`.  Epsilon pushes the sentinel
 //     `(UINT32_MAX, 0)`, which is neutral under min/max merging.
-//     Only maintained when `collect_node_extents` is enabled.
 //
 //   * `expanded_stack` tracks the merged *expanded* range in the
 //     tokens' own layer — used by
@@ -28,24 +27,25 @@
 //     the layer; mixed-layer merges collapse to the sentinel
 //     `(length=0)`, since no contiguous expansion slice can represent
 //     a node whose tokens cross layers.
-//     Always maintained — also carries `macro_root` and `from_shift`
-//     for O(1) macro straddle detection.
+//
+// Independently, `straddle_stack` (a lightweight uint32_t vec) tracks
+// macro_root per Lemon stack symbol for O(1) straddle detection.  It
+// is lazily initialized on first macro use via `lemon_depth`; without
+// macros the only cost is one integer increment/decrement per
+// shift/reduce.
 
 void synq_extent_on_shift(SynqParseCtx* pCtx,
                           unsigned int major,
                           const SynqParseToken* token) {
   (void)major;
 
-  uint32_t macro_root =
-      (token->layer_id != 0) ? pCtx->macro_root_layer : 0;
-  SynqNodeExpandedExtent e = {
-      .offset = token->offset,
-      .length = token->n,
-      .layer_id = token->layer_id,
-      .macro_root = macro_root,
-      .from_shift = 1,
-  };
-  syntaqlite_vec_push(&pCtx->expanded_stack, e, pCtx->mem);
+  pCtx->lemon_depth++;
+
+  // Straddle stack: only active after first macro (macro_root_layer > 0).
+  if (pCtx->macro_root_layer) {
+    uint32_t mr = (token->layer_id != 0) ? pCtx->macro_root_layer : 0;
+    syntaqlite_vec_push(&pCtx->straddle_stack, mr, pCtx->mem);
+  }
 
   if (!pCtx->collect_node_extents) {
     return;
@@ -59,75 +59,40 @@ void synq_extent_on_shift(SynqParseCtx* pCtx,
     r.root_end = pCtx->macro_root_end;
   }
   syntaqlite_vec_push(&pCtx->extent_stack, r, pCtx->mem);
+
+  SynqNodeExpandedExtent e = {
+      .offset = token->offset,
+      .length = token->n,
+      .layer_id = token->layer_id,
+  };
+  syntaqlite_vec_push(&pCtx->expanded_stack, e, pCtx->mem);
 }
 
 void synq_extent_on_reduce(SynqParseCtx* pCtx, unsigned int nrhs) {
-  uint32_t exp_len = syntaqlite_vec_len(&pCtx->expanded_stack);
+  // Reduce pops nrhs symbols and pushes 1: net change = 1 - nrhs.
+  pCtx->lemon_depth = pCtx->lemon_depth + 1 - nrhs;
 
-  // Straddle detection: if any two terminal (from_shift=1) entries
-  // have different macro_root values, the expansion boundary cuts
-  // through this grammar production.
-  if (!pCtx->has_macro_straddle) {
-    uint32_t first_term_root = SYNQ_MACRO_ROOT_NEUTRAL;
-    for (uint32_t i = exp_len - nrhs; i < exp_len; i++) {
-      SynqNodeExpandedExtent e =
-          syntaqlite_vec_at(&pCtx->expanded_stack, i);
-      if (!e.from_shift)
-        continue;
-      if (first_term_root == SYNQ_MACRO_ROOT_NEUTRAL) {
-        first_term_root = e.macro_root;
-      } else if (e.macro_root != first_term_root) {
-        pCtx->has_macro_straddle = 1;
-        break;
+  // Straddle detection on the lightweight stack.
+  if (pCtx->macro_root_layer) {
+    uint32_t slen = syntaqlite_vec_len(&pCtx->straddle_stack);
+    if (!pCtx->has_macro_straddle) {
+      uint32_t first = SYNQ_STRADDLE_NEUTRAL;
+      for (uint32_t i = slen - nrhs; i < slen; i++) {
+        uint32_t v = syntaqlite_vec_at(&pCtx->straddle_stack, i);
+        if (v == SYNQ_STRADDLE_NEUTRAL)
+          continue;
+        if (first == SYNQ_STRADDLE_NEUTRAL) {
+          first = v;
+        } else if (v != first) {
+          pCtx->has_macro_straddle = 1;
+          break;
+        }
       }
     }
+    syntaqlite_vec_truncate(&pCtx->straddle_stack, slen - nrhs);
+    syntaqlite_vec_push(&pCtx->straddle_stack, SYNQ_STRADDLE_NEUTRAL,
+                        pCtx->mem);
   }
-
-  // Merge expanded-layer spans.
-  SynqNodeExpandedExtent exp_merged = {
-      0, 0, 0, SYNQ_MACRO_ROOT_NEUTRAL, 0};
-  for (uint32_t i = exp_len - nrhs; i < exp_len; i++) {
-    SynqNodeExpandedExtent e = syntaqlite_vec_at(&pCtx->expanded_stack, i);
-
-    if (exp_merged.macro_root == SYNQ_MACRO_ROOT_NEUTRAL &&
-        e.macro_root != SYNQ_MACRO_ROOT_NEUTRAL) {
-      exp_merged.macro_root = e.macro_root;
-    }
-
-    if (e.layer_id == SYNQ_CROSS_LAYER) {
-      uint32_t saved_mr = exp_merged.macro_root;
-      exp_merged = e;
-      exp_merged.macro_root = saved_mr;
-      exp_merged.from_shift = 0;
-      break;
-    }
-    if (e.length == 0) {
-      continue;
-    }
-    if (exp_merged.length == 0) {
-      exp_merged.layer_id = e.layer_id;
-      exp_merged.offset = e.offset;
-      exp_merged.length = e.length;
-      continue;
-    }
-    if (exp_merged.layer_id != e.layer_id) {
-      uint32_t saved_mr = exp_merged.macro_root;
-      exp_merged =
-          (SynqNodeExpandedExtent){0, 0, SYNQ_CROSS_LAYER, 0, 0};
-      exp_merged.macro_root = saved_mr;
-      break;
-    }
-    uint32_t start =
-        exp_merged.offset < e.offset ? exp_merged.offset : e.offset;
-    uint32_t end_a = exp_merged.offset + exp_merged.length;
-    uint32_t end_b = e.offset + e.length;
-    uint32_t end = end_a > end_b ? end_a : end_b;
-    exp_merged.offset = start;
-    exp_merged.length = end - start;
-  }
-  exp_merged.from_shift = 0;
-  syntaqlite_vec_truncate(&pCtx->expanded_stack, exp_len - nrhs);
-  syntaqlite_vec_push(&pCtx->expanded_stack, exp_merged, pCtx->mem);
 
   if (!pCtx->collect_node_extents) {
     return;
@@ -146,4 +111,36 @@ void synq_extent_on_reduce(SynqParseCtx* pCtx, unsigned int nrhs) {
   }
   syntaqlite_vec_truncate(&pCtx->extent_stack, len - nrhs);
   syntaqlite_vec_push(&pCtx->extent_stack, merged, pCtx->mem);
+
+  // Merge expanded-layer spans: all same layer → merge in that layer;
+  // epsilon entries ({0,0,0}) are neutral; cross-layer poison
+  // (layer_id == SYNQ_CROSS_LAYER) propagates upward unconditionally.
+  SynqNodeExpandedExtent exp_merged = {0, 0, 0};
+  for (uint32_t i = len - nrhs; i < len; i++) {
+    SynqNodeExpandedExtent e = syntaqlite_vec_at(&pCtx->expanded_stack, i);
+    if (e.layer_id == SYNQ_CROSS_LAYER) {
+      exp_merged = e;  // propagate poison
+      break;
+    }
+    if (e.length == 0) {
+      continue;  // skip epsilon
+    }
+    if (exp_merged.length == 0) {
+      exp_merged = e;
+      continue;
+    }
+    if (exp_merged.layer_id != e.layer_id) {
+      exp_merged = (SynqNodeExpandedExtent){0, 0, SYNQ_CROSS_LAYER};
+      break;
+    }
+    uint32_t start =
+        exp_merged.offset < e.offset ? exp_merged.offset : e.offset;
+    uint32_t end_a = exp_merged.offset + exp_merged.length;
+    uint32_t end_b = e.offset + e.length;
+    uint32_t end = end_a > end_b ? end_a : end_b;
+    exp_merged.offset = start;
+    exp_merged.length = end - start;
+  }
+  syntaqlite_vec_truncate(&pCtx->expanded_stack, len - nrhs);
+  syntaqlite_vec_push(&pCtx->expanded_stack, exp_merged, pCtx->mem);
 }

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -7,6 +7,7 @@
 #define SYNTAQLITE_CSRC_PARSER_INTERNAL_H
 
 #include <stdint.h>
+#include <stdio.h>
 
 #include "syntaqlite/config.h"
 #include "syntaqlite/dialect.h"
@@ -224,8 +225,14 @@ int synq_parser_try_macro_call(SyntaqliteParser* p,
                                uint32_t id_len,
                                uint32_t bang_offset);
 
-// Diagnose macro expansions that straddle AST node boundaries.
-int synq_parser_check_macro_straddle(SyntaqliteParser* p);
+static inline int synq_parser_check_macro_straddle(SyntaqliteParser* p) {
+  if (!p->ctx.has_macro_straddle)
+    return 0;
+  snprintf(p->error_msg, sizeof(p->error_msg),
+           "macro expansion straddles node boundary");
+  p->had_error = 1;
+  return -1;
+}
 
 // Initialize macro state vecs (callback/expansion fields zeroed by memset).
 void synq_macro_state_init(SynqMacroState* m);

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -476,6 +476,11 @@ static void begin_macro_expansion(SyntaqliteParser* p,
   if (p->ctx.layer_id == 0) {
     p->ctx.macro_root_start = call_offset;
     p->ctx.macro_root_end = call_offset + call_length;
+    if (p->ctx.macro_root_layer == 0) {
+      for (uint32_t i = 0; i < p->ctx.lemon_depth; i++)
+        syntaqlite_vec_push(&p->ctx.straddle_stack, SYNQ_STRADDLE_NEUTRAL,
+                            p->mem);
+    }
     p->ctx.macro_root_layer = syntaqlite_vec_len(&p->macro.layers);
   }
 
@@ -576,19 +581,6 @@ int synq_parser_try_macro_call(SyntaqliteParser* p,
       synq_parser_record_and_feed(p, SYNTAQLITE_TK_ID, id_offset, call_length);
   p->offset = end_offset;
   return rc;
-}
-
-// ---------------------------------------------------------------------------
-// Macro straddle diagnostic
-// ---------------------------------------------------------------------------
-
-int synq_parser_check_macro_straddle(SyntaqliteParser* p) {
-  if (!p->ctx.has_macro_straddle)
-    return 0;
-  snprintf(p->error_msg, sizeof(p->error_msg),
-           "macro expansion straddles node boundary");
-  p->had_error = 1;
-  return -1;
 }
 
 // ---------------------------------------------------------------------------

--- a/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
@@ -50,24 +50,22 @@ typedef struct SynqExtentRange {
 // they live.
 //
 // Sentinel states:
-//   {0, 0, 0, *, 0}            — epsilon (no tokens); neutral in merges.
-//   {_, 0, SYNQ_CROSS_LAYER, *, 0}
-//                               — cross-layer poison; propagates through
-//                                 parent merges so the fast path falls
-//                                 through to the slow path.
-//
-// The `macro_root` and `from_shift` fields support O(1) straddle
-// detection during reduce (see parser_extents.c).
+//   {0, 0, 0}                  — epsilon (no tokens); neutral in merges.
+//   {_, 0, SYNQ_CROSS_LAYER}   — cross-layer poison; propagates through
+//                                parent merges so the fast path falls
+//                                through to the slow path.
 #define SYNQ_CROSS_LAYER UINT32_MAX
-#define SYNQ_MACRO_ROOT_NEUTRAL UINT32_MAX
 typedef struct SynqNodeExpandedExtent {
   uint32_t offset;
   uint32_t length;
   uint32_t layer_id;
-  uint32_t macro_root;  // 0 = source, >0 = outermost expansion layer idx,
-                         // SYNQ_MACRO_ROOT_NEUTRAL = epsilon / neutral.
-  uint32_t from_shift;  // 1 = terminal (pushed at shift), 0 = non-terminal.
 } SynqNodeExpandedExtent;
+
+// Straddle stack entry values (packed into uint32_t):
+//   0              = source terminal
+//   1..N           = terminal from outermost expansion layer N
+//   SYNQ_STRADDLE_NEUTRAL = non-terminal / epsilon (neutral in checks)
+#define SYNQ_STRADDLE_NEUTRAL UINT32_MAX
 
 // ---------------------------------------------------------------------------
 // Parse context — threaded through grammar actions via %extra_argument
@@ -148,6 +146,8 @@ typedef struct SynqParseCtx {
   uint32_t macro_root_end;
   uint32_t macro_root_layer;    // Outermost expansion layer idx (set on entry).
   uint32_t has_macro_straddle;  // Sticky flag set during reduce.
+  uint32_t lemon_depth;         // Lemon stack depth (always tracked, for lazy init).
+  SYNQ_VEC(uint32_t) straddle_stack;  // Lazily initialized on first macro use.
 } SynqParseCtx;
 
 // Common header for all list nodes in the arena.
@@ -205,6 +205,8 @@ static inline void synq_parse_ctx_init(SynqParseCtx* ctx,
   ctx->macro_root_end = 0;
   ctx->macro_root_layer = 0;
   ctx->has_macro_straddle = 0;
+  ctx->lemon_depth = 0;
+  syntaqlite_vec_init(&ctx->straddle_stack);
 }
 
 static inline void synq_parse_ctx_free(SynqParseCtx* ctx) {
@@ -214,6 +216,7 @@ static inline void synq_parse_ctx_free(SynqParseCtx* ctx) {
   syntaqlite_vec_free(&ctx->node_extents, ctx->mem);
   syntaqlite_vec_free(&ctx->expanded_stack, ctx->mem);
   syntaqlite_vec_free(&ctx->node_expanded_extents, ctx->mem);
+  syntaqlite_vec_free(&ctx->straddle_stack, ctx->mem);
   synq_arena_free(&ctx->ast, ctx->mem);
 }
 
@@ -230,6 +233,8 @@ static inline void synq_parse_ctx_clear(SynqParseCtx* ctx) {
   ctx->macro_root_end = 0;
   ctx->macro_root_layer = 0;
   ctx->has_macro_straddle = 0;
+  ctx->lemon_depth = 0;
+  syntaqlite_vec_clear(&ctx->straddle_stack);
 }
 
 // Record the current shadow-stack tops (authored + expanded) as the


### PR DESCRIPTION
## Motivation

Follow-up to #138. The straddle detection added there always maintained the
`expanded_stack` even for plain SQL without macros, adding unnecessary overhead
(~20 bytes per shift).

## Changes

- Use a separate lightweight `straddle_stack` (`uint32_t` per entry, 4 bytes)
  that is lazily initialized on first macro use via a `lemon_depth` counter.
- Without macros the only cost is one integer increment per shift and one
  adjustment per reduce — zero allocations.
- Inline `check_macro_straddle` into the header since it's now a trivial flag
  check.