### PR TITLE
synq: fix spurious straddle when nested-macro lookup fails

### DIFF
--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -420,13 +420,6 @@ int synq_parser_expand_and_feed_macro(SyntaqliteParser* p,
   p->macro.expansion_arg_count = 0;
 
   if (rc == -1 || rc == -2) {
-    // Callback failed — tear down the layer we pushed.  We cannot call
-    // synq_end_macro here: its parent-walk assumes the success path's
-    // `ctx.layer_id = new_layer_idx` ran, and on the failure path it didn't.
-    // Walking from the outer layer steps one level too far and clobbers
-    // ctx.layer_id with the grandparent (breaking straddle attribution of
-    // every subsequent token fed by the enclosing expansion).  Instead, pop
-    // the layer directly and free whatever the callback may have stashed.
     SynqExpansionLayer* lyr = &p->macro.layers.data[new_layer_idx];
     if (lyr->expansion_data)
       p->mem.xFree((void*)lyr->expansion_data);

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -420,14 +420,20 @@ int synq_parser_expand_and_feed_macro(SyntaqliteParser* p,
   p->macro.expansion_arg_count = 0;
 
   if (rc == -1 || rc == -2) {
-    // Callback failed — tear down the layer we pushed.
-    synq_end_macro(p);
-    // Free any data the callback may have written before failing.
+    // Callback failed — tear down the layer we pushed.  We cannot call
+    // synq_end_macro here: its parent-walk assumes the success path's
+    // `ctx.layer_id = new_layer_idx` ran, and on the failure path it didn't.
+    // Walking from the outer layer steps one level too far and clobbers
+    // ctx.layer_id with the grandparent (breaking straddle attribution of
+    // every subsequent token fed by the enclosing expansion).  Instead, pop
+    // the layer directly and free whatever the callback may have stashed.
     SynqExpansionLayer* lyr = &p->macro.layers.data[new_layer_idx];
     if (lyr->expansion_data)
       p->mem.xFree((void*)lyr->expansion_data);
-    lyr->expansion_data = NULL;
-    lyr->expansion_len = 0;
+    if (lyr->arg_segments)
+      p->mem.xFree(lyr->arg_segments);
+    p->macro.layers.count--;
+    p->macro.depth--;
     if (rc == -2)
       p->had_error = 1;
     return -1;

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -1582,6 +1582,31 @@ mod tests {
     }
 
     #[test]
+    fn macro_expansion_with_ne_after_substituted_id_no_spurious_straddle() {
+        // Regression: inside a macro body, a substituted identifier followed by
+        // `!=` (or any `!<not-lp>`) triggered expand_and_feed's nested-macro
+        // detection (it sees `ID` then `!`). The lookup callback returned
+        // "not a macro" for that identifier, and the failure path in
+        // synq_parser_expand_and_feed_macro called synq_end_macro while
+        // ctx.layer_id was still the *outer* layer. synq_end_macro then walked
+        // one parent too far and clobbered ctx.layer_id from the outer macro's
+        // layer down to 0 (source), causing every subsequent token fed from the
+        // outer expansion to be tagged with layer_id=0. The straddle detector
+        // then correctly flagged the mixed-layer RHS as a spurious straddle.
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let mut reg = TestMacroRegistry::new();
+        reg.register("m", &["d"], "(SELECT * FROM t WHERE $d != 1)");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let mut session = parser.parse("SELECT * FROM m!(dur);");
+        match session.next() {
+            ParseOutcome::Ok(_) => {}
+            ParseOutcome::Done => panic!("expected a statement"),
+            ParseOutcome::Err(e) => panic!("should parse without straddle error: {}", e.message()),
+        }
+    }
+
+    #[test]
     fn node_is_macro_free_false_without_extent_tracking() {
         let parser = Parser::new(); // no extent tracking
         let source = "SELECT 1";


### PR DESCRIPTION
## Motivation

`expand_and_feed`'s nested-macro detection fires on any `TK_ID` followed (past whitespace) by a literal `!` byte. That matches genuine macro calls, but it *also* matches an identifier directly followed by `!=` (or any other `!<not-lp>` sequence). When the identifier isn't a registered macro, the lookup callback returns -1 and the failure path called `synq_end_macro` to tear down the layer we had just pushed.

`synq_end_macro` walks the parent chain starting from `ctx.layer_id`, but on the failure path the success-path line `ctx.layer_id = new_layer_idx;` has not run. The walk therefore steps one level too far and clobbers `ctx.layer_id` with the grandparent. When this happens inside an outer expansion, every subsequent token fed by the outer `expand_and_feed` is tagged with `layer_id=0` (source), and the straddle detector correctly flags the mixed-layer RHS — a spurious straddle.

Repro:

```sql
CREATE PERFETTO MACRO m(x TableOrSubquery, d ColumnName) RETURNS TableOrSubquery AS (
  SELECT * FROM $x WHERE $d != 1
);
WITH data(ts, dur) AS (VALUES (10, 40))
SELECT * FROM m!(data, dur);
-- error: macro expansion straddles node boundary
```

Real-world stdlib macros with bodies like `... WHERE $d != 1` hit this constantly once a column name is substituted in for `$d`. Unit tests masked it because they tend to use `name!(...)` with no whitespace and few `!=` operators on substituted identifiers.

Fix: https://github.com/LalitMaganti/syntaqlite/issues/143

## Changes

- `parser_macros.c`: on the failure path, don't call `synq_end_macro`. Pop the just-pushed layer directly (`layers.count--`), free `expansion_data` and `arg_segments` the callback may have stashed, and decrement `macro.depth`. The success path is unchanged. This also plugs a minor leak: the old code freed `expansion_data` on failure but not `arg_segments`, and it left a zombie layer in the vec forever — which would grow unboundedly on any parse that repeatedly trips the false-positive trigger.
- `session.rs`: regression test `macro_expansion_with_ne_after_substituted_id_no_spurious_straddle` with a minimal SQLite-only repro (`(SELECT * FROM t WHERE \$d != 1)` expanded via `m!(dur)`).