### PR TITLE
synq: bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.4.0
+
+**Breaking:**
+- Macro lookup is now callback-driven so dialects can resolve macros lazily ([#121](https://github.com/LalitMaganti/syntaqlite/pull/121)). The incremental parser API drops `begin_macro`/`end_macro` ([#110](https://github.com/LalitMaganti/syntaqlite/pull/110)).
+- Spans now cover SQL longer than 64KB; `SyntaqliteTextSpan.length` is `uint32_t` ([#109](https://github.com/LalitMaganti/syntaqlite/pull/109)).
+- `.synq` grammar files use `//` comments instead of `#` ([#115](https://github.com/LalitMaganti/syntaqlite/pull/115)).
+
+**Macros:**
+- Expansions are now exposed as a flat rewrite list with `$param` arg segments, nested call offsets, and APIs to ask whether a span/node/statement came from a macro — enough to map cleanly between expanded SQL and source for diagnostics, hovers, and refactors ([#124](https://github.com/LalitMaganti/syntaqlite/pull/124), [#142](https://github.com/LalitMaganti/syntaqlite/pull/142), [#145](https://github.com/LalitMaganti/syntaqlite/pull/145)).
+- Unknown macro names now produce a hard parse error instead of silently expanding to nothing ([#139](https://github.com/LalitMaganti/syntaqlite/pull/139)). A permissive mode lets tools inspect bodies with unknown `$param` references ([#141](https://github.com/LalitMaganti/syntaqlite/pull/141)).
+- Embedders can compile macros out entirely with `SYNTAQLITE_OMIT_MACROS` ([#135](https://github.com/LalitMaganti/syntaqlite/pull/135)).
+- Fixed OOB read on non-NUL-terminated bodies ([#132](https://github.com/LalitMaganti/syntaqlite/pull/132)), layer-id overflow past 256 layers ([#134](https://github.com/LalitMaganti/syntaqlite/pull/134)), and several spurious-straddle and whitespace-handling bugs in deeply-nested expansions.
+
+**Spans and AST:**
+- Every parse tree node carries a precise source range, with traceback through nested macro expansions so diagnostics report the original source location ([#96](https://github.com/LalitMaganti/syntaqlite/pull/96), [#101](https://github.com/LalitMaganti/syntaqlite/pull/101), [#102](https://github.com/LalitMaganti/syntaqlite/pull/102), [#103](https://github.com/LalitMaganti/syntaqlite/pull/103)). The Rust span API now mirrors C 1:1 ([#98](https://github.com/LalitMaganti/syntaqlite/pull/98)).
+- Fixed stale span info on AST nodes from multi-RHS passthrough reductions ([#122](https://github.com/LalitMaganti/syntaqlite/pull/122), [#123](https://github.com/LalitMaganti/syntaqlite/pull/123)).
+
+**Grammar and build:**
+- SQL using `window`, `over`, or `filter` as identifiers now parses correctly ([#113](https://github.com/LalitMaganti/syntaqlite/pull/113)).
+- Dialects can list base SQL keywords in `extra_keywords` without duplicate-keyword errors ([#111](https://github.com/LalitMaganti/syntaqlite/pull/111)).
+- LSP semantic analysis is feature-gated behind `lsp` ([#97](https://github.com/LalitMaganti/syntaqlite/pull/97)).
+
 ## 0.3.1
 
 - Restored Python 3.14 (cp314) wheel publishing, which had been silently dropped since 0.2.13 ([#91](https://github.com/LalitMaganti/syntaqlite/issues/91)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "benches"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "syntaqlite",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "glob",
  "libloading",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-buildtools"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "cc",
  "clap",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-cli"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "clap",
  "glob",
@@ -1075,11 +1075,11 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-common"
-version = "0.3.1"
+version = "0.4.0"
 
 [[package]]
 name = "syntaqlite-syntax"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "cc",
  "libloading",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-wasm"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ cargo install syntaqlite-cli
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.3.1", features = ["fmt"] }
+syntaqlite = { version = "0.4.0", features = ["fmt"] }
 ```
 
 **Python** ([API docs](https://docs.syntaqlite.com/latest/reference/python-api/))

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syntaqlite",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "SQLite SQL language server — diagnostics, formatting, completions, and semantic tokens",
   "author": {
     "name": "Lalit Maganti"

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "syntaqlite",
   "displayName": "syntaqlite",
   "description": "SQL language support powered by syntaqlite — diagnostics, formatting, completions, and semantic highlighting",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "publisher": "syntaqlite",
   "license": "Apache-2.0",
   "icon": "icon.png",

--- a/integrations/zed/Cargo.toml
+++ b/integrations/zed/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "syntaqlite-zed"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 
 [lib]

--- a/integrations/zed/extension.toml
+++ b/integrations/zed/extension.toml
@@ -3,7 +3,7 @@
 
 id = "syntaqlite"
 name = "Syntaqlite"
-version = "0.3.1"
+version = "0.4.0"
 schema_version = 1
 authors = ["Lalit Maganti <lalitmaganti@gmail.com>"]
 description = "SQL language support powered by syntaqlite — tokenizer, parser, formatter and validator built on SQLite's own grammar."

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntaqlite"
-version = "0.3.1"
+version = "0.4.0"
 description = "SQLite SQL tools — parser, formatter, validator, and MCP server"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}

--- a/python/syntaqlite/__init__.py
+++ b/python/syntaqlite/__init__.py
@@ -5,7 +5,7 @@ import stat
 import subprocess
 import sys
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 
 # Library API (requires _syntaqlite C extension).
 try:

--- a/syntaqlite-buildtools/Cargo.toml
+++ b/syntaqlite-buildtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-buildtools"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 description = "Internal codegen and build tools for syntaqlite — not intended for direct use"
 license = "Apache-2.0"
@@ -20,8 +20,8 @@ dist = false
 doc = false
 
 [dependencies]
-syntaqlite-common = { version = "0.3.1", path = "../syntaqlite-common" }
-syntaqlite-syntax = { version = "0.3.1", path = "../syntaqlite-syntax", default-features = false, features = ["embedded-sources"] }
+syntaqlite-common = { version = "0.4.0", path = "../syntaqlite-common" }
+syntaqlite-syntax = { version = "0.4.0", path = "../syntaqlite-syntax", default-features = false, features = ["embedded-sources"] }
 clap = { version = "4.5", features = ["derive"] }
 tempfile = "3.8"
 serde = { version = "1", features = ["derive"] }

--- a/syntaqlite-cli/Cargo.toml
+++ b/syntaqlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-cli"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 repository.workspace = true
 description = "Fast, accurate SQLite SQL formatter, validator, and language server — built on SQLite's own grammar"
@@ -30,8 +30,8 @@ rmcp = { version = "0.1", features = ["server", "transport-io"], optional = true
 schemars = { version = "0.8", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-syntaqlite = { version = "0.3.1", path = "../syntaqlite", optional = true, features = ["fmt", "lsp", "validation", "experimental-embedded", "serde-json"] }
-syntaqlite-syntax = { version = "0.3.1", path = "../syntaqlite-syntax" }
-syntaqlite-buildtools = { version = "0.3.1", path = "../syntaqlite-buildtools", optional = true }
+syntaqlite = { version = "0.4.0", path = "../syntaqlite", optional = true, features = ["fmt", "lsp", "validation", "experimental-embedded", "serde-json"] }
+syntaqlite-syntax = { version = "0.4.0", path = "../syntaqlite-syntax" }
+syntaqlite-buildtools = { version = "0.4.0", path = "../syntaqlite-buildtools", optional = true }
 tempfile = "3.8"
 tokio = { version = "1", features = ["rt", "macros", "io-std"], optional = true }

--- a/syntaqlite-common/Cargo.toml
+++ b/syntaqlite-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-common"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 description = "Internal shared primitives for syntaqlite — not intended for direct use"
 license = "Apache-2.0"

--- a/syntaqlite-syntax/Cargo.toml
+++ b/syntaqlite-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-syntax"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 links = "syntaqlite_syntax"
 description = "Internal parser and tokenizer for syntaqlite — not intended for direct use"

--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -587,7 +587,24 @@ syntaqlite_result_macro_rewrite_at(SyntaqliteParser* p, uint32_t idx) {
   (void)p;
   (void)idx;
   return (SyntaqliteMacroRewrite){
-      SYNTAQLITE_MACRO_PARENT_SOURCE, 0, 0, NULL, 0, NULL, 0, 0, 0};
+      .parent_idx = SYNTAQLITE_MACRO_PARENT_SOURCE,
+  };
+}
+SYNTAQLITE_API uint32_t
+syntaqlite_macro_rewrite_arg_segment_count(SyntaqliteParser* p,
+                                           uint32_t rewrite_idx) {
+  (void)p;
+  (void)rewrite_idx;
+  return 0;
+}
+SYNTAQLITE_API SyntaqliteMacroArgSegment
+syntaqlite_macro_rewrite_arg_segment_at(SyntaqliteParser* p,
+                                        uint32_t rewrite_idx,
+                                        uint32_t segment_idx) {
+  (void)p;
+  (void)rewrite_idx;
+  (void)segment_idx;
+  return (SyntaqliteMacroArgSegment){0};
 }
 #else
 SYNTAQLITE_API uint32_t syntaqlite_result_macro_count(SyntaqliteParser* p) {
@@ -601,7 +618,8 @@ syntaqlite_result_macro_rewrite_at(SyntaqliteParser* p, uint32_t idx) {
   uint32_t layer_idx = idx + 1;
   if (layer_idx >= syntaqlite_vec_len(&p->macro.layers)) {
     return (SyntaqliteMacroRewrite){
-        SYNTAQLITE_MACRO_PARENT_SOURCE, 0, 0, NULL, 0, NULL, 0, 0, 0};
+        .parent_idx = SYNTAQLITE_MACRO_PARENT_SOURCE,
+    };
   }
   const SynqExpansionLayer* lyr = &p->macro.layers.data[layer_idx];
   // Internal parent_layer_id 0 = authored source sentinel.  Map it to the
@@ -611,9 +629,53 @@ syntaqlite_result_macro_rewrite_at(SyntaqliteParser* p, uint32_t idx) {
                             ? SYNTAQLITE_MACRO_PARENT_SOURCE
                             : lyr->parent_layer_id - 1;
   return (SyntaqliteMacroRewrite){
-      parent_idx,          lyr->call_offset,   lyr->call_length,
-      lyr->expansion_data, lyr->expansion_len, lyr->name,
-      lyr->name_len,       lyr->def_line,      lyr->def_col,
+      .parent_idx = parent_idx,
+      .call_offset = lyr->call_offset,
+      .call_length = lyr->call_length,
+      .expansion = lyr->expansion_data,
+      .expansion_len = lyr->expansion_len,
+      .name = lyr->name,
+      .name_len = lyr->name_len,
+      .def_line = lyr->def_line,
+      .def_col = lyr->def_col,
+      .body_call_offset = lyr->body_call_offset,
+      .body_call_length = lyr->body_call_length,
+  };
+}
+
+SYNTAQLITE_API uint32_t
+syntaqlite_macro_rewrite_arg_segment_count(SyntaqliteParser* p,
+                                           uint32_t rewrite_idx) {
+  uint32_t layer_idx = rewrite_idx + 1;
+  if (layer_idx >= syntaqlite_vec_len(&p->macro.layers))
+    return 0;
+  return p->macro.layers.data[layer_idx].arg_segment_count;
+}
+
+SYNTAQLITE_API SyntaqliteMacroArgSegment
+syntaqlite_macro_rewrite_arg_segment_at(SyntaqliteParser* p,
+                                        uint32_t rewrite_idx,
+                                        uint32_t segment_idx) {
+  uint32_t layer_idx = rewrite_idx + 1;
+  if (layer_idx >= syntaqlite_vec_len(&p->macro.layers))
+    return (SyntaqliteMacroArgSegment){0};
+  const SynqExpansionLayer* lyr = &p->macro.layers.data[layer_idx];
+  if (segment_idx >= lyr->arg_segment_count)
+    return (SyntaqliteMacroArgSegment){0};
+  const SynqArgSegment* seg = &lyr->arg_segments[segment_idx];
+  // Map internal origin_layer_id (0 = source sentinel) to the public
+  // sentinel / rewrite-index scheme used by parent_idx.
+  uint32_t origin_parent_idx = seg->origin_layer_id == 0
+                                   ? SYNTAQLITE_MACRO_PARENT_SOURCE
+                                   : seg->origin_layer_id - 1;
+  return (SyntaqliteMacroArgSegment){
+      .body_offset = seg->body_offset,
+      .body_length = seg->body_length,
+      .expansion_offset = seg->sub_offset,
+      .expansion_length = seg->sub_length,
+      .origin_parent_idx = origin_parent_idx,
+      .origin_offset = seg->origin_offset,
+      .origin_length = seg->origin_length,
   };
 }
 #endif

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -55,7 +55,14 @@ typedef struct SynqMacroArg {
 // arg landed in the expansion buffer and where the original text lives in
 // the parent layer, enabling span resolution to drill through $param
 // substitutions back to the caller's authored arg text.
+//
+// `body_offset` / `body_length` record the `$param` token position in the
+// macro's authored body (pre-substitution).  Populated by the
+// template-expansion path; zero for the set_result_with_arg_map API where
+// the caller did not supply authored-body positions.
 typedef struct SynqArgSegment {
+  uint32_t body_offset;      // Position of $param token in authored body.
+  uint32_t body_length;      // Length of $param token in authored body.
   uint32_t sub_offset;       // Where the substituted arg starts in expansion.
   uint32_t sub_length;       // Length in expansion buffer.
   uint32_t origin_layer_id;  // Layer that owns the arg text.
@@ -92,6 +99,15 @@ typedef struct SynqExpansionLayer {
   // p->mem; freed in reset_stmt / destroy.  NULL when no $param subs.
   SynqArgSegment* arg_segments;
   uint32_t arg_segment_count;
+
+  // Position of this nested call in the *parent's authored body*,
+  // computed by inverting the length shifts from the parent's $param
+  // substitutions.  body_call_length == 0 means the call was tokenized
+  // from a substituted arg's text (no clean body position) and consumers
+  // should descend through the matching arg segment instead.  Zero for
+  // top-level layers (parent_layer_id == 0).
+  uint32_t body_call_offset;
+  uint32_t body_call_length;
 
   uint32_t parent_layer_id;  // Layer containing the call (0 = source).
 } SynqExpansionLayer;

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -483,11 +483,62 @@ static void begin_macro_expansion(SyntaqliteParser* p,
     p->ctx.macro_root_layer = syntaqlite_vec_len(&p->macro.layers);
   }
 
+  // Compute position of this call in the parent's *authored* body by
+  // inverting the length shifts introduced by the parent's $param
+  // substitutions.  For top-level calls the parent is the source layer
+  // (no arg segments), so the shifts stay zero and body_call_offset /
+  // body_call_length equal call_offset / call_length.
+  //
+  // A segment's relationship to the call range determines its effect:
+  //   * fully before call → its length delta shifts body_call_offset
+  //   * fully after call  → no effect
+  //   * seg contains call (incl. equal bounds) → arg-internal: the call
+  //     was tokenized from this arg's substituted text
+  //   * seg strictly inside call → its length delta shrinks body_call_length
+  //   * partial overlap → arg-internal
+  //
+  // The "contains" check must run before "strictly inside" so the
+  // equal-bounds case (common for `m!(arg)` where arg is itself a
+  // macro call) is classified as arg-internal rather than inside.
+  const SynqExpansionLayer* parent = &p->macro.layers.data[p->ctx.layer_id];
+  uint32_t call_end = call_offset + call_length;
+  uint32_t prefix_shift = 0;
+  uint32_t inner_shift = 0;
+  int arg_internal = 0;
+  for (uint32_t i = 0; i < parent->arg_segment_count; i++) {
+    const SynqArgSegment* seg = &parent->arg_segments[i];
+    uint32_t seg_end = seg->sub_offset + seg->sub_length;
+    uint32_t body_shift = seg->sub_length >= seg->body_length
+                              ? seg->sub_length - seg->body_length
+                              : 0;
+    if (seg_end <= call_offset) {
+      prefix_shift += body_shift;
+    } else if (seg->sub_offset >= call_end) {
+      // Fully after the call — no effect.
+    } else if (seg->sub_offset <= call_offset && seg_end >= call_end) {
+      arg_internal = 1;
+      break;
+    } else if (seg->sub_offset >= call_offset && seg_end <= call_end) {
+      inner_shift += body_shift;
+    } else {
+      arg_internal = 1;
+      break;
+    }
+  }
+  uint32_t body_call_offset = arg_internal
+                                  ? SYNTAQLITE_MACRO_BODY_CALL_ARG_INTERNAL
+                                  : call_offset - prefix_shift;
+  uint32_t body_call_length = arg_internal
+                                  ? SYNTAQLITE_MACRO_BODY_CALL_ARG_INTERNAL
+                                  : call_length - inner_shift;
+
   SynqExpansionLayer layer = {
       .call_offset = call_offset,
       .call_length = call_length,
       .name = name,
       .name_len = name_len,
+      .body_call_offset = body_call_offset,
+      .body_call_length = body_call_length,
       .parent_layer_id = p->ctx.layer_id,
   };
   syntaqlite_vec_push(&p->macro.layers, layer, p->mem);
@@ -623,8 +674,16 @@ SYNTAQLITE_API int syntaqlite_macro_expansion_expand_and_set_result(
                         p->mem);
   syntaqlite_vec_push(&p->macro.body_buf, 0, p->mem);
 
-  // Collect arg mappings on the stack (max 64 params).
-  SyntaqliteArgMapping mappings[64];
+  // Collect arg mappings on the stack (max 64 params).  We extend the
+  // public SyntaqliteArgMapping with the authored-body position of the
+  // $param token (pre-substitution) so downstream tracebacks can anchor
+  // substitutions back to the macro definition.
+  struct Mapping {
+    uint32_t sub_offset;      // Offset in expansion buffer.
+    uint32_t arg_index;       // Index into callback args.
+    uint32_t body_token_off;  // Offset of $param token in authored body.
+    uint32_t body_token_len;  // Length of $param token in authored body.
+  } mappings[64];
   uint32_t mapping_count = 0;
 
   const unsigned char* z = (const unsigned char*)p->macro.body_buf.data;
@@ -664,8 +723,10 @@ SYNTAQLITE_API int syntaqlite_macro_expansion_expand_and_set_result(
 
       if ((uint32_t)found < arg_count && args[found].length > 0) {
         if (mapping_count < 64) {
-          mappings[mapping_count].body_offset = p->macro.expand_buf.count;
+          mappings[mapping_count].sub_offset = p->macro.expand_buf.count;
           mappings[mapping_count].arg_index = (uint32_t)found;
+          mappings[mapping_count].body_token_off = pos;
+          mappings[mapping_count].body_token_len = (uint32_t)tlen;
           mapping_count++;
         }
         syntaqlite_vec_push_n(&p->macro.expand_buf,
@@ -707,7 +768,9 @@ SYNTAQLITE_API int syntaqlite_macro_expansion_expand_and_set_result(
     for (uint32_t i = 0; i < mapping_count; i++) {
       uint32_t ai = mappings[i].arg_index;
       segs[i] = (SynqArgSegment){
-          .sub_offset = mappings[i].body_offset,
+          .body_offset = mappings[i].body_token_off,
+          .body_length = mappings[i].body_token_len,
+          .sub_offset = mappings[i].sub_offset,
           .sub_length = args[ai].length,
           .origin_layer_id = origin_layer_id,
           .origin_offset = (uint32_t)(args[ai].text - origin_base),

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -420,13 +420,6 @@ int synq_parser_expand_and_feed_macro(SyntaqliteParser* p,
   p->macro.expansion_arg_count = 0;
 
   if (rc == -1 || rc == -2) {
-    // Callback failed — tear down the layer we pushed.  We cannot call
-    // synq_end_macro here: its parent-walk assumes the success path's
-    // `ctx.layer_id = new_layer_idx` ran, and on the failure path it didn't.
-    // Walking from the outer layer steps one level too far and clobbers
-    // ctx.layer_id with the grandparent (breaking straddle attribution of
-    // every subsequent token fed by the enclosing expansion).  Instead, pop
-    // the layer directly and free whatever the callback may have stashed.
     SynqExpansionLayer* lyr = &p->macro.layers.data[new_layer_idx];
     if (lyr->expansion_data)
       p->mem.xFree((void*)lyr->expansion_data);

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -420,14 +420,20 @@ int synq_parser_expand_and_feed_macro(SyntaqliteParser* p,
   p->macro.expansion_arg_count = 0;
 
   if (rc == -1 || rc == -2) {
-    // Callback failed — tear down the layer we pushed.
-    synq_end_macro(p);
-    // Free any data the callback may have written before failing.
+    // Callback failed — tear down the layer we pushed.  We cannot call
+    // synq_end_macro here: its parent-walk assumes the success path's
+    // `ctx.layer_id = new_layer_idx` ran, and on the failure path it didn't.
+    // Walking from the outer layer steps one level too far and clobbers
+    // ctx.layer_id with the grandparent (breaking straddle attribution of
+    // every subsequent token fed by the enclosing expansion).  Instead, pop
+    // the layer directly and free whatever the callback may have stashed.
     SynqExpansionLayer* lyr = &p->macro.layers.data[new_layer_idx];
     if (lyr->expansion_data)
       p->mem.xFree((void*)lyr->expansion_data);
-    lyr->expansion_data = NULL;
-    lyr->expansion_len = 0;
+    if (lyr->arg_segments)
+      p->mem.xFree(lyr->arg_segments);
+    p->macro.layers.count--;
+    p->macro.depth--;
     if (rc == -2)
       p->had_error = 1;
     return -1;

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -212,6 +212,12 @@ SYNTAQLITE_API const SyntaqliteParserToken* syntaqlite_result_tokens(
 // not nested inside another macro's expansion).
 #define SYNTAQLITE_MACRO_PARENT_SOURCE UINT32_MAX
 
+// Sentinel value for `SyntaqliteMacroRewrite::body_call_offset` and
+// `body_call_length` meaning "this call was tokenized from a $param
+// substitution — it has no position in the parent's authored body;
+// consumers should descend through the matching arg segment instead."
+#define SYNTAQLITE_MACRO_BODY_CALL_ARG_INTERNAL UINT32_MAX
+
 // A recorded macro invocation — enough information to reconstruct a
 // source-to-expanded rewrite tree (e.g. to drive Perfetto's
 // SqlSource::Rewriter or an equivalent).
@@ -253,6 +259,17 @@ typedef struct SyntaqliteMacroRewrite {
   uint32_t name_len;
   uint32_t def_line;
   uint32_t def_col;
+  // Position of this call in the *parent's authored body*, computed by
+  // inverting the length shifts the parent's $param substitutions
+  // introduced.  body_call_length == 0 means the call was tokenized
+  // from a substituted arg's text (no meaningful body position) and
+  // consumers should descend through the matching arg segment instead.
+  //
+  // For top-level rewrites (parent_idx == SYNTAQLITE_MACRO_PARENT_SOURCE)
+  // the parent is the authored source, so these equal call_offset /
+  // call_length.
+  uint32_t body_call_offset;
+  uint32_t body_call_length;
 } SyntaqliteMacroRewrite;
 
 // Number of macro rewrites recorded for the current statement.
@@ -262,6 +279,45 @@ SYNTAQLITE_API uint32_t syntaqlite_result_macro_count(SyntaqliteParser* p);
 // struct if `idx >= syntaqlite_result_macro_count(p)`.
 SYNTAQLITE_API SyntaqliteMacroRewrite
 syntaqlite_result_macro_rewrite_at(SyntaqliteParser* p, uint32_t idx);
+
+// One $param substitution within a macro expansion.
+//
+// `body_offset` / `body_length` locate the `$param` token in the macro's
+// authored body.  Populated by the template-expansion path; zero for
+// macros registered via the raw set_result_with_arg_map API.
+//
+// `expansion_offset` / `expansion_length` locate the substituted arg
+// text in the rewrite's `expansion` buffer.
+//
+// `origin_parent_idx` + `origin_offset` + `origin_length` locate the
+// arg text where it was authored — either in the original source
+// (`origin_parent_idx == SYNTAQLITE_MACRO_PARENT_SOURCE`) or in another
+// rewrite's `expansion` buffer (rewrite index).  Consumers walk the
+// chain of $param substitutions by recursing into the origin rewrite's
+// arg segments.
+typedef struct SyntaqliteMacroArgSegment {
+  uint32_t body_offset;
+  uint32_t body_length;
+  uint32_t expansion_offset;
+  uint32_t expansion_length;
+  uint32_t origin_parent_idx;
+  uint32_t origin_offset;
+  uint32_t origin_length;
+} SyntaqliteMacroArgSegment;
+
+// Number of arg segments recorded on the rewrite at `rewrite_idx`.
+// Returns 0 if `rewrite_idx` is out of range.
+SYNTAQLITE_API uint32_t
+syntaqlite_macro_rewrite_arg_segment_count(SyntaqliteParser* p,
+                                           uint32_t rewrite_idx);
+
+// Returns the arg segment at `segment_idx` on the rewrite at
+// `rewrite_idx`.  Returns a zero-initialized struct if either index is
+// out of range.
+SYNTAQLITE_API SyntaqliteMacroArgSegment
+syntaqlite_macro_rewrite_arg_segment_at(SyntaqliteParser* p,
+                                        uint32_t rewrite_idx,
+                                        uint32_t segment_idx);
 
 // ---------------------------------------------------------------------------
 // Arena accessors

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! syntaqlite = { version = "0.3.1", default-features = false, features = ["sqlite"] }
+//! syntaqlite = { version = "0.4.0", default-features = false, features = ["sqlite"] }
 //! ```
 
 // ==== Public API ====

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -86,7 +86,7 @@ pub mod any {
     #[doc(inline)]
     pub use crate::parser::{
         AnyIncrementalParseSession, AnyParseError, AnyParseSession, AnyParsedStatement, AnyParser,
-        AnyParserToken, MacroRewrite, ParseOutcome, TracebackFrame,
+        AnyParserToken, ArgOrigin, MacroArgSegment, MacroRewrite, ParseOutcome, TracebackFrame,
     };
     #[doc(inline)]
     pub use crate::tokenizer::{AnyToken, AnyTokenizer};

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -101,6 +101,34 @@ pub(crate) struct CMacroRewrite {
     pub(crate) def_line: u32,
     /// 1-based column of the macro definition (0 = unknown).
     pub(crate) def_col: u32,
+    /// Call position in the parent's *authored* body.
+    /// `u32::MAX` (`ARG_INTERNAL`) means the call came from a $param
+    /// substitution and has no body position.
+    pub(crate) body_call_offset: u32,
+    pub(crate) body_call_length: u32,
+}
+
+/// One $param substitution within a macro expansion.
+///
+/// Mirrors C `SyntaqliteMacroArgSegment` from `include/syntaqlite/parser.h`.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub(crate) struct CMacroArgSegment {
+    /// Position of the $param token in the authored body (0 if unknown).
+    pub(crate) body_offset: u32,
+    /// Length of the $param token in the authored body (0 if unknown).
+    pub(crate) body_length: u32,
+    /// Position of the substituted arg text in the rewrite's expansion.
+    pub(crate) expansion_offset: u32,
+    /// Length of the substituted arg text in the rewrite's expansion.
+    pub(crate) expansion_length: u32,
+    /// Origin of the arg text: `u32::MAX` = authored source, else a
+    /// rewrite index.
+    pub(crate) origin_parent_idx: u32,
+    /// Byte offset of the arg text in the origin.
+    pub(crate) origin_offset: u32,
+    /// Byte length of the arg text in the origin.
+    pub(crate) origin_length: u32,
 }
 
 /// One frame in a traceback produced by the span traceback API.
@@ -421,6 +449,33 @@ impl CParser {
         }
     }
 
+    pub(crate) unsafe fn macro_rewrite_arg_segment_count(&self, rewrite_idx: u32) -> u32 {
+        // SAFETY: self is a valid CParser pointer; the C side clamps
+        // out-of-range indices to zero.
+        unsafe {
+            syntaqlite_macro_rewrite_arg_segment_count(
+                std::ptr::from_ref::<Self>(self).cast_mut(),
+                rewrite_idx,
+            )
+        }
+    }
+
+    pub(crate) unsafe fn macro_rewrite_arg_segment_at(
+        &self,
+        rewrite_idx: u32,
+        segment_idx: u32,
+    ) -> CMacroArgSegment {
+        // SAFETY: self is a valid CParser pointer; the C side clamps
+        // out-of-range indices to a zero-initialized segment.
+        unsafe {
+            syntaqlite_macro_rewrite_arg_segment_at(
+                std::ptr::from_ref::<Self>(self).cast_mut(),
+                rewrite_idx,
+                segment_idx,
+            )
+        }
+    }
+
     // Arena accessors
     pub(crate) unsafe fn node(&self, node_id: u32) -> *const u32 {
         // SAFETY: self is a valid, non-null CParser pointer; node_id is a
@@ -519,6 +574,12 @@ unsafe extern "C" {
     fn syntaqlite_result_tokens(p: *mut CParser, count: *mut u32) -> *const CParserToken;
     fn syntaqlite_result_macro_count(p: *mut CParser) -> u32;
     fn syntaqlite_result_macro_rewrite_at(p: *mut CParser, idx: u32) -> CMacroRewrite;
+    fn syntaqlite_macro_rewrite_arg_segment_count(p: *mut CParser, rewrite_idx: u32) -> u32;
+    fn syntaqlite_macro_rewrite_arg_segment_at(
+        p: *mut CParser,
+        rewrite_idx: u32,
+        segment_idx: u32,
+    ) -> CMacroArgSegment;
 
     // Arena accessors
     fn syntaqlite_parser_node(p: *mut CParser, node_id: u32) -> *const u32;

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -29,8 +29,9 @@ pub use incremental::{AnyIncrementalParseSession, TypedIncrementalParseSession};
 #[cfg(feature = "sqlite")]
 pub use session::{ParseError, ParseSession, ParsedStatement, Parser, ParserToken};
 pub use types::{
-    AnyParserToken, Comment, CommentKind, CommentSpan, CompletionContext, MacroRewrite,
-    ParseOutcome, ParserTokenFlags, TracebackFrame, TypedParserToken,
+    AnyParserToken, ArgOrigin, Comment, CommentKind, CommentSpan, CompletionContext,
+    MacroArgSegment, MacroRewrite, ParseOutcome, ParserTokenFlags, TracebackFrame,
+    TypedParserToken,
 };
 
 /// A single macro argument as presented to the lookup callback.
@@ -698,12 +699,17 @@ impl<'a> AnyParsedStatement<'a> {
             };
             MacroRewrite {
                 parent,
+                rewrite_idx: i,
                 call_offset: r.call_offset,
                 call_length: r.call_length,
                 expansion,
                 name,
                 def_line: r.def_line,
                 def_col: r.def_col,
+                body_call_offset: r.body_call_offset,
+                body_call_length: r.body_call_length,
+                parser: self.raw,
+                _lifetime: PhantomData,
             }
         })
     }

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -968,6 +968,193 @@ mod tests {
     }
 
     #[test]
+    fn macro_rewrite_exposes_arg_segments_with_body_positions() {
+        // For macros defined via expand_template, each $param substitution
+        // should be exposed as a MacroArgSegment that records (a) where
+        // the $param token sits in the authored body, (b) where the arg
+        // text landed in the expansion buffer, and (c) the origin of the
+        // arg text so callers can drill back to authored source.
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let mut reg = TestMacroRegistry::new();
+        reg.register("id", &["x"], "($x)");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "SELECT id!(42);";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(err) => panic!("unexpected error: {}", err.message()),
+        };
+
+        let rewrites: Vec<_> = stmt.macro_rewrites().collect();
+        assert_eq!(rewrites.len(), 1);
+        let r = &rewrites[0];
+        let segs: Vec<_> = r.arg_segments().collect();
+        assert_eq!(segs.len(), 1, "$x is the only substitution in ($x)");
+        let seg = &segs[0];
+        // Authored body is "($x)" — $x sits at offset 1, length 2.
+        assert_eq!(seg.body_offset(), 1);
+        assert_eq!(seg.body_length(), 2);
+        // Expansion buffer is "(42)" — arg text sits at offset 1, length 2.
+        assert_eq!(seg.expansion_offset(), 1);
+        assert_eq!(seg.expansion_length(), 2);
+        // Origin is the authored source.
+        assert_eq!(seg.origin_parent(), None);
+        let origin_text = &source
+            [seg.origin_offset() as usize..(seg.origin_offset() + seg.origin_length()) as usize];
+        assert_eq!(origin_text, "42");
+    }
+
+    #[test]
+    fn macro_rewrite_nested_body_call_offsets_via_substituted_arg() {
+        // Repro of the traceback example from issue #145:
+        //   CREATE PERFETTO MACRO n(x Expr) RETURNS Expr AS ($x);
+        //   CREATE PERFETTO MACRO m(x Expr) RETURNS Expr AS ($x);
+        //   SELECT m!(n!(nonexistent_col));
+        //
+        // The inner n!(...) call is tokenized from the substituted text
+        // of m's $x, not from m's authored body — downstream Rewriter
+        // consumers need body_call_length == 0 to signal "descend via
+        // arg segments" instead of "rewrite in the parent's body".
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let mut reg = TestMacroRegistry::new();
+        reg.register("n", &["x"], "($x)");
+        reg.register("m", &["x"], "($x)");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "SELECT m!(n!(42));";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(err) => panic!("unexpected error: {}", err.message()),
+        };
+
+        let rewrites: Vec<_> = stmt.macro_rewrites().collect();
+        assert_eq!(rewrites.len(), 2, "m + n");
+
+        let outer = &rewrites[0];
+        assert_eq!(outer.name(), "m");
+        assert_eq!(outer.parent(), None);
+        // For top-level calls the parent is the authored source, so
+        // body_call_offset/length fall through to call_offset/length.
+        assert_eq!(outer.body_call_offset(), outer.call_offset());
+        assert_eq!(outer.body_call_length(), outer.call_length());
+
+        let inner = &rewrites[1];
+        assert_eq!(inner.name(), "n");
+        assert_eq!(inner.parent(), Some(0));
+        // The nested n!(42) call lives entirely inside m's substituted
+        // $x arg — call_offset/length are in the post-substitution
+        // expansion buffer, but there's no clean position in m's
+        // authored body "($x)".  u32::MAX is the arg-internal sentinel.
+        assert_eq!(inner.body_call_offset(), u32::MAX);
+        assert_eq!(inner.body_call_length(), u32::MAX);
+    }
+
+    #[test]
+    fn macro_rewrite_nested_body_call_offsets_fixed_portion() {
+        // When a nested call appears verbatim in the parent macro's
+        // authored body (not via $param substitution), body_call_offset
+        // and body_call_length should locate the call in that authored
+        // body, with length shifts compensated by surrounding $param
+        // substitutions.
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let mut reg = TestMacroRegistry::new();
+        reg.register("leaf", &["v"], "$v");
+        // Body: "$a + leaf!(7)" — `leaf!(7)` is at body offset 5 length 8.
+        reg.register("wrap", &["a"], "$a + leaf!(7)");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "SELECT wrap!(99);";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(err) => panic!("unexpected error: {}", err.message()),
+        };
+
+        let rewrites: Vec<_> = stmt.macro_rewrites().collect();
+        assert_eq!(rewrites.len(), 2, "wrap + leaf");
+        let inner = &rewrites[1];
+        assert_eq!(inner.name(), "leaf");
+        assert_eq!(inner.parent(), Some(0));
+        // `leaf!(7)` sits at offset 5 in the authored body "$a + leaf!(7)".
+        assert_eq!(inner.body_call_offset(), 5);
+        assert_eq!(inner.body_call_length(), 8);
+    }
+
+    #[test]
+    fn macro_rewrite_arg_segment_chain_resolves_to_source() {
+        // Reproduces the chain from issue #145: for `m!(n!(nonexistent_col))`,
+        // downstream consumers walk each rewrite's arg_segments to anchor
+        // the innermost token back to its authored position in the source.
+        //
+        // The chain for `nonexistent_col`:
+        //   * n's $x segment: origin = rewrite(0) i.e. m's expansion buffer
+        //     at the position of "nonexistent_col" within "(n!(nonexistent_col))"
+        //     (n's arg text was tokenized from m's expansion, not the source).
+        //   * m's $x segment at that position: origin = source, pointing at
+        //     "n!(nonexistent_col)" in the authored SQL.
+        //
+        // Recursing one more step via n's arg text inside m's arg text gets
+        // back to the "nonexistent_col" position in the source.
+        use crate::parser::ArgOrigin;
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let mut reg = TestMacroRegistry::new();
+        reg.register("n", &["x"], "($x)");
+        reg.register("m", &["x"], "($x)");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "SELECT m!(n!(nonexistent_col));";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(err) => panic!("unexpected error: {}", err.message()),
+        };
+
+        let rewrites: Vec<_> = stmt.macro_rewrites().collect();
+        assert_eq!(rewrites.len(), 2);
+
+        // m's arg segment points into the authored source.
+        let m_segs: Vec<_> = rewrites[0].arg_segments().collect();
+        assert_eq!(m_segs.len(), 1);
+        assert_eq!(m_segs[0].origin(), ArgOrigin::Source);
+        let m_arg_text = &source[m_segs[0].origin_offset() as usize
+            ..(m_segs[0].origin_offset() + m_segs[0].origin_length()) as usize];
+        assert_eq!(m_arg_text, "n!(nonexistent_col)");
+
+        // n's arg segment origin is m's expansion buffer — one link in
+        // the chain.  The consumer resolves by finding the m segment
+        // whose expansion range contains n's arg, then recursing.
+        let n_segs: Vec<_> = rewrites[1].arg_segments().collect();
+        assert_eq!(n_segs.len(), 1);
+        assert_eq!(n_segs[0].origin(), ArgOrigin::Rewrite(0));
+        let m_expansion = rewrites[0].expansion();
+        let n_arg_in_m_expansion = &m_expansion[n_segs[0].origin_offset() as usize
+            ..(n_segs[0].origin_offset() + n_segs[0].origin_length()) as usize];
+        assert_eq!(n_arg_in_m_expansion, "nonexistent_col");
+
+        // Walk the chain: n's arg inside m's expansion, intersected with
+        // m's segment, lands on the position of "nonexistent_col" in
+        // the source.
+        let n_arg_off_in_m = n_segs[0].origin_offset();
+        let m_seg = &m_segs[0];
+        assert!(
+            n_arg_off_in_m >= m_seg.expansion_offset()
+                && n_arg_off_in_m + n_segs[0].origin_length()
+                    <= m_seg.expansion_offset() + m_seg.expansion_length()
+        );
+        let delta = n_arg_off_in_m - m_seg.expansion_offset();
+        let source_off = m_seg.origin_offset() + delta;
+        let source_len = n_segs[0].origin_length();
+        let authored = &source[source_off as usize..(source_off + source_len) as usize];
+        assert_eq!(authored, "nonexistent_col");
+    }
+
+    #[test]
     fn macro_expansion_multi_param() {
         let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
         let mut reg = TestMacroRegistry::new();

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -1582,6 +1582,31 @@ mod tests {
     }
 
     #[test]
+    fn macro_expansion_with_ne_after_substituted_id_no_spurious_straddle() {
+        // Regression: inside a macro body, a substituted identifier followed by
+        // `!=` (or any `!<not-lp>`) triggered expand_and_feed's nested-macro
+        // detection (it sees `ID` then `!`). The lookup callback returned
+        // "not a macro" for that identifier, and the failure path in
+        // synq_parser_expand_and_feed_macro called synq_end_macro while
+        // ctx.layer_id was still the *outer* layer. synq_end_macro then walked
+        // one parent too far and clobbered ctx.layer_id from the outer macro's
+        // layer down to 0 (source), causing every subsequent token fed from the
+        // outer expansion to be tagged with layer_id=0. The straddle detector
+        // then correctly flagged the mixed-layer RHS as a spurious straddle.
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let mut reg = TestMacroRegistry::new();
+        reg.register("m", &["d"], "(SELECT * FROM t WHERE $d != 1)");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let mut session = parser.parse("SELECT * FROM m!(dur);");
+        match session.next() {
+            ParseOutcome::Ok(_) => {}
+            ParseOutcome::Done => panic!("expected a statement"),
+            ParseOutcome::Err(e) => panic!("should parse without straddle error: {}", e.message()),
+        }
+    }
+
+    #[test]
     fn node_is_macro_free_false_without_extent_tracking() {
         let parser = Parser::new(); // no extent tracking
         let source = "SELECT 1";

--- a/syntaqlite-syntax/src/parser/types.rs
+++ b/syntaqlite-syntax/src/parser/types.rs
@@ -221,12 +221,17 @@ pub type AnyParserToken<'a> = TypedParserToken<'a, crate::dialect::AnyDialect>;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MacroRewrite<'a> {
     pub(crate) parent: Option<u32>,
+    pub(crate) rewrite_idx: u32,
     pub(crate) call_offset: u32,
     pub(crate) call_length: u32,
     pub(crate) expansion: &'a str,
     pub(crate) name: &'a str,
     pub(crate) def_line: u32,
     pub(crate) def_col: u32,
+    pub(crate) body_call_offset: u32,
+    pub(crate) body_call_length: u32,
+    pub(crate) parser: std::ptr::NonNull<crate::parser::ffi::CParser>,
+    pub(crate) _lifetime: std::marker::PhantomData<&'a ()>,
 }
 
 impl<'a> MacroRewrite<'a> {
@@ -260,6 +265,123 @@ impl<'a> MacroRewrite<'a> {
     /// 1-based column of the macro definition (0 if unknown).
     pub fn def_col(&self) -> u32 {
         self.def_col
+    }
+    /// Byte offset of this call in the parent's *authored* body, computed
+    /// by inverting the length shifts the parent's `$param` substitutions
+    /// introduced.  For top-level rewrites the parent is the authored
+    /// source, so this equals [`call_offset`](Self::call_offset).
+    ///
+    /// Returns [`u32::MAX`] (the arg-internal sentinel) when the call was
+    /// tokenized from a `$param` substitution — consumers should descend
+    /// through the matching arg segment instead of rewriting in the body.
+    /// [`body_call_length`](Self::body_call_length) mirrors the sentinel.
+    pub fn body_call_offset(&self) -> u32 {
+        self.body_call_offset
+    }
+    /// Length counterpart of [`body_call_offset`](Self::body_call_offset).
+    pub fn body_call_length(&self) -> u32 {
+        self.body_call_length
+    }
+    /// Iterator over the `$param` substitutions recorded on this rewrite.
+    pub fn arg_segments(&self) -> impl Iterator<Item = MacroArgSegment<'a>> + use<'_, 'a> {
+        // SAFETY: the parser pointer is live for 'a (the parsed
+        // statement's lifetime); the C accessors clamp out-of-range
+        // indices so count is authoritative.
+        let count = unsafe {
+            self.parser
+                .as_ref()
+                .macro_rewrite_arg_segment_count(self.rewrite_idx)
+        };
+        let rewrite_idx = self.rewrite_idx;
+        let parser = self.parser;
+        (0..count).map(move |i| {
+            // SAFETY: i < count; the C side returns a valid segment.
+            let s = unsafe { parser.as_ref().macro_rewrite_arg_segment_at(rewrite_idx, i) };
+            let origin = if s.origin_parent_idx == u32::MAX {
+                ArgOrigin::Source
+            } else {
+                ArgOrigin::Rewrite(s.origin_parent_idx)
+            };
+            MacroArgSegment {
+                body_offset: s.body_offset,
+                body_length: s.body_length,
+                expansion_offset: s.expansion_offset,
+                expansion_length: s.expansion_length,
+                origin,
+                origin_offset: s.origin_offset,
+                origin_length: s.origin_length,
+                _lifetime: std::marker::PhantomData,
+            }
+        })
+    }
+}
+
+/// Where a macro argument's text was authored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArgOrigin {
+    /// The arg text lives in the authored source.
+    Source,
+    /// The arg text lives in the expansion buffer of the referenced
+    /// rewrite (which in turn may have its own arg segments to descend).
+    Rewrite(u32),
+}
+
+/// One `$param` substitution recorded on a [`MacroRewrite`].
+///
+/// Enables downstream tracebacks to anchor each substitution back to the
+/// authored source, possibly via a chain of earlier substitutions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MacroArgSegment<'a> {
+    pub(crate) body_offset: u32,
+    pub(crate) body_length: u32,
+    pub(crate) expansion_offset: u32,
+    pub(crate) expansion_length: u32,
+    pub(crate) origin: ArgOrigin,
+    pub(crate) origin_offset: u32,
+    pub(crate) origin_length: u32,
+    pub(crate) _lifetime: std::marker::PhantomData<&'a ()>,
+}
+
+impl MacroArgSegment<'_> {
+    /// Byte offset of the `$param` token in the macro's authored body.
+    /// Zero when the rewrite was registered via the raw arg-map API
+    /// (which doesn't supply authored-body positions).
+    pub fn body_offset(&self) -> u32 {
+        self.body_offset
+    }
+    /// Byte length of the `$param` token in the authored body.
+    pub fn body_length(&self) -> u32 {
+        self.body_length
+    }
+    /// Byte offset of the substituted arg text in the rewrite's
+    /// [`expansion`](MacroRewrite::expansion) buffer.
+    pub fn expansion_offset(&self) -> u32 {
+        self.expansion_offset
+    }
+    /// Byte length of the substituted arg text in the expansion buffer.
+    pub fn expansion_length(&self) -> u32 {
+        self.expansion_length
+    }
+    /// Where the arg text was authored — the source, or another rewrite's
+    /// expansion buffer.
+    pub fn origin(&self) -> ArgOrigin {
+        self.origin
+    }
+    /// Convenience: parent rewrite index if the origin is a rewrite,
+    /// `None` if the origin is the authored source.
+    pub fn origin_parent(&self) -> Option<u32> {
+        match self.origin {
+            ArgOrigin::Source => None,
+            ArgOrigin::Rewrite(i) => Some(i),
+        }
+    }
+    /// Byte offset of the arg text in its origin.
+    pub fn origin_offset(&self) -> u32 {
+        self.origin_offset
+    }
+    /// Byte length of the arg text in its origin.
+    pub fn origin_length(&self) -> u32 {
+        self.origin_length
     }
 }
 

--- a/syntaqlite-wasm/Cargo.toml
+++ b/syntaqlite-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-wasm"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 repository.workspace = true
 

--- a/syntaqlite/Cargo.toml
+++ b/syntaqlite/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "syntaqlite"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 description = "Parser, formatter, validator, and language server for SQLite SQL — built on SQLite's own grammar"
 license = "Apache-2.0"
@@ -40,8 +40,8 @@ pin-cflags = ["sqlite", "syntaqlite-syntax/pin-cflags"]    # Pin compile-time fl
 workspace = true
 
 [dependencies]
-syntaqlite-common = { version = "0.3.1", path = "../syntaqlite-common" }
-syntaqlite-syntax = { version = "0.3.1", path = "../syntaqlite-syntax", default-features = false }
+syntaqlite-common = { version = "0.4.0", path = "../syntaqlite-common" }
+syntaqlite-syntax = { version = "0.4.0", path = "../syntaqlite-syntax", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 libloading = { version = "0.8", optional = true }

--- a/tests/benches/Cargo.toml
+++ b/tests/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benches"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 publish = false
 

--- a/tests/comparison/parser/Cargo.toml
+++ b/tests/comparison/parser/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "parser-bench"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 
 [[bin]]

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -287,6 +287,7 @@ impl syntaqlite_syntax::any::AnyNodeTag
 impl syntaqlite_syntax::any::AnyTokenType
 impl syntaqlite_syntax::any::FieldMeta<'_>
 impl syntaqlite_syntax::any::KeywordEntry
+impl syntaqlite_syntax::any::MacroArgSegment<'_>
 impl syntaqlite_syntax::any::NodeFields
 impl syntaqlite_syntax::any::TextSpan
 impl syntaqlite_syntax::nodes::AggregateFunctionCallFlags
@@ -756,6 +757,7 @@ impl<G: syntaqlite_syntax::typed::TypedDialect> syntaqlite_syntax::typed::TypedT
 impl<T, E> syntaqlite_syntax::ParseOutcome<T, E>
 pub enum syntaqlite_syntax::CommentKind
 pub enum syntaqlite_syntax::ParseOutcome<T, E>
+pub enum syntaqlite_syntax::any::ArgOrigin
 pub enum syntaqlite_syntax::any::FieldValue
 pub enum syntaqlite_syntax::any::ParseOutcome<T, E>
 pub enum syntaqlite_syntax::any::TokenCategory
@@ -939,6 +941,17 @@ pub fn syntaqlite_syntax::any::FieldMeta<'_>::name(&self) -> &'static str
 pub fn syntaqlite_syntax::any::FieldMeta<'_>::offset(&self) -> u16
 pub fn syntaqlite_syntax::any::KeywordEntry::keyword(&self) -> &'static str
 pub fn syntaqlite_syntax::any::KeywordEntry::token_type(&self) -> syntaqlite_syntax::any::AnyTokenType
+pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::body_length(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::body_offset(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::expansion_length(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::expansion_offset(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin(&self) -> syntaqlite_syntax::any::ArgOrigin
+pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin_length(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin_offset(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin_parent(&self) -> core::option::Option<u32>
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::arg_segments(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroArgSegment<'a>> + use<'_, 'a>
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::body_call_length(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::body_call_offset(&self) -> u32
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::call_length(&self) -> u32
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::call_offset(&self) -> u32
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::def_col(&self) -> u32
@@ -1702,6 +1715,7 @@ pub struct syntaqlite_syntax::any::AnyNode<'a>
 pub struct syntaqlite_syntax::any::AnyParsedStatement<'a>
 pub struct syntaqlite_syntax::any::FieldMeta<'a>(_)
 pub struct syntaqlite_syntax::any::KeywordEntry
+pub struct syntaqlite_syntax::any::MacroArgSegment<'a>
 pub struct syntaqlite_syntax::any::MacroRewrite<'a>
 pub struct syntaqlite_syntax::any::NodeFields
 pub struct syntaqlite_syntax::any::TracebackFrame<'a>
@@ -2064,6 +2078,8 @@ pub syntaqlite_syntax::TokenType::Window = 167
 pub syntaqlite_syntax::TokenType::With = 69
 pub syntaqlite_syntax::TokenType::Within = 86
 pub syntaqlite_syntax::TokenType::Without = 70
+pub syntaqlite_syntax::any::ArgOrigin::Rewrite(u32)
+pub syntaqlite_syntax::any::ArgOrigin::Source
 pub syntaqlite_syntax::any::FieldKind::Bool = 2
 pub syntaqlite_syntax::any::FieldKind::Enum = 4
 pub syntaqlite_syntax::any::FieldKind::Flags = 3

--- a/web/docs/content/guides/rust-api.md
+++ b/web/docs/content/guides/rust-api.md
@@ -10,7 +10,7 @@ weight = 1
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.3.1", features = ["fmt"] }
+syntaqlite = { version = "0.4.0", features = ["fmt"] }
 ```
 
 ## Format a query
@@ -127,7 +127,7 @@ Add the `validation` and `sqlite` features:
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.3.1", features = ["validation", "sqlite"] }
+syntaqlite = { version = "0.4.0", features = ["validation", "sqlite"] }
 ```
 
 ```rust

--- a/web/syntaqlite-js/package.json
+++ b/web/syntaqlite-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syntaqlite",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "SQLite SQL parser, formatter, and validator for the browser — powered by WebAssembly",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Motivation

Cut the 0.4.0 release.

## Changes

- Bumps version to 0.4.0 across all Cargo.toml / pyproject.toml / integration manifests / README / docs.
- Adds 0.4.0 CHANGELOG entry.

Release notes:

**Breaking:**
- Macro lookup is now callback-driven so dialects can resolve macros lazily (#121). The incremental parser API drops `begin_macro`/`end_macro` (#110).
- Spans now cover SQL longer than 64KB; `SyntaqliteTextSpan.length` is `uint32_t` (#109).
- `.synq` grammar files use `//` comments instead of `#` (#115).

**Macros:**
- Expansions are now exposed as a flat rewrite list with `$param` arg segments, nested call offsets, and APIs to ask whether a span/node/statement came from a macro — enough to map cleanly between expanded SQL and source for diagnostics, hovers, and refactors (#124, #142, #145).
- Unknown macro names now produce a hard parse error instead of silently expanding to nothing (#139). A permissive mode lets tools inspect bodies with unknown `$param` references (#141).
- Embedders can compile macros out entirely with `SYNTAQLITE_OMIT_MACROS` (#135).
- Fixed OOB read on non-NUL-terminated bodies (#132), layer-id overflow past 256 layers (#134), and several spurious-straddle and whitespace-handling bugs in deeply-nested expansions.

**Spans and AST:**
- Every parse tree node carries a precise source range, with traceback through nested macro expansions so diagnostics report the original source location (#96, #101, #102, #103). The Rust span API now mirrors C 1:1 (#98).
- Fixed stale span info on AST nodes from multi-RHS passthrough reductions (#122, #123).

**Grammar and build:**
- SQL using `window`, `over`, or `filter` as identifiers now parses correctly (#113).
- Dialects can list base SQL keywords in `extra_keywords` without duplicate-keyword errors (#111).
- LSP semantic analysis is feature-gated behind `lsp` (#97).