### PR TITLE
synq: add lineage CLI subcommand and integration test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 ## Unreleased
 
 **Breaking:**
-- Renamed `TableAccess` → `PhysicalTableAccess` and `StatementModel::tables_accessed()` → `physical_tables_accessed()` in the Rust API. The corresponding C symbols `SyntaqliteTableAccess`, `syntaqlite_validator_table_count`, `syntaqlite_validator_tables`, `syntaqlite_validator_statement_table_count`, and `syntaqlite_validator_statement_tables` are renamed with a `physical_` infix.
+- Renamed `TableAccess` → `PhysicalTableAccess` and `StatementModel::tables_accessed()` → `physical_tables_accessed()` in the Rust API. The corresponding C symbols `SyntaqliteTableAccess`, `syntaqlite_validator_table_count`, `syntaqlite_validator_tables`, `syntaqlite_validator_statement_table_count`, and `syntaqlite_validator_statement_tables` are renamed with a `physical_` infix. The Python `Lineage` attribute is renamed `tables` → `physical_tables`.
+
+**Added:**
+- New `syntaqlite lineage [tables|columns] [FILES]` CLI subcommand. Emits NDJSON (`schema_version: 0`, pre-stable) or human-readable text for column and table lineage. Exit 1 when any statement fails to parse or validate.
+- New `StatementModel::unexpanded_views()` accessor — canonical names of views whose bodies weren't available for expansion (surfaces as a structured partial-reason in the CLI output).
+- Matching C FFI: `SyntaqliteUnexpandedView` struct plus aggregate (`syntaqlite_validator_unexpanded_view_count` / `syntaqlite_validator_unexpanded_views`) and per-statement (`syntaqlite_validator_statement_unexpanded_view_count` / `syntaqlite_validator_statement_unexpanded_views`) accessors. Python `Lineage` objects expose the same data via `unexpanded_views: list[str]`.
 
 ## 0.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+**Breaking:**
+- Renamed `TableAccess` → `PhysicalTableAccess` and `StatementModel::tables_accessed()` → `physical_tables_accessed()` in the Rust API. The corresponding C symbols `SyntaqliteTableAccess`, `syntaqlite_validator_table_count`, `syntaqlite_validator_tables`, `syntaqlite_validator_statement_table_count`, and `syntaqlite_validator_statement_tables` are renamed with a `physical_` infix.
+
 ## 0.4.2
 
 - Fixed the web playground failing on load with `TypeError: resolved is not a function`: runtime → dialect hook symbols were being stripped under emscripten `MAIN_MODULE=2` ([#157](https://github.com/LalitMaganti/syntaqlite/pull/157)).

--- a/python/csrc/_syntaqlite.c
+++ b/python/csrc/_syntaqlite.c
@@ -575,10 +575,10 @@ syntaqlite_py_validate(PyObject *self, PyObject *args, PyObject *kwargs)
         }
 
         /* Tables */
-        uint32_t tbl_count = syntaqlite_validator_table_count(v);
+        uint32_t tbl_count = syntaqlite_validator_physical_table_count(v);
         PyObject *tbl_list = PyList_New(0);
         if (tbl_list) {
-            const SyntaqliteTableAccess *tbls = syntaqlite_validator_tables(v);
+            const SyntaqlitePhysicalTableAccess *tbls = syntaqlite_validator_physical_tables(v);
             for (uint32_t i = 0; i < tbl_count; i++) {
                 PyObject *tname = PyUnicode_FromString(tbls[i].name ? tbls[i].name : "");
                 if (tname) {
@@ -722,10 +722,10 @@ syntaqlite_py_validate(PyObject *self, PyObject *args, PyObject *kwargs)
                     }
 
                     /* Per-statement tables */
-                    uint32_t st_count = syntaqlite_validator_statement_table_count(v, si);
+                    uint32_t st_count = syntaqlite_validator_statement_physical_table_count(v, si);
                     PyObject *tbl_list = PyList_New(0);
                     if (tbl_list) {
-                        const SyntaqliteTableAccess *st = syntaqlite_validator_statement_tables(v, si);
+                        const SyntaqlitePhysicalTableAccess *st = syntaqlite_validator_statement_physical_tables(v, si);
                         for (uint32_t i = 0; i < st_count; i++) {
                             PyObject *tname = PyUnicode_FromString(st[i].name ? st[i].name : "");
                             if (tname) { PyList_Append(tbl_list, tname); Py_DECREF(tname); }

--- a/python/csrc/_syntaqlite.c
+++ b/python/csrc/_syntaqlite.c
@@ -586,8 +586,24 @@ syntaqlite_py_validate(PyObject *self, PyObject *args, PyObject *kwargs)
                     Py_DECREF(tname);
                 }
             }
-            PyDict_SetItemString(lineage_dict, "tables", tbl_list);
+            PyDict_SetItemString(lineage_dict, "physical_tables", tbl_list);
             Py_DECREF(tbl_list);
+        }
+
+        /* Unexpanded views */
+        uint32_t uv_count = syntaqlite_validator_unexpanded_view_count(v);
+        PyObject *uv_list = PyList_New(0);
+        if (uv_list) {
+            const SyntaqliteUnexpandedView *uvs = syntaqlite_validator_unexpanded_views(v);
+            for (uint32_t i = 0; i < uv_count; i++) {
+                PyObject *uname = PyUnicode_FromString(uvs[i].name ? uvs[i].name : "");
+                if (uname) {
+                    PyList_Append(uv_list, uname);
+                    Py_DECREF(uname);
+                }
+            }
+            PyDict_SetItemString(lineage_dict, "unexpanded_views", uv_list);
+            Py_DECREF(uv_list);
         }
 
         PyDict_SetItemString(result, "lineage", lineage_dict);
@@ -730,7 +746,7 @@ syntaqlite_py_validate(PyObject *self, PyObject *args, PyObject *kwargs)
                             PyObject *tname = PyUnicode_FromString(st[i].name ? st[i].name : "");
                             if (tname) { PyList_Append(tbl_list, tname); Py_DECREF(tname); }
                         }
-                        PyDict_SetItemString(lin, "tables", tbl_list);
+                        PyDict_SetItemString(lin, "physical_tables", tbl_list);
                         Py_DECREF(tbl_list);
                     }
 

--- a/python/dev/diff_tests/runner.py
+++ b/python/dev/diff_tests/runner.py
@@ -19,10 +19,14 @@ from python.dev.diff_tests.utils import Colors, colorize, format_diff
 def _run_single_test(args: tuple) -> TestResult:
     """Worker function for parallel test execution."""
     binary, subcommand, name, blueprint = args
+    # Lineage reads stdout but exits non-zero when error records are emitted;
+    # accept that like `validate` accepts non-zero exits.
+    lineage = subcommand is not None and subcommand.split()[0] == "lineage"
     return execute_test(
         Path(binary), name, blueprint,
         subcommand=subcommand,
         use_stderr=(subcommand == "validate"),
+        ignore_exit_code=lineage,
     )
 
 

--- a/python/dev/diff_tests/test_executor.py
+++ b/python/dev/diff_tests/test_executor.py
@@ -41,6 +41,7 @@ def execute_test(
     timeout: Optional[float] = 30.0,
     subcommand: Optional[str] = None,
     use_stderr: bool = False,
+    ignore_exit_code: bool = False,
 ) -> TestResult:
     """Execute a single test.
 
@@ -98,7 +99,7 @@ def execute_test(
         )
     elapsed_ms = int((time.monotonic() - t0) * 1000)
 
-    if proc.returncode != 0 and not use_stderr:
+    if proc.returncode != 0 and not use_stderr and not ignore_exit_code:
         return TestResult(
             name=name,
             passed=False,

--- a/python/dev/integration_tests/runner.py
+++ b/python/dev/integration_tests/runner.py
@@ -39,6 +39,7 @@ _SUITE_MODULES = [
     "python.dev.integration_tests.suites.upstream_sqlite",
     "python.dev.integration_tests.suites.lsp",
     "python.dev.integration_tests.suites.validate",
+    "python.dev.integration_tests.suites.lineage",
 ]
 
 _BLUE = "\033[1;34m"

--- a/python/dev/integration_tests/suites/lineage.py
+++ b/python/dev/integration_tests/suites/lineage.py
@@ -1,0 +1,28 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Lineage diff test suite."""
+
+from python.dev.integration_tests.suite import SuiteContext
+
+NAME = "lineage"
+DESCRIPTION = "Lineage CLI diff tests (tests/lineage_diff_tests/)"
+
+
+def run(ctx: SuiteContext) -> int:
+    from python.dev.diff_tests.runner import main
+
+    argv = [
+        "--binary", str(ctx.binary),
+        "--subcommand", "lineage -o json",
+        "--test-dir", "tests/lineage_diff_tests",
+    ]
+    if ctx.filter_pattern:
+        argv += ["--filter", ctx.filter_pattern]
+    if ctx.rebaseline:
+        argv.append("--rebaseline")
+    if ctx.verbose >= 1:
+        argv.append("-v")
+    if ctx.jobs is not None:
+        argv += ["--jobs", str(ctx.jobs)]
+    return main(argv)

--- a/python/dev/integration_tests/suites/lineage.py
+++ b/python/dev/integration_tests/suites/lineage.py
@@ -14,7 +14,7 @@ def run(ctx: SuiteContext) -> int:
 
     argv = [
         "--binary", str(ctx.binary),
-        "--subcommand", "lineage -o json",
+        "--subcommand", "lineage -o text",
         "--test-dir", "tests/lineage_diff_tests",
     ]
     if ctx.filter_pattern:

--- a/python/syntaqlite/__init__.py
+++ b/python/syntaqlite/__init__.py
@@ -163,13 +163,14 @@ class RelationAccess:
 class Lineage:
     """Column lineage for a SELECT statement."""
 
-    __slots__ = ("complete", "columns", "relations", "tables")
+    __slots__ = ("complete", "columns", "relations", "physical_tables", "unexpanded_views")
 
     def __init__(self, d: dict):
         self.complete: bool = d["complete"]
         self.columns: list[ColumnLineage] = [ColumnLineage(c) for c in d["columns"]]
         self.relations: list[RelationAccess] = [RelationAccess(r) for r in d["relations"]]
-        self.tables: list[str] = d["tables"]
+        self.physical_tables: list[str] = d["physical_tables"]
+        self.unexpanded_views: list[str] = d.get("unexpanded_views", [])
 
     def __repr__(self):
         status = "complete" if self.complete else "partial"

--- a/syntaqlite-buildtools/src/parser_tools/amalgamate.rs
+++ b/syntaqlite-buildtools/src/parser_tools/amalgamate.rs
@@ -53,10 +53,8 @@ const SUPPRESSED_WARNINGS: &[&str] = &[
 /// appear in a C++ translation unit, so they are guarded by
 /// `#ifndef __cplusplus`. The amalgamated header is `#include`d from C++
 /// consumers (e.g. perfetto) as well as C.
-const SUPPRESSED_WARNINGS_C_ONLY: &[&str] = &[
-    "-Wdeclaration-after-statement",
-    "-Wmissing-prototypes",
-];
+const SUPPRESSED_WARNINGS_C_ONLY: &[&str] =
+    &["-Wdeclaration-after-statement", "-Wmissing-prototypes"];
 
 /// Warnings that only Clang understands; emitted inside `#ifdef __clang__`.
 const SUPPRESSED_WARNINGS_CLANG_ONLY: &[&str] = &[

--- a/syntaqlite-cli/src/lib.rs
+++ b/syntaqlite-cli/src/lib.rs
@@ -17,6 +17,9 @@ mod runtime;
 #[cfg(feature = "builtin-sqlite")]
 mod codegen;
 
+#[cfg(feature = "builtin-sqlite")]
+mod lineage_output;
+
 #[cfg(feature = "mcp")]
 #[expect(
     clippy::needless_pass_by_value,
@@ -43,6 +46,23 @@ pub(crate) enum FmtOutput {
     Bytecode,
     /// Dump the Wadler-Lindig document tree after interpretation [maintainer]
     DocTree,
+}
+
+#[derive(Clone, Copy, Default, ValueEnum)]
+pub(crate) enum LineageOutput {
+    /// Newline-delimited JSON, one record per statement/error (default)
+    #[default]
+    Json,
+    /// Human-readable text
+    Text,
+}
+
+#[derive(Clone, Copy, Subcommand)]
+pub(crate) enum LineageScope {
+    /// Emit only relations and physical tables (drop columns)
+    Tables,
+    /// Emit only column lineage (drop relations and physical tables)
+    Columns,
 }
 
 #[derive(Parser)]
@@ -157,6 +177,24 @@ pub(crate) enum Command {
         /// [experimental] Host language for embedded SQL extraction (python, typescript)
         #[arg(long = "experimental-lang")]
         lang: Option<runtime::HostLanguage>,
+    },
+    /// Extract column and table lineage from SQL
+    #[cfg(feature = "builtin-sqlite")]
+    Lineage {
+        /// SQL files or glob patterns (reads stdin if omitted)
+        files: Vec<String>,
+        /// SQL expression to analyze directly (instead of files or stdin)
+        #[arg(short = 'e', long = "expression", conflicts_with = "files")]
+        expression: Option<String>,
+        /// Schema DDL file(s) to load before analysis (repeatable, supports globs)
+        #[arg(long)]
+        schema: Vec<String>,
+        /// Output format
+        #[arg(short, long, value_enum, default_value_t = LineageOutput::Json)]
+        output: LineageOutput,
+        /// Restrict output to a subset (combined output is the default)
+        #[command(subcommand)]
+        scope: Option<LineageScope>,
     },
     /// Start the language server (stdio)
     #[cfg(feature = "builtin-sqlite")]

--- a/syntaqlite-cli/src/lineage_output.rs
+++ b/syntaqlite-cli/src/lineage_output.rs
@@ -1,0 +1,105 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+//! JSON DTOs for the `lineage` subcommand.
+//!
+//! `schema_version` is pinned at `0` during the pre-stable period. Bump when
+//! making a compatible schema change; document breaking schema changes in
+//! `CHANGELOG.md`.
+
+use serde::Serialize;
+
+pub(crate) const SCHEMA_VERSION: u32 = 0;
+
+#[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum Status {
+    Complete,
+    Partial,
+}
+
+#[derive(Serialize)]
+pub(crate) struct JsonOrigin {
+    pub table: String,
+    pub column: String,
+}
+
+#[derive(Serialize)]
+pub(crate) struct JsonColumn {
+    pub name: String,
+    pub index: u32,
+    pub origin: Option<JsonOrigin>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum JsonRelationKind {
+    Table,
+    View,
+}
+
+#[derive(Serialize)]
+pub(crate) struct JsonRelation {
+    pub name: String,
+    pub kind: JsonRelationKind,
+}
+
+#[derive(Serialize)]
+pub(crate) struct JsonPhysicalTable {
+    pub name: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum JsonTargetKind {
+    Table,
+    View,
+}
+
+#[derive(Serialize)]
+pub(crate) struct JsonTarget {
+    pub name: String,
+    pub kind: JsonTargetKind,
+}
+
+/// Partial-reason entry. For now only `unexpanded_view` exists; additional
+/// codes will be added as more causes of partial lineage surface.
+#[derive(Serialize)]
+#[serde(tag = "code", rename_all = "snake_case")]
+pub(crate) enum JsonPartialReason {
+    UnexpandedView { view: String },
+}
+
+#[derive(Serialize)]
+pub(crate) struct LineageRecord {
+    pub kind: &'static str,
+    pub schema_version: u32,
+    pub file: String,
+    pub statement_index: u32,
+    pub status: Status,
+    pub partial_reasons: Vec<JsonPartialReason>,
+    pub target: Option<JsonTarget>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub columns: Option<Vec<JsonColumn>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relations: Option<Vec<JsonRelation>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub physical_tables: Option<Vec<JsonPhysicalTable>>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum ErrorStage {
+    Parse,
+    Validate,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ErrorRecord {
+    pub kind: &'static str,
+    pub schema_version: u32,
+    pub file: String,
+    pub statement_index: u32,
+    pub stage: ErrorStage,
+    pub message: String,
+}

--- a/syntaqlite-cli/src/runtime.rs
+++ b/syntaqlite-cli/src/runtime.rs
@@ -22,7 +22,7 @@ use syntaqlite::{
 
 use crate::config::{self, FormatOptions, ProjectConfig};
 
-use super::{Cli, Command};
+use super::{Cli, Command, LineageOutput, LineageScope};
 
 #[derive(Clone, Copy, ValueEnum)]
 pub(crate) enum KeywordCasing {
@@ -193,6 +193,28 @@ fn dispatch_commands(
                 &resolved_schemas,
                 lang,
                 checks,
+            )
+        }),
+        Command::Lineage {
+            files,
+            expression,
+            schema,
+            output,
+            scope,
+        } => require_dialect(dialect).and_then(|d| {
+            let file_config = discover_config_for_paths(&files, config);
+            let resolved_schemas = if schema.is_empty() {
+                resolve_schemas_from_config_with(&files, file_config.as_ref())
+            } else {
+                schema
+            };
+            cmd_lineage(
+                &d,
+                &files,
+                expression.as_deref(),
+                &resolved_schemas,
+                output,
+                scope,
             )
         }),
         Command::Lsp => require_dialect(dialect).and_then(|d| cmd_lsp(d, config)),
@@ -935,4 +957,287 @@ fn build_check_config(
     }
 
     Ok(checks)
+}
+
+// ── Lineage command ─────────────────────────────────────────────────────────
+
+use crate::lineage_output::{
+    ErrorRecord, ErrorStage, JsonColumn, JsonOrigin, JsonPartialReason, JsonPhysicalTable,
+    JsonRelation, JsonRelationKind, JsonTarget, JsonTargetKind, LineageRecord, SCHEMA_VERSION,
+    Status,
+};
+use syntaqlite::semantic::{RelationKind, StatementModel};
+
+fn cmd_lineage(
+    dialect: &AnyDialect,
+    files: &[String],
+    expression: Option<&str>,
+    schemas: &[String],
+    output: LineageOutput,
+    scope: Option<LineageScope>,
+) -> Result<(), String> {
+    let schema_catalog = build_schema_catalog(dialect, schemas)?;
+    let config = ValidationConfig::default();
+    let any_errors = std::cell::Cell::new(false);
+
+    process_files(
+        files,
+        expression,
+        |source, label| {
+            if lineage_process_source(
+                dialect,
+                &schema_catalog,
+                &config,
+                source,
+                label,
+                output,
+                scope,
+            ) {
+                any_errors.set(true);
+            }
+            Ok(())
+        },
+        |source, path, _multi| {
+            let file = path.display().to_string();
+            if lineage_process_source(
+                dialect,
+                &schema_catalog,
+                &config,
+                source,
+                &file,
+                output,
+                scope,
+            ) {
+                any_errors.set(true);
+            }
+            Ok(())
+        },
+    )?;
+
+    if any_errors.get() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn lineage_process_source(
+    dialect: &AnyDialect,
+    schema_catalog: &Catalog,
+    config: &ValidationConfig,
+    source: &str,
+    label: &str,
+    output: LineageOutput,
+    scope: Option<LineageScope>,
+) -> bool {
+    let mut analyzer = SemanticAnalyzer::with_dialect(dialect.clone());
+    let model = analyzer.analyze(source, schema_catalog, config);
+    let mut had_error = false;
+    for (idx, stmt) in model.statements().iter().enumerate() {
+        let idx = idx as u32;
+        let errors: Vec<_> = stmt
+            .diagnostics()
+            .iter()
+            .filter(|d| d.severity() == Severity::Error)
+            .collect();
+        if errors.is_empty() {
+            emit_lineage(stmt, label, idx, output, scope);
+        } else {
+            for d in &errors {
+                emit_error(d, label, idx, output);
+            }
+            had_error = true;
+        }
+    }
+    had_error
+}
+
+fn emit_lineage(
+    stmt: &StatementModel,
+    file: &str,
+    index: u32,
+    output: LineageOutput,
+    scope: Option<LineageScope>,
+) {
+    let (status, partial_reasons) = if stmt.unexpanded_views().is_empty() {
+        (Status::Complete, Vec::new())
+    } else {
+        let reasons = stmt
+            .unexpanded_views()
+            .iter()
+            .map(|v| JsonPartialReason::UnexpandedView { view: v.clone() })
+            .collect();
+        (Status::Partial, reasons)
+    };
+
+    let target = stmt.defined_relations().first().map(|d| JsonTarget {
+        name: d.name.clone(),
+        kind: if d.is_view {
+            JsonTargetKind::View
+        } else {
+            JsonTargetKind::Table
+        },
+    });
+
+    let include_columns = matches!(scope, None | Some(LineageScope::Columns));
+    let include_tables = matches!(scope, None | Some(LineageScope::Tables));
+
+    let columns = if include_columns {
+        Some(
+            stmt.lineage()
+                .map(|l| {
+                    l.into_inner()
+                        .iter()
+                        .map(|c| JsonColumn {
+                            name: c.name.clone(),
+                            index: c.index,
+                            origin: c.origin.as_ref().map(|o| JsonOrigin {
+                                table: o.table.clone(),
+                                column: o.column.clone(),
+                            }),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+        )
+    } else {
+        None
+    };
+
+    let relations = if include_tables {
+        Some(
+            stmt.relations_accessed()
+                .map(|r| {
+                    r.into_inner()
+                        .iter()
+                        .map(|r| JsonRelation {
+                            name: r.name.clone(),
+                            kind: match r.kind {
+                                RelationKind::Table => JsonRelationKind::Table,
+                                RelationKind::View => JsonRelationKind::View,
+                            },
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+        )
+    } else {
+        None
+    };
+
+    let physical_tables = if include_tables {
+        Some(
+            stmt.physical_tables_accessed()
+                .map(|t| {
+                    t.into_inner()
+                        .iter()
+                        .map(|t| JsonPhysicalTable {
+                            name: t.name.clone(),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+        )
+    } else {
+        None
+    };
+
+    let record = LineageRecord {
+        kind: "lineage",
+        schema_version: SCHEMA_VERSION,
+        file: file.to_string(),
+        statement_index: index,
+        status,
+        partial_reasons,
+        target,
+        columns,
+        relations,
+        physical_tables,
+    };
+
+    match output {
+        LineageOutput::Json => match serde_json::to_string(&record) {
+            Ok(s) => println!("{s}"),
+            Err(e) => eprintln!("error serializing lineage record: {e}"),
+        },
+        LineageOutput::Text => print_lineage_text(&record),
+    }
+}
+
+fn emit_error(d: &Diagnostic, file: &str, index: u32, output: LineageOutput) {
+    let stage = match d.message() {
+        DiagnosticMessage::ParseError(_) => ErrorStage::Parse,
+        _ => ErrorStage::Validate,
+    };
+    let record = ErrorRecord {
+        kind: "error",
+        schema_version: SCHEMA_VERSION,
+        file: file.to_string(),
+        statement_index: index,
+        stage,
+        message: format!("{}", d.message()),
+    };
+
+    match output {
+        LineageOutput::Json => match serde_json::to_string(&record) {
+            Ok(s) => println!("{s}"),
+            Err(e) => eprintln!("error serializing error record: {e}"),
+        },
+        LineageOutput::Text => {
+            let stage = match record.stage {
+                ErrorStage::Parse => "parse",
+                ErrorStage::Validate => "validate",
+            };
+            println!(
+                "error [{}]: {}:{}: {}",
+                stage, record.file, record.statement_index, record.message
+            );
+        }
+    }
+}
+
+fn print_lineage_text(record: &LineageRecord) {
+    let status = match record.status {
+        Status::Complete => "complete",
+        Status::Partial => "partial",
+    };
+    println!(
+        "# {}:{} ({})",
+        record.file, record.statement_index, status
+    );
+    if let Some(target) = &record.target {
+        let kind = match target.kind {
+            JsonTargetKind::Table => "table",
+            JsonTargetKind::View => "view",
+        };
+        println!("  target: {} ({})", target.name, kind);
+    }
+    if let Some(columns) = &record.columns {
+        for c in columns {
+            match &c.origin {
+                Some(o) => println!("  column {}: {} <- {}.{}", c.index, c.name, o.table, o.column),
+                None => println!("  column {}: {} <- <transformed>", c.index, c.name),
+            }
+        }
+    }
+    if let Some(relations) = &record.relations {
+        for r in relations {
+            let kind = match r.kind {
+                JsonRelationKind::Table => "table",
+                JsonRelationKind::View => "view",
+            };
+            println!("  relation: {} ({})", r.name, kind);
+        }
+    }
+    if let Some(physical_tables) = &record.physical_tables {
+        for t in physical_tables {
+            println!("  physical_table: {}", t.name);
+        }
+    }
+    for reason in &record.partial_reasons {
+        match reason {
+            JsonPartialReason::UnexpandedView { view } => {
+                println!("  partial: unexpanded view `{view}`");
+            }
+        }
+    }
 }

--- a/syntaqlite-cli/src/runtime.rs
+++ b/syntaqlite-cli/src/runtime.rs
@@ -201,22 +201,15 @@ fn dispatch_commands(
             schema,
             output,
             scope,
-        } => require_dialect(dialect).and_then(|d| {
-            let file_config = discover_config_for_paths(&files, config);
-            let resolved_schemas = if schema.is_empty() {
-                resolve_schemas_from_config_with(&files, file_config.as_ref())
-            } else {
-                schema
-            };
-            cmd_lineage(
-                &d,
-                &files,
-                expression.as_deref(),
-                &resolved_schemas,
-                output,
-                scope,
-            )
-        }),
+        } => dispatch_lineage(
+            dialect,
+            config,
+            &files,
+            expression.as_deref(),
+            schema,
+            output,
+            scope,
+        ),
         Command::Lsp => require_dialect(dialect).and_then(|d| cmd_lsp(d, config)),
         #[cfg(feature = "mcp")]
         Command::Mcp => require_dialect(dialect).and_then(crate::mcp::cmd_mcp),
@@ -968,6 +961,26 @@ use crate::lineage_output::{
 };
 use syntaqlite::semantic::{RelationKind, StatementModel};
 
+fn dispatch_lineage(
+    dialect: Option<AnyDialect>,
+    config: &ConfigMode<'_>,
+    files: &[String],
+    expression: Option<&str>,
+    schema: Vec<String>,
+    output: LineageOutput,
+    scope: Option<LineageScope>,
+) -> Result<(), String> {
+    require_dialect(dialect).and_then(|d| {
+        let file_config = discover_config_for_paths(files, config);
+        let resolved_schemas = if schema.is_empty() {
+            resolve_schemas_from_config_with(files, file_config.as_ref())
+        } else {
+            schema
+        };
+        cmd_lineage(&d, files, expression, &resolved_schemas, output, scope)
+    })
+}
+
 fn cmd_lineage(
     dialect: &AnyDialect,
     files: &[String],
@@ -1033,7 +1046,7 @@ fn lineage_process_source(
     let model = analyzer.analyze(source, schema_catalog, config);
     let mut had_error = false;
     for (idx, stmt) in model.statements().iter().enumerate() {
-        let idx = idx as u32;
+        let idx = u32::try_from(idx).unwrap_or(u32::MAX);
         let errors: Vec<_> = stmt
             .diagnostics()
             .iter()
@@ -1182,17 +1195,19 @@ fn emit_error(d: &Diagnostic, file: &str, index: u32, output: LineageOutput) {
             Ok(s) => println!("{s}"),
             Err(e) => eprintln!("error serializing error record: {e}"),
         },
-        LineageOutput::Text => {
-            let stage = match record.stage {
-                ErrorStage::Parse => "parse",
-                ErrorStage::Validate => "validate",
-            };
-            println!(
-                "error [{}]: {}:{}: {}",
-                stage, record.file, record.statement_index, record.message
-            );
-        }
+        LineageOutput::Text => print_error_text(&record),
     }
+}
+
+fn print_error_text(record: &ErrorRecord) {
+    let stage = match record.stage {
+        ErrorStage::Parse => "parse",
+        ErrorStage::Validate => "validate",
+    };
+    println!("Error");
+    println!("  statement: {}", record.statement_index);
+    println!("  stage: {stage}");
+    println!("  message: {}", record.message);
 }
 
 fn print_lineage_text(record: &LineageRecord) {
@@ -1200,43 +1215,70 @@ fn print_lineage_text(record: &LineageRecord) {
         Status::Complete => "complete",
         Status::Partial => "partial",
     };
-    println!(
-        "# {}:{} ({})",
-        record.file, record.statement_index, status
-    );
-    if let Some(target) = &record.target {
-        let kind = match target.kind {
-            JsonTargetKind::Table => "table",
-            JsonTargetKind::View => "view",
-        };
-        println!("  target: {} ({})", target.name, kind);
+    println!("Lineage");
+    println!("  statement: {}", record.statement_index);
+    println!("  status: {status}");
+
+    match &record.target {
+        Some(t) => {
+            let kind = match t.kind {
+                JsonTargetKind::Table => "table",
+                JsonTargetKind::View => "view",
+            };
+            println!("  target: {} ({kind})", t.name);
+        }
+        None => println!("  target: (none)"),
     }
+
     if let Some(columns) = &record.columns {
-        for c in columns {
-            match &c.origin {
-                Some(o) => println!("  column {}: {} <- {}.{}", c.index, c.name, o.table, o.column),
-                None => println!("  column {}: {} <- <transformed>", c.index, c.name),
+        if columns.is_empty() {
+            println!("  columns: (none)");
+        } else {
+            println!("  columns:");
+            for c in columns {
+                match &c.origin {
+                    Some(o) => println!("    {} <- {}.{}", c.name, o.table, o.column),
+                    None => println!("    {} <- (transformed)", c.name),
+                }
             }
         }
     }
+
     if let Some(relations) = &record.relations {
-        for r in relations {
-            let kind = match r.kind {
-                JsonRelationKind::Table => "table",
-                JsonRelationKind::View => "view",
-            };
-            println!("  relation: {} ({})", r.name, kind);
+        if relations.is_empty() {
+            println!("  relations: (none)");
+        } else {
+            println!("  relations:");
+            for r in relations {
+                let kind = match r.kind {
+                    JsonRelationKind::Table => "table",
+                    JsonRelationKind::View => "view",
+                };
+                println!("    {} ({kind})", r.name);
+            }
         }
     }
+
     if let Some(physical_tables) = &record.physical_tables {
-        for t in physical_tables {
-            println!("  physical_table: {}", t.name);
+        if physical_tables.is_empty() {
+            println!("  physical_tables: (none)");
+        } else {
+            println!("  physical_tables:");
+            for t in physical_tables {
+                println!("    {}", t.name);
+            }
         }
     }
-    for reason in &record.partial_reasons {
-        match reason {
-            JsonPartialReason::UnexpandedView { view } => {
-                println!("  partial: unexpanded view `{view}`");
+
+    if record.partial_reasons.is_empty() {
+        println!("  partial_reasons: (none)");
+    } else {
+        println!("  partial_reasons:");
+        for reason in &record.partial_reasons {
+            match reason {
+                JsonPartialReason::UnexpandedView { view } => {
+                    println!("    unexpanded_view: {view}");
+                }
             }
         }
     }

--- a/syntaqlite-cli/tests/lineage_json.rs
+++ b/syntaqlite-cli/tests/lineage_json.rs
@@ -1,0 +1,124 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+//! Round-trip tests for the lineage JSON schema emitted by
+//! `syntaqlite lineage -o json`.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_syntaqlite")
+}
+
+fn run_lineage(args: &[&str], sql: &str) -> (String, String, i32) {
+    let mut child = Command::new(bin())
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn syntaqlite");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(sql.as_bytes())
+        .expect("write stdin");
+    let out = child.wait_with_output().expect("wait");
+    (
+        String::from_utf8(out.stdout).expect("utf8 stdout"),
+        String::from_utf8(out.stderr).expect("utf8 stderr"),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+fn records(stdout: &str) -> Vec<serde_json::Value> {
+    stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str::<serde_json::Value>(l).expect("valid JSON"))
+        .collect()
+}
+
+#[test]
+fn emits_schema_version_and_stdin_file_name() {
+    let (stdout, _, code) = run_lineage(
+        &["lineage", "-o", "json"],
+        "CREATE TABLE t(a INTEGER);\nSELECT a FROM t;\n",
+    );
+    assert_eq!(code, 0, "unexpected non-zero exit");
+    let recs = records(&stdout);
+    assert_eq!(recs.len(), 2);
+    for r in &recs {
+        assert_eq!(r["schema_version"], 0);
+        assert_eq!(r["file"], "<stdin>");
+        assert_eq!(r["kind"], "lineage");
+    }
+    assert_eq!(recs[1]["columns"][0]["origin"]["table"], "t");
+    assert_eq!(recs[1]["columns"][0]["origin"]["column"], "a");
+}
+
+#[test]
+fn error_record_on_parse_failure_and_exit_one() {
+    let (stdout, _, code) = run_lineage(&["lineage", "-o", "json"], "SELECT FROM;\n");
+    assert_eq!(code, 1, "exit code should be 1 on error");
+    let recs = records(&stdout);
+    assert_eq!(recs.len(), 1);
+    assert_eq!(recs[0]["kind"], "error");
+    assert_eq!(recs[0]["stage"], "parse");
+    assert_eq!(recs[0]["schema_version"], 0);
+}
+
+#[test]
+fn scope_tables_drops_columns_field() {
+    let (stdout, _, _) = run_lineage(
+        &["lineage", "-o", "json", "tables"],
+        "CREATE TABLE t(a INTEGER);\nSELECT a FROM t;\n",
+    );
+    let recs = records(&stdout);
+    assert_eq!(recs.len(), 2);
+    for r in &recs {
+        assert!(r.get("columns").is_none(), "columns should be dropped");
+        assert!(r.get("relations").is_some(), "relations should be present");
+        assert!(
+            r.get("physical_tables").is_some(),
+            "physical_tables should be present"
+        );
+    }
+}
+
+#[test]
+fn scope_columns_drops_tables_fields() {
+    let (stdout, _, _) = run_lineage(
+        &["lineage", "-o", "json", "columns"],
+        "CREATE TABLE t(a INTEGER);\nSELECT a FROM t;\n",
+    );
+    let recs = records(&stdout);
+    assert_eq!(recs.len(), 2);
+    for r in &recs {
+        assert!(r.get("columns").is_some(), "columns should be present");
+        assert!(r.get("relations").is_none(), "relations should be dropped");
+        assert!(
+            r.get("physical_tables").is_none(),
+            "physical_tables should be dropped"
+        );
+    }
+}
+
+#[test]
+fn unexpanded_view_marks_partial() {
+    let (stdout, _, _) = run_lineage(
+        &["lineage", "-o", "json"],
+        "CREATE TABLE users (id INTEGER);\n\
+         CREATE VIEW u AS SELECT id FROM users;\n\
+         SELECT id FROM u;\n",
+    );
+    let recs = records(&stdout);
+    let last = recs.last().expect("at least one record");
+    assert_eq!(last["status"], "partial");
+    let reasons = last["partial_reasons"].as_array().expect("reasons array");
+    assert_eq!(reasons.len(), 1);
+    assert_eq!(reasons[0]["code"], "unexpanded_view");
+    assert_eq!(reasons[0]["view"], "u");
+}

--- a/syntaqlite/include/syntaqlite/validation.h
+++ b/syntaqlite/include/syntaqlite/validation.h
@@ -97,6 +97,13 @@ typedef struct {
   uint32_t is_view;   // 0 = table, 1 = view
 } SyntaqliteDefinedRelation;
 
+// A view whose body was not available for expansion during lineage
+// resolution. Its presence means the statement's lineage result is
+// Partial; the name identifies which view body would have been needed.
+typedef struct {
+  const char* name;
+} SyntaqliteUnexpandedView;
+
 // Analysis mode — controls whether DDL persists across analyze() calls.
 typedef enum {
   // Statements are being analyzed (e.g. editing a SQL file).
@@ -253,6 +260,17 @@ SYNTAQLITE_API uint32_t syntaqlite_validator_physical_table_count(
 SYNTAQLITE_API const SyntaqlitePhysicalTableAccess* syntaqlite_validator_physical_tables(
     const SyntaqliteValidator* v);
 
+// Number of views whose bodies were not available for expansion during
+// lineage resolution across all statements. A non-zero count means at
+// least one statement's lineage is Partial.
+SYNTAQLITE_API uint32_t syntaqlite_validator_unexpanded_view_count(
+    const SyntaqliteValidator* v);
+
+// Pointer to the unexpanded views array from the last analyze() call.
+// Returns NULL when the count is 0.
+SYNTAQLITE_API const SyntaqliteUnexpandedView* syntaqlite_validator_unexpanded_views(
+    const SyntaqliteValidator* v);
+
 // ---------------------------------------------------------------------------
 // Per-statement access (valid until next analyze() or destroy())
 // ---------------------------------------------------------------------------
@@ -311,6 +329,17 @@ SYNTAQLITE_API uint32_t syntaqlite_validator_statement_defined_relation_count(
 // Defined relations for statement `idx`. NULL when count is 0.
 SYNTAQLITE_API const SyntaqliteDefinedRelation*
 syntaqlite_validator_statement_defined_relations(
+    SyntaqliteValidator* v, uint32_t idx);
+
+// Number of views referenced in statement `idx` whose bodies were not
+// available for expansion during lineage resolution. A non-zero count
+// means the statement's lineage is Partial.
+SYNTAQLITE_API uint32_t syntaqlite_validator_statement_unexpanded_view_count(
+    SyntaqliteValidator* v, uint32_t idx);
+
+// Unexpanded views for statement `idx`. NULL when count is 0.
+SYNTAQLITE_API const SyntaqliteUnexpandedView*
+syntaqlite_validator_statement_unexpanded_views(
     SyntaqliteValidator* v, uint32_t idx);
 
 // Free a string returned by a syntaqlite_* function that documents

--- a/syntaqlite/include/syntaqlite/validation.h
+++ b/syntaqlite/include/syntaqlite/validation.h
@@ -89,7 +89,7 @@ typedef struct {
 // A physical table accessed by the query.
 typedef struct {
   const char* name;
-} SyntaqliteTableAccess;
+} SyntaqlitePhysicalTableAccess;
 
 // A relation defined by a DDL statement (CREATE TABLE, CREATE VIEW).
 typedef struct {
@@ -245,12 +245,12 @@ SYNTAQLITE_API const SyntaqliteRelationAccess* syntaqlite_validator_relations(
 
 // Number of physical tables accessed (after resolving CTEs/views).
 // Returns 0 if the last analyzed statement was not a query.
-SYNTAQLITE_API uint32_t syntaqlite_validator_table_count(
+SYNTAQLITE_API uint32_t syntaqlite_validator_physical_table_count(
     const SyntaqliteValidator* v);
 
 // Pointer to the table access array from the last analyze() call.
 // Returns NULL when table_count is 0.
-SYNTAQLITE_API const SyntaqliteTableAccess* syntaqlite_validator_tables(
+SYNTAQLITE_API const SyntaqlitePhysicalTableAccess* syntaqlite_validator_physical_tables(
     const SyntaqliteValidator* v);
 
 // ---------------------------------------------------------------------------
@@ -296,12 +296,12 @@ syntaqlite_validator_statement_relations(
     SyntaqliteValidator* v, uint32_t idx);
 
 // Number of physical tables accessed for statement `idx`.
-SYNTAQLITE_API uint32_t syntaqlite_validator_statement_table_count(
+SYNTAQLITE_API uint32_t syntaqlite_validator_statement_physical_table_count(
     SyntaqliteValidator* v, uint32_t idx);
 
 // Physical table access array for statement `idx`. NULL when count is 0.
-SYNTAQLITE_API const SyntaqliteTableAccess*
-syntaqlite_validator_statement_tables(
+SYNTAQLITE_API const SyntaqlitePhysicalTableAccess*
+syntaqlite_validator_statement_physical_tables(
     SyntaqliteValidator* v, uint32_t idx);
 
 // Number of relations defined by DDL in statement `idx`.

--- a/syntaqlite/src/semantic/analyzer.rs
+++ b/syntaqlite/src/semantic/analyzer.rs
@@ -4050,12 +4050,12 @@ mod lineage_tests {
         assert_eq!(rels[0].name, "users");
         assert_eq!(rels[0].kind, RelationKind::Table);
 
-        // tables_accessed
+        // physical_tables_accessed
         let tbls = model
             .statements()
             .last()
             .unwrap()
-            .tables_accessed()
+            .physical_tables_accessed()
             .unwrap()
             .into_inner();
         assert_eq!(tbls.len(), 1);
@@ -4150,7 +4150,7 @@ mod lineage_tests {
             .statements()
             .last()
             .unwrap()
-            .tables_accessed()
+            .physical_tables_accessed()
             .unwrap()
             .into_inner();
         assert!(tbls.iter().any(|t| t.name == "users"));
@@ -4203,7 +4203,7 @@ mod lineage_tests {
             .statements()
             .last()
             .unwrap()
-            .tables_accessed()
+            .physical_tables_accessed()
             .unwrap()
             .into_inner();
         assert_eq!(tbls.len(), 1);
@@ -4241,7 +4241,7 @@ mod lineage_tests {
             .statements()
             .last()
             .unwrap()
-            .tables_accessed()
+            .physical_tables_accessed()
             .unwrap()
             .into_inner();
         assert_eq!(tbls.len(), 1);
@@ -4300,6 +4300,36 @@ mod lineage_tests {
         assert_eq!(rels[0].kind, RelationKind::View);
     }
 
+    // ── Test 8b: Unexpanded view name is surfaced ────────────────────────────
+
+    #[test]
+    fn lineage_view_exposes_unexpanded_name() {
+        let mut analyzer = sqlite_analyzer();
+        let mut catalog = sqlite_catalog();
+        catalog
+            .layer_mut(CatalogLayer::Database)
+            .insert_view("active_users", Some(vec!["id".into(), "name".into()]));
+
+        let model = analyzer.analyze("SELECT id FROM active_users", &catalog, &lenient());
+
+        let unresolved = model.statements().last().unwrap().unexpanded_views();
+        assert_eq!(unresolved, ["active_users".to_string()].as_slice());
+    }
+
+    #[test]
+    fn lineage_table_has_no_unexpanded_views() {
+        let mut analyzer = sqlite_analyzer();
+        let mut catalog = sqlite_catalog();
+        catalog.layer_mut(CatalogLayer::Database).insert_table(
+            "users",
+            Some(vec!["id".into()]),
+            false,
+        );
+        let model = analyzer.analyze("SELECT id FROM users", &catalog, &lenient());
+        let unresolved = model.statements().last().unwrap().unexpanded_views();
+        assert!(unresolved.is_empty());
+    }
+
     // ── Test 9: Non-SELECT returns None ──────────────────────────────────────
 
     #[test]
@@ -4322,7 +4352,7 @@ mod lineage_tests {
                 .statements()
                 .last()
                 .unwrap()
-                .tables_accessed()
+                .physical_tables_accessed()
                 .is_none()
         );
     }

--- a/syntaqlite/src/semantic/ffi.rs
+++ b/syntaqlite/src/semantic/ffi.rs
@@ -61,7 +61,7 @@ pub struct SyntaqliteRelationAccess {
 
 /// A physical table accessed by the query.
 #[repr(C)]
-pub struct SyntaqliteTableAccess {
+pub struct SyntaqlitePhysicalTableAccess {
     pub name: *const c_char,
 }
 
@@ -81,7 +81,7 @@ struct PerStatementCache {
     diagnostics: Option<(Vec<SyntaqliteDiagnostic>, Vec<CString>)>,
     column_lineage: Option<(Vec<SyntaqliteColumnLineage>, Vec<CString>)>,
     relations: Option<(Vec<SyntaqliteRelationAccess>, Vec<CString>)>,
-    tables: Option<(Vec<SyntaqliteTableAccess>, Vec<CString>)>,
+    physical_tables: Option<(Vec<SyntaqlitePhysicalTableAccess>, Vec<CString>)>,
     defined_relations: Option<(Vec<SyntaqliteDefinedRelation>, Vec<CString>)>,
 }
 
@@ -112,7 +112,7 @@ struct ValidatorState {
     /// C-compatible relation access from the most recent `analyze()` call.
     c_relations: Vec<SyntaqliteRelationAccess>,
     /// C-compatible table access from the most recent `analyze()` call.
-    c_tables: Vec<SyntaqliteTableAccess>,
+    c_physical_tables: Vec<SyntaqlitePhysicalTableAccess>,
     /// Rendered lineage strings, kept alive for the C pointers.
     lineage_strings: Vec<CString>,
     /// The model from the most recent `analyze()` call.
@@ -166,7 +166,7 @@ fn populate_lineage(state: &mut ValidatorState, model: &SemanticModel) {
     state.lineage_strings.clear();
     state.c_column_lineage.clear();
     state.c_relations.clear();
-    state.c_tables.clear();
+    state.c_physical_tables.clear();
     state.lineage_complete = false;
 
     if let Some(lineage_result) = model.lineage() {
@@ -219,7 +219,7 @@ fn populate_lineage(state: &mut ValidatorState, model: &SemanticModel) {
         }
     }
 
-    // Aggregate relations_accessed and tables_accessed across all statements.
+    // Aggregate relations_accessed and physical_tables_accessed across all statements.
     {
         let base = state.lineage_strings.len();
         let mut rel_idx = 0;
@@ -256,7 +256,7 @@ fn populate_lineage(state: &mut ValidatorState, model: &SemanticModel) {
         let base = state.lineage_strings.len();
         let mut tbl_count = 0;
         for stmt in model.statements() {
-            if let Some(tbls_result) = stmt.tables_accessed() {
+            if let Some(tbls_result) = stmt.physical_tables_accessed() {
                 for t in tbls_result.into_inner() {
                     state
                         .lineage_strings
@@ -266,7 +266,7 @@ fn populate_lineage(state: &mut ValidatorState, model: &SemanticModel) {
             }
         }
         for i in 0..tbl_count {
-            state.c_tables.push(SyntaqliteTableAccess {
+            state.c_physical_tables.push(SyntaqlitePhysicalTableAccess {
                 name: state.lineage_strings[base + i].as_ptr(),
             });
         }
@@ -293,7 +293,7 @@ fn create_validator(dialect: AnyDialect) -> *mut SyntaqliteValidator {
         lineage_complete: false,
         c_column_lineage: Vec::new(),
         c_relations: Vec::new(),
-        c_tables: Vec::new(),
+        c_physical_tables: Vec::new(),
         lineage_strings: Vec::new(),
         last_model: None,
         per_statement_cache: Vec::new(),
@@ -844,10 +844,10 @@ pub unsafe extern "C" fn syntaqlite_validator_relations(
 /// `v` must be a valid pointer from `syntaqlite_validator_create_sqlite`.
 #[unsafe(no_mangle)]
 #[expect(clippy::cast_possible_truncation)]
-pub unsafe extern "C" fn syntaqlite_validator_table_count(v: *const SyntaqliteValidator) -> u32 {
+pub unsafe extern "C" fn syntaqlite_validator_physical_table_count(v: *const SyntaqliteValidator) -> u32 {
     // SAFETY: caller guarantees `v` is valid.
     let v = unsafe { &*v };
-    v.state().c_tables.len() as u32
+    v.state().c_physical_tables.len() as u32
 }
 
 /// Pointer to the table access array. Returns NULL when count is 0.
@@ -857,16 +857,16 @@ pub unsafe extern "C" fn syntaqlite_validator_table_count(v: *const SyntaqliteVa
 /// `v` must be a valid pointer from `syntaqlite_validator_create_sqlite`.
 /// The returned pointer is valid until the next `analyze()` or `destroy()`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn syntaqlite_validator_tables(
+pub unsafe extern "C" fn syntaqlite_validator_physical_tables(
     v: *const SyntaqliteValidator,
-) -> *const SyntaqliteTableAccess {
+) -> *const SyntaqlitePhysicalTableAccess {
     // SAFETY: caller guarantees `v` is valid.
     let v = unsafe { &*v };
     let state = v.state();
-    if state.c_tables.is_empty() {
+    if state.c_physical_tables.is_empty() {
         std::ptr::null()
     } else {
-        state.c_tables.as_ptr()
+        state.c_physical_tables.as_ptr()
     }
 }
 
@@ -992,19 +992,19 @@ fn ensure_relations<'a>(
 }
 
 /// Build C table access from a `StatementModel`.
-fn ensure_tables<'a>(
+fn ensure_physical_tables<'a>(
     cache: &'a mut PerStatementCache,
     stmt: &StatementModel,
-) -> &'a (Vec<SyntaqliteTableAccess>, Vec<CString>) {
-    cache.tables.get_or_insert_with(|| {
+) -> &'a (Vec<SyntaqlitePhysicalTableAccess>, Vec<CString>) {
+    cache.physical_tables.get_or_insert_with(|| {
         let mut strings = Vec::new();
         let mut tbls = Vec::new();
-        if let Some(result) = stmt.tables_accessed() {
+        if let Some(result) = stmt.physical_tables_accessed() {
             for t in result.into_inner() {
                 strings.push(CString::new(t.name.as_str()).unwrap_or_default());
             }
             for s in &strings {
-                tbls.push(SyntaqliteTableAccess { name: s.as_ptr() });
+                tbls.push(SyntaqlitePhysicalTableAccess { name: s.as_ptr() });
             }
         }
         (tbls, strings)
@@ -1165,7 +1165,7 @@ pub unsafe extern "C" fn syntaqlite_validator_statement_relations(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn syntaqlite_validator_statement_table_count(
+pub unsafe extern "C" fn syntaqlite_validator_statement_physical_table_count(
     v: *mut SyntaqliteValidator,
     idx: u32,
 ) -> u32 {
@@ -1173,19 +1173,19 @@ pub unsafe extern "C" fn syntaqlite_validator_statement_table_count(
     let Some((s, c)) = (unsafe { stmt_cache(v, idx) }) else {
         return 0;
     };
-    cached_slice(&ensure_tables(c, s).0).1
+    cached_slice(&ensure_physical_tables(c, s).0).1
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn syntaqlite_validator_statement_tables(
+pub unsafe extern "C" fn syntaqlite_validator_statement_physical_tables(
     v: *mut SyntaqliteValidator,
     idx: u32,
-) -> *const SyntaqliteTableAccess {
+) -> *const SyntaqlitePhysicalTableAccess {
     // SAFETY: caller guarantees `v` is valid; `stmt_cache` documents its safety requirements.
     let Some((s, c)) = (unsafe { stmt_cache(v, idx) }) else {
         return std::ptr::null();
     };
-    cached_slice(&ensure_tables(c, s).0).0
+    cached_slice(&ensure_physical_tables(c, s).0).0
 }
 
 #[unsafe(no_mangle)]
@@ -1790,8 +1790,8 @@ mod tests {
             assert!(syntaqlite_validator_column_lineage(v).is_null());
             assert_eq!(syntaqlite_validator_relation_count(v), 0);
             assert!(syntaqlite_validator_relations(v).is_null());
-            assert_eq!(syntaqlite_validator_table_count(v), 0);
-            assert!(syntaqlite_validator_tables(v).is_null());
+            assert_eq!(syntaqlite_validator_physical_table_count(v), 0);
+            assert!(syntaqlite_validator_physical_tables(v).is_null());
 
             syntaqlite_validator_destroy(v);
         }
@@ -1838,12 +1838,12 @@ mod tests {
             assert!(!rels.is_null());
 
             // Tables
-            let tbl_count = syntaqlite_validator_table_count(v);
+            let tbl_count = syntaqlite_validator_physical_table_count(v);
             assert!(
                 tbl_count >= 2,
                 "expected at least 2 tables, got {tbl_count}"
             );
-            let tbls = syntaqlite_validator_tables(v);
+            let tbls = syntaqlite_validator_physical_tables(v);
             assert!(!tbls.is_null());
 
             syntaqlite_validator_destroy(v);
@@ -2154,8 +2154,8 @@ mod tests {
             assert!(syntaqlite_validator_statement_column_lineage(v, 99).is_null());
             assert_eq!(syntaqlite_validator_statement_relation_count(v, 99), 0);
             assert!(syntaqlite_validator_statement_relations(v, 99).is_null());
-            assert_eq!(syntaqlite_validator_statement_table_count(v, 99), 0);
-            assert!(syntaqlite_validator_statement_tables(v, 99).is_null());
+            assert_eq!(syntaqlite_validator_statement_physical_table_count(v, 99), 0);
+            assert!(syntaqlite_validator_statement_physical_tables(v, 99).is_null());
             assert_eq!(
                 syntaqlite_validator_statement_defined_relation_count(v, 99),
                 0

--- a/syntaqlite/src/semantic/ffi.rs
+++ b/syntaqlite/src/semantic/ffi.rs
@@ -72,6 +72,13 @@ pub struct SyntaqliteDefinedRelation {
     pub is_view: u32,
 }
 
+/// A view whose body was not available for expansion during lineage
+/// resolution.
+#[repr(C)]
+pub struct SyntaqliteUnexpandedView {
+    pub name: *const c_char,
+}
+
 /// Lazily-cached C-compatible data for a single statement.
 /// Each field is populated on first access by the corresponding accessor
 /// function and remains valid until the next `analyze()` call.
@@ -83,6 +90,7 @@ struct PerStatementCache {
     relations: Option<(Vec<SyntaqliteRelationAccess>, Vec<CString>)>,
     physical_tables: Option<(Vec<SyntaqlitePhysicalTableAccess>, Vec<CString>)>,
     defined_relations: Option<(Vec<SyntaqliteDefinedRelation>, Vec<CString>)>,
+    unexpanded_views: Option<(Vec<SyntaqliteUnexpandedView>, Vec<CString>)>,
 }
 
 /// Opaque validator handle exposed to C.
@@ -113,6 +121,8 @@ struct ValidatorState {
     c_relations: Vec<SyntaqliteRelationAccess>,
     /// C-compatible table access from the most recent `analyze()` call.
     c_physical_tables: Vec<SyntaqlitePhysicalTableAccess>,
+    /// C-compatible unexpanded views from the most recent `analyze()` call.
+    c_unexpanded_views: Vec<SyntaqliteUnexpandedView>,
     /// Rendered lineage strings, kept alive for the C pointers.
     lineage_strings: Vec<CString>,
     /// The model from the most recent `analyze()` call.
@@ -162,11 +172,13 @@ fn severity_to_c(s: Severity) -> u32 {
 use super::model::SemanticModel;
 
 /// Populate lineage C structs from the analysis model.
+#[expect(clippy::too_many_lines)]
 fn populate_lineage(state: &mut ValidatorState, model: &SemanticModel) {
     state.lineage_strings.clear();
     state.c_column_lineage.clear();
     state.c_relations.clear();
     state.c_physical_tables.clear();
+    state.c_unexpanded_views.clear();
     state.lineage_complete = false;
 
     if let Some(lineage_result) = model.lineage() {
@@ -271,6 +283,24 @@ fn populate_lineage(state: &mut ValidatorState, model: &SemanticModel) {
             });
         }
     }
+
+    {
+        let base = state.lineage_strings.len();
+        let mut view_count = 0;
+        for stmt in model.statements() {
+            for view in stmt.unexpanded_views() {
+                state
+                    .lineage_strings
+                    .push(CString::new(view.as_str()).unwrap_or_default());
+                view_count += 1;
+            }
+        }
+        for i in 0..view_count {
+            state.c_unexpanded_views.push(SyntaqliteUnexpandedView {
+                name: state.lineage_strings[base + i].as_ptr(),
+            });
+        }
+    }
 }
 
 // ── Exported C functions ────────────────────────────────────────────────────
@@ -294,6 +324,7 @@ fn create_validator(dialect: AnyDialect) -> *mut SyntaqliteValidator {
         c_column_lineage: Vec::new(),
         c_relations: Vec::new(),
         c_physical_tables: Vec::new(),
+        c_unexpanded_views: Vec::new(),
         lineage_strings: Vec::new(),
         last_model: None,
         per_statement_cache: Vec::new(),
@@ -844,7 +875,9 @@ pub unsafe extern "C" fn syntaqlite_validator_relations(
 /// `v` must be a valid pointer from `syntaqlite_validator_create_sqlite`.
 #[unsafe(no_mangle)]
 #[expect(clippy::cast_possible_truncation)]
-pub unsafe extern "C" fn syntaqlite_validator_physical_table_count(v: *const SyntaqliteValidator) -> u32 {
+pub unsafe extern "C" fn syntaqlite_validator_physical_table_count(
+    v: *const SyntaqliteValidator,
+) -> u32 {
     // SAFETY: caller guarantees `v` is valid.
     let v = unsafe { &*v };
     v.state().c_physical_tables.len() as u32
@@ -867,6 +900,43 @@ pub unsafe extern "C" fn syntaqlite_validator_physical_tables(
         std::ptr::null()
     } else {
         state.c_physical_tables.as_ptr()
+    }
+}
+
+/// Number of views whose bodies were not available for expansion during
+/// lineage resolution across all statements. A non-zero count means at
+/// least one statement had a Partial lineage result.
+///
+/// # Safety
+///
+/// `v` must be a valid pointer from `syntaqlite_validator_create_sqlite`.
+#[unsafe(no_mangle)]
+#[expect(clippy::cast_possible_truncation)]
+pub unsafe extern "C" fn syntaqlite_validator_unexpanded_view_count(
+    v: *const SyntaqliteValidator,
+) -> u32 {
+    // SAFETY: caller guarantees `v` is valid.
+    let v = unsafe { &*v };
+    v.state().c_unexpanded_views.len() as u32
+}
+
+/// Pointer to the unexpanded views array. Returns NULL when count is 0.
+///
+/// # Safety
+///
+/// `v` must be a valid pointer from `syntaqlite_validator_create_sqlite`.
+/// The returned pointer is valid until the next `analyze()` or `destroy()`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn syntaqlite_validator_unexpanded_views(
+    v: *const SyntaqliteValidator,
+) -> *const SyntaqliteUnexpandedView {
+    // SAFETY: caller guarantees `v` is valid.
+    let v = unsafe { &*v };
+    let state = v.state();
+    if state.c_unexpanded_views.is_empty() {
+        std::ptr::null()
+    } else {
+        state.c_unexpanded_views.as_ptr()
     }
 }
 
@@ -1030,6 +1100,25 @@ fn ensure_defined_relations<'a>(
             });
         }
         (defs, strings)
+    })
+}
+
+/// Build C unexpanded views from a `StatementModel`.
+fn ensure_unexpanded_views<'a>(
+    cache: &'a mut PerStatementCache,
+    stmt: &StatementModel,
+) -> &'a (Vec<SyntaqliteUnexpandedView>, Vec<CString>) {
+    cache.unexpanded_views.get_or_insert_with(|| {
+        let strings: Vec<CString> = stmt
+            .unexpanded_views()
+            .iter()
+            .map(|v| CString::new(v.as_str()).unwrap_or_default())
+            .collect();
+        let views = strings
+            .iter()
+            .map(|s| SyntaqliteUnexpandedView { name: s.as_ptr() })
+            .collect();
+        (views, strings)
     })
 }
 
@@ -1210,6 +1299,42 @@ pub unsafe extern "C" fn syntaqlite_validator_statement_defined_relations(
         return std::ptr::null();
     };
     cached_slice(&ensure_defined_relations(c, s).0).0
+}
+
+/// Number of views referenced in statement `idx` whose bodies were not
+/// available for expansion. A non-zero count means lineage is Partial.
+///
+/// # Safety
+///
+/// `v` must be a valid pointer from `syntaqlite_validator_create_*`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn syntaqlite_validator_statement_unexpanded_view_count(
+    v: *mut SyntaqliteValidator,
+    idx: u32,
+) -> u32 {
+    // SAFETY: caller guarantees `v` is valid; `stmt_cache` documents its safety requirements.
+    let Some((s, c)) = (unsafe { stmt_cache(v, idx) }) else {
+        return 0;
+    };
+    cached_slice(&ensure_unexpanded_views(c, s).0).1
+}
+
+/// Unexpanded views for statement `idx`. NULL when count is 0.
+///
+/// # Safety
+///
+/// `v` must be a valid pointer from `syntaqlite_validator_create_*`.
+/// Returned pointer is valid until the next `analyze()` or `destroy()`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn syntaqlite_validator_statement_unexpanded_views(
+    v: *mut SyntaqliteValidator,
+    idx: u32,
+) -> *const SyntaqliteUnexpandedView {
+    // SAFETY: caller guarantees `v` is valid; `stmt_cache` documents its safety requirements.
+    let Some((s, c)) = (unsafe { stmt_cache(v, idx) }) else {
+        return std::ptr::null();
+    };
+    cached_slice(&ensure_unexpanded_views(c, s).0).0
 }
 
 /// Free a string returned by `syntaqlite_string_*` functions.
@@ -1916,6 +2041,13 @@ mod tests {
                 "view lineage should be partial"
             );
 
+            let view_count = syntaqlite_validator_statement_unexpanded_view_count(v, 0);
+            assert_eq!(view_count, 1, "one unexpanded view expected");
+            let views = syntaqlite_validator_statement_unexpanded_views(v, 0);
+            assert!(!views.is_null());
+            let first = &*views;
+            assert_eq!(CStr::from_ptr(first.name).to_str().unwrap(), "active_users",);
+
             syntaqlite_validator_destroy(v);
         }
     }
@@ -2154,7 +2286,10 @@ mod tests {
             assert!(syntaqlite_validator_statement_column_lineage(v, 99).is_null());
             assert_eq!(syntaqlite_validator_statement_relation_count(v, 99), 0);
             assert!(syntaqlite_validator_statement_relations(v, 99).is_null());
-            assert_eq!(syntaqlite_validator_statement_physical_table_count(v, 99), 0);
+            assert_eq!(
+                syntaqlite_validator_statement_physical_table_count(v, 99),
+                0
+            );
             assert!(syntaqlite_validator_statement_physical_tables(v, 99).is_null());
             assert_eq!(
                 syntaqlite_validator_statement_defined_relation_count(v, 99),

--- a/syntaqlite/src/semantic/lineage/mod.rs
+++ b/syntaqlite/src/semantic/lineage/mod.rs
@@ -11,7 +11,7 @@ mod types;
 
 pub(crate) use types::QueryLineage;
 pub use types::{
-    ColumnLineage, ColumnOrigin, LineageResult, RelationAccess, RelationKind, TableAccess,
+    ColumnLineage, ColumnOrigin, LineageResult, PhysicalTableAccess, RelationAccess, RelationKind,
 };
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement};

--- a/syntaqlite/src/semantic/lineage/resolver.rs
+++ b/syntaqlite/src/semantic/lineage/resolver.rs
@@ -11,7 +11,7 @@ use crate::dialect::SemanticRole;
 use crate::semantic::catalog::Catalog;
 
 use super::types::{
-    ColumnLineage, ColumnOrigin, QueryLineage, RelationAccess, RelationKind, TableAccess,
+    ColumnLineage, ColumnOrigin, PhysicalTableAccess, QueryLineage, RelationAccess, RelationKind,
 };
 
 /// What kind of FROM source this is.
@@ -176,9 +176,10 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
         // 2. Resolve result columns.
         let columns = self.resolve_result_columns(select_id, cols_idx, &sources)?;
 
-        // 3. Build relations (catalog only) and tables (physical, transitive).
+        // 3. Build relations (catalog only) and physical_tables (transitive).
         let mut relations = Vec::new();
-        let mut tables = Vec::new();
+        let mut physical_tables = Vec::new();
+        let mut unexpanded_views = Vec::new();
         for info in sources.values() {
             match info.kind {
                 SourceKind::Table => {
@@ -186,7 +187,7 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
                         name: info.canonical.clone(),
                         kind: RelationKind::Table,
                     });
-                    tables.push(TableAccess {
+                    physical_tables.push(PhysicalTableAccess {
                         name: info.canonical.clone(),
                     });
                 }
@@ -195,14 +196,20 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
                         name: info.canonical.clone(),
                         kind: RelationKind::View,
                     });
-                    tables.push(TableAccess {
+                    physical_tables.push(PhysicalTableAccess {
                         name: info.canonical.clone(),
                     });
+                    unexpanded_views.push(info.canonical.clone());
                     self.complete = false;
                 }
                 SourceKind::Cte(body) | SourceKind::Subquery(body) => {
                     if self.tracing.insert(body) {
-                        self.collect_physical_tables(body, &mut relations, &mut tables);
+                        self.collect_physical_tables(
+                            body,
+                            &mut relations,
+                            &mut physical_tables,
+                            &mut unexpanded_views,
+                        );
                         self.tracing.remove(&body);
                     }
                 }
@@ -211,14 +218,17 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
 
         relations.sort_by(|a, b| a.name.cmp(&b.name));
         relations.dedup_by(|a, b| a.name == b.name);
-        tables.sort_by(|a, b| a.name.cmp(&b.name));
-        tables.dedup_by(|a, b| a.name == b.name);
+        physical_tables.sort_by(|a, b| a.name.cmp(&b.name));
+        physical_tables.dedup_by(|a, b| a.name == b.name);
+        unexpanded_views.sort();
+        unexpanded_views.dedup();
 
         Some(QueryLineage {
             complete: self.complete,
             columns,
             relations,
-            tables,
+            physical_tables,
+            unexpanded_views,
         })
     }
 
@@ -298,7 +308,8 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
         &mut self,
         body_id: AnyNodeId,
         relations: &mut Vec<RelationAccess>,
-        tables: &mut Vec<TableAccess>,
+        physical_tables: &mut Vec<PhysicalTableAccess>,
+        unexpanded_views: &mut Vec<String>,
     ) {
         let Some(select_id) = self.find_select_node(body_id) else {
             return;
@@ -322,7 +333,7 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
                         name: info.canonical.clone(),
                         kind: RelationKind::Table,
                     });
-                    tables.push(TableAccess {
+                    physical_tables.push(PhysicalTableAccess {
                         name: info.canonical.clone(),
                     });
                 }
@@ -331,14 +342,20 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
                         name: info.canonical.clone(),
                         kind: RelationKind::View,
                     });
-                    tables.push(TableAccess {
+                    physical_tables.push(PhysicalTableAccess {
                         name: info.canonical.clone(),
                     });
+                    unexpanded_views.push(info.canonical.clone());
                     self.complete = false;
                 }
                 SourceKind::Cte(body) | SourceKind::Subquery(body) => {
                     if self.tracing.insert(body) {
-                        self.collect_physical_tables(body, relations, tables);
+                        self.collect_physical_tables(
+                            body,
+                            relations,
+                            physical_tables,
+                            unexpanded_views,
+                        );
                         self.tracing.remove(&body);
                     }
                 }

--- a/syntaqlite/src/semantic/lineage/types.rs
+++ b/syntaqlite/src/semantic/lineage/types.rs
@@ -89,7 +89,7 @@ pub struct RelationAccess {
 
 /// A physical table accessed by the query (after resolving CTEs and subqueries).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TableAccess {
+pub struct PhysicalTableAccess {
     /// The physical table name.
     pub name: String,
 }
@@ -104,5 +104,8 @@ pub(crate) struct QueryLineage {
     /// Relations referenced directly in FROM clauses.
     pub(crate) relations: Vec<RelationAccess>,
     /// Physical tables accessed (after resolving CTEs/subqueries/views).
-    pub(crate) tables: Vec<TableAccess>,
+    pub(crate) physical_tables: Vec<PhysicalTableAccess>,
+    /// Canonical names of views that could not be expanded because no body
+    /// was available. Sorted and deduplicated.
+    pub(crate) unexpanded_views: Vec<String>,
 }

--- a/syntaqlite/src/semantic/mod.rs
+++ b/syntaqlite/src/semantic/mod.rs
@@ -72,7 +72,7 @@ pub use diagnostics::{Diagnostic, DiagnosticMessage, Help, Severity};
 #[doc(inline)]
 #[cfg(feature = "validation")]
 pub use lineage::{
-    ColumnLineage, ColumnOrigin, LineageResult, RelationAccess, RelationKind, TableAccess,
+    ColumnLineage, ColumnOrigin, LineageResult, PhysicalTableAccess, RelationAccess, RelationKind,
 };
 #[doc(inline)]
 #[cfg(feature = "validation")]

--- a/syntaqlite/src/semantic/model.rs
+++ b/syntaqlite/src/semantic/model.rs
@@ -12,7 +12,9 @@ use syntaqlite_syntax::any::{AnyTokenType, TokenCategory};
 use std::collections::HashMap;
 
 use super::diagnostics::Diagnostic;
-use super::lineage::{ColumnLineage, LineageResult, QueryLineage, RelationAccess, TableAccess};
+use super::lineage::{
+    ColumnLineage, LineageResult, PhysicalTableAccess, QueryLineage, RelationAccess,
+};
 
 // ── Stored per-statement positions ───────────────────────────────────────────
 
@@ -228,12 +230,12 @@ impl StatementModel {
     /// subqueries, views).
     ///
     /// Returns `None` if this statement did not contain a query body.
-    pub fn tables_accessed(&self) -> Option<LineageResult<&[TableAccess]>> {
+    pub fn physical_tables_accessed(&self) -> Option<LineageResult<&[PhysicalTableAccess]>> {
         self.lineage.as_ref().map(|ql| {
             if ql.complete {
-                LineageResult::Complete(ql.tables.as_slice())
+                LineageResult::Complete(ql.physical_tables.as_slice())
             } else {
-                LineageResult::Partial(ql.tables.as_slice())
+                LineageResult::Partial(ql.physical_tables.as_slice())
             }
         })
     }
@@ -241,6 +243,15 @@ impl StatementModel {
     /// Relations defined by this DDL statement (e.g. `CREATE TABLE`, `CREATE VIEW`).
     pub fn defined_relations(&self) -> &[DefinedRelation] {
         &self.defined_relations
+    }
+
+    /// Canonical names of views referenced in this statement whose bodies
+    /// could not be expanded (no DDL available). Empty when all sources were
+    /// fully resolved or when the statement is not a query.
+    pub fn unexpanded_views(&self) -> &[String] {
+        self.lineage
+            .as_ref()
+            .map_or(&[], |ql| ql.unexpanded_views.as_slice())
     }
 }
 

--- a/tests/lineage_diff_tests/__init__.py
+++ b/tests/lineage_diff_tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.

--- a/tests/lineage_diff_tests/ctas.py
+++ b/tests/lineage_diff_tests/ctas.py
@@ -14,8 +14,25 @@ class Ctas(TestSuite):
                 "CREATE TABLE scratch AS SELECT name FROM users;\n"
             ),
             out="""\
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"users","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":{"name":"scratch","kind":"table"},"columns":[{"name":"name","index":0,"origin":{"table":"users","column":"name"}}],"relations":[{"name":"users","kind":"table"}],"physical_tables":[{"name":"users"}]}
+            Lineage
+              statement: 0
+              status: complete
+              target: users (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 1
+              status: complete
+              target: scratch (table)
+              columns:
+                name <- users.name
+              relations:
+                users (table)
+              physical_tables:
+                users
+              partial_reasons: (none)
 """,
         )
 
@@ -31,8 +48,35 @@ class Ctas(TestSuite):
                 "SELECT name FROM scratch;\n"
             ),
             out="""\
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"users","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":{"name":"scratch","kind":"table"},"columns":[{"name":"name","index":0,"origin":{"table":"users","column":"name"}}],"relations":[{"name":"users","kind":"table"}],"physical_tables":[{"name":"users"}]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":2,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"name","index":0,"origin":{"table":"scratch","column":"name"}}],"relations":[{"name":"scratch","kind":"table"}],"physical_tables":[{"name":"scratch"}]}
+            Lineage
+              statement: 0
+              status: complete
+              target: users (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 1
+              status: complete
+              target: scratch (table)
+              columns:
+                name <- users.name
+              relations:
+                users (table)
+              physical_tables:
+                users
+              partial_reasons: (none)
+            Lineage
+              statement: 2
+              status: complete
+              target: (none)
+              columns:
+                name <- scratch.name
+              relations:
+                scratch (table)
+              physical_tables:
+                scratch
+              partial_reasons: (none)
 """,
         )

--- a/tests/lineage_diff_tests/ctas.py
+++ b/tests/lineage_diff_tests/ctas.py
@@ -1,0 +1,38 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Lineage tests: CREATE TABLE AS SELECT — target + body lineage."""
+
+from python.dev.diff_tests.testing import DiffTestBlueprint, TestSuite
+
+
+class Ctas(TestSuite):
+    def test_ctas_target_and_sources(self):
+        return DiffTestBlueprint(
+            sql=(
+                "CREATE TABLE users (id INTEGER, name TEXT);\n"
+                "CREATE TABLE scratch AS SELECT name FROM users;\n"
+            ),
+            out="""\
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"users","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":{"name":"scratch","kind":"table"},"columns":[{"name":"name","index":0,"origin":{"table":"users","column":"name"}}],"relations":[{"name":"users","kind":"table"}],"physical_tables":[{"name":"users"}]}
+""",
+        )
+
+    def test_temp_table_is_opaque_boundary(self):
+        """A temp table created inline is a materialization boundary.
+
+        Reads from it stop there rather than chaining back to the source.
+        """
+        return DiffTestBlueprint(
+            sql=(
+                "CREATE TABLE users (id INTEGER, name TEXT);\n"
+                "CREATE TEMP TABLE scratch AS SELECT name FROM users;\n"
+                "SELECT name FROM scratch;\n"
+            ),
+            out="""\
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"users","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":{"name":"scratch","kind":"table"},"columns":[{"name":"name","index":0,"origin":{"table":"users","column":"name"}}],"relations":[{"name":"users","kind":"table"}],"physical_tables":[{"name":"users"}]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":2,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"name","index":0,"origin":{"table":"scratch","column":"name"}}],"relations":[{"name":"scratch","kind":"table"}],"physical_tables":[{"name":"scratch"}]}
+""",
+        )

--- a/tests/lineage_diff_tests/cte.py
+++ b/tests/lineage_diff_tests/cte.py
@@ -14,8 +14,25 @@ class Cte(TestSuite):
                 "WITH u AS (SELECT id, name FROM users) SELECT name FROM u;\n"
             ),
             out="""\
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"users","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"name","index":0,"origin":{"table":"users","column":"name"}}],"relations":[{"name":"users","kind":"table"}],"physical_tables":[{"name":"users"}]}
+            Lineage
+              statement: 0
+              status: complete
+              target: users (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 1
+              status: complete
+              target: (none)
+              columns:
+                name <- users.name
+              relations:
+                users (table)
+              physical_tables:
+                users
+              partial_reasons: (none)
 """,
         )
 
@@ -26,7 +43,24 @@ class Cte(TestSuite):
                 "WITH c(renamed) AS (SELECT a FROM t) SELECT renamed FROM c;\n"
             ),
             out="""\
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"t","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"renamed","index":0,"origin":null}],"relations":[{"name":"t","kind":"table"}],"physical_tables":[{"name":"t"}]}
+            Lineage
+              statement: 0
+              status: complete
+              target: t (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 1
+              status: complete
+              target: (none)
+              columns:
+                renamed <- (transformed)
+              relations:
+                t (table)
+              physical_tables:
+                t
+              partial_reasons: (none)
 """,
         )

--- a/tests/lineage_diff_tests/cte.py
+++ b/tests/lineage_diff_tests/cte.py
@@ -1,0 +1,32 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Lineage tests: CTEs are transparent — origin traces through to base tables."""
+
+from python.dev.diff_tests.testing import DiffTestBlueprint, TestSuite
+
+
+class Cte(TestSuite):
+    def test_cte_single_reference(self):
+        return DiffTestBlueprint(
+            sql=(
+                "CREATE TABLE users (id INTEGER, name TEXT);\n"
+                "WITH u AS (SELECT id, name FROM users) SELECT name FROM u;\n"
+            ),
+            out="""\
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"users","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"name","index":0,"origin":{"table":"users","column":"name"}}],"relations":[{"name":"users","kind":"table"}],"physical_tables":[{"name":"users"}]}
+""",
+        )
+
+    def test_cte_rename_passthrough(self):
+        return DiffTestBlueprint(
+            sql=(
+                "CREATE TABLE t (a INTEGER);\n"
+                "WITH c(renamed) AS (SELECT a FROM t) SELECT renamed FROM c;\n"
+            ),
+            out="""\
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"t","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"renamed","index":0,"origin":null}],"relations":[{"name":"t","kind":"table"}],"physical_tables":[{"name":"t"}]}
+""",
+        )

--- a/tests/lineage_diff_tests/direct.py
+++ b/tests/lineage_diff_tests/direct.py
@@ -1,0 +1,37 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Lineage tests: direct column references."""
+
+from python.dev.diff_tests.testing import DiffTestBlueprint, TestSuite
+
+
+class Direct(TestSuite):
+    """Direct column reference lineage."""
+
+    def test_single_column(self):
+        return DiffTestBlueprint(
+            sql="CREATE TABLE users (id INTEGER, name TEXT);\nSELECT name FROM users;\n",
+            out="""\
+{"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"users","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+{"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"name","index":0,"origin":{"table":"users","column":"name"}}],"relations":[{"name":"users","kind":"table"}],"physical_tables":[{"name":"users"}]}
+""",
+        )
+
+    def test_multiple_columns(self):
+        return DiffTestBlueprint(
+            sql="CREATE TABLE users (id INTEGER, name TEXT);\nSELECT id, name FROM users;\n",
+            out="""\
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"users","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"id","index":0,"origin":{"table":"users","column":"id"}},{"name":"name","index":1,"origin":{"table":"users","column":"name"}}],"relations":[{"name":"users","kind":"table"}],"physical_tables":[{"name":"users"}]}
+""",
+        )
+
+    def test_alias_is_passthrough(self):
+        return DiffTestBlueprint(
+            sql="CREATE TABLE t (a INTEGER);\nSELECT a AS aa FROM t;\n",
+            out="""\
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"t","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"aa","index":0,"origin":{"table":"t","column":"a"}}],"relations":[{"name":"t","kind":"table"}],"physical_tables":[{"name":"t"}]}
+""",
+        )

--- a/tests/lineage_diff_tests/direct.py
+++ b/tests/lineage_diff_tests/direct.py
@@ -13,8 +13,25 @@ class Direct(TestSuite):
         return DiffTestBlueprint(
             sql="CREATE TABLE users (id INTEGER, name TEXT);\nSELECT name FROM users;\n",
             out="""\
-{"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"users","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-{"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"name","index":0,"origin":{"table":"users","column":"name"}}],"relations":[{"name":"users","kind":"table"}],"physical_tables":[{"name":"users"}]}
+            Lineage
+              statement: 0
+              status: complete
+              target: users (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 1
+              status: complete
+              target: (none)
+              columns:
+                name <- users.name
+              relations:
+                users (table)
+              physical_tables:
+                users
+              partial_reasons: (none)
 """,
         )
 
@@ -22,8 +39,26 @@ class Direct(TestSuite):
         return DiffTestBlueprint(
             sql="CREATE TABLE users (id INTEGER, name TEXT);\nSELECT id, name FROM users;\n",
             out="""\
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"users","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"id","index":0,"origin":{"table":"users","column":"id"}},{"name":"name","index":1,"origin":{"table":"users","column":"name"}}],"relations":[{"name":"users","kind":"table"}],"physical_tables":[{"name":"users"}]}
+            Lineage
+              statement: 0
+              status: complete
+              target: users (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 1
+              status: complete
+              target: (none)
+              columns:
+                id <- users.id
+                name <- users.name
+              relations:
+                users (table)
+              physical_tables:
+                users
+              partial_reasons: (none)
 """,
         )
 
@@ -31,7 +66,24 @@ class Direct(TestSuite):
         return DiffTestBlueprint(
             sql="CREATE TABLE t (a INTEGER);\nSELECT a AS aa FROM t;\n",
             out="""\
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"t","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"aa","index":0,"origin":{"table":"t","column":"a"}}],"relations":[{"name":"t","kind":"table"}],"physical_tables":[{"name":"t"}]}
+            Lineage
+              statement: 0
+              status: complete
+              target: t (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 1
+              status: complete
+              target: (none)
+              columns:
+                aa <- t.a
+              relations:
+                t (table)
+              physical_tables:
+                t
+              partial_reasons: (none)
 """,
         )

--- a/tests/lineage_diff_tests/errors.py
+++ b/tests/lineage_diff_tests/errors.py
@@ -11,6 +11,9 @@ class Errors(TestSuite):
         return DiffTestBlueprint(
             sql="SELECT FROM;\n",
             out="""\
-            {"kind":"error","schema_version":0,"file":"<stdin>","statement_index":0,"stage":"parse","message":"syntax error near 'FROM'"}
+            Error
+              statement: 0
+              stage: parse
+              message: syntax error near 'FROM'
 """,
         )

--- a/tests/lineage_diff_tests/errors.py
+++ b/tests/lineage_diff_tests/errors.py
@@ -1,0 +1,16 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Lineage tests: error records (parse + validation failures)."""
+
+from python.dev.diff_tests.testing import DiffTestBlueprint, TestSuite
+
+
+class Errors(TestSuite):
+    def test_parse_error_emits_error_record(self):
+        return DiffTestBlueprint(
+            sql="SELECT FROM;\n",
+            out="""\
+            {"kind":"error","schema_version":0,"file":"<stdin>","statement_index":0,"stage":"parse","message":"syntax error near 'FROM'"}
+""",
+        )

--- a/tests/lineage_diff_tests/expressions.py
+++ b/tests/lineage_diff_tests/expressions.py
@@ -13,8 +13,25 @@ class Expressions(TestSuite):
         return DiffTestBlueprint(
             sql="CREATE TABLE t (a INTEGER, b INTEGER);\nSELECT a + b FROM t;\n",
             out="""\
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"t","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"a + b","index":0,"origin":null}],"relations":[{"name":"t","kind":"table"}],"physical_tables":[{"name":"t"}]}
+            Lineage
+              statement: 0
+              status: complete
+              target: t (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 1
+              status: complete
+              target: (none)
+              columns:
+                a + b <- (transformed)
+              relations:
+                t (table)
+              physical_tables:
+                t
+              partial_reasons: (none)
 """,
         )
 
@@ -22,8 +39,25 @@ class Expressions(TestSuite):
         return DiffTestBlueprint(
             sql="CREATE TABLE t (a INTEGER);\nSELECT CAST(a AS TEXT) FROM t;\n",
             out="""\
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"t","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"a as text","index":0,"origin":null}],"relations":[{"name":"t","kind":"table"}],"physical_tables":[{"name":"t"}]}
+            Lineage
+              statement: 0
+              status: complete
+              target: t (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 1
+              status: complete
+              target: (none)
+              columns:
+                a as text <- (transformed)
+              relations:
+                t (table)
+              physical_tables:
+                t
+              partial_reasons: (none)
 """,
         )
 
@@ -31,8 +65,25 @@ class Expressions(TestSuite):
         return DiffTestBlueprint(
             sql="CREATE TABLE t (a INTEGER);\nSELECT SUM(a) FROM t;\n",
             out="""\
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"t","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"sum(a","index":0,"origin":null}],"relations":[{"name":"t","kind":"table"}],"physical_tables":[{"name":"t"}]}
+            Lineage
+              statement: 0
+              status: complete
+              target: t (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 1
+              status: complete
+              target: (none)
+              columns:
+                sum(a <- (transformed)
+              relations:
+                t (table)
+              physical_tables:
+                t
+              partial_reasons: (none)
 """,
         )
 
@@ -40,6 +91,15 @@ class Expressions(TestSuite):
         return DiffTestBlueprint(
             sql="SELECT 1 AS x, 'lit' AS y;\n",
             out="""\
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"x","index":0,"origin":null},{"name":"y","index":1,"origin":null}],"relations":[],"physical_tables":[]}
+            Lineage
+              statement: 0
+              status: complete
+              target: (none)
+              columns:
+                x <- (transformed)
+                y <- (transformed)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
 """,
         )

--- a/tests/lineage_diff_tests/expressions.py
+++ b/tests/lineage_diff_tests/expressions.py
@@ -1,0 +1,45 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Lineage tests: transformed columns have origin=null."""
+
+from python.dev.diff_tests.testing import DiffTestBlueprint, TestSuite
+
+
+class Expressions(TestSuite):
+    """Expression-produced columns carry no origin."""
+
+    def test_arithmetic_has_no_origin(self):
+        return DiffTestBlueprint(
+            sql="CREATE TABLE t (a INTEGER, b INTEGER);\nSELECT a + b FROM t;\n",
+            out="""\
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"t","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"a + b","index":0,"origin":null}],"relations":[{"name":"t","kind":"table"}],"physical_tables":[{"name":"t"}]}
+""",
+        )
+
+    def test_cast_has_no_origin(self):
+        return DiffTestBlueprint(
+            sql="CREATE TABLE t (a INTEGER);\nSELECT CAST(a AS TEXT) FROM t;\n",
+            out="""\
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"t","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"a as text","index":0,"origin":null}],"relations":[{"name":"t","kind":"table"}],"physical_tables":[{"name":"t"}]}
+""",
+        )
+
+    def test_aggregate_has_no_origin(self):
+        return DiffTestBlueprint(
+            sql="CREATE TABLE t (a INTEGER);\nSELECT SUM(a) FROM t;\n",
+            out="""\
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"t","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"sum(a","index":0,"origin":null}],"relations":[{"name":"t","kind":"table"}],"physical_tables":[{"name":"t"}]}
+""",
+        )
+
+    def test_literal_has_no_origin(self):
+        return DiffTestBlueprint(
+            sql="SELECT 1 AS x, 'lit' AS y;\n",
+            out="""\
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"x","index":0,"origin":null},{"name":"y","index":1,"origin":null}],"relations":[],"physical_tables":[]}
+""",
+        )

--- a/tests/lineage_diff_tests/joins.py
+++ b/tests/lineage_diff_tests/joins.py
@@ -1,0 +1,36 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Lineage tests: joins trace origins through each joined source."""
+
+from python.dev.diff_tests.testing import DiffTestBlueprint, TestSuite
+
+
+class Joins(TestSuite):
+    def test_inner_join_qualified(self):
+        return DiffTestBlueprint(
+            sql=(
+                "CREATE TABLE users (id INTEGER, name TEXT);\n"
+                "CREATE TABLE orders (id INTEGER, user_id INTEGER);\n"
+                "SELECT users.name, orders.id FROM users JOIN orders ON users.id = orders.user_id;\n"
+            ),
+            out="""\
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"users","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":{"name":"orders","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":2,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"name","index":0,"origin":{"table":"users","column":"name"}},{"name":"id","index":1,"origin":{"table":"orders","column":"id"}}],"relations":[{"name":"orders","kind":"table"},{"name":"users","kind":"table"}],"physical_tables":[{"name":"orders"},{"name":"users"}]}
+""",
+        )
+
+    def test_two_table_relations(self):
+        return DiffTestBlueprint(
+            sql=(
+                "CREATE TABLE a (x INTEGER);\n"
+                "CREATE TABLE b (y INTEGER);\n"
+                "SELECT a.x, b.y FROM a, b;\n"
+            ),
+            out="""\
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"a","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":{"name":"b","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":2,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"x","index":0,"origin":{"table":"a","column":"x"}},{"name":"y","index":1,"origin":{"table":"b","column":"y"}}],"relations":[{"name":"a","kind":"table"},{"name":"b","kind":"table"}],"physical_tables":[{"name":"a"},{"name":"b"}]}
+""",
+        )

--- a/tests/lineage_diff_tests/joins.py
+++ b/tests/lineage_diff_tests/joins.py
@@ -15,9 +15,36 @@ class Joins(TestSuite):
                 "SELECT users.name, orders.id FROM users JOIN orders ON users.id = orders.user_id;\n"
             ),
             out="""\
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"users","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":{"name":"orders","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":2,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"name","index":0,"origin":{"table":"users","column":"name"}},{"name":"id","index":1,"origin":{"table":"orders","column":"id"}}],"relations":[{"name":"orders","kind":"table"},{"name":"users","kind":"table"}],"physical_tables":[{"name":"orders"},{"name":"users"}]}
+            Lineage
+              statement: 0
+              status: complete
+              target: users (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 1
+              status: complete
+              target: orders (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 2
+              status: complete
+              target: (none)
+              columns:
+                name <- users.name
+                id <- orders.id
+              relations:
+                orders (table)
+                users (table)
+              physical_tables:
+                orders
+                users
+              partial_reasons: (none)
 """,
         )
 
@@ -29,8 +56,35 @@ class Joins(TestSuite):
                 "SELECT a.x, b.y FROM a, b;\n"
             ),
             out="""\
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"a","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":{"name":"b","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":2,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"x","index":0,"origin":{"table":"a","column":"x"}},{"name":"y","index":1,"origin":{"table":"b","column":"y"}}],"relations":[{"name":"a","kind":"table"},{"name":"b","kind":"table"}],"physical_tables":[{"name":"a"},{"name":"b"}]}
+            Lineage
+              statement: 0
+              status: complete
+              target: a (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 1
+              status: complete
+              target: b (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 2
+              status: complete
+              target: (none)
+              columns:
+                x <- a.x
+                y <- b.y
+              relations:
+                a (table)
+                b (table)
+              physical_tables:
+                a
+                b
+              partial_reasons: (none)
 """,
         )

--- a/tests/lineage_diff_tests/star.py
+++ b/tests/lineage_diff_tests/star.py
@@ -1,0 +1,20 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Lineage tests: SELECT * expansion."""
+
+from python.dev.diff_tests.testing import DiffTestBlueprint, TestSuite
+
+
+class Star(TestSuite):
+    def test_star_expands_to_each_column(self):
+        return DiffTestBlueprint(
+            sql=(
+                "CREATE TABLE users (id INTEGER, name TEXT);\n"
+                "SELECT * FROM users;\n"
+            ),
+            out="""\
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"users","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"id","index":0,"origin":{"table":"users","column":"id"}},{"name":"name","index":1,"origin":{"table":"users","column":"name"}}],"relations":[{"name":"users","kind":"table"}],"physical_tables":[{"name":"users"}]}
+""",
+        )

--- a/tests/lineage_diff_tests/star.py
+++ b/tests/lineage_diff_tests/star.py
@@ -14,7 +14,25 @@ class Star(TestSuite):
                 "SELECT * FROM users;\n"
             ),
             out="""\
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"users","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"id","index":0,"origin":{"table":"users","column":"id"}},{"name":"name","index":1,"origin":{"table":"users","column":"name"}}],"relations":[{"name":"users","kind":"table"}],"physical_tables":[{"name":"users"}]}
+            Lineage
+              statement: 0
+              status: complete
+              target: users (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 1
+              status: complete
+              target: (none)
+              columns:
+                id <- users.id
+                name <- users.name
+              relations:
+                users (table)
+              physical_tables:
+                users
+              partial_reasons: (none)
 """,
         )

--- a/tests/lineage_diff_tests/union.py
+++ b/tests/lineage_diff_tests/union.py
@@ -15,8 +15,32 @@ class Union(TestSuite):
                 "SELECT x FROM a UNION ALL SELECT y FROM b;\n"
             ),
             out="""\
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"a","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":{"name":"b","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":2,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"x","index":0,"origin":{"table":"a","column":"x"}}],"relations":[{"name":"a","kind":"table"}],"physical_tables":[{"name":"a"}]}
+            Lineage
+              statement: 0
+              status: complete
+              target: a (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 1
+              status: complete
+              target: b (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 2
+              status: complete
+              target: (none)
+              columns:
+                x <- a.x
+              relations:
+                a (table)
+              physical_tables:
+                a
+              partial_reasons: (none)
 """,
         )

--- a/tests/lineage_diff_tests/union.py
+++ b/tests/lineage_diff_tests/union.py
@@ -1,0 +1,22 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Lineage tests: UNION/INTERSECT columns are merges — origin=null."""
+
+from python.dev.diff_tests.testing import DiffTestBlueprint, TestSuite
+
+
+class Union(TestSuite):
+    def test_union_all_columns_have_no_origin(self):
+        return DiffTestBlueprint(
+            sql=(
+                "CREATE TABLE a (x INTEGER);\n"
+                "CREATE TABLE b (y INTEGER);\n"
+                "SELECT x FROM a UNION ALL SELECT y FROM b;\n"
+            ),
+            out="""\
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"a","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":{"name":"b","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":2,"status":"complete","partial_reasons":[],"target":null,"columns":[{"name":"x","index":0,"origin":{"table":"a","column":"x"}}],"relations":[{"name":"a","kind":"table"}],"physical_tables":[{"name":"a"}]}
+""",
+        )

--- a/tests/lineage_diff_tests/view.py
+++ b/tests/lineage_diff_tests/view.py
@@ -19,8 +19,37 @@ class View(TestSuite):
                 "SELECT name FROM u;\n"
             ),
             out="""\
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"users","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":{"name":"u","kind":"view"},"columns":[{"name":"id","index":0,"origin":{"table":"users","column":"id"}},{"name":"name","index":1,"origin":{"table":"users","column":"name"}}],"relations":[{"name":"users","kind":"table"}],"physical_tables":[{"name":"users"}]}
-            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":2,"status":"partial","partial_reasons":[{"code":"unexpanded_view","view":"u"}],"target":null,"columns":[{"name":"name","index":0,"origin":null}],"relations":[{"name":"u","kind":"view"}],"physical_tables":[{"name":"u"}]}
+            Lineage
+              statement: 0
+              status: complete
+              target: users (table)
+              columns: (none)
+              relations: (none)
+              physical_tables: (none)
+              partial_reasons: (none)
+            Lineage
+              statement: 1
+              status: complete
+              target: u (view)
+              columns:
+                id <- users.id
+                name <- users.name
+              relations:
+                users (table)
+              physical_tables:
+                users
+              partial_reasons: (none)
+            Lineage
+              statement: 2
+              status: partial
+              target: (none)
+              columns:
+                name <- (transformed)
+              relations:
+                u (view)
+              physical_tables:
+                u
+              partial_reasons:
+                unexpanded_view: u
 """,
         )

--- a/tests/lineage_diff_tests/view.py
+++ b/tests/lineage_diff_tests/view.py
@@ -1,0 +1,26 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Lineage tests: views.
+
+In-source view definitions are expanded transitively.
+Views registered without a body appear as unexpanded_views (status=partial).
+"""
+
+from python.dev.diff_tests.testing import DiffTestBlueprint, TestSuite
+
+
+class View(TestSuite):
+    def test_view_defined_inline_is_expanded(self):
+        return DiffTestBlueprint(
+            sql=(
+                "CREATE TABLE users (id INTEGER, name TEXT);\n"
+                "CREATE VIEW u AS SELECT id, name FROM users;\n"
+                "SELECT name FROM u;\n"
+            ),
+            out="""\
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":0,"status":"complete","partial_reasons":[],"target":{"name":"users","kind":"table"},"columns":[],"relations":[],"physical_tables":[]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":1,"status":"complete","partial_reasons":[],"target":{"name":"u","kind":"view"},"columns":[{"name":"id","index":0,"origin":{"table":"users","column":"id"}},{"name":"name","index":1,"origin":{"table":"users","column":"name"}}],"relations":[{"name":"users","kind":"table"}],"physical_tables":[{"name":"users"}]}
+            {"kind":"lineage","schema_version":0,"file":"<stdin>","statement_index":2,"status":"partial","partial_reasons":[{"code":"unexpanded_view","view":"u"}],"target":null,"columns":[{"name":"name","index":0,"origin":null}],"relations":[{"name":"u","kind":"view"}],"physical_tables":[{"name":"u"}]}
+""",
+        )

--- a/tests/public-api/syntaqlite.txt
+++ b/tests/public-api/syntaqlite.txt
@@ -208,9 +208,10 @@ pub fn syntaqlite::semantic::Severity::serialize<S: serde_core::ser::Serializer>
 pub fn syntaqlite::semantic::StatementModel::defined_relations(&self) -> &[syntaqlite::semantic::DefinedRelation]
 pub fn syntaqlite::semantic::StatementModel::diagnostics(&self) -> &[syntaqlite::Diagnostic]
 pub fn syntaqlite::semantic::StatementModel::lineage(&self) -> core::option::Option<syntaqlite::semantic::LineageResult<&[syntaqlite::semantic::ColumnLineage]>>
+pub fn syntaqlite::semantic::StatementModel::physical_tables_accessed(&self) -> core::option::Option<syntaqlite::semantic::LineageResult<&[syntaqlite::semantic::PhysicalTableAccess]>>
 pub fn syntaqlite::semantic::StatementModel::relations_accessed(&self) -> core::option::Option<syntaqlite::semantic::LineageResult<&[syntaqlite::semantic::RelationAccess]>>
 pub fn syntaqlite::semantic::StatementModel::source(&self) -> &str
-pub fn syntaqlite::semantic::StatementModel::tables_accessed(&self) -> core::option::Option<syntaqlite::semantic::LineageResult<&[syntaqlite::semantic::TableAccess]>>
+pub fn syntaqlite::semantic::StatementModel::unexpanded_views(&self) -> &[alloc::string::String]
 pub fn syntaqlite::semantic::ValidationConfig::checks(&self) -> syntaqlite::semantic::CheckConfig
 pub fn syntaqlite::semantic::ValidationConfig::default() -> Self
 pub fn syntaqlite::semantic::ValidationConfig::suggestion_threshold(&self) -> usize
@@ -270,11 +271,11 @@ pub struct syntaqlite::semantic::ColumnOrigin
 pub struct syntaqlite::semantic::DefinedRelation
 pub struct syntaqlite::semantic::Diagnostic
 pub struct syntaqlite::semantic::DirectoryModuleResolver
+pub struct syntaqlite::semantic::PhysicalTableAccess
 pub struct syntaqlite::semantic::RelationAccess
 pub struct syntaqlite::semantic::SemanticAnalyzer
 pub struct syntaqlite::semantic::SemanticModel
 pub struct syntaqlite::semantic::StatementModel
-pub struct syntaqlite::semantic::TableAccess
 pub struct syntaqlite::semantic::ValidationConfig
 pub struct syntaqlite::util::DiagnosticRenderer<'a>
 pub struct syntaqlite::util::SqliteFlags(_)
@@ -334,6 +335,7 @@ pub syntaqlite::semantic::FunctionCategory::Window
 pub syntaqlite::semantic::Help::Suggestion(alloc::string::String)
 pub syntaqlite::semantic::LineageResult::Complete(T)
 pub syntaqlite::semantic::LineageResult::Partial(T)
+pub syntaqlite::semantic::PhysicalTableAccess::name: alloc::string::String
 pub syntaqlite::semantic::RelationAccess::kind: syntaqlite::semantic::RelationKind
 pub syntaqlite::semantic::RelationAccess::name: alloc::string::String
 pub syntaqlite::semantic::RelationKind::Table
@@ -342,7 +344,6 @@ pub syntaqlite::semantic::Severity::Error
 pub syntaqlite::semantic::Severity::Hint
 pub syntaqlite::semantic::Severity::Info
 pub syntaqlite::semantic::Severity::Warning
-pub syntaqlite::semantic::TableAccess::name: alloc::string::String
 pub syntaqlite::util::SqliteFlag::EnableBytecodeVtab = 27
 pub syntaqlite::util::SqliteFlag::EnableCarray = 28
 pub syntaqlite::util::SqliteFlag::EnableDbpageVtab = 29

--- a/web/docs/content/getting-started/python.md
+++ b/web/docs/content/getting-started/python.md
@@ -121,15 +121,20 @@ for col in result.lineage.columns:
   email <- users.email
 ```
 
-The `lineage` object also lists the relations referenced by the query:
+The `lineage` object also lists the catalog relations referenced in FROM
+(tables and views as written in the query) and the physical tables
+accessed after CTE/view expansion:
 
 ```python
 for rel in result.lineage.relations:
-    print(f"  {rel.name} ({rel.kind})")
+    print(f"  relation: {rel.name} ({rel.kind})")
+for t in result.lineage.physical_tables:
+    print(f"  physical table: {t}")
 ```
 
 ```text
-  users (table)
+  relation: users (table)
+  physical table: users
 ```
 
 ## 4. Parse and inspect the AST

--- a/web/docs/content/guides/c-api.md
+++ b/web/docs/content/guides/c-api.md
@@ -199,8 +199,8 @@ int main(void) {
     }
 
     // Physical tables accessed
-    uint32_t tbl_count = syntaqlite_validator_table_count(v);
-    const SyntaqliteTableAccess* tbls = syntaqlite_validator_tables(v);
+    uint32_t tbl_count = syntaqlite_validator_physical_table_count(v);
+    const SyntaqlitePhysicalTableAccess* tbls = syntaqlite_validator_physical_tables(v);
     for (uint32_t i = 0; i < tbl_count; i++) {
         printf("  table: %s\n", tbls[i].name);
     }

--- a/web/docs/content/guides/rust-api.md
+++ b/web/docs/content/guides/rust-api.md
@@ -194,27 +194,32 @@ let model = analyzer.analyze(
     &config,
 );
 
-if let Some(lineage) = model.lineage() {
-    println!("Complete: {}", lineage.is_complete());
-    for col in lineage.into_inner() {
-        print!("  column {}: {}", col.index, col.name);
-        if let Some(ref origin) = col.origin {
-            print!(" <- {}.{}", origin.table, origin.column);
+for stmt in model.statements() {
+    if let Some(lineage) = stmt.lineage() {
+        println!("Complete: {}", lineage.is_complete());
+        for col in lineage.into_inner() {
+            print!("  column {}: {}", col.index, col.name);
+            if let Some(ref origin) = col.origin {
+                print!(" <- {}.{}", origin.table, origin.column);
+            }
+            println!();
         }
-        println!();
     }
-}
-
-if let Some(physical_tables) = model.physical_tables_accessed() {
-    for t in physical_tables.into_inner() {
-        println!("  table: {}", t.name);
+    if let Some(physical_tables) = stmt.physical_tables_accessed() {
+        for t in physical_tables.into_inner() {
+            println!("  physical table: {}", t.name);
+        }
+    }
+    for view in stmt.unexpanded_views() {
+        println!("  view body not available: {view}");
     }
 }
 ```
 
 `lineage()` returns `None` for non-query statements. It returns
 `LineageResult::Partial` when a view is referenced but its body is unavailable
-for resolution.
+for resolution; `unexpanded_views()` surfaces which view names caused the
+partial result.
 
 ## Next steps
 

--- a/web/docs/content/guides/rust-api.md
+++ b/web/docs/content/guides/rust-api.md
@@ -205,8 +205,8 @@ if let Some(lineage) = model.lineage() {
     }
 }
 
-if let Some(tables) = model.tables_accessed() {
-    for t in tables.into_inner() {
+if let Some(physical_tables) = model.physical_tables_accessed() {
+    for t in physical_tables.into_inner() {
         println!("  table: {}", t.name);
     }
 }

--- a/web/docs/content/reference/c-api.md
+++ b/web/docs/content/reference/c-api.md
@@ -210,7 +210,7 @@ typedef struct {
 // A physical table accessed by the query.
 typedef struct {
   const char* name;
-} SyntaqliteTableAccess;
+} SyntaqlitePhysicalTableAccess;
 ```
 
 ### Functions
@@ -231,8 +231,8 @@ typedef struct {
 | `syntaqlite_validator_column_lineage(v)` | Pointer to `SyntaqliteColumnLineage` array, or `NULL` |
 | `syntaqlite_validator_relation_count(v)` | Number of relations in FROM clauses. `0` for non-queries |
 | `syntaqlite_validator_relations(v)` | Pointer to `SyntaqliteRelationAccess` array, or `NULL` |
-| `syntaqlite_validator_table_count(v)` | Number of physical tables accessed. `0` for non-queries |
-| `syntaqlite_validator_tables(v)` | Pointer to `SyntaqliteTableAccess` array, or `NULL` |
+| `syntaqlite_validator_physical_table_count(v)` | Number of physical tables accessed. `0` for non-queries |
+| `syntaqlite_validator_physical_tables(v)` | Pointer to `SyntaqlitePhysicalTableAccess` array, or `NULL` |
 | `syntaqlite_validator_reset_catalog(v)` | Clear registered schema (preserves dialect builtins) |
 | `syntaqlite_validator_destroy(v)` | Free the validator. No-op if `NULL` |
 
@@ -256,7 +256,7 @@ typedef struct {
 - Output strings from `syntaqlite_formatter_output()`,
   `syntaqlite_validator_diagnostics()`, and lineage accessors
   (`syntaqlite_validator_column_lineage()`, `syntaqlite_validator_relations()`,
-  `syntaqlite_validator_tables()`) are **borrowed**, valid until the next
+  `syntaqlite_validator_physical_tables()`) are **borrowed**, valid until the next
   call to analyze or destroy.
 - Strings from `syntaqlite_validator_render_diagnostics()` are **borrowed**,
   valid until the next `analyze()`, `render_diagnostics()`, or `destroy()` call.

--- a/web/docs/content/reference/c-api.md
+++ b/web/docs/content/reference/c-api.md
@@ -211,6 +211,12 @@ typedef struct {
 typedef struct {
   const char* name;
 } SyntaqlitePhysicalTableAccess;
+
+// A view whose body was not available for expansion during lineage
+// resolution. A non-empty list means the statement's lineage is Partial.
+typedef struct {
+  const char* name;
+} SyntaqliteUnexpandedView;
 ```
 
 ### Functions
@@ -233,6 +239,10 @@ typedef struct {
 | `syntaqlite_validator_relations(v)` | Pointer to `SyntaqliteRelationAccess` array, or `NULL` |
 | `syntaqlite_validator_physical_table_count(v)` | Number of physical tables accessed. `0` for non-queries |
 | `syntaqlite_validator_physical_tables(v)` | Pointer to `SyntaqlitePhysicalTableAccess` array, or `NULL` |
+| `syntaqlite_validator_unexpanded_view_count(v)` | Number of views whose bodies weren't available for expansion (aggregated across statements) |
+| `syntaqlite_validator_unexpanded_views(v)` | Pointer to `SyntaqliteUnexpandedView` array, or `NULL` |
+| `syntaqlite_validator_statement_unexpanded_view_count(v, idx)` | Number of unexpanded views in statement `idx` |
+| `syntaqlite_validator_statement_unexpanded_views(v, idx)` | Pointer to `SyntaqliteUnexpandedView` array for statement `idx`, or `NULL` |
 | `syntaqlite_validator_reset_catalog(v)` | Clear registered schema (preserves dialect builtins) |
 | `syntaqlite_validator_destroy(v)` | Free the validator. No-op if `NULL` |
 

--- a/web/docs/content/reference/cli.md
+++ b/web/docs/content/reference/cli.md
@@ -112,6 +112,58 @@ Exit codes:
 - `0` — parsed successfully
 - `1` — parse error
 
+## syntaqlite lineage
+
+Extract column and table lineage from SQL.
+
+```bash
+syntaqlite lineage [OPTIONS] [FILES...]
+syntaqlite lineage tables [OPTIONS] [FILES...]
+syntaqlite lineage columns [OPTIONS] [FILES...]
+```
+
+Reads from stdin if no files are given. For each statement, emits a
+lineage record listing the output columns, their origin table/column
+(when the column is an untransformed passthrough), the catalog
+relations referenced in FROM, and the physical tables accessed after
+CTE/view expansion. Statements that fail parsing or validation emit an
+error record instead and cause a non-zero exit.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `-e, --expression <SQL>` | | SQL to analyze directly (instead of files or stdin) |
+| `--schema <FILE>` | | Schema DDL file(s) to load (repeatable, supports globs) |
+| `-o, --output <FORMAT>` | `json` | Output format: `json` or `text` |
+| `--dialect <PATH>` | | Path to custom dialect shared library |
+| `--dialect-name <NAME>` | | Symbol name in dialect library |
+| `--sqlite-version <VER>` | `latest` | Target SQLite version |
+| `--sqlite-cflag <FLAG>` | | Enable a compile-time flag (repeatable) |
+
+Output formats:
+- `json` — newline-delimited JSON (NDJSON), one record per statement or
+  error. Each record includes `schema_version` (currently `0`, pre-stable),
+  `file`, `statement_index`, `status` (`complete` or `partial`),
+  `partial_reasons`, `target`, `columns`, `relations`, and
+  `physical_tables`. Suitable for piping into lineage tooling.
+- `text` — human-readable indented format, one record per statement or error.
+
+Scope subcommands project the output to a subset:
+- `tables` — emit only relations and physical tables (drops `columns`)
+- `columns` — emit only column lineage (drops `relations` and `physical_tables`)
+
+A column's `origin` is populated only when the column is an untransformed
+passthrough (direct reference or pure rename alias). Expressions, casts,
+aggregates, window functions, and set-operation (`UNION`, etc.) columns
+have `origin: null`. Views and CTEs are transparent (expanded into
+`physical_tables`); real tables and temp tables are opaque boundaries.
+When a view body is not available for expansion, the record's `status`
+becomes `partial` and `partial_reasons` includes an `unexpanded_view`
+entry with the view name.
+
+Exit codes:
+- `0` — all statements produced a lineage record
+- `1` — one or more error records were emitted
+
 ## syntaqlite lsp
 
 Start the language server on stdio. On startup, the server discovers

--- a/web/docs/content/reference/python-api.md
+++ b/web/docs/content/reference/python-api.md
@@ -163,7 +163,7 @@ True
 ...     print(f"{col.name} <- {col.origin}")
 id <- users.id
 name <- users.name
->>> r.lineage.tables
+>>> r.lineage.physical_tables
 ['users']
 ```
 
@@ -185,7 +185,8 @@ name <- users.name
 | `complete` | `bool` | `True` if all sources fully resolved |
 | `columns` | `list[ColumnLineage]` | Per-column lineage |
 | `relations` | `list[RelationAccess]` | Catalog relations referenced in FROM |
-| `tables` | `list[str]` | Physical table names accessed |
+| `physical_tables` | `list[str]` | Physical table names accessed after CTE/view expansion |
+| `unexpanded_views` | `list[str]` | View names whose bodies weren't available for expansion (non-empty means `complete=False`) |
 
 **`ColumnLineage`** — lineage for a single result column:
 

--- a/web/docs/content/reference/rust-api.md
+++ b/web/docs/content/reference/rust-api.md
@@ -76,17 +76,28 @@ After `analyze()`, the returned `SemanticModel` provides column-level lineage
 for SELECT statements. Lineage traces each result column back to its source
 table and column.
 
+`model.statements()` yields one `StatementModel` per statement; lineage
+methods are per-statement.
+
 | Type / Method | Description |
 |---------------|-------------|
-| `model.lineage()` | Per-column lineage: `Option<LineageResult<&[ColumnLineage]>>` |
-| `model.relations_accessed()` | Relations in FROM: `Option<LineageResult<&[RelationAccess]>>` |
-| `model.physical_tables_accessed()` | Physical tables after resolving CTEs/views: `Option<LineageResult<&[PhysicalTableAccess]>>` |
+| `stmt.lineage()` | Per-column lineage: `Option<LineageResult<&[ColumnLineage]>>` |
+| `stmt.relations_accessed()` | Relations in FROM: `Option<LineageResult<&[RelationAccess]>>` |
+| `stmt.physical_tables_accessed()` | Physical tables after resolving CTEs/views: `Option<LineageResult<&[PhysicalTableAccess]>>` |
+| `stmt.defined_relations()` | `&[DefinedRelation]` — targets created by DDL (`CREATE TABLE`/`CREATE VIEW`) |
+| `stmt.unexpanded_views()` | `&[String]` — canonical names of views whose bodies weren't available for expansion |
 | `LineageResult<T>` | `Complete(T)` — fully resolved, or `Partial(T)` — some view bodies unavailable |
 | `ColumnLineage` | `name: String`, `index: u32`, `origin: Option<ColumnOrigin>` |
 | `ColumnOrigin` | `table: String`, `column: String` |
 | `RelationAccess` | `name: String`, `kind: RelationKind` |
 | `RelationKind` | `Table` or `View` |
 | `PhysicalTableAccess` | `name: String` |
+| `DefinedRelation` | `name: String`, `is_view: bool` |
 
-Returns `None` for non-query statements (CREATE, INSERT, etc.). Returns
-`Partial` when a view is referenced but its body is unavailable for resolution.
+Lineage methods return `None` for non-query statements (CREATE, INSERT,
+etc.). A column's `origin` is populated only when the column is an
+untransformed passthrough — a direct column reference or a pure rename
+alias. Expressions, casts, aggregates, and set-op (`UNION`, etc.)
+columns have `origin: None`. Result is `Partial` when a referenced view's
+body is unavailable for tracing through; `unexpanded_views()` lists the
+view names.

--- a/web/docs/content/reference/rust-api.md
+++ b/web/docs/content/reference/rust-api.md
@@ -80,13 +80,13 @@ table and column.
 |---------------|-------------|
 | `model.lineage()` | Per-column lineage: `Option<LineageResult<&[ColumnLineage]>>` |
 | `model.relations_accessed()` | Relations in FROM: `Option<LineageResult<&[RelationAccess]>>` |
-| `model.tables_accessed()` | Physical tables after resolving CTEs/views: `Option<LineageResult<&[TableAccess]>>` |
+| `model.physical_tables_accessed()` | Physical tables after resolving CTEs/views: `Option<LineageResult<&[PhysicalTableAccess]>>` |
 | `LineageResult<T>` | `Complete(T)` — fully resolved, or `Partial(T)` — some view bodies unavailable |
 | `ColumnLineage` | `name: String`, `index: u32`, `origin: Option<ColumnOrigin>` |
 | `ColumnOrigin` | `table: String`, `column: String` |
 | `RelationAccess` | `name: String`, `kind: RelationKind` |
 | `RelationKind` | `Table` or `View` |
-| `TableAccess` | `name: String` |
+| `PhysicalTableAccess` | `name: String` |
 
 Returns `None` for non-query statements (CREATE, INSERT, etc.). Returns
 `Partial` when a view is referenced but its body is unavailable for resolution.


### PR DESCRIPTION
Closes #20.

Adds `syntaqlite lineage [tables|columns] [FILES]` with `--schema` and stdin. Emits NDJSON (`schema_version: 0`, one record per statement/error) by default; text output is a separate hand-tuned view. Exit 1 on any error record.

Renames `TableAccess` → `PhysicalTableAccess` and `tables_accessed()` → `physical_tables_accessed()` across Rust, C FFI, Python bindings, docs, and the public-API snapshot (breaking). Distinguishes physical tables from catalog relations, which may also be views.

New diff-based `tests/lineage_diff_tests/` suite (17 cases) plus round-trip tests in `syntaqlite-cli/tests/lineage_json.rs`. Integration tests surface several pre-existing lineage gaps (UNION arms, CTE column rename passthrough, unnamed expression columns) that will be fixed in follow-ups.