### PR TITLE
synq: wrap bare multi-RHS passthroughs in synq_pass

### DIFF
--- a/syntaqlite-buildtools/parser-actions/compound.y
+++ b/syntaqlite-buildtools/parser-actions/compound.y
@@ -70,4 +70,4 @@ dbnm(A) ::= . { A.z = NULL; A.n = 0; }
 dbnm(A) ::= DOT nm(X). { A = X; }
 
 paren_exprlist(A) ::= . { A = SYNTAQLITE_NULL_NODE; }
-paren_exprlist(A) ::= LP exprlist(X) RP. { A = X; }
+paren_exprlist(A) ::= LP exprlist(X) RP. { A = synq_pass(pCtx, X); }

--- a/syntaqlite-buildtools/parser-actions/table_source.y
+++ b/syntaqlite-buildtools/parser-actions/table_source.y
@@ -122,7 +122,7 @@ seltablist(A) ::= stl_prefix(A) LP select(S) RP as(Z) on_using(N). {
 seltablist(A) ::= stl_prefix(A) LP seltablist(F) RP as(Z) on_using(N). {
     (void)Z; (void)N;
     if (A == SYNTAQLITE_NULL_NODE) {
-        A = F;
+        A = synq_pass(pCtx, F);
     } else {
         SyntaqliteNode *pfx = AST_NODE(&pCtx->ast, A);
         A = synq_parse_join_clause(pCtx,

--- a/syntaqlite-buildtools/parser-actions/virtual_table.y
+++ b/syntaqlite-buildtools/parser-actions/virtual_table.y
@@ -36,7 +36,7 @@ cmd(A) ::= create_vtab(X) LP(L) vtabarglist RP(R). {
         .flags = 0,
         ._layer_id = L.layer_id,
     };
-    A = X;
+    A = synq_pass(pCtx, X);
 }
 
 // create_vtab builds the node with table name, schema, module name

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_keyword.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_keyword.c
@@ -242,8 +242,8 @@ const unsigned char synq_sqlite_aKWLen[149] = {
     8, 6,  4,  9, 5, 8, 4,  3,  9,  5, 5, 6, 4, 6, 2, 2,  7,
 };
 /* synq_sqlite_aKWOffset[i] is the index into synq_sqlite_zKWText[] of the start
- *of
- ** the text for the i-th keyword. */
+*of
+** the text for the i-th keyword. */
 const unsigned short int synq_sqlite_aKWOffset[149] = {
     0,   0,   2,   2,   8,   9,   14,  16,  20,  23,  25,  25,  29,  33,  36,
     41,  46,  48,  53,  54,  59,  62,  65,  67,  69,  78,  81,  86,  90,  90,

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
@@ -7442,7 +7442,7 @@ static YYACTIONTYPE yy_reduce(
     } break;
     case 36: /* paren_exprlist ::= LP exprlist RP */
     {
-      yymsp[-2].minor.yy277 = yymsp[-1].minor.yy277;
+      yymsp[-2].minor.yy277 = synq_pass(pCtx, yymsp[-1].minor.yy277);
     } break;
     case 37: /* expr ::= expr ISNULL|NOTNULL */
     {
@@ -9250,7 +9250,7 @@ static YYACTIONTYPE yy_reduce(
       (void)yymsp[-1].minor.yy277;
       (void)yymsp[0].minor.yy632;
       if (yymsp[-5].minor.yy277 == SYNTAQLITE_NULL_NODE) {
-        yymsp[-5].minor.yy277 = yymsp[-3].minor.yy277;
+        yymsp[-5].minor.yy277 = synq_pass(pCtx, yymsp[-3].minor.yy277);
       } else {
         SyntaqliteNode* pfx = AST_NODE(&pCtx->ast, yymsp[-5].minor.yy277);
         yymsp[-5].minor.yy277 = synq_parse_join_clause(
@@ -9785,7 +9785,7 @@ static YYACTIONTYPE yy_reduce(
           .flags = 0,
           ._layer_id = yymsp[-2].minor.yy0.layer_id,
       };
-      yylhsminor.yy277 = yymsp[-3].minor.yy277;
+      yylhsminor.yy277 = synq_pass(pCtx, yymsp[-3].minor.yy277);
     }
       yymsp[-3].minor.yy277 = yylhsminor.yy277;
       break;
@@ -10056,7 +10056,7 @@ static void yy_syntax_error(
   SynqSqliteParseARG_FETCH SynqSqliteParseCTX_FETCH
 #define TOKEN yyminor
       /************ Begin %syntax_error code
-       ****************************************/
+         ****************************************/
 
       (void) yymajor;
   (void)TOKEN;

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -613,6 +613,21 @@ mod tests {
             .node_text(root_id)
             .expect("root node should have recorded text");
         assert_eq!(text, "SELECT (1 + 2)");
+        drop(session);
+
+        // CREATE VIRTUAL TABLE t USING mod(a, b) — the cmd rule does
+        // A = X (passthrough with LP vtabarglist RP consumed).  Regression
+        // test for #144.
+        let source = "CREATE VIRTUAL TABLE t USING mod(a, b);";
+        let mut session = parser.parse(source);
+        let ParseOutcome::Ok(statement) = session.next() else {
+            panic!("expected Ok");
+        };
+        let root_id = statement.erase().root_id();
+        let (text, _) = statement
+            .node_text(root_id)
+            .expect("root node should have recorded text");
+        assert_eq!(text, "CREATE VIRTUAL TABLE t USING mod(a, b)");
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

Fixes #144. In `virtual_table.y`, the rule

```
cmd(A) ::= create_vtab(X) LP vtabarglist RP. { ... A = X; }
```

used a bare `A = X` passthrough. Because this rule consumes `LP vtabarglist RP` but doesn't re-record the extent on X, the resulting `create_virtual_table_stmt` node's extent only covered `CREATE VIRTUAL TABLE t USING mod` — the `(arg1, arg2)` portion was silently dropped. `syntaqlite_parser_node_text(...)` on such a node would return

```
CREATE VIRTUAL TABLE t USING mod
```

instead of

```
CREATE VIRTUAL TABLE t USING mod(arg1, arg2)
```

which broke Perfetto's stdlib SPAN_JOIN tables when re-fed to SQLite (`SPAN_JOIN: expected exactly two arguments`).

Auditing the other `.y` files surfaced two more instances of the same pattern: `paren_exprlist ::= LP exprlist RP` in `compound.y` and the null-prefix branch of the parenthesized seltablist in `table_source.y`. Neither is user-visible today (one's consumer discards the node; the other is eclipsed by a downstream `synq_pass` in `from`), but they break the pattern #122/#123 established.

## Changes

- Wrap the three bare passthroughs in `synq_pass(pCtx, X)` so the node's extent is re-recorded to the enclosing rule's merged range.
- Regenerate the affected portions of `sqlite_parse.c` / `sqlite_keyword.c` via `tools/run-codegen`.
- Add a regression test in `parser_collect_node_extents_passthrough_rules_cover_full_range` that asserts `CREATE VIRTUAL TABLE t USING mod(a, b)` round-trips through `node_text`.