### PR TITLE
synq: formalize runtime↔dialect ABI and fix wasm side-module break

### DIFF
--- a/syntaqlite-buildtools/src/dialect_codegen/c_dialect.rs
+++ b/syntaqlite-buildtools/src/dialect_codegen/c_dialect.rs
@@ -357,34 +357,39 @@ pub(crate) fn generate_parse_h(dialect: &str) -> String {
     w.line("#include <stdio.h>");
     w.newline();
     w.include_local("syntaqlite_dialect/ast_builder.h");
+    w.include_local("syntaqlite_dialect/dialect_abi.h");
     w.newline();
     w.line("#ifdef __cplusplus");
     w.line("extern \"C\" {");
     w.line("#endif");
     w.newline();
     w.line(&format!(
-        "void* Synq{pascal}ParseAlloc(void* (*mallocProc)(size_t), SynqParseCtx* pCtx);"
+        "SYNTAQLITE_DIALECT_API void* Synq{pascal}ParseAlloc(void* (*mallocProc)(size_t), SynqParseCtx* pCtx);"
     ));
     w.line(&format!(
-        "void Synq{pascal}ParseInit(void* parser, SynqParseCtx* pCtx);"
-    ));
-    w.line(&format!("void Synq{pascal}ParseFinalize(void* parser);"));
-    w.line(&format!(
-        "void Synq{pascal}ParseFree(void* parser, void (*freeProc)(void*));"
+        "SYNTAQLITE_DIALECT_API void Synq{pascal}ParseInit(void* parser, SynqParseCtx* pCtx);"
     ));
     w.line(&format!(
-        "void Synq{pascal}Parse(void* parser, int token_type, SynqParseToken minor);"
+        "SYNTAQLITE_DIALECT_API void Synq{pascal}ParseFinalize(void* parser);"
     ));
     w.line(&format!(
-        "uint32_t Synq{pascal}ParseExpectedTokens(void* parser, uint32_t* out_tokens, uint32_t out_cap);"
+        "SYNTAQLITE_DIALECT_API void Synq{pascal}ParseFree(void* parser, void (*freeProc)(void*));"
     ));
     w.line(&format!(
-        "uint32_t Synq{pascal}ParseCompletionContext(void* parser);"
+        "SYNTAQLITE_DIALECT_API void Synq{pascal}Parse(void* parser, int token_type, SynqParseToken minor);"
     ));
-    w.line(&format!("int Synq{pascal}ParseFallback(int iToken);"));
+    w.line(&format!(
+        "SYNTAQLITE_DIALECT_API uint32_t Synq{pascal}ParseExpectedTokens(void* parser, uint32_t* out_tokens, uint32_t out_cap);"
+    ));
+    w.line(&format!(
+        "SYNTAQLITE_DIALECT_API uint32_t Synq{pascal}ParseCompletionContext(void* parser);"
+    ));
+    w.line(&format!(
+        "SYNTAQLITE_DIALECT_API int Synq{pascal}ParseFallback(int iToken);"
+    ));
     w.line("#ifndef NDEBUG");
     w.line(&format!(
-        "void Synq{pascal}ParseTrace(FILE* trace_file, char* prompt);"
+        "SYNTAQLITE_DIALECT_API void Synq{pascal}ParseTrace(FILE* trace_file, char* prompt);"
     ));
     w.line("#endif");
     w.newline();
@@ -406,9 +411,10 @@ pub(crate) fn generate_tokenize_h(dialect: &str) -> String {
     w.header_guard_start(&guard);
     w.include_local("syntaqlite_dialect/sqlite_compat.h");
     w.include_local("syntaqlite/dialect.h");
+    w.include_local("syntaqlite_dialect/dialect_abi.h");
     w.newline();
     w.line(&format!(
-        "i64 Synq{pascal}GetToken(const SyntaqliteDialect* env, const unsigned char* z, int* tokenType);"
+        "SYNTAQLITE_DIALECT_API i64 Synq{pascal}GetToken(const SyntaqliteDialect* env, const unsigned char* z, int* tokenType);"
     ));
     w.newline();
     w.header_guard_end(&guard);

--- a/syntaqlite-buildtools/src/dialect_codegen/rust_dialect.rs
+++ b/syntaqlite-buildtools/src/dialect_codegen/rust_dialect.rs
@@ -70,7 +70,7 @@ use {syntax_crate}::util::{{SqliteSyntaxFlags, SqliteVersion}};
 ///
 /// Wraps an [`AnyDialect`] and implements [`TypedDialect`]. Obtain via [`dialect()`];
 /// configure with [`with_version`](Self::with_version) and [`with_cflags`](Self::with_cflags).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct {dialect_struct} {{
     raw: AnyDialect,
 }}
@@ -174,7 +174,7 @@ use {dialect_crate}::util::SqliteFlags;
 ///
 /// Wraps an [`AnyDialect`] and implements [`TypedDialect`]. Obtain via [`dialect()`];
 /// configure with [`with_version`](Self::with_version) and [`with_cflags`](Self::with_cflags).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Dialect {{
     raw: AnyDialect,
 }}

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_parse.h
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_parse.h
@@ -11,23 +11,31 @@
 #include <stdio.h>
 
 #include "syntaqlite_dialect/ast_builder.h"
+#include "syntaqlite_dialect/dialect_abi.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void* SynqSqliteParseAlloc(void* (*mallocProc)(size_t), SynqParseCtx* pCtx);
-void SynqSqliteParseInit(void* parser, SynqParseCtx* pCtx);
-void SynqSqliteParseFinalize(void* parser);
-void SynqSqliteParseFree(void* parser, void (*freeProc)(void*));
-void SynqSqliteParse(void* parser, int token_type, SynqParseToken minor);
-uint32_t SynqSqliteParseExpectedTokens(void* parser,
-                                       uint32_t* out_tokens,
-                                       uint32_t out_cap);
-uint32_t SynqSqliteParseCompletionContext(void* parser);
-int SynqSqliteParseFallback(int iToken);
+SYNTAQLITE_DIALECT_API void* SynqSqliteParseAlloc(void* (*mallocProc)(size_t),
+                                                  SynqParseCtx* pCtx);
+SYNTAQLITE_DIALECT_API void SynqSqliteParseInit(void* parser,
+                                                SynqParseCtx* pCtx);
+SYNTAQLITE_DIALECT_API void SynqSqliteParseFinalize(void* parser);
+SYNTAQLITE_DIALECT_API void SynqSqliteParseFree(void* parser,
+                                                void (*freeProc)(void*));
+SYNTAQLITE_DIALECT_API void SynqSqliteParse(void* parser,
+                                            int token_type,
+                                            SynqParseToken minor);
+SYNTAQLITE_DIALECT_API uint32_t
+SynqSqliteParseExpectedTokens(void* parser,
+                              uint32_t* out_tokens,
+                              uint32_t out_cap);
+SYNTAQLITE_DIALECT_API uint32_t SynqSqliteParseCompletionContext(void* parser);
+SYNTAQLITE_DIALECT_API int SynqSqliteParseFallback(int iToken);
 #ifndef NDEBUG
-void SynqSqliteParseTrace(FILE* trace_file, char* prompt);
+SYNTAQLITE_DIALECT_API void SynqSqliteParseTrace(FILE* trace_file,
+                                                 char* prompt);
 #endif
 
 #ifdef __cplusplus

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_tokenize.h
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_tokenize.h
@@ -7,10 +7,11 @@
 #define SYNTAQLITE_INTERNAL_SQLITE_TOKENIZE_H
 
 #include "syntaqlite/dialect.h"
+#include "syntaqlite_dialect/dialect_abi.h"
 #include "syntaqlite_dialect/sqlite_compat.h"
 
-i64 SynqSqliteGetToken(const SyntaqliteDialect* env,
-                       const unsigned char* z,
-                       int* tokenType);
+SYNTAQLITE_DIALECT_API i64 SynqSqliteGetToken(const SyntaqliteDialect* env,
+                                              const unsigned char* z,
+                                              int* tokenType);
 
 #endif  // SYNTAQLITE_INTERNAL_SQLITE_TOKENIZE_H

--- a/syntaqlite-syntax/include/syntaqlite_dialect/dialect_abi.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/dialect_abi.h
@@ -1,0 +1,53 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+// Runtime ↔ dialect ABI contract.
+//
+// Dialects can be linked into the runtime statically (amalgamation builds,
+// cargo-built native binaries) or loaded as separately-compiled side modules
+// (emscripten MAIN_MODULE=2 / SIDE_MODULE=1, future `dlopen` support). In the
+// latter case, neither half of the link sees the other's symbols at compile
+// time, and dead-code elimination will drop any symbol that isn't explicitly
+// marked as part of the cross-module surface.
+//
+// Two kinds of calls cross this boundary:
+//
+//   dialect → runtime
+//     The generated grammar action code and Lemon-emitted parser call back
+//     into runtime-owned helpers during reduce/shift. Everything exported
+//     here lives in `syntaqlite-syntax/csrc/parser_extents.c` or similar
+//     runtime-side C files. Current members:
+//       - synq_extent_on_shift   (see syntaqlite_dialect/extent_hooks.h)
+//       - synq_extent_on_reduce  (see syntaqlite_dialect/extent_hooks.h)
+//
+//   runtime → dialect
+//     The runtime drives each dialect through a `SyntaqliteDialectTemplate`
+//     whose function pointers reference symbols emitted by the dialect's
+//     generated parser/tokenizer. Current members (per dialect, Pascal-cased):
+//       - Synq<Dialect>ParseAlloc / ParseInit / ParseFinalize / ParseFree
+//       - Synq<Dialect>Parse
+//       - Synq<Dialect>ParseTrace
+//       - Synq<Dialect>ParseExpectedTokens
+//       - Synq<Dialect>ParseCompletionContext
+//       - Synq<Dialect>ParseFallback
+//       - Synq<Dialect>GetToken
+//
+// Every declaration in that set must be tagged with `SYNTAQLITE_DIALECT_API`
+// so it survives dead-code elimination and is visible across module
+// boundaries. Renaming or changing the signature of any symbol above is an
+// ABI break: update both sides in lockstep.
+
+#ifndef SYNTAQLITE_INTERNAL_DIALECT_ABI_H
+#define SYNTAQLITE_INTERNAL_DIALECT_ABI_H
+
+// `used` keeps wasm-ld / LTO from discarding the symbol when the main module
+// has no direct reference to it (the referencing side module is linked
+// separately). `visibility("default")` ensures it ends up in the module's
+// export table rather than being internal.
+#if defined(__GNUC__) || defined(__clang__)
+#define SYNTAQLITE_DIALECT_API __attribute__((used, visibility("default")))
+#else
+#define SYNTAQLITE_DIALECT_API
+#endif
+
+#endif  // SYNTAQLITE_INTERNAL_DIALECT_ABI_H

--- a/syntaqlite-syntax/include/syntaqlite_dialect/extent_hooks.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/extent_hooks.h
@@ -11,6 +11,7 @@
 #define SYNTAQLITE_INTERNAL_EXTENT_HOOKS_H
 
 #include "syntaqlite_dialect/ast_builder.h"  // for SynqParseCtx, SynqParseToken
+#include "syntaqlite_dialect/dialect_abi.h"  // for SYNTAQLITE_DIALECT_API
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,14 +20,15 @@ extern "C" {
 // Called from the top of Lemon's `yy_shift` for every terminal shift.
 // Pushes a `(root_start, root_end)` range onto the shadow stack when
 // per-node extent tracking is enabled.
-void synq_extent_on_shift(SynqParseCtx* pCtx,
-                          unsigned int major,
-                          const SynqParseToken* token);
+SYNTAQLITE_DIALECT_API void synq_extent_on_shift(SynqParseCtx* pCtx,
+                                                 unsigned int major,
+                                                 const SynqParseToken* token);
 
 // Called from the top of Lemon's `yy_reduce` for every rule reduction,
 // before the user action switch.  Pops `nrhs` entries from the shadow
 // stack and pushes their merged range.
-void synq_extent_on_reduce(SynqParseCtx* pCtx, unsigned int nrhs);
+SYNTAQLITE_DIALECT_API void synq_extent_on_reduce(SynqParseCtx* pCtx,
+                                                  unsigned int nrhs);
 
 // Lemon stores `yyRuleInfoNRhs[r]` as the negative of the rule's RHS
 // symbol count, so the reduce macro negates it to recover `nrhs`.

--- a/syntaqlite-syntax/src/embedded_sources.rs
+++ b/syntaqlite-syntax/src/embedded_sources.rs
@@ -89,6 +89,10 @@ pub const DIALECT_EXT_HEADERS: &[(&str, &str)] = &[
         include_str!("../include/syntaqlite_dialect/ast_builder.h"),
     ),
     (
+        "dialect_abi.h",
+        include_str!("../include/syntaqlite_dialect/dialect_abi.h"),
+    ),
+    (
         "dialect_macros.h",
         include_str!("../include/syntaqlite_dialect/dialect_macros.h"),
     ),

--- a/syntaqlite-wasm/src/main.rs
+++ b/syntaqlite-wasm/src/main.rs
@@ -111,8 +111,35 @@ fn decode_input(ptr: u32, len: u32) -> Result<String, String> {
     Ok(source.to_string())
 }
 
+/// Installs a panic hook that prints the panic location and message to stderr
+/// (which emscripten routes to `console.error`). Without this the default hook
+/// runs, but the message can get swallowed by the nounwind guard inserted at
+/// `extern "C"` boundaries, leaving the JS side with only a generic wasm trap.
+/// `main` is not called by the emscripten loader for `MAIN_MODULE` builds, so
+/// we install lazily on first export call.
+fn install_panic_hook() {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        std::panic::set_hook(Box::new(|info| {
+            let loc = info.location().map_or_else(
+                || "unknown location".to_string(),
+                |l| format!("{}:{}:{}", l.file(), l.line(), l.column()),
+            );
+            let msg = info
+                .payload()
+                .downcast_ref::<&str>()
+                .copied()
+                .or_else(|| info.payload().downcast_ref::<String>().map(String::as_str))
+                .unwrap_or("<non-string panic payload>");
+            eprintln!("syntaqlite-wasm panic at {loc}: {msg}");
+        }));
+    });
+}
+
 /// Runs `f`, catching any panic and writing `msg` to the result buffer on failure.
 fn catch_unwind<F: FnOnce() -> i32>(f: F, msg: &'static str) -> i32 {
+    install_panic_hook();
     if let Ok(result) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
         result
     } else {


### PR DESCRIPTION
## Motivation

The web playground started failing on load with `TypeError: resolved is not a function` from the emscripten dynamic linker, triggered on the first `wasm_diagnostics` / `wasm_semantic_tokens` call. The immediate cause was that the runtime wasm defined `synq_extent_on_shift` / `synq_extent_on_reduce` (dialect → runtime hooks added in #102) but didn't *export* them, so the SQLite side module's `GOT.func` imports resolved to `undefined`. `MAIN_MODULE=2` strips any symbol not referenced from the main module itself.

The deeper issue: the set of symbols that crosses the runtime↔dialect boundary wasn't documented or marked anywhere. Whenever a new hook is added, whoever adds it has to remember to keep it linker-visible — with no signal in the code to tell them that. So this PR formalizes the boundary instead of just fixing the two symbols.

## Changes

**New contract header** — `syntaqlite-syntax/include/syntaqlite_dialect/dialect_abi.h`:
- Documents the runtime↔dialect calls in both directions, naming each symbol that currently crosses.
- Defines `SYNTAQLITE_DIALECT_API` = `__attribute__((used, visibility(\"default\")))` on GCC/Clang. The `used` attribute is what keeps wasm-ld/LTO from discarding exports that aren't locally referenced.
- Bundled in `DIALECT_EXT_HEADERS` so amalgamation consumers (perfetto side module etc.) receive it.

**Runtime-side exports** (dialect → runtime):
- `extent_hooks.h` declarations for `synq_extent_on_shift` / `synq_extent_on_reduce` now carry `SYNTAQLITE_DIALECT_API`. Declaration-level attributes propagate to the definitions in `parser_extents.c`, so no generated-file changes needed there.

**Dialect-side exports** (runtime → dialect):
- `generate_parse_h` / `generate_tokenize_h` in `c_dialect.rs` emit `SYNTAQLITE_DIALECT_API` on every `Synq<Dialect>Parse*` and `Synq<Dialect>GetToken` declaration and include the new header.
- Regenerated `sqlite_parse.h` / `sqlite_tokenize.h` as a consequence. Perfetto picks it up automatically on its next codegen run.

**Incidental fixes**:
- `rust_dialect.rs` codegen now derives `Debug` on the emitted `Dialect` structs. The committed `dialect.rs` had it manually added; codegen was stripping it on every regen, which broke the build the first time I re-ran codegen.
- `syntaqlite-wasm` installs a `Once`-gated panic hook at the top of `catch_unwind` — emscripten's `MAIN_MODULE` loader doesn't run `fn main()`, so the hook has to install lazily. Future Rust-side panics will now print `syntaqlite-wasm panic at <file>:<line>:<col>: <msg>` to the browser console instead of surfacing only as an opaque wasm trap.

## Test plan

- [ ] `cargo check --workspace --all-features` — clean locally
- [ ] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean locally
- [ ] `tools/run-web-playground` — loads without `resolved is not a function`; diagnostics and semantic highlighting both work on the default SQLite preset
- [ ] Verify `synq_extent_on_shift` / `synq_extent_on_reduce` appear in runtime wasm exports (wasm-dis)