### PR TITLE
synq: expose macro expansions as a flat list of rewrites

### DIFF
--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -582,11 +582,12 @@ SYNTAQLITE_API uint32_t syntaqlite_result_macro_count(SyntaqliteParser* p) {
   (void)p;
   return 0;
 }
-SYNTAQLITE_API SyntaqliteMacroRegion
-syntaqlite_result_macro_at(SyntaqliteParser* p, uint32_t idx) {
+SYNTAQLITE_API SyntaqliteMacroRewrite
+syntaqlite_result_macro_rewrite_at(SyntaqliteParser* p, uint32_t idx) {
   (void)p;
   (void)idx;
-  return (SyntaqliteMacroRegion){0, 0};
+  return (SyntaqliteMacroRewrite){
+      SYNTAQLITE_MACRO_PARENT_SOURCE, 0, 0, NULL, 0, NULL, 0, 0, 0};
 }
 #else
 SYNTAQLITE_API uint32_t syntaqlite_result_macro_count(SyntaqliteParser* p) {
@@ -594,15 +595,26 @@ SYNTAQLITE_API uint32_t syntaqlite_result_macro_count(SyntaqliteParser* p) {
   // Entry 0 is the source sentinel; real expansion layers start at 1.
   return total <= 1 ? 0 : total - 1;
 }
-SYNTAQLITE_API SyntaqliteMacroRegion
-syntaqlite_result_macro_at(SyntaqliteParser* p, uint32_t idx) {
+SYNTAQLITE_API SyntaqliteMacroRewrite
+syntaqlite_result_macro_rewrite_at(SyntaqliteParser* p, uint32_t idx) {
   // +1 to skip the source sentinel at index 0.
   uint32_t layer_idx = idx + 1;
   if (layer_idx >= syntaqlite_vec_len(&p->macro.layers)) {
-    return (SyntaqliteMacroRegion){0, 0};
+    return (SyntaqliteMacroRewrite){
+        SYNTAQLITE_MACRO_PARENT_SOURCE, 0, 0, NULL, 0, NULL, 0, 0, 0};
   }
   const SynqExpansionLayer* lyr = &p->macro.layers.data[layer_idx];
-  return (SyntaqliteMacroRegion){lyr->call_offset, lyr->call_length};
+  // Internal parent_layer_id 0 = authored source sentinel.  Map it to the
+  // public sentinel value; otherwise subtract 1 to account for the skipped
+  // source entry.
+  uint32_t parent_idx = lyr->parent_layer_id == 0
+                            ? SYNTAQLITE_MACRO_PARENT_SOURCE
+                            : lyr->parent_layer_id - 1;
+  return (SyntaqliteMacroRewrite){
+      parent_idx,          lyr->call_offset,   lyr->call_length,
+      lyr->expansion_data, lyr->expansion_len, lyr->name,
+      lyr->name_len,       lyr->def_line,      lyr->def_col,
+  };
 }
 #endif
 

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -552,9 +552,8 @@ int synq_parser_try_macro_call(SyntaqliteParser* p,
     // Lookup callback is registered but the macro was not found.
     // This is a hard error — the user likely misspelled the macro name
     // or forgot to define it.
-    snprintf(p->error_msg, sizeof(p->error_msg),
-             "unknown macro '%.*s'", (int)id_len,
-             (const char*)z + id_offset);
+    snprintf(p->error_msg, sizeof(p->error_msg), "unknown macro '%.*s'",
+             (int)id_len, (const char*)z + id_offset);
     p->had_error = 1;
     return -1;
   }

--- a/syntaqlite-syntax/include/syntaqlite/incremental.h
+++ b/syntaqlite-syntax/include/syntaqlite/incremental.h
@@ -41,8 +41,8 @@
 // done:
 //   syntaqlite_parser_destroy(p);
 //
-// Read accumulated macro regions via syntaqlite_result_macro_count() /
-// syntaqlite_result_macro_at() after parsing.
+// Read accumulated macro rewrites via syntaqlite_result_macro_count() /
+// syntaqlite_result_macro_rewrite_at() after parsing.
 
 #ifndef SYNTAQLITE_INCREMENTAL_PARSER_H
 #define SYNTAQLITE_INCREMENTAL_PARSER_H

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -127,7 +127,7 @@ SYNTAQLITE_API int32_t syntaqlite_parser_set_trace(SyntaqliteParser* p,
 // Enable macro fallback: when the dialect uses SYNQ_MACRO_STYLE_RUST and a
 // name!(args) call is encountered but the name is NOT in the macro registry,
 // consume the entire name!(args) as a single TK_ID token instead of raising
-// a parse error. A MacroRegion is recorded so the formatter can emit the
+// a parse error. A MacroRewrite is recorded so the formatter can emit the
 // call verbatim. Default: off (0).
 // Returns 0 on success, -1 if the parser has already been used.
 SYNTAQLITE_API int32_t syntaqlite_parser_set_macro_fallback(SyntaqliteParser* p,
@@ -207,20 +207,61 @@ SYNTAQLITE_API const SyntaqliteParserToken* syntaqlite_result_tokens(
     SyntaqliteParser* p,
     uint32_t* count);
 
-// A recorded macro invocation region.
-// For the input-side begin/end API see incremental.h.
-typedef struct SyntaqliteMacroRegion {
-  uint32_t call_offset;  // Byte offset of macro call in original source.
-  uint32_t call_length;  // Byte length of entire macro call.
-} SyntaqliteMacroRegion;
+// Sentinel value for `SyntaqliteMacroRewrite::parent_idx` meaning "this
+// rewrite applies directly to the authored source" (i.e. the rewrite is
+// not nested inside another macro's expansion).
+#define SYNTAQLITE_MACRO_PARENT_SOURCE UINT32_MAX
 
-// Macro-invocation call sites recorded during parsing.  Accessed via count
-// + indexed getter rather than an array pointer to avoid materializing a
-// separate view — the internal representation carries more data per entry
-// than `SyntaqliteMacroRegion` exposes.
+// A recorded macro invocation — enough information to reconstruct a
+// source-to-expanded rewrite tree (e.g. to drive Perfetto's
+// SqlSource::Rewriter or an equivalent).
+//
+// Entries are reported in insertion order: outer macros appear before the
+// nested macros they contain, and macros at the same nesting level appear
+// in source order.
+//
+// `parent_idx` is either SYNTAQLITE_MACRO_PARENT_SOURCE (the rewrite
+// replaces a range in the authored source) or the index of another entry
+// in this same flat list (the rewrite replaces a range in that entry's
+// `expansion` buffer).
+//
+// `call_offset` / `call_length` describe the byte range of the macro call
+// inside the parent's text (authored source if `parent_idx` is the
+// sentinel, otherwise the parent entry's `expansion` buffer).
+//
+// `expansion` is the replacement text for that range.  It is NOT
+// NUL-terminated; use `expansion_len`.  Nested macro calls appearing
+// inside `expansion` are reported as separate entries that reference this
+// entry via their `parent_idx`.
+//
+// `name` is the macro name as it appears at the call site (NOT
+// NUL-terminated; use `name_len`).
+//
+// `def_line` / `def_col` record the 1-based line/column of the macro
+// definition (0 if unknown), for traceback purposes.
+//
+// Pointers (`expansion`, `name`) are owned by the parser and remain valid
+// until the next `syntaqlite_parser_next`, `syntaqlite_parser_reset`, or
+// `syntaqlite_parser_destroy` call.
+typedef struct SyntaqliteMacroRewrite {
+  uint32_t parent_idx;
+  uint32_t call_offset;
+  uint32_t call_length;
+  const char* expansion;
+  uint32_t expansion_len;
+  const char* name;
+  uint32_t name_len;
+  uint32_t def_line;
+  uint32_t def_col;
+} SyntaqliteMacroRewrite;
+
+// Number of macro rewrites recorded for the current statement.
 SYNTAQLITE_API uint32_t syntaqlite_result_macro_count(SyntaqliteParser* p);
-SYNTAQLITE_API SyntaqliteMacroRegion
-syntaqlite_result_macro_at(SyntaqliteParser* p, uint32_t idx);
+
+// Returns the rewrite at `idx` (0-based).  Returns a zero-initialized
+// struct if `idx >= syntaqlite_result_macro_count(p)`.
+SYNTAQLITE_API SyntaqliteMacroRewrite
+syntaqlite_result_macro_rewrite_at(SyntaqliteParser* p, uint32_t idx);
 
 // ---------------------------------------------------------------------------
 // Arena accessors

--- a/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
@@ -146,7 +146,7 @@ typedef struct SynqParseCtx {
   uint32_t macro_root_end;
   uint32_t macro_root_layer;    // Outermost expansion layer idx (set on entry).
   uint32_t has_macro_straddle;  // Sticky flag set during reduce.
-  uint32_t lemon_depth;         // Lemon stack depth (always tracked, for lazy init).
+  uint32_t lemon_depth;  // Lemon stack depth (always tracked, for lazy init).
   SYNQ_VEC(uint32_t) straddle_stack;  // Lazily initialized on first macro use.
 } SynqParseCtx;
 

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -86,7 +86,7 @@ pub mod any {
     #[doc(inline)]
     pub use crate::parser::{
         AnyIncrementalParseSession, AnyParseError, AnyParseSession, AnyParsedStatement, AnyParser,
-        AnyParserToken, MacroRegion, ParseOutcome, TracebackFrame,
+        AnyParserToken, MacroRewrite, ParseOutcome, TracebackFrame,
     };
     #[doc(inline)]
     pub use crate::tokenizer::{AnyToken, AnyTokenizer};

--- a/syntaqlite-syntax/src/parser/config.rs
+++ b/syntaqlite-syntax/src/parser/config.rs
@@ -51,7 +51,7 @@ impl ParserConfig {
     ///
     /// When enabled and the dialect uses Rust-style macros, unregistered
     /// `name!(args)` calls are consumed as a single `TK_ID` token instead
-    /// of causing a parse error. A `MacroRegion` is recorded so the
+    /// of causing a parse error. A `MacroRewrite` is recorded so the
     /// formatter can emit the call verbatim.
     pub fn macro_fallback(&self) -> bool {
         self.macro_fallback

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -77,16 +77,30 @@ pub(crate) struct CToken {
     pub(crate) type_: u32,
 }
 
-/// A recorded macro invocation region.
+/// A recorded macro rewrite.
 ///
-/// Mirrors C `SyntaqliteMacroRegion` from `include/syntaqlite/parser.h`.
+/// Mirrors C `SyntaqliteMacroRewrite` from `include/syntaqlite/parser.h`.
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
-pub(crate) struct CMacroRegion {
-    /// Byte offset of the macro call in the original source.
+pub(crate) struct CMacroRewrite {
+    /// Index of the parent rewrite (`u32::MAX` = authored source).
+    pub(crate) parent_idx: u32,
+    /// Byte offset of the macro call in the parent's text.
     pub(crate) call_offset: u32,
-    /// Byte length of the entire macro call.
+    /// Byte length of the entire macro call in the parent's text.
     pub(crate) call_length: u32,
+    /// Pointer to the expansion (replacement) text.  Not NUL-terminated.
+    pub(crate) expansion: *const u8,
+    /// Length of `expansion`.
+    pub(crate) expansion_len: u32,
+    /// Pointer to the macro name.  Not NUL-terminated; may be null.
+    pub(crate) name: *const u8,
+    /// Length of `name`.
+    pub(crate) name_len: u32,
+    /// 1-based line of the macro definition (0 = unknown).
+    pub(crate) def_line: u32,
+    /// 1-based column of the macro definition (0 = unknown).
+    pub(crate) def_col: u32,
 }
 
 /// One frame in a traceback produced by the span traceback API.
@@ -398,11 +412,13 @@ impl CParser {
         unsafe { syntaqlite_result_macro_count(std::ptr::from_ref::<Self>(self).cast_mut()) }
     }
 
-    pub(crate) unsafe fn result_macro_at(&self, idx: u32) -> CMacroRegion {
+    pub(crate) unsafe fn result_macro_rewrite_at(&self, idx: u32) -> CMacroRewrite {
         // SAFETY: self is a valid, non-null CParser pointer; result
         // accessors are valid after `next()` returns a non-DONE code.
-        // The C side clamps out-of-range indices to {0, 0}.
-        unsafe { syntaqlite_result_macro_at(std::ptr::from_ref::<Self>(self).cast_mut(), idx) }
+        // The C side clamps out-of-range indices to a zero-initialized rewrite.
+        unsafe {
+            syntaqlite_result_macro_rewrite_at(std::ptr::from_ref::<Self>(self).cast_mut(), idx)
+        }
     }
 
     // Arena accessors
@@ -502,7 +518,7 @@ unsafe extern "C" {
     fn syntaqlite_result_comments(p: *mut CParser, count: *mut u32) -> *const CComment;
     fn syntaqlite_result_tokens(p: *mut CParser, count: *mut u32) -> *const CParserToken;
     fn syntaqlite_result_macro_count(p: *mut CParser) -> u32;
-    fn syntaqlite_result_macro_at(p: *mut CParser, idx: u32) -> CMacroRegion;
+    fn syntaqlite_result_macro_rewrite_at(p: *mut CParser, idx: u32) -> CMacroRewrite;
 
     // Arena accessors
     fn syntaqlite_parser_node(p: *mut CParser, node_id: u32) -> *const u32;
@@ -1090,9 +1106,7 @@ mod tests {
         // When a lookup callback is registered but the macro is not found,
         // the parser should produce a hard error with "unknown macro 'name'".
         // We need macro_fallback to enable macro syntax for SQLite dialect.
-        let mut parser = Parser::with_config(
-            &ParserConfig::default().with_macro_fallback(true),
-        );
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
         // Lookup callback that always returns false (nothing registered).
         parser.set_macro_lookup(Some(Box::new(TestLookup::prefix("__never__"))));
 
@@ -1118,9 +1132,7 @@ mod tests {
     fn unknown_macro_without_lookup_fn_falls_through() {
         // When macro_fallback is enabled but NO lookup callback is
         // registered, unknown macro calls should fall through to TK_ID.
-        let mut parser = Parser::with_config(
-            &ParserConfig::default().with_macro_fallback(true),
-        );
+        let parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
         // No set_macro_lookup — no callback.
 
         let mut session = parser.parse("SELECT foo!(1, 2);");
@@ -1147,7 +1159,7 @@ mod tests {
         let count = unsafe { parser.result_macro_count() };
         assert_eq!(count, 1, "expected one macro region");
         // SAFETY: idx < count.
-        let r = unsafe { parser.result_macro_at(0) };
+        let r = unsafe { parser.result_macro_rewrite_at(0) };
         #[expect(clippy::cast_possible_truncation)]
         let call_start = sql.find("foo!").unwrap() as u32;
         assert_eq!(r.call_offset, call_start);
@@ -1224,7 +1236,7 @@ mod tests {
         let count = unsafe { parser.result_macro_count() };
         assert_eq!(count, 1);
         // SAFETY: idx < count.
-        let r = unsafe { parser.result_macro_at(0) };
+        let r = unsafe { parser.result_macro_rewrite_at(0) };
         let call_text = &sql[r.call_offset as usize..(r.call_offset + r.call_length) as usize];
         assert!(
             call_text.starts_with("graph!(") && call_text.ends_with(')'),

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -639,33 +639,41 @@ impl<'a> AnyParsedStatement<'a> {
 
     /// Macro rewrites recorded during parsing.  See [`MacroRewrite`] for
     /// the shape of each entry.
-    pub fn macro_rewrites(&self) -> impl Iterator<Item = MacroRewrite> + use<'_> {
+    pub fn macro_rewrites(&self) -> impl Iterator<Item = MacroRewrite<'a>> + use<'_, 'a> {
         // SAFETY: self.raw is valid for 'a; the indexed accessor is stable
         // until the next parser_next / reset / destroy call.
         let count = unsafe { self.raw.as_ref().result_macro_count() };
         (0..count).map(move |i| {
             // SAFETY: i < count, so the C side returns a valid rewrite.
             let r = unsafe { self.raw.as_ref().result_macro_rewrite_at(i) };
-            // Expansion and name pointers are borrowed from parser memory
-            // valid until the next reset/destroy; we copy them into owned
-            // Strings so the returned value has no lifetime tie to the parser.
-            let expansion = if r.expansion.is_null() {
-                String::new()
+            // `expansion` and `name` borrow from parser memory valid for
+            // 'a (until the next parser_next / reset / destroy, which
+            // requires ending the 'a-tied statement borrow).
+            let expansion: &'a str = if r.expansion.is_null() {
+                ""
             } else {
-                // SAFETY: `expansion` is non-null and points to
-                // `expansion_len` bytes owned by the parser, valid for
-                // this call.
-                let bytes =
-                    unsafe { std::slice::from_raw_parts(r.expansion, r.expansion_len as usize) };
-                String::from_utf8_lossy(bytes).into_owned()
+                // SAFETY: `expansion` points to `expansion_len` bytes
+                // owned by the parser, valid for 'a.  Parser buffers are
+                // UTF-8 by construction (source text or expansion text
+                // produced by the callback, which accepts a &str body).
+                unsafe {
+                    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+                        r.expansion,
+                        r.expansion_len as usize,
+                    ))
+                }
             };
-            let name = if r.name.is_null() {
-                String::new()
+            let name: &'a str = if r.name.is_null() {
+                ""
             } else {
-                // SAFETY: `name` is non-null and points to `name_len`
-                // bytes owned by the parser, valid for this call.
-                let bytes = unsafe { std::slice::from_raw_parts(r.name, r.name_len as usize) };
-                String::from_utf8_lossy(bytes).into_owned()
+                // SAFETY: `name` points to `name_len` bytes owned by the
+                // parser, valid for 'a; ASCII identifier by construction.
+                unsafe {
+                    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+                        r.name,
+                        r.name_len as usize,
+                    ))
+                }
             };
             let parent = if r.parent_idx == u32::MAX {
                 None
@@ -1056,7 +1064,7 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
     /// expansion — enough to reconstruct a source-to-expanded rewrite
     /// tree (see [`MacroRewrite`] for details).  Populated automatically
     /// when the dialect's `macro_style` is set.
-    pub fn macro_rewrites(&self) -> impl Iterator<Item = MacroRewrite> + use<'_, 'a, G> {
+    pub fn macro_rewrites(&self) -> impl Iterator<Item = MacroRewrite<'a>> + use<'_, 'a, G> {
         self.any.macro_rewrites()
     }
 

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -29,7 +29,7 @@ pub use incremental::{AnyIncrementalParseSession, TypedIncrementalParseSession};
 #[cfg(feature = "sqlite")]
 pub use session::{ParseError, ParseSession, ParsedStatement, Parser, ParserToken};
 pub use types::{
-    AnyParserToken, Comment, CommentKind, CommentSpan, CompletionContext, MacroRegion,
+    AnyParserToken, Comment, CommentKind, CommentSpan, CompletionContext, MacroRewrite,
     ParseOutcome, ParserTokenFlags, TracebackFrame, TypedParserToken,
 };
 
@@ -637,17 +637,49 @@ impl<'a> AnyParsedStatement<'a> {
         unsafe { self.raw.as_ref().result_macro_count() == 0 }
     }
 
-    /// Macro expansion call-site spans recorded during parsing.
-    pub fn macro_regions(&self) -> impl Iterator<Item = MacroRegion> + use<'_> {
+    /// Macro rewrites recorded during parsing.  See [`MacroRewrite`] for
+    /// the shape of each entry.
+    pub fn macro_rewrites(&self) -> impl Iterator<Item = MacroRewrite> + use<'_> {
         // SAFETY: self.raw is valid for 'a; the indexed accessor is stable
         // until the next parser_next / reset / destroy call.
         let count = unsafe { self.raw.as_ref().result_macro_count() };
         (0..count).map(move |i| {
-            // SAFETY: i < count, so the C side returns a valid region.
-            let r = unsafe { self.raw.as_ref().result_macro_at(i) };
-            MacroRegion {
+            // SAFETY: i < count, so the C side returns a valid rewrite.
+            let r = unsafe { self.raw.as_ref().result_macro_rewrite_at(i) };
+            // Expansion and name pointers are borrowed from parser memory
+            // valid until the next reset/destroy; we copy them into owned
+            // Strings so the returned value has no lifetime tie to the parser.
+            let expansion = if r.expansion.is_null() {
+                String::new()
+            } else {
+                // SAFETY: `expansion` is non-null and points to
+                // `expansion_len` bytes owned by the parser, valid for
+                // this call.
+                let bytes =
+                    unsafe { std::slice::from_raw_parts(r.expansion, r.expansion_len as usize) };
+                String::from_utf8_lossy(bytes).into_owned()
+            };
+            let name = if r.name.is_null() {
+                String::new()
+            } else {
+                // SAFETY: `name` is non-null and points to `name_len`
+                // bytes owned by the parser, valid for this call.
+                let bytes = unsafe { std::slice::from_raw_parts(r.name, r.name_len as usize) };
+                String::from_utf8_lossy(bytes).into_owned()
+            };
+            let parent = if r.parent_idx == u32::MAX {
+                None
+            } else {
+                Some(r.parent_idx)
+            };
+            MacroRewrite {
+                parent,
                 call_offset: r.call_offset,
                 call_length: r.call_length,
+                expansion,
+                name,
+                def_line: r.def_line,
+                def_col: r.def_col,
             }
         })
     }
@@ -1018,13 +1050,14 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
         self.any.expanded_text()
     }
 
-    /// Macro expansion call-site spans recorded during parsing.
+    /// Macro rewrites recorded during parsing.
     ///
-    /// Each [`MacroRegion`] describes a byte range in the original source
-    /// that was identified as a macro invocation (e.g. `name!(args)`).
-    /// Populated automatically when the dialect's `macro_style` is set.
-    pub fn macro_regions(&self) -> impl Iterator<Item = MacroRegion> + use<'_, 'a, G> {
-        self.any.macro_regions()
+    /// Each [`MacroRewrite`] describes a macro invocation and its
+    /// expansion — enough to reconstruct a source-to-expanded rewrite
+    /// tree (see [`MacroRewrite`] for details).  Populated automatically
+    /// when the dialect's `macro_style` is set.
+    pub fn macro_rewrites(&self) -> impl Iterator<Item = MacroRewrite> + use<'_, 'a, G> {
+        self.any.macro_rewrites()
     }
 
     /// Statement-local token stream for this parse result.

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -352,7 +352,7 @@ impl<'a> ParsedStatement<'a> {
 
     /// Macro rewrites recorded during parsing.  See [`super::MacroRewrite`]
     /// for the shape of each entry.
-    pub fn macro_rewrites(&self) -> impl Iterator<Item = super::MacroRewrite> + use<'_, 'a> {
+    pub fn macro_rewrites(&self) -> impl Iterator<Item = super::MacroRewrite<'a>> + use<'_, 'a> {
         self.0.macro_rewrites()
     }
 

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -350,9 +350,10 @@ impl<'a> ParsedStatement<'a> {
         self.0.any.is_macro_free()
     }
 
-    /// Macro expansion call-site spans recorded during parsing.
-    pub fn macro_regions(&self) -> impl Iterator<Item = super::MacroRegion> + use<'_, 'a> {
-        self.0.macro_regions()
+    /// Macro rewrites recorded during parsing.  See [`super::MacroRewrite`]
+    /// for the shape of each entry.
+    pub fn macro_rewrites(&self) -> impl Iterator<Item = super::MacroRewrite> + use<'_, 'a> {
+        self.0.macro_rewrites()
     }
 
     /// Dump the AST as indented text into `out`.
@@ -897,7 +898,7 @@ mod tests {
     }
 
     #[test]
-    fn macro_expansion_records_macro_region() {
+    fn macro_rewrites_records_single_expansion() {
         let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
         let mut reg = TestMacroRegistry::new();
         reg.register("id", &["x"], "$x");
@@ -911,11 +912,59 @@ mod tests {
             ParseOutcome::Err(err) => panic!("unexpected error: {}", err.message()),
         };
 
-        let regions: Vec<_> = stmt.macro_regions().collect();
-        assert_eq!(regions.len(), 1, "expected exactly one macro region");
-        let r = &regions[0];
-        let call_text = &source[r.call_offset as usize..(r.call_offset + r.call_length) as usize];
+        let rewrites: Vec<_> = stmt.macro_rewrites().collect();
+        assert_eq!(rewrites.len(), 1, "expected exactly one macro rewrite");
+        let r = &rewrites[0];
+        assert_eq!(r.parent(), None, "top-level rewrite");
+        assert_eq!(r.name(), "id");
+        assert_eq!(r.expansion(), "42");
+        let call_text =
+            &source[r.call_offset() as usize..(r.call_offset() + r.call_length()) as usize];
         assert_eq!(call_text, "id!(42)");
+    }
+
+    #[test]
+    fn macro_rewrites_records_nested_expansion_tree() {
+        // `mwrap` body contains an `mpass!(...)` call, so expanding `mwrap`
+        // produces a nested expansion layer.  The flat rewrite list carries
+        // a `parent` pointer so callers (e.g. Perfetto's SqlSource::Rewriter)
+        // can reconstruct the tree.
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let mut reg = TestMacroRegistry::new();
+        reg.register("mpass", &["x"], "$x");
+        reg.register("mwrap", &["x"], "mpass!($x)");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "SELECT mwrap!(42);";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(err) => panic!("unexpected error: {}", err.message()),
+        };
+
+        let rewrites: Vec<_> = stmt.macro_rewrites().collect();
+        assert_eq!(rewrites.len(), 2, "mwrap + mpass");
+
+        // mwrap is top-level; call_offset/call_length are into `source`.
+        let outer = &rewrites[0];
+        assert_eq!(outer.parent(), None);
+        assert_eq!(outer.name(), "mwrap");
+        let outer_call = &source
+            [outer.call_offset() as usize..(outer.call_offset() + outer.call_length()) as usize];
+        assert_eq!(outer_call, "mwrap!(42)");
+        assert_eq!(outer.expansion(), "mpass!(42)");
+
+        // mpass is nested inside mwrap; call_offset/call_length are into
+        // outer.expansion().
+        let inner = &rewrites[1];
+        assert_eq!(inner.parent(), Some(0));
+        assert_eq!(inner.name(), "mpass");
+        let outer_exp = outer.expansion();
+        let inner_call = &outer_exp
+            [inner.call_offset() as usize..(inner.call_offset() + inner.call_length()) as usize];
+        assert_eq!(inner_call, "mpass!(42)");
+        assert_eq!(inner.expansion(), "42");
     }
 
     #[test]
@@ -1403,9 +1452,7 @@ mod tests {
         // positive on 3-deep nested no-arg macros because it compared
         // span offsets across different expansion layers without
         // accounting for _layer_id.
-        let mut parser = Parser::with_config(
-            &ParserConfig::default().with_macro_fallback(true),
-        );
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
         let mut reg = TestMacroRegistry::new();
         reg.register("_dfs", &[], "(SELECT node_id AS id)");
         reg.register("_tree_reach", &[], "(SELECT node_id FROM _dfs!())");
@@ -1420,10 +1467,7 @@ mod tests {
         match session.next() {
             ParseOutcome::Ok(_) => {} // expected
             ParseOutcome::Done => panic!("expected a statement"),
-            ParseOutcome::Err(e) => panic!(
-                "should parse without straddle error: {}",
-                e.message()
-            ),
+            ParseOutcome::Err(e) => panic!("should parse without straddle error: {}", e.message()),
         }
     }
 

--- a/syntaqlite-syntax/src/parser/types.rs
+++ b/syntaqlite-syntax/src/parser/types.rs
@@ -213,19 +213,23 @@ pub type AnyParserToken<'a> = TypedParserToken<'a, crate::dialect::AnyDialect>;
 /// source; a rewrite with `parent() == Some(i)` replaces a range in the
 /// `i`-th entry's [`expansion`](Self::expansion) buffer.
 ///
+/// [`expansion`](Self::expansion) and [`name`](Self::name) borrow from
+/// parser-owned memory — they are valid for the lifetime of the
+/// originating parsed statement.
+///
 /// Returned by [`super::AnyParsedStatement::macro_rewrites`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MacroRewrite {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MacroRewrite<'a> {
     pub(crate) parent: Option<u32>,
     pub(crate) call_offset: u32,
     pub(crate) call_length: u32,
-    pub(crate) expansion: String,
-    pub(crate) name: String,
+    pub(crate) expansion: &'a str,
+    pub(crate) name: &'a str,
     pub(crate) def_line: u32,
     pub(crate) def_col: u32,
 }
 
-impl MacroRewrite {
+impl<'a> MacroRewrite<'a> {
     /// Index of the parent rewrite, or `None` if this rewrite applies
     /// directly to the authored source.
     pub fn parent(&self) -> Option<u32> {
@@ -242,12 +246,12 @@ impl MacroRewrite {
     /// The replacement text for the macro call.  Nested macro calls that
     /// appear in this buffer are reported as separate [`MacroRewrite`]
     /// entries whose [`parent`](Self::parent) refers back to this one.
-    pub fn expansion(&self) -> &str {
-        &self.expansion
+    pub fn expansion(&self) -> &'a str {
+        self.expansion
     }
     /// The macro name as it appears at the call site.
-    pub fn name(&self) -> &str {
-        &self.name
+    pub fn name(&self) -> &'a str {
+        self.name
     }
     /// 1-based line of the macro definition (0 if unknown).
     pub fn def_line(&self) -> u32 {

--- a/syntaqlite-syntax/src/parser/types.rs
+++ b/syntaqlite-syntax/src/parser/types.rs
@@ -201,25 +201,61 @@ impl<'a, G: TypedDialect> TypedParserToken<'a, G> {
 /// Parser-token alias for dialect-independent pipelines.
 pub type AnyParserToken<'a> = TypedParserToken<'a, crate::dialect::AnyDialect>;
 
-/// Byte range of a macro call that contributed to this parse.
+/// A macro rewrite recorded during parsing.
 ///
-/// Returned by [`super::AnyParsedStatement::macro_regions`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MacroRegion {
-    /// Byte offset of the macro call in the original source.
+/// Carries enough information to reconstruct a source-to-expanded rewrite
+/// tree (e.g. to drive Perfetto's `SqlSource::Rewriter` or an equivalent).
+///
+/// Entries are reported in insertion order: outer macros appear before the
+/// nested macros they contain, and macros at the same nesting level appear
+/// in source order.  Nesting is expressed via [`parent`](Self::parent): a
+/// rewrite with `parent() == None` replaces a range in the authored
+/// source; a rewrite with `parent() == Some(i)` replaces a range in the
+/// `i`-th entry's [`expansion`](Self::expansion) buffer.
+///
+/// Returned by [`super::AnyParsedStatement::macro_rewrites`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MacroRewrite {
+    pub(crate) parent: Option<u32>,
     pub(crate) call_offset: u32,
-    /// Byte length of the entire macro call.
     pub(crate) call_length: u32,
+    pub(crate) expansion: String,
+    pub(crate) name: String,
+    pub(crate) def_line: u32,
+    pub(crate) def_col: u32,
 }
 
-impl MacroRegion {
-    /// Byte offset of the macro call in the original source.
+impl MacroRewrite {
+    /// Index of the parent rewrite, or `None` if this rewrite applies
+    /// directly to the authored source.
+    pub fn parent(&self) -> Option<u32> {
+        self.parent
+    }
+    /// Byte offset of the macro call in the parent's text.
     pub fn call_offset(&self) -> u32 {
         self.call_offset
     }
-    /// Byte length of the entire macro call.
+    /// Byte length of the entire macro call in the parent's text.
     pub fn call_length(&self) -> u32 {
         self.call_length
+    }
+    /// The replacement text for the macro call.  Nested macro calls that
+    /// appear in this buffer are reported as separate [`MacroRewrite`]
+    /// entries whose [`parent`](Self::parent) refers back to this one.
+    pub fn expansion(&self) -> &str {
+        &self.expansion
+    }
+    /// The macro name as it appears at the call site.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    /// 1-based line of the macro definition (0 if unknown).
+    pub fn def_line(&self) -> u32 {
+        self.def_line
+    }
+    /// 1-based column of the macro definition (0 if unknown).
+    pub fn def_col(&self) -> u32 {
+        self.def_col
     }
 }
 

--- a/syntaqlite/src/embedded/mod.rs
+++ b/syntaqlite/src/embedded/mod.rs
@@ -11,7 +11,7 @@
 //! with macro-call placeholders (`HOLE_PLACEHOLDER`), runs validation via
 //! [`SemanticAnalyzer`](crate::SemanticAnalyzer) with `macro_fallback` enabled,
 //! and maps diagnostic offsets back to host-file positions. The parser records a
-//! [`MacroRegion`](crate::parse::MacroRegion) for each hole, which is used to filter
+//! [`MacroRewrite`](crate::parse::MacroRewrite) for each hole, which is used to filter
 //! diagnostics that would otherwise reference the placeholder.
 //!
 //! Language-specific extractors live in submodules:
@@ -83,7 +83,7 @@ impl EmbeddedFragment {
 ///
 /// Holes are replaced with [`HOLE_PLACEHOLDER`] in `sql_text` and parsed as
 /// macro calls via the parser's `macro_fallback` mode. The parser records a
-/// [`MacroRegion`](syntaqlite_syntax::any::MacroRegion) for each one.
+/// [`MacroRewrite`](syntaqlite_syntax::any::MacroRewrite) for each one.
 #[derive(Debug)]
 pub struct Hole {
     /// Byte range of the hole expression in the host file.
@@ -106,7 +106,7 @@ impl Hole {
 /// Placeholder text inserted into `sql_text` for each interpolation hole.
 ///
 /// Uses macro-call syntax so the parser's `macro_fallback` mode treats it as a
-/// single identifier token and records a [`MacroRegion`](syntaqlite_syntax::any::MacroRegion).
+/// single identifier token and records a [`MacroRewrite`](syntaqlite_syntax::any::MacroRewrite).
 pub const HOLE_PLACEHOLDER: &str = "__h__!()";
 
 // ── Shared scanner utilities ────────────────────────────────────────────

--- a/syntaqlite/src/fmt/formatter.rs
+++ b/syntaqlite/src/fmt/formatter.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 use syntaqlite_syntax::any::{
-    AnyNodeId, AnyParsedStatement, AnyParser, AnyTokenizer, FieldValue, MacroRewrite, ParseOutcome,
+    AnyNodeId, AnyParsedStatement, AnyParser, AnyTokenizer, FieldValue, ParseOutcome,
 };
 use syntaqlite_syntax::{CommentKind, ParserConfig};
 
@@ -50,7 +50,11 @@ pub struct Formatter {
     pub(super) arena: DocArena<'static>,
     pub(super) interpret_scratch: InterpretScratch,
     pub(super) render_bufs: RenderBuffers,
-    pub(super) macro_rewrites: Vec<MacroRewrite>,
+    /// Byte ranges (offset, length) of macro calls in the source.  The
+    /// formatter only needs positions to decide when to emit a call
+    /// verbatim; full `MacroRewrite` records would tie this buffer to
+    /// the statement lifetime and prevent reuse across statements.
+    pub(super) macro_rewrites: Vec<(u32, u32)>,
     pub(super) comment_entries: Vec<CommentEntry>,
     pub(super) token_entries: Vec<TokenEntry>,
     pub(super) parts: Vec<DocId>,
@@ -136,7 +140,11 @@ impl Formatter {
                 .token_spans()
                 .map(|(offset, length)| TokenEntry { offset, length }),
         );
-        self.macro_rewrites.extend(erased.macro_rewrites());
+        self.macro_rewrites.extend(
+            erased
+                .macro_rewrites()
+                .map(|r| (r.call_offset(), r.call_length())),
+        );
     }
 
     /// Format SQL source text. Handles multiple statements and preserves comments.
@@ -607,7 +615,7 @@ fn drain_gap_comments<'a>(
 /// the verbatim text at the appropriate level.
 pub(crate) fn try_macro_verbatim<'a>(
     ctx: &FmtCtx<'a>,
-    regions: &[MacroRewrite],
+    regions: &[(u32, u32)],
     arena: &mut DocArena<'a>,
     consumed: &mut [bool],
     tokenizer: &AnyTokenizer,
@@ -617,9 +625,8 @@ pub(crate) fn try_macro_verbatim<'a>(
     let (tok_offset, _) = cctx.peek_next_token()?;
     let source = ctx.text();
 
-    for (i, r) in regions.iter().enumerate() {
-        let r_start = r.call_offset();
-        let r_end = r_start + r.call_length();
+    for (i, &(r_start, r_len)) in regions.iter().enumerate() {
+        let r_end = r_start + r_len;
 
         if tok_offset >= r_start && tok_offset < r_end {
             // Check if this child node extends beyond the macro region

--- a/syntaqlite/src/fmt/formatter.rs
+++ b/syntaqlite/src/fmt/formatter.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 use syntaqlite_syntax::any::{
-    AnyNodeId, AnyParsedStatement, AnyParser, AnyTokenizer, FieldValue, MacroRegion, ParseOutcome,
+    AnyNodeId, AnyParsedStatement, AnyParser, AnyTokenizer, FieldValue, MacroRewrite, ParseOutcome,
 };
 use syntaqlite_syntax::{CommentKind, ParserConfig};
 
@@ -50,7 +50,7 @@ pub struct Formatter {
     pub(super) arena: DocArena<'static>,
     pub(super) interpret_scratch: InterpretScratch,
     pub(super) render_bufs: RenderBuffers,
-    pub(super) macro_regions: Vec<MacroRegion>,
+    pub(super) macro_rewrites: Vec<MacroRewrite>,
     pub(super) comment_entries: Vec<CommentEntry>,
     pub(super) token_entries: Vec<TokenEntry>,
     pub(super) parts: Vec<DocId>,
@@ -111,7 +111,7 @@ impl Formatter {
             arena: DocArena::with_capacity(256),
             interpret_scratch: InterpretScratch::new(),
             render_bufs: RenderBuffers::new(),
-            macro_regions: Vec::with_capacity(32),
+            macro_rewrites: Vec::with_capacity(32),
             comment_entries: Vec::with_capacity(64),
             token_entries: Vec::with_capacity(256),
             parts: Vec::with_capacity(64),
@@ -122,7 +122,7 @@ impl Formatter {
 
     /// Populate side-channel buffers (comments, tokens, macro regions) from an erased statement.
     fn collect_side_channels(&mut self, erased: &AnyParsedStatement<'_>) {
-        self.macro_regions.clear();
+        self.macro_rewrites.clear();
         self.comment_entries.clear();
         self.comment_entries
             .extend(erased.comment_spans().map(|c| CommentEntry {
@@ -136,7 +136,7 @@ impl Formatter {
                 .token_spans()
                 .map(|(offset, length)| TokenEntry { offset, length }),
         );
-        self.macro_regions.extend(erased.macro_regions());
+        self.macro_rewrites.extend(erased.macro_rewrites());
     }
 
     /// Format SQL source text. Handles multiple statements and preserves comments.
@@ -193,7 +193,7 @@ impl Formatter {
             last_has_root = !root_id.is_null();
             let semicolons = self.config.semicolons;
             let has_comments = !self.comment_entries.is_empty();
-            let has_macros = !self.macro_regions.is_empty();
+            let has_macros = !self.macro_rewrites.is_empty();
             let needs_token_ctx = has_comments || has_macros;
 
             let comment_ctx = if needs_token_ctx {
@@ -230,7 +230,7 @@ impl Formatter {
                 dialect: self.dialect.clone(),
                 reader: erased,
                 comment_ctx,
-                macro_regions: std::mem::take(&mut self.macro_regions),
+                macro_rewrites: std::mem::take(&mut self.macro_rewrites),
             };
             let interpreted = self.interpret_node(&ctx, root_id, &mut arena);
             self.parts.push(interpreted);
@@ -255,7 +255,7 @@ impl Formatter {
                 self.comment_entries = comments;
                 self.token_entries = tokens;
             }
-            self.macro_regions = ctx.macro_regions;
+            self.macro_rewrites = ctx.macro_rewrites;
 
             // Recycle the arena, releasing all Doc borrows from this iteration.
             self.arena = DocArena::recycle(arena);
@@ -432,7 +432,7 @@ impl Formatter {
             }
 
             let has_comments = !self.comment_entries.is_empty();
-            let has_macros = !self.macro_regions.is_empty();
+            let has_macros = !self.macro_rewrites.is_empty();
             let needs_token_ctx = has_comments || has_macros;
 
             let comment_ctx = if needs_token_ctx {
@@ -467,7 +467,7 @@ impl Formatter {
                 dialect: self.dialect.clone(),
                 reader: erased,
                 comment_ctx,
-                macro_regions: std::mem::take(&mut self.macro_regions),
+                macro_rewrites: std::mem::take(&mut self.macro_rewrites),
             };
             let interpreted = self.interpret_node(&ctx, root_id, &mut arena);
             self.parts.push(interpreted);
@@ -487,7 +487,7 @@ impl Formatter {
                 self.comment_entries = comments;
                 self.token_entries = tokens;
             }
-            self.macro_regions = ctx.macro_regions;
+            self.macro_rewrites = ctx.macro_rewrites;
             self.arena = DocArena::recycle(arena);
 
             stmt_num += 1;
@@ -607,7 +607,7 @@ fn drain_gap_comments<'a>(
 /// the verbatim text at the appropriate level.
 pub(crate) fn try_macro_verbatim<'a>(
     ctx: &FmtCtx<'a>,
-    regions: &[MacroRegion],
+    regions: &[MacroRewrite],
     arena: &mut DocArena<'a>,
     consumed: &mut [bool],
     tokenizer: &AnyTokenizer,

--- a/syntaqlite/src/fmt/interpret.rs
+++ b/syntaqlite/src/fmt/interpret.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue, MacroRewrite};
+use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue};
 
 use super::comment::{CommentCtx, DrainResult};
 use super::doc::{DocArena, DocId, NIL_DOC};
@@ -15,7 +15,10 @@ pub(crate) struct FmtCtx<'a> {
     pub reader: AnyParsedStatement<'a>,
     /// Owned comment context — no lifetime needed since `CommentCtx` owns its data.
     pub comment_ctx: Option<CommentCtx>,
-    pub macro_rewrites: Vec<MacroRewrite>,
+    /// `(call_offset, call_length)` for each macro call in the source.
+    /// Full `MacroRewrite` records are not needed here since the
+    /// formatter only uses positions to decide verbatim emission.
+    pub macro_rewrites: Vec<(u32, u32)>,
 }
 
 impl<'a> FmtCtx<'a> {

--- a/syntaqlite/src/fmt/interpret.rs
+++ b/syntaqlite/src/fmt/interpret.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue, MacroRegion};
+use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue, MacroRewrite};
 
 use super::comment::{CommentCtx, DrainResult};
 use super::doc::{DocArena, DocId, NIL_DOC};
@@ -15,7 +15,7 @@ pub(crate) struct FmtCtx<'a> {
     pub reader: AnyParsedStatement<'a>,
     /// Owned comment context — no lifetime needed since `CommentCtx` owns its data.
     pub comment_ctx: Option<CommentCtx>,
-    pub macro_regions: Vec<MacroRegion>,
+    pub macro_rewrites: Vec<MacroRewrite>,
 }
 
 impl<'a> FmtCtx<'a> {
@@ -70,7 +70,8 @@ impl Formatter {
         arena: &mut DocArena<'a>,
     ) -> DocId {
         self.consumed_regions.clear();
-        self.consumed_regions.resize(ctx.macro_regions.len(), false);
+        self.consumed_regions
+            .resize(ctx.macro_rewrites.len(), false);
         let consumed_regions = &mut self.consumed_regions;
         let scratch = &mut self.interpret_scratch;
         let macro_tokenizer = &self.macro_tokenizer;
@@ -258,12 +259,12 @@ impl Formatter {
                         );
 
                         let mut return_action = ReturnAction::CatOntoRunning;
-                        let macro_regions = &ctx.macro_regions;
-                        if !macro_regions.is_empty()
+                        let macro_rewrites = &ctx.macro_rewrites;
+                        if !macro_rewrites.is_empty()
                             && ctx.reader.list_children(child_id).is_none()
                             && let Some(doc) = super::formatter::try_macro_verbatim(
                                 ctx,
-                                macro_regions,
+                                macro_rewrites,
                                 arena,
                                 consumed_regions,
                                 macro_tokenizer,
@@ -373,13 +374,13 @@ impl Formatter {
                     let children = ctx.reader.list_children(state.list_id).unwrap_or(&[]);
                     let child_id = children[state.index];
 
-                    let macro_regions = &ctx.macro_regions;
-                    let macro_doc = if !macro_regions.is_empty()
+                    let macro_rewrites = &ctx.macro_rewrites;
+                    let macro_doc = if !macro_rewrites.is_empty()
                         && ctx.reader.list_children(child_id).is_none()
                     {
                         super::formatter::try_macro_verbatim(
                             ctx,
-                            macro_regions,
+                            macro_rewrites,
                             arena,
                             consumed_regions,
                             macro_tokenizer,
@@ -575,12 +576,12 @@ impl Formatter {
                         );
 
                         let mut return_action = ReturnAction::CatOntoRunning;
-                        let macro_regions = &ctx.macro_regions;
-                        if !macro_regions.is_empty()
+                        let macro_rewrites = &ctx.macro_rewrites;
+                        if !macro_rewrites.is_empty()
                             && ctx.reader.list_children(child_id).is_none()
                             && let Some(doc) = super::formatter::try_macro_verbatim(
                                 ctx,
-                                macro_regions,
+                                macro_rewrites,
                                 arena,
                                 consumed_regions,
                                 macro_tokenizer,
@@ -630,12 +631,12 @@ impl Formatter {
                         );
 
                         let mut return_action = ReturnAction::CatOntoRunning;
-                        let macro_regions = &ctx.macro_regions;
-                        if !macro_regions.is_empty()
+                        let macro_rewrites = &ctx.macro_rewrites;
+                        if !macro_rewrites.is_empty()
                             && ctx.reader.list_children(child_id).is_none()
                             && let Some(doc) = super::formatter::try_macro_verbatim(
                                 ctx,
-                                macro_regions,
+                                macro_rewrites,
                                 arena,
                                 consumed_regions,
                                 macro_tokenizer,
@@ -682,12 +683,12 @@ impl Formatter {
                         );
 
                         let mut return_action = ReturnAction::CatOntoRunning;
-                        let macro_regions = &ctx.macro_regions;
-                        if !macro_regions.is_empty()
+                        let macro_rewrites = &ctx.macro_rewrites;
+                        if !macro_rewrites.is_empty()
                             && ctx.reader.list_children(child_id).is_none()
                             && let Some(doc) = super::formatter::try_macro_verbatim(
                                 ctx,
-                                macro_regions,
+                                macro_rewrites,
                                 arena,
                                 consumed_regions,
                                 macro_tokenizer,

--- a/syntaqlite/src/lib.rs
+++ b/syntaqlite/src/lib.rs
@@ -214,8 +214,9 @@ pub fn sqlite_dialect() -> Dialect {
 /// - [`ParserTokenFlags`](self::parse::ParserTokenFlags) — parser-inferred
 ///   semantic flags for individual tokens.
 /// - [`CommentKind`](self::parse::CommentKind) — SQL comment style.
-/// - [`MacroRegion`](self::parse::MacroRegion) — byte range of a macro-call
-///   placeholder (used by the embedded SQL extractor).
+/// - [`MacroRewrite`](self::parse::MacroRewrite) — recorded macro call
+///   and its expansion, used by the embedded SQL extractor and downstream
+///   rewriters.
 ///
 /// # Example
 ///
@@ -233,7 +234,7 @@ pub fn sqlite_dialect() -> Dialect {
 /// ```
 pub mod parse {
     #[doc(inline)]
-    pub use syntaqlite_syntax::any::MacroRegion;
+    pub use syntaqlite_syntax::any::MacroRewrite;
     #[doc(inline)]
     pub use syntaqlite_syntax::{CommentKind, ParserConfig, ParserTokenFlags};
     #[doc(inline)]

--- a/syntaqlite/src/semantic/analyzer.rs
+++ b/syntaqlite/src/semantic/analyzer.rs
@@ -146,7 +146,7 @@ impl SemanticAnalyzer {
     }
 
     /// Enable macro fallback: unregistered `name!(args)` calls parse as
-    /// identifiers and record [`MacroRegion`]s on the resulting model.
+    /// identifiers and record [`MacroRewrite`]s on the resulting model.
     #[must_use]
     pub(crate) fn with_macro_fallback(mut self, enabled: bool) -> Self {
         self.macro_fallback = enabled;

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -140,6 +140,7 @@ impl core::convert::From<syntaqlite_syntax::nodes::WithClauseId> for syntaqlite_
 impl core::convert::From<syntaqlite_syntax::typed::Dialect> for syntaqlite_syntax::any::AnyDialect
 impl core::convert::From<syntaqlite_syntax::typed::TypedIncrementalParseSession<syntaqlite_syntax::typed::Dialect>> for syntaqlite_syntax::IncrementalParseSession
 impl core::fmt::Debug for syntaqlite_syntax::ParserToken<'_>
+impl core::fmt::Debug for syntaqlite_syntax::any::AnyDialect
 impl core::fmt::Debug for syntaqlite_syntax::any::AnyNode<'_>
 impl core::fmt::Debug for syntaqlite_syntax::any::NodeFields
 impl core::fmt::Debug for syntaqlite_syntax::nodes::AggregateFunctionCall<'_>
@@ -286,7 +287,7 @@ impl syntaqlite_syntax::any::AnyNodeTag
 impl syntaqlite_syntax::any::AnyTokenType
 impl syntaqlite_syntax::any::FieldMeta<'_>
 impl syntaqlite_syntax::any::KeywordEntry
-impl syntaqlite_syntax::any::MacroRegion
+impl syntaqlite_syntax::any::MacroRewrite
 impl syntaqlite_syntax::any::NodeFields
 impl syntaqlite_syntax::any::TextSpan
 impl syntaqlite_syntax::nodes::AggregateFunctionCallFlags
@@ -810,6 +811,7 @@ pub fn syntaqlite_syntax::TokenType::from_token_type(raw: syntaqlite_syntax::any
 pub fn syntaqlite_syntax::any::AnyDialect::cflags(&self) -> syntaqlite_syntax::util::SqliteSyntaxFlags
 pub fn syntaqlite_syntax::any::AnyDialect::classify_token(&self, token_type: syntaqlite_syntax::any::AnyTokenType, flags: syntaqlite_syntax::ParserTokenFlags) -> syntaqlite_syntax::any::TokenCategory
 pub fn syntaqlite_syntax::any::AnyDialect::field_meta(&self, tag: syntaqlite_syntax::any::AnyNodeTag) -> impl core::iter::traits::exact_size::ExactSizeIterator<Item = syntaqlite_syntax::any::FieldMeta<'static>>
+pub fn syntaqlite_syntax::any::AnyDialect::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn syntaqlite_syntax::any::AnyDialect::from(g: syntaqlite_syntax::typed::Dialect) -> syntaqlite_syntax::any::AnyDialect
 pub fn syntaqlite_syntax::any::AnyDialect::has_macro_style(&self) -> bool
 pub fn syntaqlite_syntax::any::AnyDialect::is_list(&self, tag: syntaqlite_syntax::any::AnyNodeTag) -> bool
@@ -915,7 +917,7 @@ pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::expanded_text(&self) -> &
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::extract_fields(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(syntaqlite_syntax::any::AnyNodeTag, syntaqlite_syntax::any::NodeFields)>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::is_macro_free(&self) -> bool
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::list_children(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a [syntaqlite_syntax::any::AnyNodeId]>
-pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::macro_regions(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRegion> + use<'_>
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::macro_rewrites(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRewrite> + use<'_>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_expanded_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a str>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_is_macro_free(&self, id: syntaqlite_syntax::any::AnyNodeId) -> bool
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(&'a str, u32)>
@@ -936,8 +938,13 @@ pub fn syntaqlite_syntax::any::FieldMeta<'_>::name(&self) -> &'static str
 pub fn syntaqlite_syntax::any::FieldMeta<'_>::offset(&self) -> u16
 pub fn syntaqlite_syntax::any::KeywordEntry::keyword(&self) -> &'static str
 pub fn syntaqlite_syntax::any::KeywordEntry::token_type(&self) -> syntaqlite_syntax::any::AnyTokenType
-pub fn syntaqlite_syntax::any::MacroRegion::call_length(&self) -> u32
-pub fn syntaqlite_syntax::any::MacroRegion::call_offset(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroRewrite::call_length(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroRewrite::call_offset(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroRewrite::def_col(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroRewrite::def_line(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroRewrite::expansion(&self) -> &str
+pub fn syntaqlite_syntax::any::MacroRewrite::name(&self) -> &str
+pub fn syntaqlite_syntax::any::MacroRewrite::parent(&self) -> core::option::Option<u32>
 pub fn syntaqlite_syntax::any::NodeFields::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn syntaqlite_syntax::any::NodeFields::index(&self, idx: usize) -> &syntaqlite_syntax::any::FieldValue
 pub fn syntaqlite_syntax::any::NodeFields::is_empty(&self) -> bool
@@ -1643,7 +1650,7 @@ pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::comments(&self) ->
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::dump(&self, out: &mut alloc::string::String, indent: usize)
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::erase(self) -> syntaqlite_syntax::any::AnyParsedStatement<'a>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::expanded_text(&self) -> &'a str
-pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::macro_regions(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRegion> + use<'_, 'a, G>
+pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::macro_rewrites(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRewrite> + use<'_, 'a, G>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::root(&'a self) -> core::option::Option<<G as syntaqlite_syntax::typed::TypedDialect>::Node>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::text(&self) -> &'a str
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::typed::TypedParserToken<'a, G>>
@@ -1694,7 +1701,7 @@ pub struct syntaqlite_syntax::any::AnyNode<'a>
 pub struct syntaqlite_syntax::any::AnyParsedStatement<'a>
 pub struct syntaqlite_syntax::any::FieldMeta<'a>(_)
 pub struct syntaqlite_syntax::any::KeywordEntry
-pub struct syntaqlite_syntax::any::MacroRegion
+pub struct syntaqlite_syntax::any::MacroRewrite
 pub struct syntaqlite_syntax::any::NodeFields
 pub struct syntaqlite_syntax::any::TracebackFrame<'a>
 pub struct syntaqlite_syntax::nodes::AggregateFunctionCall<'a>

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -287,7 +287,6 @@ impl syntaqlite_syntax::any::AnyNodeTag
 impl syntaqlite_syntax::any::AnyTokenType
 impl syntaqlite_syntax::any::FieldMeta<'_>
 impl syntaqlite_syntax::any::KeywordEntry
-impl syntaqlite_syntax::any::MacroRewrite
 impl syntaqlite_syntax::any::NodeFields
 impl syntaqlite_syntax::any::TextSpan
 impl syntaqlite_syntax::nodes::AggregateFunctionCallFlags
@@ -598,6 +597,7 @@ impl<'a> core::convert::From<syntaqlite_syntax::typed::TypedNodeList<'a, syntaql
 impl<'a> syntaqlite_syntax::Comment<'a>
 impl<'a> syntaqlite_syntax::ParserToken<'a>
 impl<'a> syntaqlite_syntax::any::AnyParsedStatement<'a>
+impl<'a> syntaqlite_syntax::any::MacroRewrite<'a>
 impl<'a> syntaqlite_syntax::nodes::AggregateFunctionCall<'a>
 impl<'a> syntaqlite_syntax::nodes::AlterTableStmt<'a>
 impl<'a> syntaqlite_syntax::nodes::AnalyzeOrReindexStmt<'a>
@@ -917,7 +917,7 @@ pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::expanded_text(&self) -> &
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::extract_fields(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(syntaqlite_syntax::any::AnyNodeTag, syntaqlite_syntax::any::NodeFields)>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::is_macro_free(&self) -> bool
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::list_children(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a [syntaqlite_syntax::any::AnyNodeId]>
-pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::macro_rewrites(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRewrite> + use<'_>
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::macro_rewrites(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRewrite<'a>> + use<'_, 'a>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_expanded_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a str>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_is_macro_free(&self, id: syntaqlite_syntax::any::AnyNodeId) -> bool
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(&'a str, u32)>
@@ -938,13 +938,13 @@ pub fn syntaqlite_syntax::any::FieldMeta<'_>::name(&self) -> &'static str
 pub fn syntaqlite_syntax::any::FieldMeta<'_>::offset(&self) -> u16
 pub fn syntaqlite_syntax::any::KeywordEntry::keyword(&self) -> &'static str
 pub fn syntaqlite_syntax::any::KeywordEntry::token_type(&self) -> syntaqlite_syntax::any::AnyTokenType
-pub fn syntaqlite_syntax::any::MacroRewrite::call_length(&self) -> u32
-pub fn syntaqlite_syntax::any::MacroRewrite::call_offset(&self) -> u32
-pub fn syntaqlite_syntax::any::MacroRewrite::def_col(&self) -> u32
-pub fn syntaqlite_syntax::any::MacroRewrite::def_line(&self) -> u32
-pub fn syntaqlite_syntax::any::MacroRewrite::expansion(&self) -> &str
-pub fn syntaqlite_syntax::any::MacroRewrite::name(&self) -> &str
-pub fn syntaqlite_syntax::any::MacroRewrite::parent(&self) -> core::option::Option<u32>
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::call_length(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::call_offset(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::def_col(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::def_line(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::expansion(&self) -> &'a str
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::name(&self) -> &'a str
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::parent(&self) -> core::option::Option<u32>
 pub fn syntaqlite_syntax::any::NodeFields::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn syntaqlite_syntax::any::NodeFields::index(&self, idx: usize) -> &syntaqlite_syntax::any::FieldValue
 pub fn syntaqlite_syntax::any::NodeFields::is_empty(&self) -> bool
@@ -1650,7 +1650,7 @@ pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::comments(&self) ->
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::dump(&self, out: &mut alloc::string::String, indent: usize)
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::erase(self) -> syntaqlite_syntax::any::AnyParsedStatement<'a>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::expanded_text(&self) -> &'a str
-pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::macro_rewrites(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRewrite> + use<'_, 'a, G>
+pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::macro_rewrites(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRewrite<'a>> + use<'_, 'a, G>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::root(&'a self) -> core::option::Option<<G as syntaqlite_syntax::typed::TypedDialect>::Node>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::text(&self) -> &'a str
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::typed::TypedParserToken<'a, G>>
@@ -1701,7 +1701,7 @@ pub struct syntaqlite_syntax::any::AnyNode<'a>
 pub struct syntaqlite_syntax::any::AnyParsedStatement<'a>
 pub struct syntaqlite_syntax::any::FieldMeta<'a>(_)
 pub struct syntaqlite_syntax::any::KeywordEntry
-pub struct syntaqlite_syntax::any::MacroRewrite
+pub struct syntaqlite_syntax::any::MacroRewrite<'a>
 pub struct syntaqlite_syntax::any::NodeFields
 pub struct syntaqlite_syntax::any::TracebackFrame<'a>
 pub struct syntaqlite_syntax::nodes::AggregateFunctionCall<'a>

--- a/tests/public-api/syntaqlite.txt
+++ b/tests/public-api/syntaqlite.txt
@@ -397,7 +397,7 @@ pub use syntaqlite::any::ffi::CDialectTemplate
 pub use syntaqlite::nodes::<<syntaqlite_syntax::nodes::*>>
 pub use syntaqlite::parse::CommentKind
 pub use syntaqlite::parse::IncrementalParseSession
-pub use syntaqlite::parse::MacroRegion
+pub use syntaqlite::parse::MacroRewrite
 pub use syntaqlite::parse::ParseErrorKind
 pub use syntaqlite::parse::ParseOutcome
 pub use syntaqlite::parse::ParserConfig


### PR DESCRIPTION
## Motivation

syntaqlite has a rich macro expansion system, but the public API only surfaced the byte range of each macro call via `SyntaqliteMacroRegion` / `syntaqlite_result_macro_at`. That is enough to skip over calls during formatting, but not enough for an external consumer (e.g. Perfetto's `SqlSource::Rewriter`) to reconstruct the expanded source with provenance preserved — the actual expansion text, the nesting relationship between layers, and the macro name/definition location were all kept internal.

## Changes

- **C API**: removed `SyntaqliteMacroRegion` + `syntaqlite_result_macro_at`; added `SyntaqliteMacroRewrite` carrying `{parent_idx, call_offset, call_length, expansion, expansion_len, name, name_len, def_line, def_col}`, plus `syntaqlite_result_macro_rewrite_at(p, idx)` and the `SYNTAQLITE_MACRO_PARENT_SOURCE` sentinel for top-level rewrites.
- **Rust surface kept fully in sync**: `MacroRegion` → `MacroRewrite`, `macro_regions()` → `macro_rewrites()` on `AnyParsedStatement`, `TypedParsedStatement`, `ParsedStatement`. `parent()` returns `Option<u32>` (maps C `UINT32_MAX` → `None`). Owned `String` for `expansion` / `name` so the returned type has no lifetime tie to the parser.
- **Semantics**: rewrites are reported in insertion order (outer-before-inner, siblings in source order). Each rewrite's `call_offset` / `call_length` are offsets into the parent's text — authored source for top-level rewrites, or the parent rewrite's `expansion` buffer for nested ones. Maps 1:1 to Perfetto's rewrite tree.
- **Formatter** only ever used `call_offset()` / `call_length()`, so the update is a rename.
- **Tests**: two new Rust tests (`macro_rewrites_records_single_expansion`, `macro_rewrites_records_nested_expansion_tree`) covering top-level + nested (`mwrap` → `mpass`) cases and asserting parent linkage. Public-API goldens rebaselined.

The existing API was not part of a stable release, so this is a clean rename rather than a compatibility shim.