### PR TITLE
synq: add permissive mode for unknown $param in macro expansion

### DIFF
--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -552,9 +552,8 @@ int synq_parser_try_macro_call(SyntaqliteParser* p,
     // Lookup callback is registered but the macro was not found.
     // This is a hard error — the user likely misspelled the macro name
     // or forgot to define it.
-    snprintf(p->error_msg, sizeof(p->error_msg),
-             "unknown macro '%.*s'", (int)id_len,
-             (const char*)z + id_offset);
+    snprintf(p->error_msg, sizeof(p->error_msg), "unknown macro '%.*s'",
+             (int)id_len, (const char*)z + id_offset);
     p->had_error = 1;
     return -1;
   }
@@ -606,7 +605,8 @@ SYNTAQLITE_API int syntaqlite_macro_expansion_expand_and_set_result(
     uint32_t body_len,
     const char* const* param_names,
     const uint32_t* param_name_lens,
-    uint32_t param_count) {
+    uint32_t param_count,
+    uint32_t flags) {
   const SyntaqliteToken* args = p->macro.expansion_args;
   uint32_t arg_count = p->macro.expansion_arg_count;
 
@@ -651,8 +651,17 @@ SYNTAQLITE_API int syntaqlite_macro_expansion_expand_and_set_result(
         }
       }
 
-      if (found < 0)
+      if (found < 0) {
+        if (flags & SYNTAQLITE_EXPAND_PASSTHROUGH_UNKNOWN) {
+          // Copy the unknown $param verbatim into the expansion buffer.
+          syntaqlite_vec_push_n(&p->macro.expand_buf,
+                                (const uint8_t*)(zbody + pos), (uint32_t)tlen,
+                                p->mem);
+          pos += (uint32_t)tlen;
+          continue;
+        }
         return -1;
+      }
 
       if ((uint32_t)found < arg_count && args[found].length > 0) {
         if (mapping_count < 64) {

--- a/syntaqlite-syntax/include/syntaqlite/incremental.h
+++ b/syntaqlite-syntax/include/syntaqlite/incremental.h
@@ -147,13 +147,23 @@ SYNTAQLITE_API void syntaqlite_macro_expansion_set_result_with_arg_map(
 // Template expansion helper: substitute `$param` placeholders with the
 // current invocation's args and call set_result.  Arg segments are built
 // automatically.  Returns 0 on success.
+//
+// `flags` is a bitwise OR of SYNTAQLITE_EXPAND_* constants (0 for defaults).
+//
+// By default, encountering a `$param` that does not match any entry in
+// `param_names` is an error (returns -1).  Pass
+// SYNTAQLITE_EXPAND_PASSTHROUGH_UNKNOWN to copy unknown `$param` tokens
+// verbatim into the expansion buffer instead.
+#define SYNTAQLITE_EXPAND_PASSTHROUGH_UNKNOWN 0x1u
+
 SYNTAQLITE_API int syntaqlite_macro_expansion_expand_and_set_result(
     SyntaqliteParser* p,
     const char* body,
     uint32_t body_len,
     const char* const* param_names,
     const uint32_t* param_name_lens,
-    uint32_t param_count);
+    uint32_t param_count,
+    uint32_t flags);
 
 #ifdef __cplusplus
 }

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -579,6 +579,7 @@ unsafe extern "C" {
         param_names: *const *const c_char,
         param_name_lens: *const u32,
         param_count: u32,
+        flags: u32,
     ) -> i32;
 
     // Macro lookup callback
@@ -1090,9 +1091,7 @@ mod tests {
         // When a lookup callback is registered but the macro is not found,
         // the parser should produce a hard error with "unknown macro 'name'".
         // We need macro_fallback to enable macro syntax for SQLite dialect.
-        let mut parser = Parser::with_config(
-            &ParserConfig::default().with_macro_fallback(true),
-        );
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
         // Lookup callback that always returns false (nothing registered).
         parser.set_macro_lookup(Some(Box::new(TestLookup::prefix("__never__"))));
 
@@ -1118,9 +1117,7 @@ mod tests {
     fn unknown_macro_without_lookup_fn_falls_through() {
         // When macro_fallback is enabled but NO lookup callback is
         // registered, unknown macro calls should fall through to TK_ID.
-        let mut parser = Parser::with_config(
-            &ParserConfig::default().with_macro_fallback(true),
-        );
+        let parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
         // No set_macro_lookup — no callback.
 
         let mut session = parser.parse("SELECT foo!(1, 2);");

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -87,8 +87,20 @@ impl MacroOutput {
     /// Uses the SQL tokenizer to correctly skip `$param` inside string
     /// literals and comments. Returns `true` on success, `false` if arg
     /// count doesn't match or a placeholder references an unknown param.
-    #[expect(clippy::cast_possible_truncation)]
     pub fn expand_template(&mut self, body: &str, params: &[String]) -> bool {
+        self.expand_template_inner(body, params, 0)
+    }
+
+    /// Like [`expand_template`](Self::expand_template), but unknown `$param`
+    /// tokens (those not in `params`) are copied verbatim into the expansion
+    /// buffer instead of causing a failure. This is useful for macros whose
+    /// bodies contain `$placeholders` intended for a nested macro.
+    pub fn expand_template_permissive(&mut self, body: &str, params: &[String]) -> bool {
+        self.expand_template_inner(body, params, EXPAND_PASSTHROUGH_UNKNOWN)
+    }
+
+    #[expect(clippy::cast_possible_truncation)]
+    fn expand_template_inner(&mut self, body: &str, params: &[String], flags: u32) -> bool {
         let param_ptrs: Vec<*const std::ffi::c_char> =
             params.iter().map(|p| p.as_ptr().cast()).collect();
         let param_lens: Vec<u32> = params.iter().map(|p| p.len() as u32).collect();
@@ -102,11 +114,15 @@ impl MacroOutput {
                 param_ptrs.as_ptr(),
                 param_lens.as_ptr(),
                 params.len() as u32,
+                flags,
             )
         };
         rc == 0
     }
 }
+
+/// Flag: copy unknown `$param` tokens verbatim instead of failing.
+const EXPAND_PASSTHROUGH_UNKNOWN: u32 = 0x1;
 
 /// Trait for macro lookup callbacks.
 ///

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -1397,15 +1397,123 @@ mod tests {
         );
     }
 
+    /// A macro registry that uses permissive expansion (unknown $params pass through).
+    struct PermissiveMacroRegistry {
+        macros: HashMap<String, (Vec<String>, String)>,
+    }
+    impl PermissiveMacroRegistry {
+        fn new() -> Self {
+            Self {
+                macros: HashMap::new(),
+            }
+        }
+        fn register(&mut self, name: &str, params: &[&str], body: &str) {
+            self.macros.insert(
+                name.to_ascii_lowercase(),
+                (
+                    params.iter().map(ToString::to_string).collect(),
+                    body.to_string(),
+                ),
+            );
+        }
+    }
+    impl MacroLookup for PermissiveMacroRegistry {
+        fn lookup(&mut self, name: &str, _args: &[MacroArg<'_>], out: &mut MacroOutput) -> bool {
+            let Some((params, body)) = self.macros.get(&name.to_ascii_lowercase()) else {
+                return false;
+            };
+            out.expand_template_permissive(body, params)
+        }
+    }
+
+    #[test]
+    fn expand_template_strict_rejects_unknown_param() {
+        // Default (strict) expand_template should fail when the body
+        // references a $param not in the declared param list.
+        // We verify by checking that the lookup returns false.
+        struct StrictCheckRegistry {
+            lookup_failed: bool,
+        }
+        impl MacroLookup for StrictCheckRegistry {
+            fn lookup(
+                &mut self,
+                _name: &str,
+                _args: &[MacroArg<'_>],
+                out: &mut MacroOutput,
+            ) -> bool {
+                let params = vec!["x".to_string()];
+                let ok = out.expand_template("SELECT $x, $unknown", &params);
+                if !ok {
+                    self.lookup_failed = true;
+                }
+                ok
+            }
+        }
+
+        struct Wrapper(Rc<RefCell<StrictCheckRegistry>>);
+        impl MacroLookup for Wrapper {
+            fn lookup(&mut self, name: &str, args: &[MacroArg<'_>], out: &mut MacroOutput) -> bool {
+                self.0.borrow_mut().lookup(name, args, out)
+            }
+        }
+
+        let reg = Rc::new(RefCell::new(StrictCheckRegistry {
+            lookup_failed: false,
+        }));
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        parser.set_macro_lookup(Some(Box::new(Wrapper(Rc::clone(&reg)))));
+
+        let mut session = parser.parse("SELECT foo!(1);");
+        let _ = session.next();
+        assert!(
+            reg.borrow().lookup_failed,
+            "strict expand_template should reject unknown $param"
+        );
+    }
+
+    #[test]
+    fn expand_template_permissive_passes_through_unknown_param() {
+        // Permissive expansion should copy unknown $params verbatim.
+        let mut parser = Parser::with_config(
+            &ParserConfig::default()
+                .with_macro_fallback(true)
+                .with_collect_node_extents(true),
+        );
+        let mut reg = PermissiveMacroRegistry::new();
+        // Body uses $x (declared) and $y (not declared — should pass through).
+        // $y is in a value position so the parser accepts it as a variable.
+        reg.register("foo", &["x"], "SELECT $x, $y");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let mut session = parser.parse("foo!(42);");
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(err) => panic!("unexpected error: {}", err.message()),
+        };
+
+        // The expanded text should contain `$y` verbatim and `42` substituted.
+        let root_id = stmt.erase().root_id();
+        let expanded = stmt
+            .node_expanded_text(root_id)
+            .expect("should have expanded text");
+        assert!(
+            expanded.contains("42"),
+            "expected substituted arg in expansion, got: {expanded:?}"
+        );
+        assert!(
+            expanded.contains("$y"),
+            "expected unknown $y to pass through verbatim, got: {expanded:?}"
+        );
+    }
+
     #[test]
     fn three_deep_nested_no_arg_macros_no_spurious_straddle() {
         // Regression test for #125: check_macro_straddle fired a false
         // positive on 3-deep nested no-arg macros because it compared
         // span offsets across different expansion layers without
         // accounting for _layer_id.
-        let mut parser = Parser::with_config(
-            &ParserConfig::default().with_macro_fallback(true),
-        );
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
         let mut reg = TestMacroRegistry::new();
         reg.register("_dfs", &[], "(SELECT node_id AS id)");
         reg.register("_tree_reach", &[], "(SELECT node_id FROM _dfs!())");
@@ -1420,10 +1528,7 @@ mod tests {
         match session.next() {
             ParseOutcome::Ok(_) => {} // expected
             ParseOutcome::Done => panic!("expected a statement"),
-            ParseOutcome::Err(e) => panic!(
-                "should parse without straddle error: {}",
-                e.message()
-            ),
+            ParseOutcome::Err(e) => panic!("should parse without straddle error: {}", e.message()),
         }
     }
 

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -140,6 +140,7 @@ impl core::convert::From<syntaqlite_syntax::nodes::WithClauseId> for syntaqlite_
 impl core::convert::From<syntaqlite_syntax::typed::Dialect> for syntaqlite_syntax::any::AnyDialect
 impl core::convert::From<syntaqlite_syntax::typed::TypedIncrementalParseSession<syntaqlite_syntax::typed::Dialect>> for syntaqlite_syntax::IncrementalParseSession
 impl core::fmt::Debug for syntaqlite_syntax::ParserToken<'_>
+impl core::fmt::Debug for syntaqlite_syntax::any::AnyDialect
 impl core::fmt::Debug for syntaqlite_syntax::any::AnyNode<'_>
 impl core::fmt::Debug for syntaqlite_syntax::any::NodeFields
 impl core::fmt::Debug for syntaqlite_syntax::nodes::AggregateFunctionCall<'_>
@@ -783,6 +784,7 @@ pub fn syntaqlite_syntax::IncrementalParseSession::from(inner: syntaqlite_syntax
 pub fn syntaqlite_syntax::IncrementalParseSession::node_count(&self) -> u32
 pub fn syntaqlite_syntax::MacroLookup::lookup(&mut self, name: &str, args: &[syntaqlite_syntax::MacroArg<'_>], out: &mut syntaqlite_syntax::MacroOutput) -> bool
 pub fn syntaqlite_syntax::MacroOutput::expand_template(&mut self, body: &str, params: &[alloc::string::String]) -> bool
+pub fn syntaqlite_syntax::MacroOutput::expand_template_permissive(&mut self, body: &str, params: &[alloc::string::String]) -> bool
 pub fn syntaqlite_syntax::MacroOutput::set_definition(&mut self, line: u32, col: u32)
 pub fn syntaqlite_syntax::MacroOutput::write(&mut self, body: &str)
 pub fn syntaqlite_syntax::ParseOutcome<T, E>::map<U>(self, f: impl core::ops::function::FnOnce(T) -> U) -> syntaqlite_syntax::ParseOutcome<U, E>
@@ -810,6 +812,7 @@ pub fn syntaqlite_syntax::TokenType::from_token_type(raw: syntaqlite_syntax::any
 pub fn syntaqlite_syntax::any::AnyDialect::cflags(&self) -> syntaqlite_syntax::util::SqliteSyntaxFlags
 pub fn syntaqlite_syntax::any::AnyDialect::classify_token(&self, token_type: syntaqlite_syntax::any::AnyTokenType, flags: syntaqlite_syntax::ParserTokenFlags) -> syntaqlite_syntax::any::TokenCategory
 pub fn syntaqlite_syntax::any::AnyDialect::field_meta(&self, tag: syntaqlite_syntax::any::AnyNodeTag) -> impl core::iter::traits::exact_size::ExactSizeIterator<Item = syntaqlite_syntax::any::FieldMeta<'static>>
+pub fn syntaqlite_syntax::any::AnyDialect::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn syntaqlite_syntax::any::AnyDialect::from(g: syntaqlite_syntax::typed::Dialect) -> syntaqlite_syntax::any::AnyDialect
 pub fn syntaqlite_syntax::any::AnyDialect::has_macro_style(&self) -> bool
 pub fn syntaqlite_syntax::any::AnyDialect::is_list(&self, tag: syntaqlite_syntax::any::AnyNodeTag) -> bool


### PR DESCRIPTION
## Motivation

Fixes #126. `expand_and_set_result` rejects any `$foo` in a macro body that doesn't match a declared param, but users composing nested macros need unknown `$params` to survive the outer expansion verbatim so inner macros can resolve them.

## Changes

- Add `uint32_t flags` parameter to the C `expand_and_set_result` API with a new `SYNTAQLITE_EXPAND_PASSTHROUGH_UNKNOWN` flag
- When set, unknown `$param` tokens are copied verbatim into the expansion buffer instead of returning -1
- Default (flags=0) remains strict — no behavior change for existing callers
- Expose via `MacroOutput::expand_template_permissive()` on the Rust side
- Tests for both strict rejection and permissive passthrough