### PR TITLE
synq: add SYNQ_STATIC_ASSERT wrapper, reintroduce FFI size checks

### DIFF
--- a/syntaqlite-buildtools/src/dialect_codegen/c_nodes_codegen.rs
+++ b/syntaqlite-buildtools/src/dialect_codegen/c_nodes_codegen.rs
@@ -23,6 +23,7 @@ impl AstModel<'_> {
         w.include_system("stddef.h");
         w.include_system("stdint.h");
         w.newline();
+        w.include_local("syntaqlite/compiler.h");
         w.include_local("syntaqlite/types.h");
         w.newline();
         // C++ doesn't have flexible array members; use [1] as a common workaround.
@@ -85,6 +86,8 @@ impl AstModel<'_> {
         }
         tag_variants.push(("SYNTAQLITE_NODE_COUNT".into(), None));
         w.typedef_enum("SyntaqliteNodeTag", &refs_i32(&tag_variants));
+        w.line("SYNQ_STATIC_ASSERT(sizeof(SyntaqliteNodeTag) == sizeof(uint32_t),");
+        w.line("                   \"SyntaqliteNodeTag must be 32 bits for FFI compatibility\");");
         w.newline();
 
         // Node structs
@@ -340,4 +343,21 @@ fn field_c_type(field: &Field, enum_names: &HashSet<&str>, flags_names: &HashSet
 
 fn refs_i32(owned: &[(String, Option<i32>)]) -> Vec<(&str, Option<i32>)> {
     owned.iter().map(|(s, v)| (s.as_str(), *v)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::AstModel;
+    use crate::util::synq_parser::parse_synq_file;
+
+    #[test]
+    fn node_tag_size_is_statically_asserted() {
+        let items = parse_synq_file("node Foo { x: inline Bool }").expect("parse");
+        let model = AstModel::new(&items);
+        let header = model.generate_ast_nodes_header("sqlite");
+        assert!(
+            header.contains("SYNQ_STATIC_ASSERT(sizeof(SyntaqliteNodeTag) == sizeof(uint32_t),"),
+            "expected node tag size assertion, got:\n{header}"
+        );
+    }
 }

--- a/syntaqlite-buildtools/src/extract/mod.rs
+++ b/syntaqlite-buildtools/src/extract/mod.rs
@@ -118,6 +118,15 @@ fn write_cflag_struct(
     }
     out.push_str("} SyntaqliteCflags;\n");
     out.push('\n');
+    writeln!(
+        out,
+        "SYNQ_STATIC_ASSERT(sizeof(SyntaqliteCflags) == {byte_count},"
+    )
+    .expect("write to String");
+    out.push_str(
+        "                   \"SyntaqliteCflags layout must match byte-wise accessor assumptions\");\n",
+    );
+    out.push('\n');
     out.push_str("#define SYNQ_CFLAGS_DEFAULT {0}\n");
     out.push('\n');
 }
@@ -194,6 +203,8 @@ pub(crate) fn generate_cflags_h(group: &str) -> String {
     out.push('\n');
     out.push_str("#include <stdint.h>\n");
     out.push_str("#include <string.h>\n");
+    out.push('\n');
+    out.push_str("#include \"syntaqlite/compiler.h\"\n");
     out.push('\n');
     write_cflag_defines(&mut out, &entries_ref, count);
     write_cflag_struct(&mut out, &entries_ref, bits_total, padding, byte_count);
@@ -323,5 +334,17 @@ mod tests {
                 "cflags.h defines {name}={val} but it is not a parser-group entry in CFLAG_REGISTRY"
             );
         }
+    }
+
+    /// The byte-wise accessor `synq_has_cflag` reads `SyntaqliteCflags` as
+    /// a flat byte array. A `SYNQ_STATIC_ASSERT` on the struct size catches
+    /// any layout drift at compile time.
+    #[test]
+    fn generate_cflags_h_emits_struct_size_assertion() {
+        let generated = super::generate_cflags_h("parser");
+        assert!(
+            generated.contains("SYNQ_STATIC_ASSERT(sizeof(SyntaqliteCflags) =="),
+            "expected SyntaqliteCflags size assertion, got:\n{generated}"
+        );
     }
 }

--- a/syntaqlite-syntax/include/syntaqlite/cflags.h
+++ b/syntaqlite-syntax/include/syntaqlite/cflags.h
@@ -13,6 +13,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "syntaqlite/compiler.h"
+
 // ── Cflag index constants ───────────────────────────────────────────────
 //
 // These are group-local indices used in keyword/parser tables.
@@ -75,6 +77,10 @@ typedef struct SyntaqliteCflags {
   // Padding to 24 bits (3 bytes):
   uint8_t _reserved : 2;
 } SyntaqliteCflags;
+
+SYNQ_STATIC_ASSERT(
+    sizeof(SyntaqliteCflags) == 3,
+    "SyntaqliteCflags layout must match byte-wise accessor assumptions");
 
 #define SYNQ_CFLAGS_DEFAULT {0}
 

--- a/syntaqlite-syntax/include/syntaqlite/compiler.h
+++ b/syntaqlite-syntax/include/syntaqlite/compiler.h
@@ -1,0 +1,35 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+// Compiler abstraction macros.
+//
+// Wrappers for features that differ across compilers and C/C++ dialects,
+// letting the rest of the codebase use a single spelling.
+
+#ifndef SYNTAQLITE_COMPILER_H
+#define SYNTAQLITE_COMPILER_H
+
+// Portable compile-time assertion. Use in file scope.
+//
+// MSVC does not support C's `_Static_assert` keyword in C mode unless built
+// with `/std:c11` or newer, so we need dialect-specific fallbacks:
+//   - C++: `static_assert` is a keyword since C++11.
+//   - C23: `static_assert` is a keyword.
+//   - C11+: `_Static_assert` is the keyword form.
+//   - Older C (including MSVC without /std:c11): typedef a 1- or -1-element
+//     char array, which fails to compile on false.
+#if defined(__cplusplus)
+#define SYNQ_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define SYNQ_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define SYNQ_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
+#else
+#define SYNQ_STATIC_ASSERT_CAT_(a, b) a##b
+#define SYNQ_STATIC_ASSERT_CAT(a, b) SYNQ_STATIC_ASSERT_CAT_(a, b)
+#define SYNQ_STATIC_ASSERT(cond, msg)                      \
+  typedef char SYNQ_STATIC_ASSERT_CAT(synq_static_assert_, \
+                                      __LINE__)[(cond) ? 1 : -1]
+#endif
+
+#endif  // SYNTAQLITE_COMPILER_H

--- a/syntaqlite-syntax/include/syntaqlite_sqlite/sqlite_node.h
+++ b/syntaqlite-syntax/include/syntaqlite_sqlite/sqlite_node.h
@@ -9,6 +9,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "syntaqlite/compiler.h"
 #include "syntaqlite/types.h"
 
 #ifdef __cplusplus
@@ -386,6 +387,8 @@ typedef enum SyntaqliteNodeTag {
   SYNTAQLITE_NODE_FILTER_OVER = 78,
   SYNTAQLITE_NODE_COUNT
 } SyntaqliteNodeTag;
+SYNQ_STATIC_ASSERT(sizeof(SyntaqliteNodeTag) == sizeof(uint32_t),
+                   "SyntaqliteNodeTag must be 32 bits for FFI compatibility");
 
 // ============ Node Structs ============
 

--- a/syntaqlite-syntax/src/embedded_sources.rs
+++ b/syntaqlite-syntax/src/embedded_sources.rs
@@ -26,6 +26,10 @@ pub const RUNTIME_HEADERS: &[(&str, &str)] = &[
         "cflags.h",
         include_str!(concat!(env!("OUT_DIR"), "/embedded_cflags.h")),
     ),
+    (
+        "compiler.h",
+        include_str!("../include/syntaqlite/compiler.h"),
+    ),
     ("config.h", include_str!("../include/syntaqlite/config.h")),
     ("parser.h", include_str!("../include/syntaqlite/parser.h")),
     (


### PR DESCRIPTION
## Motivation

`_Static_assert` isn't available in MSVC's C mode without `/std:c11`,
which caused the `SyntaqliteNodeTag == sizeof(uint32_t)` ABI check to
be reverted in f55c617 so the Python extension could build on Windows.
That left the FFI layout unchecked, and the `SyntaqliteCflags`
byte-wise accessor (`synq_has_cflag`) has a similar layout assumption
that was never asserted at all.

## Changes

- New `syntaqlite/compiler.h` holding a portable `SYNQ_STATIC_ASSERT`
  macro: `static_assert` (C++/C23), `_Static_assert` (C11), or a
  typedef-array fallback for older MSVC in C mode.
- Reintroduced the `sizeof(SyntaqliteNodeTag) == sizeof(uint32_t)`
  assertion in `c_nodes_codegen.rs` using the wrapper.
- Added `sizeof(SyntaqliteCflags) == <byte_count>` assertion in the
  `cflags.h` codegen (`extract/mod.rs`).
- Registered `compiler.h` in `RUNTIME_HEADERS` so the amalgamation
  picks it up.
- Unit tests in both codegen paths verify the assertion lines are
  emitted.

Fixes #23.