### PR TITLE
synq: detect nested macro call by TK_BANG, not raw '!' byte

### DIFF
--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -289,25 +289,27 @@ static int expand_and_feed(SyntaqliteParser* p,
       continue;
     }
 
-    // Check for nested macro call: ID followed by '!'.
-    // Skip whitespace/comments between ID and '!' to mirror the main parse
+    // Check for nested macro call: ID followed by TK_BANG.
+    // Skip whitespace/comments between ID and BANG to mirror the main parse
     // loop's next_token() behaviour (issue #130).
     // Skip when inside a macro definition body — body should be verbatim.
     uint32_t bang_pos = pos + (uint32_t)tlen;
+    uint32_t la_type = 0;
     if (ttype == SYNTAQLITE_TK_ID && p->ctx.in_macro_def_body == 0) {
-      // Scan past whitespace/comments to find the next significant byte.
       while (bang_pos < buf_len) {
-        uint32_t la_type = 0;
+        uint32_t lt = 0;
         int64_t la_len = SynqSqliteGetTokenVersionWrapped(
-            &p->dialect, p->macro.macro_fallback, z + bang_pos, &la_type);
+            &p->dialect, p->macro.macro_fallback, z + bang_pos, &lt);
         if (la_len <= 0)
           break;
-        if (la_type != SYNTAQLITE_TK_SPACE && la_type != SYNTAQLITE_TK_COMMENT)
+        if (lt != SYNTAQLITE_TK_SPACE && lt != SYNTAQLITE_TK_COMMENT) {
+          la_type = lt;
           break;
+        }
         bang_pos += (uint32_t)la_len;
       }
     }
-    if (ttype == SYNTAQLITE_TK_ID && bang_pos < buf_len && z[bang_pos] == '!' &&
+    if (ttype == SYNTAQLITE_TK_ID && la_type == SYNTAQLITE_TK_BANG &&
         p->ctx.in_macro_def_body == 0) {
       uint32_t nested_end = 0;
       int erc = synq_parser_expand_and_feed_macro(p, buf, buf_len, pos,


### PR DESCRIPTION
## Motivation

`expand_and_feed`'s nested-macro detection fired on any `TK_ID` followed
(past whitespace) by a literal `!` byte.  The tokenizer already
distinguishes `!` (TK_BANG) from `!=` (TK_NE), and the main parse loop
in `parser.c` correctly gates on `la_type == TK_BANG`.  Only the
in-expansion path was byte-checking, so `id != 1` inside a macro body
would hit the lookup callback, fail, and take the failure-cleanup path.

PR #147 fixed the failure-cleanup path so the spurious-straddle symptom
stopped, but the underlying false positive remained: every `!=` after a
substituted identifier still pushed a layer, invoked the callback, and
tore it back down.

## Changes

- `parser_macros.c`: hoist the significant-token type out of the
  whitespace/comment skip loop in `expand_and_feed` and gate the nested
  macro detection on `la_type == SYNTAQLITE_TK_BANG`.  Matches the
  check in `parser.c`.
- Existing regression test
  `macro_expansion_with_ne_after_substituted_id_no_spurious_straddle`
  still passes; it now exercises the early-reject path instead of the
  failure-cleanup path.
- PR #147's cleanup changes are retained: genuine `name!(args)` calls
  against an unregistered macro still take the failure path, and that
  path must not clobber `ctx.layer_id` or leak layer memory.