### PR TITLE
synq: bump download-artifact and github-script to Node 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Download Playwright report
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: playwright-report
           path: playwright-report
@@ -275,7 +275,7 @@ jobs:
           command: pages deploy playwright-report --project-name=syntaqlite-playwright-reports --branch=pr-${{ github.event.number }}
 
       - name: Comment PR with report URL
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const url = '${{ steps.deploy.outputs.deployment-url }}';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.2
+
+- Fixed the web playground failing on load with `TypeError: resolved is not a function`: runtime → dialect hook symbols were being stripped under emscripten `MAIN_MODULE=2` ([#157](https://github.com/LalitMaganti/syntaqlite/pull/157)).
+- Added `syntaqlite_dialect/dialect_abi.h` with the new `SYNTAQLITE_DIALECT_API` macro documenting and enforcing the runtime↔dialect symbol boundary; relevant for anyone building custom dialects as side modules ([#157](https://github.com/LalitMaganti/syntaqlite/pull/157)).
+
 ## 0.4.1
 
 - Amalgamated C sources no longer trigger `-Werror=pragmas` when `#include`d from C++ translation units; C-only warning pragmas (`-Wdeclaration-after-statement`, `-Wmissing-prototypes`, `-Wold-style-declaration`) are now guarded by `#ifndef __cplusplus` ([#153](https://github.com/LalitMaganti/syntaqlite/pull/153)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "benches"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "criterion",
  "syntaqlite",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "glob",
  "libloading",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-buildtools"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "cc",
  "clap",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap",
  "glob",
@@ -1075,11 +1075,11 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-common"
-version = "0.4.1"
+version = "0.4.2"
 
 [[package]]
 name = "syntaqlite-syntax"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "cc",
  "libloading",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-wasm"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ cargo install syntaqlite-cli
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.4.1", features = ["fmt"] }
+syntaqlite = { version = "0.4.2", features = ["fmt"] }
 ```
 
 **Python** ([API docs](https://docs.syntaqlite.com/latest/reference/python-api/))

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syntaqlite",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "SQLite SQL language server — diagnostics, formatting, completions, and semantic tokens",
   "author": {
     "name": "Lalit Maganti"

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "syntaqlite",
   "displayName": "syntaqlite",
   "description": "SQL language support powered by syntaqlite — diagnostics, formatting, completions, and semantic highlighting",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "syntaqlite",
   "license": "Apache-2.0",
   "icon": "icon.png",

--- a/integrations/zed/Cargo.toml
+++ b/integrations/zed/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "syntaqlite-zed"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 
 [lib]

--- a/integrations/zed/extension.toml
+++ b/integrations/zed/extension.toml
@@ -3,7 +3,7 @@
 
 id = "syntaqlite"
 name = "Syntaqlite"
-version = "0.4.1"
+version = "0.4.2"
 schema_version = 1
 authors = ["Lalit Maganti <lalitmaganti@gmail.com>"]
 description = "SQL language support powered by syntaqlite — tokenizer, parser, formatter and validator built on SQLite's own grammar."

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntaqlite"
-version = "0.4.1"
+version = "0.4.2"
 description = "SQLite SQL tools — parser, formatter, validator, and MCP server"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}

--- a/python/syntaqlite/__init__.py
+++ b/python/syntaqlite/__init__.py
@@ -5,7 +5,7 @@ import stat
 import subprocess
 import sys
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 # Library API (requires _syntaqlite C extension).
 try:

--- a/syntaqlite-buildtools/Cargo.toml
+++ b/syntaqlite-buildtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-buildtools"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "Internal codegen and build tools for syntaqlite — not intended for direct use"
 license = "Apache-2.0"
@@ -20,8 +20,8 @@ dist = false
 doc = false
 
 [dependencies]
-syntaqlite-common = { version = "0.4.1", path = "../syntaqlite-common" }
-syntaqlite-syntax = { version = "0.4.1", path = "../syntaqlite-syntax", default-features = false, features = ["embedded-sources"] }
+syntaqlite-common = { version = "0.4.2", path = "../syntaqlite-common" }
+syntaqlite-syntax = { version = "0.4.2", path = "../syntaqlite-syntax", default-features = false, features = ["embedded-sources"] }
 clap = { version = "4.5", features = ["derive"] }
 tempfile = "3.8"
 serde = { version = "1", features = ["derive"] }

--- a/syntaqlite-cli/Cargo.toml
+++ b/syntaqlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-cli"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 repository.workspace = true
 description = "Fast, accurate SQLite SQL formatter, validator, and language server — built on SQLite's own grammar"
@@ -30,8 +30,8 @@ rmcp = { version = "0.1", features = ["server", "transport-io"], optional = true
 schemars = { version = "0.8", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-syntaqlite = { version = "0.4.1", path = "../syntaqlite", optional = true, features = ["fmt", "lsp", "validation", "experimental-embedded", "serde-json"] }
-syntaqlite-syntax = { version = "0.4.1", path = "../syntaqlite-syntax" }
-syntaqlite-buildtools = { version = "0.4.1", path = "../syntaqlite-buildtools", optional = true }
+syntaqlite = { version = "0.4.2", path = "../syntaqlite", optional = true, features = ["fmt", "lsp", "validation", "experimental-embedded", "serde-json"] }
+syntaqlite-syntax = { version = "0.4.2", path = "../syntaqlite-syntax" }
+syntaqlite-buildtools = { version = "0.4.2", path = "../syntaqlite-buildtools", optional = true }
 tempfile = "3.8"
 tokio = { version = "1", features = ["rt", "macros", "io-std"], optional = true }

--- a/syntaqlite-common/Cargo.toml
+++ b/syntaqlite-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-common"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "Internal shared primitives for syntaqlite — not intended for direct use"
 license = "Apache-2.0"

--- a/syntaqlite-syntax/Cargo.toml
+++ b/syntaqlite-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-syntax"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 links = "syntaqlite_syntax"
 description = "Internal parser and tokenizer for syntaqlite — not intended for direct use"

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! syntaqlite = { version = "0.4.1", default-features = false, features = ["sqlite"] }
+//! syntaqlite = { version = "0.4.2", default-features = false, features = ["sqlite"] }
 //! ```
 
 // ==== Public API ====

--- a/syntaqlite-wasm/Cargo.toml
+++ b/syntaqlite-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-wasm"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 repository.workspace = true
 

--- a/syntaqlite/Cargo.toml
+++ b/syntaqlite/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "syntaqlite"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "Parser, formatter, validator, and language server for SQLite SQL — built on SQLite's own grammar"
 license = "Apache-2.0"
@@ -40,8 +40,8 @@ pin-cflags = ["sqlite", "syntaqlite-syntax/pin-cflags"]    # Pin compile-time fl
 workspace = true
 
 [dependencies]
-syntaqlite-common = { version = "0.4.1", path = "../syntaqlite-common" }
-syntaqlite-syntax = { version = "0.4.1", path = "../syntaqlite-syntax", default-features = false }
+syntaqlite-common = { version = "0.4.2", path = "../syntaqlite-common" }
+syntaqlite-syntax = { version = "0.4.2", path = "../syntaqlite-syntax", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 libloading = { version = "0.8", optional = true }

--- a/tests/benches/Cargo.toml
+++ b/tests/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benches"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 publish = false
 

--- a/tests/comparison/parser/Cargo.toml
+++ b/tests/comparison/parser/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "parser-bench"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 [[bin]]

--- a/web/docs/content/guides/rust-api.md
+++ b/web/docs/content/guides/rust-api.md
@@ -10,7 +10,7 @@ weight = 1
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.4.1", features = ["fmt"] }
+syntaqlite = { version = "0.4.2", features = ["fmt"] }
 ```
 
 ## Format a query
@@ -127,7 +127,7 @@ Add the `validation` and `sqlite` features:
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.4.1", features = ["validation", "sqlite"] }
+syntaqlite = { version = "0.4.2", features = ["validation", "sqlite"] }
 ```
 
 ```rust

--- a/web/syntaqlite-js/package.json
+++ b/web/syntaqlite-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syntaqlite",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "SQLite SQL parser, formatter, and validator for the browser — powered by WebAssembly",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Motivation

CI surfaces a Node.js 20 deprecation warning on the Playwright report deploy job:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are
> being forced to run on Node.js 24: actions/download-artifact@v6,
> actions/github-script@v7, cloudflare/wrangler-action@v3.

`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` keeps the actions running, but doesn't
silence the warning — that requires bumping to versions that natively target
Node 24.

## Changes

- `actions/download-artifact@v6` → `@v7` (verified: v7's `action.yml` uses `node24`)
- `actions/github-script@v7` → `@v8` (verified: v8's `action.yml` uses `node24`)

`cloudflare/wrangler-action` has no v4 release yet (latest is v3.15.0, still
pinned to `node20`), so it remains on v3 and continues to rely on the env var
until Cloudflare ships a Node 24 build.