### PR TITLE
synq: formatter reads comment side from parser instead of recomputing

### DIFF
--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -555,8 +555,43 @@ SYNTAQLITE_API int32_t syntaqlite_parser_next(SyntaqliteParser* p) {
 #endif
 
     // Normal token (or macro fallthrough): record + feed to Lemon.
-    if (synq_parser_record_and_feed(p, cur_type, cur_offset, (uint32_t)cur_len))
+    if (synq_parser_record_and_feed(p, cur_type, cur_offset,
+                                    (uint32_t)cur_len)) {
+      // Eagerly consume same-line trailing comments after the statement
+      // terminator so they attach to this statement's last token instead
+      // of the next statement's first.  Stop at the first newline or
+      // non-skip token; own-line comments belong to the next statement.
+      uint32_t scan = p->offset;
+      while (scan < p->source_len && z[scan] != '\0') {
+        uint32_t tt = 0;
+        int64_t tl =
+            SynqSqliteGetTokenVersionWrapped(&p->dialect, 0, z + scan, &tt);
+        if (tl <= 0)
+          break;
+        if (tt == SYNTAQLITE_TK_SPACE) {
+          int hit_newline = 0;
+          for (uint32_t i = 0; i < (uint32_t)tl; i++) {
+            if (z[scan + i] == '\n') {
+              hit_newline = 1;
+              break;
+            }
+          }
+          if (hit_newline)
+            break;
+          scan += (uint32_t)tl;
+          continue;
+        }
+        if (tt == SYNTAQLITE_TK_COMMENT) {
+          if (p->collect_tokens)
+            synq_parser_record_comment(p, scan, (uint32_t)tl);
+          scan += (uint32_t)tl;
+          p->offset = scan;
+          continue;
+        }
+        break;
+      }
       return set_result_status(p, stmt_boundary(p));
+    }
 
     // Shift: lookahead becomes current.
     cur_type = la_type;

--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -364,18 +364,10 @@ void synq_parser_record_comment(SyntaqliteParser* p,
   uint8_t side = SYNQ_COMMENT_LEADING;
   uint32_t owner_idx = syntaqlite_vec_len(&p->tokens);
   uint32_t prev_end = p->last_layer0_token_end;
-  if (prev_end != UINT32_MAX && prev_end <= offset) {
-    int saw_newline = 0;
-    for (uint32_t i = prev_end; i < offset; i++) {
-      if (z[i] == '\n') {
-        saw_newline = 1;
-        break;
-      }
-    }
-    if (!saw_newline) {
-      side = SYNQ_COMMENT_TRAILING;
-      owner_idx = syntaqlite_vec_len(&p->tokens) - 1;
-    }
+  if (prev_end != UINT32_MAX && prev_end <= offset &&
+      memchr(z + prev_end, '\n', offset - prev_end) == NULL) {
+    side = SYNQ_COMMENT_TRAILING;
+    owner_idx = syntaqlite_vec_len(&p->tokens) - 1;
   }
 
   SyntaqliteComment t = {
@@ -569,14 +561,7 @@ SYNTAQLITE_API int32_t syntaqlite_parser_next(SyntaqliteParser* p) {
         if (tl <= 0)
           break;
         if (tt == SYNTAQLITE_TK_SPACE) {
-          int hit_newline = 0;
-          for (uint32_t i = 0; i < (uint32_t)tl; i++) {
-            if (z[scan + i] == '\n') {
-              hit_newline = 1;
-              break;
-            }
-          }
-          if (hit_newline)
+          if (memchr(z + scan, '\n', (size_t)tl) != NULL)
             break;
           scan += (uint32_t)tl;
           continue;

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -881,7 +881,11 @@ impl<'a> AnyParsedStatement<'a> {
                 ffi::CCommentKind::LineComment => CommentKind::Line,
                 ffi::CCommentKind::BlockComment => CommentKind::Block,
             };
-            CommentSpan::new(c.offset, c.length, kind)
+            let side = match c.side {
+                ffi::CCommentSide::Leading => CommentSide::Leading,
+                ffi::CCommentSide::Trailing => CommentSide::Trailing,
+            };
+            CommentSpan::new(c.offset, c.length, kind, c.token_idx, side)
         })
     }
 

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -654,6 +654,39 @@ mod tests {
     }
 
     #[test]
+    fn inter_statement_same_line_comment_attaches_to_prev_semi() {
+        // `SELECT 1; -- trailing` — the comment is on the same source line
+        // as stmt 1's `;`, so it belongs to stmt 1 (TRAILING the SEMI),
+        // not to stmt 2.
+        let parser = Parser::with_config(&ParserConfig::default().with_collect_tokens(true));
+        let mut session = parser.parse("SELECT 1; -- trailing\nSELECT 2;");
+
+        let stmt1 = ok_stmt!(session);
+        let tokens1: Vec<ParserToken<'_>> = stmt1.tokens().collect();
+        let semi_idx = tokens1
+            .iter()
+            .rposition(|t| t.text() == ";")
+            .map(|i| u32::try_from(i).unwrap())
+            .expect("`;` token in stmt 1");
+
+        let trailing: Vec<_> = stmt1.trailing_comments(semi_idx).collect();
+        assert_eq!(
+            trailing.len(),
+            1,
+            "same-line comment should trail stmt 1's `;`"
+        );
+        assert!(trailing[0].text().contains("trailing"));
+        drop(stmt1);
+
+        let stmt2 = ok_stmt!(session);
+        assert_eq!(
+            stmt2.comments().count(),
+            0,
+            "stmt 2 should have no comments"
+        );
+    }
+
+    #[test]
     fn inter_statement_comment_rolls_forward_as_leading() {
         let parser = Parser::with_config(&ParserConfig::default().with_collect_tokens(true));
         let mut session = parser.parse("SELECT 1;\n-- between\nSELECT 2;");

--- a/syntaqlite-syntax/src/parser/types.rs
+++ b/syntaqlite-syntax/src/parser/types.rs
@@ -152,6 +152,8 @@ pub struct CommentSpan {
     offset: u32,
     length: u32,
     kind: CommentKind,
+    token_idx: u32,
+    side: CommentSide,
 }
 
 impl CommentSpan {
@@ -170,11 +172,30 @@ impl CommentSpan {
         self.kind
     }
 
-    pub(super) fn new(offset: u32, length: u32, kind: CommentKind) -> Self {
+    /// Index of the owning token in the statement's token stream.
+    /// See [`Comment::token_idx`] for attachment semantics.
+    pub fn token_idx(&self) -> u32 {
+        self.token_idx
+    }
+
+    /// Whether this comment leads or trails its owning token.
+    pub fn side(&self) -> CommentSide {
+        self.side
+    }
+
+    pub(super) fn new(
+        offset: u32,
+        length: u32,
+        kind: CommentKind,
+        token_idx: u32,
+        side: CommentSide,
+    ) -> Self {
         CommentSpan {
             offset,
             length,
             kind,
+            token_idx,
+            side,
         }
     }
 }

--- a/syntaqlite/src/fmt/comment.rs
+++ b/syntaqlite/src/fmt/comment.rs
@@ -3,16 +3,18 @@
 
 use std::cell::Cell;
 
-use syntaqlite_syntax::CommentKind;
+use syntaqlite_syntax::{CommentKind, CommentSide};
 
 use super::doc::{DocArena, DocId, NIL_DOC};
 
-/// A collected comment entry with pre-computed byte offset and length.
+/// A collected comment entry with pre-computed byte offset, length, and
+/// parser-supplied attachment (`side` + `token_idx`).
 #[derive(Clone, Copy)]
 pub(crate) struct CommentEntry {
     pub offset: u32,
     pub length: u32,
     pub kind: CommentKind,
+    pub side: CommentSide,
 }
 
 /// A collected token entry with pre-computed byte offset and length.
@@ -131,13 +133,17 @@ impl CommentCtx {
 
             let text = &source[t.offset as usize..comment_end];
 
+            // Leading vs trailing is fixed at parse time
+            // (see synq_parser_record_comment).  The gap text is still
+            // scanned below for blank-line preservation between adjacent
+            // leading comments.
             let gap_start = (last_end as usize).min(source.len());
             let gap_end = (t.offset as usize).min(source.len());
-            let has_newline = gap_start < gap_end && source[gap_start..gap_end].contains('\n');
+            let is_leading = matches!(t.side, CommentSide::Leading);
 
             match t.kind {
                 CommentKind::Line => {
-                    if has_newline {
+                    if is_leading {
                         // Preserve blank lines between separate comment blocks.
                         let has_blank_line = {
                             let gs = gap_start.min(source.len());
@@ -193,7 +199,7 @@ impl CommentCtx {
                     }
                 }
                 CommentKind::Block => {
-                    if has_newline {
+                    if is_leading {
                         let hl = arena.hardline();
                         let comment_doc = arena.text(text);
                         let chunk = arena.cat(hl, comment_doc);

--- a/syntaqlite/src/fmt/comment.rs
+++ b/syntaqlite/src/fmt/comment.rs
@@ -313,9 +313,13 @@ impl CommentCtx {
         self.tokens.get(idx).map(|tp| (tp.offset, tp.length))
     }
 
-    /// Flush all remaining comments.
+    /// Flush all remaining comments.  Bypasses the `has_non_comment_text`
+    /// guard because, at end-of-statement drain, every remaining comment
+    /// is a trailing comment that this statement owns; the guard's check
+    /// for "syntax text past the comment" would spuriously fire when the
+    /// source text continues into the next statement.
     pub(crate) fn drain_remaining<'a>(&self, source: &'a str, arena: &mut DocArena<'a>) -> DocId {
-        let drain = self.drain_before(u32::MAX, source, arena);
+        let drain = self.drain_impl(u32::MAX, source, arena, true);
         arena.cat(drain.trailing, drain.leading)
     }
 }

--- a/syntaqlite/src/fmt/formatter.rs
+++ b/syntaqlite/src/fmt/formatter.rs
@@ -133,6 +133,7 @@ impl Formatter {
                 offset: c.offset(),
                 length: c.length(),
                 kind: c.kind(),
+                side: c.side(),
             }));
         self.token_entries.clear();
         self.token_entries.extend(
@@ -772,6 +773,7 @@ fn reindent_macro<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use syntaqlite_syntax::CommentSide;
 
     /// Verify that `Formatter` stores an `AnyParser` derived from the dialect,
     /// not a hardcoded `SQLite` `Parser`.
@@ -820,6 +822,7 @@ mod tests {
                 offset: 0,
                 length: 5,
                 kind: CommentKind::Block,
+                side: CommentSide::Leading,
             }],
             vec![TokenEntry {
                 offset: 5,
@@ -841,11 +844,13 @@ mod tests {
                     offset: 0,
                     length: 3,
                     kind: CommentKind::Line,
+                    side: CommentSide::Leading,
                 },
                 CommentEntry {
                     offset: 4,
                     length: 5,
                     kind: CommentKind::Block,
+                    side: CommentSide::Leading,
                 },
             ],
             vec![TokenEntry {

--- a/syntaqlite/src/fmt/formatter.rs
+++ b/syntaqlite/src/fmt/formatter.rs
@@ -1,10 +1,10 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+use syntaqlite_syntax::ParserConfig;
 use syntaqlite_syntax::any::{
     AnyNodeId, AnyParsedStatement, AnyParser, AnyTokenizer, FieldValue, ParseOutcome,
 };
-use syntaqlite_syntax::{CommentKind, ParserConfig};
 
 use super::FormatConfig;
 use super::FormatError;
@@ -178,7 +178,6 @@ impl Formatter {
         let mut session = self.parser.parse(source);
         let mut result = String::with_capacity(source.len());
         let mut stmt_num: usize = 0;
-        let mut last_has_root = false;
 
         loop {
             let stmt = match session.next() {
@@ -198,8 +197,6 @@ impl Formatter {
             let stmt_source = erased.text();
 
             let root_id = erased.root_id();
-            let prev_has_root = last_has_root;
-            last_has_root = !root_id.is_null();
             let semicolons = self.config.semicolons;
             let has_comments = !self.comment_entries.is_empty();
             let has_macros = !self.macro_rewrites.is_empty();
@@ -223,7 +220,6 @@ impl Formatter {
             if stmt_num > 0 {
                 emit_stmt_separator(
                     comment_ctx.as_ref(),
-                    semicolons && prev_has_root,
                     stmt_source,
                     &mut arena,
                     &mut self.parts,
@@ -243,6 +239,16 @@ impl Formatter {
             };
             let interpreted = self.interpret_node(&ctx, root_id, &mut arena);
             self.parts.push(interpreted);
+
+            // Emit this statement's terminator.  Trailing comments now
+            // live on the SEMI's token attachment, so they belong in the
+            // *same* render cycle as the SEMI; the previous design that
+            // added the SEMI in the next statement's emit_stmt_separator
+            // would render the trailing line_suffix in the wrong cycle.
+            if semicolons && !root_id.is_null() {
+                let semi = arena.text(";");
+                self.parts.push(semi);
+            }
 
             if let Some(cctx) = ctx.comment_ctx.as_ref() {
                 self.parts
@@ -276,9 +282,6 @@ impl Formatter {
             return Ok(String::new());
         }
 
-        if self.config.semicolons && last_has_root {
-            result.push(';');
-        }
         result.push('\n');
 
         Ok(result)
@@ -461,7 +464,6 @@ impl Formatter {
             if stmt_num > 0 {
                 emit_stmt_separator(
                     comment_ctx.as_ref(),
-                    false, // no semicolons in debug output
                     stmt_source,
                     &mut arena,
                     &mut self.parts,
@@ -510,63 +512,16 @@ impl Formatter {
 
 fn emit_stmt_separator<'a>(
     comment_ctx: Option<&CommentCtx>,
-    semicolons: bool,
     source: &'a str,
     arena: &mut DocArena<'a>,
     parts: &mut Vec<DocId>,
 ) {
+    parts.push(arena.hardline());
+    parts.push(arena.hardline());
     if let Some(cctx) = comment_ctx
         && let Some((next_offset, _)) = cctx.peek_next_token()
     {
-        if semicolons {
-            parts.push(arena.text(";"));
-        }
-        drain_trailing_gap(cctx, next_offset, source, arena, parts);
-        parts.push(arena.hardline());
-        parts.push(arena.hardline());
         drain_gap_comments(cctx, next_offset, source, arena, parts);
-        return;
-    }
-    if semicolons {
-        parts.push(arena.text(";"));
-    }
-    parts.push(arena.hardline());
-    parts.push(arena.hardline());
-}
-
-fn drain_trailing_gap<'a>(
-    ctx: &CommentCtx,
-    before: u32,
-    source: &'a str,
-    arena: &mut DocArena<'a>,
-    parts: &mut Vec<DocId>,
-) {
-    let mut last_end = ctx.prev_token_end();
-    while let Some(c) = ctx.peek_comment() {
-        if c.offset >= before {
-            break;
-        }
-        let gap_start = (last_end as usize).min(source.len());
-        let gap_end = (c.offset as usize).min(source.len());
-        if gap_start < gap_end && source[gap_start..gap_end].contains('\n') {
-            break;
-        }
-        let text = &source[c.offset as usize..(c.offset + c.length) as usize];
-        match c.kind {
-            CommentKind::Line => {
-                let space = arena.text(" ");
-                let comment = arena.text(text);
-                let inner = arena.cat(space, comment);
-                parts.push(arena.line_suffix(inner));
-                parts.push(arena.break_parent());
-            }
-            CommentKind::Block => {
-                parts.push(arena.text(" "));
-                parts.push(arena.text(text));
-            }
-        }
-        last_end = c.offset + c.length;
-        ctx.advance_comment();
     }
 }
 
@@ -773,7 +728,7 @@ fn reindent_macro<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use syntaqlite_syntax::CommentSide;
+    use syntaqlite_syntax::{CommentKind, CommentSide};
 
     /// Verify that `Formatter` stores an `AnyParser` derived from the dialect,
     /// not a hardcoded `SQLite` `Parser`.
@@ -797,25 +752,20 @@ mod tests {
     }
 
     #[test]
-    fn emit_stmt_separator_without_comments_with_semicolon() {
+    fn emit_stmt_separator_without_comments_emits_blank_line() {
         let source = "SELECT 1";
         let mut arena = DocArena::new();
         let mut parts = Vec::new();
-        emit_stmt_separator(None, true, source, &mut arena, &mut parts);
-        assert_eq!(render_parts(&mut arena, &parts), ";\n\n");
-    }
-
-    #[test]
-    fn emit_stmt_separator_without_comments_without_semicolon() {
-        let source = "SELECT 1";
-        let mut arena = DocArena::new();
-        let mut parts = Vec::new();
-        emit_stmt_separator(None, false, source, &mut arena, &mut parts);
+        emit_stmt_separator(None, source, &mut arena, &mut parts);
         assert_eq!(render_parts(&mut arena, &parts), "\n\n");
     }
 
     #[test]
-    fn emit_stmt_separator_emits_inline_block_comment_before_break() {
+    fn emit_stmt_separator_drains_leading_block_comment_after_break() {
+        // emit_stmt_separator now only handles the inter-statement break
+        // and drains LEADING comments of the next statement.  The
+        // statement terminator (`;`) and any TRAILING comments on it are
+        // emitted by per-statement processing in `format`, not here.
         let source = "/*x*/SELECT";
         let ctx = CommentCtx::new(
             vec![CommentEntry {
@@ -831,8 +781,8 @@ mod tests {
         );
         let mut arena = DocArena::new();
         let mut parts = Vec::new();
-        emit_stmt_separator(Some(&ctx), true, source, &mut arena, &mut parts);
-        assert_eq!(render_parts(&mut arena, &parts), "; /*x*/\n\n");
+        emit_stmt_separator(Some(&ctx), source, &mut arena, &mut parts);
+        assert_eq!(render_parts(&mut arena, &parts), "\n\n/*x*/\n");
     }
 
     #[test]

--- a/tests/fmt_diff_tests/comments.py
+++ b/tests/fmt_diff_tests/comments.py
@@ -28,7 +28,7 @@ class TrailingLineComment(TestSuite):
     def test_end_of_statement(self):
         return DiffTestBlueprint(
             sql="SELECT a FROM t -- trailing",
-            out="SELECT a FROM t -- trailing;",
+            out="SELECT a FROM t; -- trailing",
         )
 
     def test_after_column(self):
@@ -50,7 +50,7 @@ class TrailingLineComment(TestSuite):
     def test_after_where(self):
         return DiffTestBlueprint(
             sql="SELECT a FROM t WHERE x = 1 -- filter active",
-            out="SELECT a FROM t WHERE x = 1 -- filter active;",
+            out="SELECT a FROM t WHERE x = 1; -- filter active",
         )
 
     def test_after_select(self):

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -779,6 +779,8 @@ pub fn syntaqlite_syntax::Comment<'a>::token_idx(&self) -> u32
 pub fn syntaqlite_syntax::CommentSpan::kind(&self) -> syntaqlite_syntax::CommentKind
 pub fn syntaqlite_syntax::CommentSpan::length(&self) -> u32
 pub fn syntaqlite_syntax::CommentSpan::offset(&self) -> u32
+pub fn syntaqlite_syntax::CommentSpan::side(&self) -> syntaqlite_syntax::CommentSide
+pub fn syntaqlite_syntax::CommentSpan::token_idx(&self) -> u32
 pub fn syntaqlite_syntax::CompletionContext::from_raw(v: u32) -> Self
 pub fn syntaqlite_syntax::CompletionContext::raw(self) -> u32
 pub fn syntaqlite_syntax::IncrementalParseSession::completion_context(&self) -> syntaqlite_syntax::CompletionContext


### PR DESCRIPTION
Follow-up to #164 — completes the comment-attachment de-hackification
for #13.

**Parser:** when a statement boundary completes, eagerly consume
same-line trailing comments before returning.  Same-line comments
attach as TRAILING to the preceding SEMI; own-line comments still
attach as LEADING to the next statement.  Inter-statement comments now
end up on the right side of the boundary regardless of input.

**Formatter:** the offset/newline classification in \`drain_impl\`
swaps for \`c.side\` from the parser.  \`drain_trailing_gap\` is gone —
trailing comments now drain naturally via \`drain_remaining\` at
end-of-statement, since they live on the previous statement's
CommentCtx.  SEMI emission moves out of the next statement's
\`emit_stmt_separator\` and into per-statement processing so the SEMI
and the trailing comment land in the same render cycle.

\`CommentSpan\` (the lightweight, dialect-erased descriptor) gains the
same \`side()\` / \`token_idx()\` accessors that the typed \`Comment\`
already had.

Latent bug fixed along the way: \`SELECT a -- trailing\` used to
format to \`SELECT a -- trailing;\` with the \`;\` becoming part of
the comment; now formats to the correctly round-trippable
\`SELECT a; -- trailing\`.  Two TrailingLineComment fmt baselines
updated.

Closes #13.