### PR TITLE
synq: attach captured comments to their owning token

### DIFF
--- a/syntaqlite-buildtools/src/parser_tools/amalgamate.rs
+++ b/syntaqlite-buildtools/src/parser_tools/amalgamate.rs
@@ -53,10 +53,8 @@ const SUPPRESSED_WARNINGS: &[&str] = &[
 /// appear in a C++ translation unit, so they are guarded by
 /// `#ifndef __cplusplus`. The amalgamated header is `#include`d from C++
 /// consumers (e.g. perfetto) as well as C.
-const SUPPRESSED_WARNINGS_C_ONLY: &[&str] = &[
-    "-Wdeclaration-after-statement",
-    "-Wmissing-prototypes",
-];
+const SUPPRESSED_WARNINGS_C_ONLY: &[&str] =
+    &["-Wdeclaration-after-statement", "-Wmissing-prototypes"];
 
 /// Warnings that only Clang understands; emitted inside `#ifdef __clang__`.
 const SUPPRESSED_WARNINGS_CLANG_ONLY: &[&str] = &[

--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -83,6 +83,7 @@ static void reset_stmt(SyntaqliteParser* p) {
   p->ctx.saw_subquery = 0;
   p->ctx.saw_update_delete_limit = 0;
   p->had_comment = 0;
+  p->last_layer0_token_end = UINT32_MAX;
   p->had_error = 0;
   p->error_msg[0] = '\0';
   p->ctx.error_offset = 0xFFFFFFFF;
@@ -320,6 +321,8 @@ int synq_parser_record_and_feed(SyntaqliteParser* p,
                                 p->ctx.layer_id};
     syntaqlite_vec_push(&p->tokens, tp, p->mem);
     tidx = syntaqlite_vec_len(&p->tokens) - 1;
+    if (p->ctx.layer_id == 0)
+      p->last_layer0_token_end = cur_offset + cur_len;
   }
   // Publish the upcoming token's start *before* Lemon processes it so
   // that BEFORE-style empty-marker reductions firing inside feed_one_token
@@ -345,13 +348,43 @@ int synq_parser_record_and_feed(SyntaqliteParser* p,
 }
 
 // Record a comment token (outlined from the hot loop).
+//
+// Computes attachment from the parser's current state: a comment is
+// TRAILING the previous layer-0 token when there is no '\n' in the source
+// gap between that token's end and the comment's start; otherwise LEADING
+// the next token to be pushed. The predicted owner index for LEADING
+// comments equals `vec_len(p->tokens)` — the index the next push will
+// land on.
 SYNQ_NOINLINE
 void synq_parser_record_comment(SyntaqliteParser* p,
                                 uint32_t offset,
                                 uint32_t len) {
   const unsigned char* z = (const unsigned char*)p->source;
-  SyntaqliteComment t = {offset, len,
-                         z[offset] == '-' ? (uint8_t)0 : (uint8_t)1};
+
+  uint8_t side = SYNQ_COMMENT_LEADING;
+  uint32_t owner_idx = syntaqlite_vec_len(&p->tokens);
+  uint32_t prev_end = p->last_layer0_token_end;
+  if (prev_end != UINT32_MAX && prev_end <= offset) {
+    int saw_newline = 0;
+    for (uint32_t i = prev_end; i < offset; i++) {
+      if (z[i] == '\n') {
+        saw_newline = 1;
+        break;
+      }
+    }
+    if (!saw_newline) {
+      side = SYNQ_COMMENT_TRAILING;
+      owner_idx = syntaqlite_vec_len(&p->tokens) - 1;
+    }
+  }
+
+  SyntaqliteComment t = {
+      .offset = offset,
+      .length = len,
+      .token_idx = owner_idx,
+      .kind = z[offset] == '-' ? (uint8_t)0 : (uint8_t)1,
+      .side = side,
+  };
   syntaqlite_vec_push(&p->comments, t, p->mem);
 }
 
@@ -579,6 +612,45 @@ SYNTAQLITE_API const SyntaqliteParserToken* syntaqlite_result_tokens(
   return p->tokens.data;
 }
 
+// Locate the contiguous run of comments owned by `token_idx` with the
+// requested side. Comments for a given (token_idx, side) are recorded in
+// source order and live as a contiguous slice within p->comments because
+// each is emitted at the moment the owning token is being processed.
+static const SyntaqliteComment* token_side_comments(SyntaqliteParser* p,
+                                                    uint32_t token_idx,
+                                                    uint8_t side,
+                                                    uint32_t* count) {
+  uint32_t total = syntaqlite_vec_len(&p->comments);
+  const SyntaqliteComment* base = NULL;
+  uint32_t found = 0;
+  for (uint32_t i = 0; i < total; i++) {
+    const SyntaqliteComment* c = &p->comments.data[i];
+    if (c->token_idx == token_idx && c->side == side) {
+      if (base == NULL)
+        base = c;
+      found++;
+    } else if (base != NULL) {
+      break;
+    }
+  }
+  *count = found;
+  return base;
+}
+
+SYNTAQLITE_API const SyntaqliteComment* syntaqlite_token_leading_comments(
+    SyntaqliteParser* p,
+    uint32_t token_idx,
+    uint32_t* count) {
+  return token_side_comments(p, token_idx, SYNQ_COMMENT_LEADING, count);
+}
+
+SYNTAQLITE_API const SyntaqliteComment* syntaqlite_token_trailing_comments(
+    SyntaqliteParser* p,
+    uint32_t token_idx,
+    uint32_t* count) {
+  return token_side_comments(p, token_idx, SYNQ_COMMENT_TRAILING, count);
+}
+
 #ifdef SYNTAQLITE_OMIT_MACROS
 SYNTAQLITE_API uint32_t syntaqlite_result_macro_count(SyntaqliteParser* p) {
   (void)p;
@@ -762,6 +834,8 @@ SYNTAQLITE_API int32_t syntaqlite_parser_feed_token(SyntaqliteParser* p,
                                 p->ctx.layer_id};
     syntaqlite_vec_push(&p->tokens, tp, p->mem);
     tidx = syntaqlite_vec_len(&p->tokens) - 1;
+    if (p->ctx.layer_id == 0)
+      p->last_layer0_token_end = tok_offset + len;
   }
 
   int rc = feed_one_token(p, token_type, text, len, tidx);

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -179,7 +179,12 @@ struct SyntaqliteParser {
   uint32_t last_token_type;  // Last non-whitespace token fed to Lemon.
   uint32_t finished;         // 1 after EOF has been sent to Lemon.
   uint32_t had_comment;      // 1 if any comment token was seen this stmt.
-  int32_t last_status;       // Last SYNTAQLITE_PARSE_* status returned.
+  // End offset (in p->source) of the most recent layer-0 significant
+  // token recorded into p->tokens this statement, or UINT32_MAX if none.
+  // Used to classify a recorded comment as TRAILING (same source line as
+  // the preceding token) vs LEADING (its own line / before any token).
+  uint32_t last_layer0_token_end;
+  int32_t last_status;  // Last SYNTAQLITE_PARSE_* status returned.
   uint32_t trace;
   uint32_t collect_tokens;
   uint32_t sealed;
@@ -205,7 +210,11 @@ static inline int synq_token_is_skip(uint32_t type) {
 }
 
 // Record a comment span into p->comments. `offset` is the byte offset into
-// p->source. Caller must check p->collect_tokens before calling.
+// p->source. The owning token_idx and side are computed from the parser's
+// current state (last_layer0_token_end + p->tokens length): TRAILING when
+// the previous layer-0 token ends on the same source line as this comment,
+// LEADING otherwise (in which case the predicted owner is the next token
+// to be pushed). Caller must check p->collect_tokens before calling.
 void synq_parser_record_comment(SyntaqliteParser* p,
                                 uint32_t offset,
                                 uint32_t len);

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -182,10 +182,30 @@ SYNTAQLITE_API uint32_t syntaqlite_result_error_offset(SyntaqliteParser* p);
 SYNTAQLITE_API uint32_t syntaqlite_result_error_length(SyntaqliteParser* p);
 
 // A comment captured during parsing.
+//
+// Each comment is bound at parse time to one of the statement's tokens:
+//   - `side == SYNQ_COMMENT_LEADING` and `token_idx == N` means the comment
+//     appears immediately before token N (no significant token between them
+//     in the source) and either token N is the first token of the statement
+//     or the comment is on its own source line.
+//   - `side == SYNQ_COMMENT_TRAILING` and `token_idx == N` means the comment
+//     appears on the same source line as token N's end, with no significant
+//     token between them.
+// `token_idx` indexes into the same per-statement token array returned by
+// `syntaqlite_result_tokens`.  When the comment trails the last token of a
+// statement and no following statement exists, `token_idx` may equal
+// `count` (one past the last token) — consumers should treat that as
+// "statement-trailing with no owner."
+typedef uint8_t SyntaqliteCommentSide;
+#define SYNQ_COMMENT_LEADING ((SyntaqliteCommentSide)0)
+#define SYNQ_COMMENT_TRAILING ((SyntaqliteCommentSide)1)
+
 typedef struct SyntaqliteComment {
-  uint32_t offset;  // Byte offset in source.
-  uint32_t length;  // Byte length.
-  uint8_t kind;     // 0 = line comment (--), 1 = block comment (/* */).
+  uint32_t offset;     // Byte offset in source.
+  uint32_t length;     // Byte length.
+  uint32_t token_idx;  // Index of the owning token in p->tokens.
+  uint8_t kind;        // 0 = line comment (--), 1 = block comment (/* */).
+  uint8_t side;        // SYNQ_COMMENT_LEADING or SYNQ_COMMENT_TRAILING.
 } SyntaqliteComment;
 
 // Token-usage flags: set by the parser during disambiguation to record how
@@ -222,6 +242,24 @@ SYNTAQLITE_API const SyntaqliteComment* syntaqlite_result_comments(
     uint32_t* count);
 SYNTAQLITE_API const SyntaqliteParserToken* syntaqlite_result_tokens(
     SyntaqliteParser* p,
+    uint32_t* count);
+
+// Get the comments attached to a specific token.
+//
+// Returns a pointer to the first comment in `p->comments` whose
+// `token_idx == token_idx` and `side == side`, and writes the count of
+// such comments to `*count`.  Comments attached to the same token are
+// contiguous in `p->comments` and recorded in source order.
+//
+// Returns NULL with `*count == 0` when there are no matching comments.
+SYNTAQLITE_API const SyntaqliteComment* syntaqlite_token_leading_comments(
+    SyntaqliteParser* p,
+    uint32_t token_idx,
+    uint32_t* count);
+
+SYNTAQLITE_API const SyntaqliteComment* syntaqlite_token_trailing_comments(
+    SyntaqliteParser* p,
+    uint32_t token_idx,
     uint32_t* count);
 
 // Sentinel value for `SyntaqliteMacroRewrite::parent_idx` meaning "this

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -31,7 +31,9 @@ pub use parser::{
 // Token/comment data types shared across dialects.
 #[cfg(feature = "sqlite-minimal")]
 #[doc(inline)]
-pub use parser::{Comment, CommentKind, CommentSpan, CompletionContext, ParserTokenFlags};
+pub use parser::{
+    Comment, CommentKind, CommentSide, CommentSpan, CompletionContext, ParserTokenFlags,
+};
 
 // Top-level tokenizer types.
 #[cfg(feature = "sqlite-minimal")]

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -40,13 +40,25 @@ pub(crate) enum CCommentKind {
     BlockComment = 1,
 }
 
+/// Which side of a token a comment attaches to.  Matches C
+/// `SYNQ_COMMENT_LEADING` / `SYNQ_COMMENT_TRAILING`.
+#[expect(dead_code)] // C FFI mirror — variants match the C enum values
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum CCommentSide {
+    Leading = 0,
+    Trailing = 1,
+}
+
 /// Mirrors C `SyntaqliteComment`.
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub(crate) struct CComment {
     pub offset: u32,
     pub length: u32,
+    pub token_idx: u32,
     pub kind: CCommentKind,
+    pub side: CCommentSide,
 }
 
 #[expect(dead_code)] // C FFI mirrors — not yet consumed on the Rust side
@@ -384,6 +396,44 @@ impl CParser {
         unsafe { std::slice::from_raw_parts(ptr, count as usize) }
     }
 
+    pub(crate) unsafe fn token_leading_comments(&self, token_idx: u32) -> &[CComment] {
+        let mut count: u32 = 0;
+        // SAFETY: self is a valid, non-null CParser pointer; result
+        // accessors are valid after `next()` returns a non-DONE code.
+        let ptr = unsafe {
+            syntaqlite_token_leading_comments(
+                std::ptr::from_ref::<Self>(self).cast_mut(),
+                token_idx,
+                &raw mut count,
+            )
+        };
+        if count == 0 || ptr.is_null() {
+            return &[];
+        }
+        // SAFETY: ptr+count describe a contiguous slice of CComment values
+        // inside the parser's comments vec; valid for the parser's lifetime.
+        unsafe { std::slice::from_raw_parts(ptr, count as usize) }
+    }
+
+    pub(crate) unsafe fn token_trailing_comments(&self, token_idx: u32) -> &[CComment] {
+        let mut count: u32 = 0;
+        // SAFETY: self is a valid, non-null CParser pointer; result
+        // accessors are valid after `next()` returns a non-DONE code.
+        let ptr = unsafe {
+            syntaqlite_token_trailing_comments(
+                std::ptr::from_ref::<Self>(self).cast_mut(),
+                token_idx,
+                &raw mut count,
+            )
+        };
+        if count == 0 || ptr.is_null() {
+            return &[];
+        }
+        // SAFETY: ptr+count describe a contiguous slice of CComment values
+        // inside the parser's comments vec; valid for the parser's lifetime.
+        unsafe { std::slice::from_raw_parts(ptr, count as usize) }
+    }
+
     pub(crate) unsafe fn span_expanded_text(
         &self,
         span: crate::ast::TextSpan,
@@ -580,6 +630,16 @@ unsafe extern "C" {
     fn syntaqlite_result_error_length(p: *mut CParser) -> u32;
     fn syntaqlite_result_comments(p: *mut CParser, count: *mut u32) -> *const CComment;
     fn syntaqlite_result_tokens(p: *mut CParser, count: *mut u32) -> *const CParserToken;
+    fn syntaqlite_token_leading_comments(
+        p: *mut CParser,
+        token_idx: u32,
+        count: *mut u32,
+    ) -> *const CComment;
+    fn syntaqlite_token_trailing_comments(
+        p: *mut CParser,
+        token_idx: u32,
+        count: *mut u32,
+    ) -> *const CComment;
     fn syntaqlite_result_macro_count(p: *mut CParser) -> u32;
     fn syntaqlite_result_macro_rewrite_at(p: *mut CParser, idx: u32) -> CMacroRewrite;
     fn syntaqlite_macro_rewrite_arg_segment_count(p: *mut CParser, rewrite_idx: u32) -> u32;

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -29,7 +29,7 @@ pub use incremental::{AnyIncrementalParseSession, TypedIncrementalParseSession};
 #[cfg(feature = "sqlite")]
 pub use session::{ParseError, ParseSession, ParsedStatement, Parser, ParserToken};
 pub use types::{
-    AnyParserToken, ArgOrigin, Comment, CommentKind, CommentSpan, CompletionContext,
+    AnyParserToken, ArgOrigin, Comment, CommentKind, CommentSide, CommentSpan, CompletionContext,
     MacroArgSegment, MacroRewrite, ParseOutcome, ParserTokenFlags, TracebackFrame,
     TypedParserToken,
 };
@@ -1117,14 +1117,31 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
         let source = self.any.text();
         // SAFETY: self.any.raw is valid for 'a; the returned slice lives for 'a.
         let raw: &'a [ffi::CComment] = unsafe { self.any.raw.as_ref().result_comments() };
-        raw.iter().map(move |c| {
-            let text = &source[c.offset as usize..(c.offset + c.length) as usize];
-            let kind = match c.kind {
-                ffi::CCommentKind::LineComment => CommentKind::Line,
-                ffi::CCommentKind::BlockComment => CommentKind::Block,
-            };
-            Comment::new(text, kind, c.offset, c.length)
-        })
+        raw.iter().map(move |c| ffi_comment(source, c))
+    }
+
+    /// Comments that appear immediately before token `token_idx`, in source
+    /// order.  See [`Comment`] for attachment semantics.
+    ///
+    /// Requires `collect_tokens: true` in [`ParserConfig`].
+    pub fn leading_comments(&self, token_idx: u32) -> impl Iterator<Item = Comment<'a>> {
+        let source = self.any.text();
+        // SAFETY: self.any.raw is valid for 'a; the returned slice lives for 'a.
+        let raw: &'a [ffi::CComment] =
+            unsafe { self.any.raw.as_ref().token_leading_comments(token_idx) };
+        raw.iter().map(move |c| ffi_comment(source, c))
+    }
+
+    /// Comments that appear on the same source line as token `token_idx`,
+    /// after it, in source order.  See [`Comment`] for attachment semantics.
+    ///
+    /// Requires `collect_tokens: true` in [`ParserConfig`].
+    pub fn trailing_comments(&self, token_idx: u32) -> impl Iterator<Item = Comment<'a>> {
+        let source = self.any.text();
+        // SAFETY: self.any.raw is valid for 'a; the returned slice lives for 'a.
+        let raw: &'a [ffi::CComment] =
+            unsafe { self.any.raw.as_ref().token_trailing_comments(token_idx) };
+        raw.iter().map(move |c| ffi_comment(source, c))
     }
 
     // ── Result accessors (mirror syntaqlite_result_*) ──────────────────────
@@ -1180,6 +1197,21 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
         }
         G::Node::from_result(&self.any, id)
     }
+}
+
+/// Build a public [`Comment`] from an FFI [`ffi::CComment`] borrowing into
+/// `source`.
+fn ffi_comment<'a>(source: &'a str, c: &ffi::CComment) -> Comment<'a> {
+    let text = &source[c.offset as usize..(c.offset + c.length) as usize];
+    let kind = match c.kind {
+        ffi::CCommentKind::LineComment => CommentKind::Line,
+        ffi::CCommentKind::BlockComment => CommentKind::Block,
+    };
+    let side = match c.side {
+        ffi::CCommentSide::Leading => CommentSide::Leading,
+        ffi::CCommentSide::Trailing => CommentSide::Trailing,
+    };
+    Comment::new(text, kind, c.offset, c.length, c.token_idx, side)
 }
 
 /// Extract a single [`crate::ast::FieldValue`] from a raw arena node pointer.

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -316,6 +316,21 @@ impl<'a> ParsedStatement<'a> {
         self.0.comments()
     }
 
+    /// Comments that appear immediately before token `token_idx`.
+    ///
+    /// Requires `collect_tokens: true` in [`ParserConfig`].
+    pub fn leading_comments(&self, token_idx: u32) -> impl Iterator<Item = Comment<'a>> {
+        self.0.leading_comments(token_idx)
+    }
+
+    /// Comments that appear on the same source line as token `token_idx`,
+    /// after it.
+    ///
+    /// Requires `collect_tokens: true` in [`ParserConfig`].
+    pub fn trailing_comments(&self, token_idx: u32) -> impl Iterator<Item = Comment<'a>> {
+        self.0.trailing_comments(token_idx)
+    }
+
     /// Convert this result into the dialect-agnostic [`AnyParsedStatement`].
     ///
     /// Use this when handing statement data to dialect-independent tooling.
@@ -453,7 +468,7 @@ mod tests {
     use std::panic::{self, AssertUnwindSafe};
     use std::rc::Rc;
 
-    use super::{ParseErrorKind, ParseOutcome, Parser, ParserConfig};
+    use super::{ParseErrorKind, ParseOutcome, Parser, ParserConfig, ParserToken};
     use crate::parser::{MacroArg, MacroLookup, MacroOutput};
     use crate::{CommentKind, TokenType};
 
@@ -558,6 +573,100 @@ mod tests {
                 .any(|comment| comment.kind() == CommentKind::Line
                     && comment.text().contains("tail"))
         );
+    }
+
+    macro_rules! ok_stmt {
+        ($session:expr) => {
+            match $session.next() {
+                ParseOutcome::Ok(stmt) => stmt,
+                ParseOutcome::Done => panic!("statement is missing"),
+                ParseOutcome::Err(err) => panic!("statement should parse: {err}"),
+            }
+        };
+    }
+
+    #[test]
+    fn comment_attaches_as_trailing_when_same_line() {
+        let parser = Parser::with_config(&ParserConfig::default().with_collect_tokens(true));
+        let mut session = parser.parse("SELECT 1 -- inline\nFROM t;");
+        let stmt = ok_stmt!(session);
+
+        let tokens: Vec<ParserToken<'_>> = stmt.tokens().collect();
+        let one_idx = tokens
+            .iter()
+            .position(|t| t.text() == "1")
+            .map(|i| u32::try_from(i).unwrap())
+            .expect("`1` token");
+
+        let trailing: Vec<_> = stmt.trailing_comments(one_idx).collect();
+        assert_eq!(trailing.len(), 1, "comment should be trailing of `1`");
+        assert!(trailing[0].text().contains("inline"));
+
+        let leading_one: Vec<_> = stmt.leading_comments(one_idx).collect();
+        assert!(leading_one.is_empty(), "no leading comments on `1`");
+    }
+
+    #[test]
+    fn comment_attaches_as_leading_when_on_own_line() {
+        let parser = Parser::with_config(&ParserConfig::default().with_collect_tokens(true));
+        let mut session = parser.parse("SELECT 1\n-- standalone\nFROM t;");
+        let stmt = ok_stmt!(session);
+
+        let tokens: Vec<ParserToken<'_>> = stmt.tokens().collect();
+        let from_idx = tokens
+            .iter()
+            .position(|t| t.token_type() == TokenType::From)
+            .map(|i| u32::try_from(i).unwrap())
+            .expect("FROM token");
+
+        let leading: Vec<_> = stmt.leading_comments(from_idx).collect();
+        assert_eq!(leading.len(), 1, "comment should be leading of FROM");
+        assert!(leading[0].text().contains("standalone"));
+    }
+
+    #[test]
+    fn header_comment_attaches_as_leading_to_first_token() {
+        let parser = Parser::with_config(&ParserConfig::default().with_collect_tokens(true));
+        let mut session = parser.parse("-- header\nSELECT 1;");
+        let stmt = ok_stmt!(session);
+
+        let leading: Vec<_> = stmt.leading_comments(0).collect();
+        assert_eq!(leading.len(), 1);
+        assert!(leading[0].text().contains("header"));
+    }
+
+    #[test]
+    fn block_comment_same_line_attaches_as_trailing() {
+        let parser = Parser::with_config(&ParserConfig::default().with_collect_tokens(true));
+        let mut session = parser.parse("SELECT 1 /* inline */\nFROM t;");
+        let stmt = ok_stmt!(session);
+
+        let tokens: Vec<ParserToken<'_>> = stmt.tokens().collect();
+        let one_idx = tokens
+            .iter()
+            .position(|t| t.text() == "1")
+            .map(|i| u32::try_from(i).unwrap())
+            .expect("`1` token");
+
+        let trailing: Vec<_> = stmt.trailing_comments(one_idx).collect();
+        assert_eq!(trailing.len(), 1);
+        assert_eq!(trailing[0].kind(), CommentKind::Block);
+    }
+
+    #[test]
+    fn inter_statement_comment_rolls_forward_as_leading() {
+        let parser = Parser::with_config(&ParserConfig::default().with_collect_tokens(true));
+        let mut session = parser.parse("SELECT 1;\n-- between\nSELECT 2;");
+
+        let stmt1 = ok_stmt!(session);
+        // Inter-statement comment belongs to stmt2, not stmt1.
+        assert_eq!(stmt1.comments().count(), 0);
+        drop(stmt1);
+
+        let stmt2 = ok_stmt!(session);
+        let leading_first: Vec<_> = stmt2.leading_comments(0).collect();
+        assert_eq!(leading_first.len(), 1);
+        assert!(leading_first[0].text().contains("between"));
     }
 
     #[test]

--- a/syntaqlite-syntax/src/parser/types.rs
+++ b/syntaqlite-syntax/src/parser/types.rs
@@ -61,6 +61,22 @@ pub enum CommentKind {
     Block,
 }
 
+/// Which token a comment is attached to, and on which side.
+///
+/// Set at parse time so consumers can ask "what comments belong to
+/// token N?" without walking the source.  See
+/// [`super::TypedParsedStatement::leading_comments`] /
+/// [`super::TypedParsedStatement::trailing_comments`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommentSide {
+    /// The comment appears on its own line (or before any token of the
+    /// statement) and immediately precedes the owning token.
+    Leading,
+    /// The comment appears on the same source line as the owning token,
+    /// after it.
+    Trailing,
+}
+
 /// Comment captured from source during parsing.
 ///
 /// Returned by [`super::TypedParsedStatement::comments`]. Requires
@@ -71,15 +87,26 @@ pub struct Comment<'a> {
     kind: CommentKind,
     offset: u32,
     length: u32,
+    token_idx: u32,
+    side: CommentSide,
 }
 
 impl<'a> Comment<'a> {
-    pub(super) fn new(text: &'a str, kind: CommentKind, offset: u32, length: u32) -> Self {
+    pub(super) fn new(
+        text: &'a str,
+        kind: CommentKind,
+        offset: u32,
+        length: u32,
+        token_idx: u32,
+        side: CommentSide,
+    ) -> Self {
         Comment {
             text,
             kind,
             offset,
             length,
+            token_idx,
+            side,
         }
     }
 
@@ -101,6 +128,18 @@ impl<'a> Comment<'a> {
     /// Byte length of the comment text.
     pub fn length(&self) -> u32 {
         self.length
+    }
+
+    /// Index of the owning token in the statement's token stream.
+    /// May equal the token count when the comment trails the last token
+    /// of the statement and no following statement exists.
+    pub fn token_idx(&self) -> u32 {
+        self.token_idx
+    }
+
+    /// Whether this comment leads or trails its owning token.
+    pub fn side(&self) -> CommentSide {
+        self.side
     }
 }
 

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -756,6 +756,7 @@ impl<G: syntaqlite_syntax::typed::TypedDialect> syntaqlite_syntax::typed::TypedP
 impl<G: syntaqlite_syntax::typed::TypedDialect> syntaqlite_syntax::typed::TypedTokenizer<G>
 impl<T, E> syntaqlite_syntax::ParseOutcome<T, E>
 pub enum syntaqlite_syntax::CommentKind
+pub enum syntaqlite_syntax::CommentSide
 pub enum syntaqlite_syntax::ParseOutcome<T, E>
 pub enum syntaqlite_syntax::any::ArgOrigin
 pub enum syntaqlite_syntax::any::FieldValue
@@ -772,7 +773,9 @@ pub enum syntaqlite_syntax::typed::ParseOutcome<T, E>
 pub fn syntaqlite_syntax::Comment<'a>::kind(&self) -> syntaqlite_syntax::CommentKind
 pub fn syntaqlite_syntax::Comment<'a>::length(&self) -> u32
 pub fn syntaqlite_syntax::Comment<'a>::offset(&self) -> u32
+pub fn syntaqlite_syntax::Comment<'a>::side(&self) -> syntaqlite_syntax::CommentSide
 pub fn syntaqlite_syntax::Comment<'a>::text(&self) -> &'a str
+pub fn syntaqlite_syntax::Comment<'a>::token_idx(&self) -> u32
 pub fn syntaqlite_syntax::CommentSpan::kind(&self) -> syntaqlite_syntax::CommentKind
 pub fn syntaqlite_syntax::CommentSpan::length(&self) -> u32
 pub fn syntaqlite_syntax::CommentSpan::offset(&self) -> u32
@@ -1664,10 +1667,12 @@ pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::comments(&self) ->
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::dump(&self, out: &mut alloc::string::String, indent: usize)
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::erase(self) -> syntaqlite_syntax::any::AnyParsedStatement<'a>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::expanded_text(&self) -> &'a str
+pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::leading_comments(&self, token_idx: u32) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::macro_rewrites(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRewrite<'a>> + use<'_, 'a, G>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::root(&'a self) -> core::option::Option<<G as syntaqlite_syntax::typed::TypedDialect>::Node>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::text(&self) -> &'a str
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::typed::TypedParserToken<'a, G>>
+pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::trailing_comments(&self, token_idx: u32) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>>
 pub fn syntaqlite_syntax::typed::TypedParser<G>::incremental_parse(&self, source: &str) -> syntaqlite_syntax::typed::TypedIncrementalParseSession<G>
 pub fn syntaqlite_syntax::typed::TypedParser<G>::new(dialect: G) -> Self
 pub fn syntaqlite_syntax::typed::TypedParser<G>::parse(&self, source: &str) -> syntaqlite_syntax::typed::TypedParseSession<G>
@@ -1881,6 +1886,8 @@ pub struct syntaqlite_syntax::typed::TypedTokenizer<G: syntaqlite_syntax::typed:
 pub struct syntaqlite_syntax::util::SqliteSyntaxFlags(_)
 pub syntaqlite_syntax::CommentKind::Block
 pub syntaqlite_syntax::CommentKind::Line
+pub syntaqlite_syntax::CommentSide::Leading
+pub syntaqlite_syntax::CommentSide::Trailing
 pub syntaqlite_syntax::CompletionContext::Expression = 1
 pub syntaqlite_syntax::CompletionContext::TableRef = 2
 pub syntaqlite_syntax::CompletionContext::Unknown = 0


### PR DESCRIPTION
First substantive step toward #13. Comment-attachment to tokens used to
be re-derived in the formatter via offset/newline math (~120 lines in
`fmt/comment.rs`); push that work into the parser, where the previous
token's end and the next-token-to-be-pushed index are already live
state.

`SyntaqliteComment` gains `side` (LEADING|TRAILING) and `token_idx`,
populated at record time. Added accessors
`syntaqlite_token_leading_comments(idx)` / `_trailing_comments(idx)` on
the C side, mirrored by `ParsedStatement::leading_comments(idx)` /
`trailing_comments(idx)` on the Rust side. Inter-statement comments
naturally roll forward to the next statement's first token because
`reset_stmt` clears `p->tokens` before the comment hits `feed_token`.

Macro-expansion-buffer comments remain a documented non-goal — only
source comments are recorded. Formatter migration to the new accessors
is a follow-up; this PR is API + parser changes only.

Drive-by: rustfmt collapsed a `SUPPRESSED_WARNINGS_C_ONLY` const onto
one line in `amalgamate.rs`.