### PR TITLE
synq: presere empty double-quited strings through fmt

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+gh = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,0 @@
-[tools]
-gh = "latest"

--- a/syntaqlite/src/fmt/interpret.rs
+++ b/syntaqlite/src/fmt/interpret.rs
@@ -221,8 +221,11 @@ impl Formatter {
                     };
 
                     let (s, span_start) = ctx.reader.span_text(span);
-                    if !s.is_empty() {
-                        let quoted = span.is_quoted();
+                    let quoted = span.is_quoted();
+                    // A zero-length unquoted span means the field is absent
+                    // (optional, unset). A zero-length *quoted* span is a
+                    // real `""` token and must round-trip as `""`.
+                    if quoted || !s.is_empty() {
                         if let Some(ref cctx) = ctx.comment_ctx {
                             // For quoted spans, the original token in source
                             // starts one byte earlier (the opening quote) and

--- a/tests/fmt_diff_tests/select.py
+++ b/tests/fmt_diff_tests/select.py
@@ -271,3 +271,15 @@ class TableValuedFunctionFormat(TestSuite):
             sql="SELECT name FROM users",
             out="SELECT name FROM users;",
         )
+
+    def test_empty_double_quoted_literal_preserved(self):
+        return DiffTestBlueprint(
+            sql='SELECT iif(x = "", \'empty\', x);',
+            out='SELECT iif(x = "", \'empty\', x);',
+        )
+
+    def test_empty_double_quoted_in_select_list(self):
+        return DiffTestBlueprint(
+            sql='SELECT "", 1;',
+            out='SELECT "", 1;',
+        )


### PR DESCRIPTION
Fixes: https://github.com/LalitMaganti/syntaqlite/issues/167