### PR TITLE
synq: tighten PR template to encourage shorter descriptions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,13 @@
+<!--
+Keep this PR description SHORT. Aim for a few sentences total — not paragraphs.
+Convey the minimum context a reviewer needs. No headers, no bullet lists, no
+restating the diff. If a section below has nothing meaningful to add, omit it.
+-->
+
 ## Motivation
 
-<!-- Why is this change needed? What problem exists, what's missing, or what broke? -->
+<!-- One or two sentences: why this change exists. -->
 
 ## Changes
 
-<!-- What does this PR do to address the motivation? -->
+<!-- One or two sentences: what was done. Skip if obvious from the diff. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,5 @@
 <!--
-Keep this PR description SHORT. Aim for a few sentences total — not paragraphs.
-Convey the minimum context a reviewer needs. No headers, no bullet lists, no
-restating the diff. If a section below has nothing meaningful to add, omit it.
+Keep this PR description SHORT. A few sentences total — not paragraphs of
+detail. Convey only the minimum context a reviewer needs: why the change
+exists, and anything about the approach that isn't obvious from the diff.
 -->
-
-## Motivation
-
-<!-- One or two sentences: why this change exists. -->
-
-## Changes
-
-<!-- One or two sentences: what was done. Skip if obvious from the diff. -->


### PR DESCRIPTION
The prior template was prompting overly verbose descriptions. Replaces the Motivation/Changes scaffolding with a single comment block instructing brevity.