### PR TITLE
synq: fix stale body_call_length==0 doc for arg-internal sentinel

### DIFF
--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -102,10 +102,11 @@ typedef struct SynqExpansionLayer {
 
   // Position of this nested call in the *parent's authored body*,
   // computed by inverting the length shifts from the parent's $param
-  // substitutions.  body_call_length == 0 means the call was tokenized
-  // from a substituted arg's text (no clean body position) and consumers
-  // should descend through the matching arg segment instead.  Zero for
-  // top-level layers (parent_layer_id == 0).
+  // substitutions.  Both fields equal SYNTAQLITE_MACRO_BODY_CALL_ARG_INTERNAL
+  // (UINT32_MAX) when the call was tokenized from a substituted arg's
+  // text (no clean body position) and consumers should descend through
+  // the matching arg segment instead.  Zero for top-level layers
+  // (parent_layer_id == 0).
   uint32_t body_call_offset;
   uint32_t body_call_length;
 

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -278,9 +278,10 @@ typedef struct SyntaqliteMacroRewrite {
   uint32_t def_col;
   // Position of this call in the *parent's authored body*, computed by
   // inverting the length shifts the parent's $param substitutions
-  // introduced.  body_call_length == 0 means the call was tokenized
-  // from a substituted arg's text (no meaningful body position) and
-  // consumers should descend through the matching arg segment instead.
+  // introduced.  Both fields equal SYNTAQLITE_MACRO_BODY_CALL_ARG_INTERNAL
+  // (UINT32_MAX) when the call was tokenized from a substituted arg's
+  // text (no meaningful body position) and consumers should descend
+  // through the matching arg segment instead.
   //
   // For top-level rewrites (parent_idx == SYNTAQLITE_MACRO_PARENT_SOURCE)
   // the parent is the authored source, so these equal call_offset /

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -1030,7 +1030,8 @@ mod tests {
         //
         // The inner n!(...) call is tokenized from the substituted text
         // of m's $x, not from m's authored body — downstream Rewriter
-        // consumers need body_call_length == 0 to signal "descend via
+        // consumers need the arg-internal sentinel (u32::MAX on both
+        // body_call_offset and body_call_length) to signal "descend via
         // arg segments" instead of "rewrite in the parent's body".
         let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
         let mut reg = TestMacroRegistry::new();


### PR DESCRIPTION
## Motivation

The public header, internal header, and a session.rs test comment all said the arg-internal case for a nested macro call was signalled by `body_call_length == 0`. That contradicts the implementation: `parser_macros.c:530-535` sets *both* `body_call_offset` and `body_call_length` to `SYNTAQLITE_MACRO_BODY_CALL_ARG_INTERNAL` (= `UINT32_MAX`), matching the sentinel defined at `parser.h:236` and the Rust docs at `types.rs:274-277`.

Downstream consumers that trusted the stale comment can crash. Concrete example: google/perfetto#5472 filtered with `if (c.body_call_length == 0) continue;`, which never trips for arg-internal calls, so a `RewriteItem{start = UINT32_MAX, end = UINT32_MAX + UINT32_MAX}` ended up in `SqlSource::Rewriter` and tripped its `start <= end` check.

## Changes

Pure documentation fix — no behavior change:

- `syntaqlite-syntax/include/syntaqlite/parser.h` — refer to `SYNTAQLITE_MACRO_BODY_CALL_ARG_INTERNAL` (UINT32_MAX) as the arg-internal sentinel on both fields.
- `syntaqlite-syntax/csrc/parser_internal.h` — same fix on the `SynqExpansionLayer` fields.
- `syntaqlite-syntax/src/parser/session.rs` — update the test comment that still said `body_call_length == 0`.