### PR TITLE
synq: centralize trivia-skip primitive in parser comment handling

### DIFF
--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -346,7 +346,9 @@ int synq_parser_record_and_feed(SyntaqliteParser* p,
 
 // Record a comment token (outlined from the hot loop).
 SYNQ_NOINLINE
-static void record_comment(SyntaqliteParser* p, uint32_t offset, uint32_t len) {
+void synq_parser_record_comment(SyntaqliteParser* p,
+                                uint32_t offset,
+                                uint32_t len) {
   const unsigned char* z = (const unsigned char*)p->source;
   SyntaqliteComment t = {offset, len,
                          z[offset] == '-' ? (uint8_t)0 : (uint8_t)1};
@@ -479,7 +481,7 @@ SYNTAQLITE_API int32_t syntaqlite_parser_next(SyntaqliteParser* p) {
     if (cur_type == SYNTAQLITE_TK_COMMENT) {
       p->had_comment = 1;
       if (p->collect_tokens)
-        record_comment(p, cur_offset, (uint32_t)cur_len);
+        synq_parser_record_comment(p, cur_offset, (uint32_t)cur_len);
       cur_len = next_token(p, z, cur_offset + (uint32_t)cur_len, &cur_offset,
                            &cur_type);
       continue;
@@ -744,18 +746,10 @@ SYNTAQLITE_API int32_t syntaqlite_parser_feed_token(SyntaqliteParser* p,
     p->pending_reset = 0;
   }
 
-  // Skip whitespace silently.
-  if (token_type == SYNTAQLITE_TK_SPACE) {
-    return set_result_status(p, SYNTAQLITE_PARSE_DONE);
-  }
-
-  // Record comments but don't feed to Lemon.
-  if (token_type == SYNTAQLITE_TK_COMMENT) {
-    if (p->collect_tokens && text) {
-      uint32_t tok_offset = (uint32_t)(text - p->source);
-      SyntaqliteComment t = {tok_offset, len,
-                             (uint8_t)(text[0] == '-' ? 0 : 1)};
-      syntaqlite_vec_push(&p->comments, t, p->mem);
+  // Skip trivia (whitespace and comments) without feeding to Lemon.
+  if (synq_token_is_trivia(token_type)) {
+    if (token_type == SYNTAQLITE_TK_COMMENT && p->collect_tokens && text) {
+      synq_parser_record_comment(p, (uint32_t)(text - p->source), len);
     }
     return set_result_status(p, SYNTAQLITE_PARSE_DONE);
   }

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "csrc/tokens.h"
 #include "syntaqlite/config.h"
 #include "syntaqlite/dialect.h"
 #include "syntaqlite/incremental.h"
@@ -194,6 +195,20 @@ struct SyntaqliteParser {
 };
 
 // ── Cross-file helpers ──────────────────────────────────────────────────────
+
+// Whitespace-or-comment classifier. Centralizes the trivia predicate used by
+// every site that needs to skip over insignificant tokens (the high-level
+// feed_token path, scan_macro_args, and the macro-expansion loop and its
+// ID-BANG lookahead).
+static inline int synq_token_is_trivia(uint32_t type) {
+  return type == SYNTAQLITE_TK_SPACE || type == SYNTAQLITE_TK_COMMENT;
+}
+
+// Record a comment span into p->comments. `offset` is the byte offset into
+// p->source. Caller must check p->collect_tokens before calling.
+void synq_parser_record_comment(SyntaqliteParser* p,
+                                uint32_t offset,
+                                uint32_t len);
 
 // Set the parser's last_status and return it (used by both parser.c and
 // parser_macros.c as a convenient exit helper).

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -36,6 +36,36 @@ static void begin_macro_expansion(SyntaqliteParser* p,
                                   uint32_t name_len);
 static void synq_end_macro(SyntaqliteParser* p);
 
+// Forward-scan an expansion buffer past trivia (whitespace + comments) and
+// return the next significant token. `*out_pos` is updated to that token's
+// offset; `*out_type` and the return value give its type and length. Returns
+// 0 (with *out_type == 0) at end-of-buffer or tokenizer failure. Comments
+// inside expansion buffers are intentionally not recorded — only source
+// comments are kept on p->comments.
+static int64_t synq_macro_skip_trivia(SyntaqliteParser* p,
+                                      const unsigned char* z,
+                                      uint32_t buf_len,
+                                      uint32_t* out_pos,
+                                      uint32_t* out_type) {
+  uint32_t pos = *out_pos;
+  while (pos < buf_len) {
+    uint32_t ttype = 0;
+    int64_t tlen = SynqSqliteGetTokenVersionWrapped(
+        &p->dialect, p->macro.macro_fallback, z + pos, &ttype);
+    if (tlen <= 0)
+      break;
+    if (!synq_token_is_trivia(ttype)) {
+      *out_pos = pos;
+      *out_type = ttype;
+      return tlen;
+    }
+    pos += (uint32_t)tlen;
+  }
+  *out_pos = pos;
+  *out_type = 0;
+  return 0;
+}
+
 // ---------------------------------------------------------------------------
 // Macro argument scanning
 // ---------------------------------------------------------------------------
@@ -83,8 +113,7 @@ uint32_t synq_parser_scan_macro_args(SyntaqliteParser* p,
     if (tlen <= 0)
       return 0;
 
-    int is_skip =
-        (ttype == SYNTAQLITE_TK_SPACE || ttype == SYNTAQLITE_TK_COMMENT);
+    int is_skip = synq_token_is_trivia(ttype);
 
     if (ttype == SYNTAQLITE_TK_LP) {
       depth++;
@@ -279,36 +308,18 @@ static int expand_and_feed(SyntaqliteParser* p,
 
   while (pos < buf_len) {
     uint32_t ttype = 0;
-    int64_t tlen = SynqSqliteGetTokenVersionWrapped(
-        &p->dialect, p->macro.macro_fallback, z + pos, &ttype);
+    int64_t tlen = synq_macro_skip_trivia(p, z, buf_len, &pos, &ttype);
     if (tlen <= 0)
       break;
 
-    if (ttype == SYNTAQLITE_TK_SPACE || ttype == SYNTAQLITE_TK_COMMENT) {
-      pos += (uint32_t)tlen;
-      continue;
-    }
-
-    // Check for nested macro call: ID followed by TK_BANG.
-    // Skip whitespace/comments between ID and BANG to mirror the main parse
-    // loop's next_token() behaviour (issue #130).
-    // Skip when inside a macro definition body — body should be verbatim.
+    // Check for nested macro call: ID followed by TK_BANG, mirroring the
+    // main parse loop's next_token() behaviour and skipping any trivia
+    // between the two (issue #130). Suppressed inside macro definition
+    // bodies — those should be tokenized verbatim.
     uint32_t bang_pos = pos + (uint32_t)tlen;
     uint32_t la_type = 0;
-    if (ttype == SYNTAQLITE_TK_ID && p->ctx.in_macro_def_body == 0) {
-      while (bang_pos < buf_len) {
-        uint32_t lt = 0;
-        int64_t la_len = SynqSqliteGetTokenVersionWrapped(
-            &p->dialect, p->macro.macro_fallback, z + bang_pos, &lt);
-        if (la_len <= 0)
-          break;
-        if (lt != SYNTAQLITE_TK_SPACE && lt != SYNTAQLITE_TK_COMMENT) {
-          la_type = lt;
-          break;
-        }
-        bang_pos += (uint32_t)la_len;
-      }
-    }
+    if (ttype == SYNTAQLITE_TK_ID && p->ctx.in_macro_def_body == 0)
+      synq_macro_skip_trivia(p, z, buf_len, &bang_pos, &la_type);
     if (ttype == SYNTAQLITE_TK_ID && la_type == SYNTAQLITE_TK_BANG &&
         p->ctx.in_macro_def_body == 0) {
       uint32_t nested_end = 0;

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_keyword.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_keyword.c
@@ -242,8 +242,8 @@ const unsigned char synq_sqlite_aKWLen[149] = {
     8, 6,  4,  9, 5, 8, 4,  3,  9,  5, 5, 6, 4, 6, 2, 2,  7,
 };
 /* synq_sqlite_aKWOffset[i] is the index into synq_sqlite_zKWText[] of the start
-*of
-** the text for the i-th keyword. */
+ *of
+ ** the text for the i-th keyword. */
 const unsigned short int synq_sqlite_aKWOffset[149] = {
     0,   0,   2,   2,   8,   9,   14,  16,  20,  23,  25,  25,  29,  33,  36,
     41,  46,  48,  53,  54,  59,  62,  65,  67,  69,  78,  81,  86,  90,  90,

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
@@ -10056,7 +10056,7 @@ static void yy_syntax_error(
   SynqSqliteParseARG_FETCH SynqSqliteParseCTX_FETCH
 #define TOKEN yyminor
       /************ Begin %syntax_error code
-         ****************************************/
+       ****************************************/
 
       (void) yymajor;
   (void)TOKEN;


### PR DESCRIPTION
First step toward #13. Three sites in the parser had each re-implemented
"skip whitespace + comments" — `feed_token` (which also duplicated the
`record_comment` body inline), `scan_macro_args`, and the macro
expansion loop's ID-BANG lookahead added for #130. Consolidate to one
inline predicate, one cross-file comment recorder, and one file-local
forward-scanner. No behaviour change; existing regression tests cover
all three sites.

Drive-by: clang-format whitespace fixups in vendored sqlite files
emitted by `pre-push --fix`.