### PR TITLE
synq: add SYNTAQLITE_OMIT_RUNTIME flag for cdylib dialect plugins

### DIFF
--- a/python/dev/diff_tests/amalg_executor.py
+++ b/python/dev/diff_tests/amalg_executor.py
@@ -6,12 +6,16 @@
 Generates dialect amalgamations, compiles test binaries, and runs
 diff tests against them.
 
-Two amalgamation modes are supported:
+Three amalgamation modes are supported:
 
-  FULL         -- runtime inlined into dialect amalgam; self-contained
-                  syntaqlite_<name>.{h,c} that compiles with no extra deps.
-  DIALECT_ONLY -- dialect references an external syntaqlite_runtime.h;
-                  runtime must be compiled and linked separately.
+  FULL              -- runtime inlined into dialect amalgam; self-contained
+                       syntaqlite_<name>.{h,c} that compiles with no extra deps.
+  DIALECT_ONLY      -- dialect references an external syntaqlite_runtime.h;
+                       runtime must be compiled and linked separately.
+  FULL_OMIT_RUNTIME -- same checked-in full amalgamation, but compiled with
+                       -DSYNTAQLITE_OMIT_RUNTIME to strip runtime bodies;
+                       a separate runtime-only .c is linked in. Models the
+                       cdylib dialect-plugin use case from issue #166.
 """
 
 import enum
@@ -28,6 +32,7 @@ from python.dev.diff_tests.testing import DiffTestBlueprint
 class AmalgMode(enum.Enum):
     FULL = "full"
     DIALECT_ONLY = "dialect_only"
+    FULL_OMIT_RUNTIME = "full_omit_runtime"
 
 
 @dataclass
@@ -116,6 +121,43 @@ def _compile_full_binary(
     if proc.returncode != 0:
         raise RuntimeError(
             f"Compilation failed (full) for {dialect_name}:\n{proc.stderr}"
+        )
+
+
+def _compile_full_omit_runtime_binary(
+    test_c: Path,
+    amalg_dir: Path,
+    runtime_dir: Path,
+    dialect_name: str,
+    output_binary: Path,
+) -> None:
+    """Compile test_ast.c against a full amalgamation built with
+    -DSYNTAQLITE_OMIT_RUNTIME, linked against a separately-generated
+    runtime-only .c.
+
+    Models the cdylib dialect-plugin use case: the host binary already
+    provides the runtime, so the plugin's copy of the full amalgamation
+    strips runtime implementations to avoid duplication. Here we stand
+    in for the host runtime by linking a runtime-only .c directly.
+    """
+    grammar_header = f'"syntaqlite_{dialect_name}.h"'
+    grammar_fn = f"syntaqlite_{dialect_name}_dialect"
+    dialect_src = amalg_dir / f"syntaqlite_{dialect_name}.c"
+    runtime_src = runtime_dir / "syntaqlite_runtime.c"
+    cmd = [
+        "cc", "-o", str(output_binary),
+        str(test_c), str(dialect_src), str(runtime_src),
+        f"-I{amalg_dir}",
+        f"-I{runtime_dir}",
+        f"-DGRAMMAR_HEADER={grammar_header}",
+        f"-DGRAMMAR_FN={grammar_fn}",
+        "-DSYNTAQLITE_OMIT_RUNTIME",
+        "-Werror",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"Compilation failed (full + OMIT_RUNTIME) for {dialect_name}:\n{proc.stderr}"
         )
 
 
@@ -301,6 +343,14 @@ class AmalgTestContext:
                 self.test_c, amalg_dir, runtime_dir, dialect.name, binary
             )
 
+        elif dialect.mode == AmalgMode.FULL_OMIT_RUNTIME:
+            _build_full(self.cli_binary, dialect, amalg_dir)
+            runtime_dir = self._ensure_runtime()
+            binary = temp / f"test_{key}"
+            _compile_full_omit_runtime_binary(
+                self.test_c, amalg_dir, runtime_dir, dialect.name, binary
+            )
+
         else:
             raise ValueError(f"Unknown AmalgMode: {dialect.mode}")
 
@@ -320,7 +370,7 @@ class AmalgTestContext:
         output = temp / f"strict_{key}"
         runtime_dir = (
             self._runtime_dir
-            if dialect.mode == AmalgMode.DIALECT_ONLY
+            if dialect.mode in (AmalgMode.DIALECT_ONLY, AmalgMode.FULL_OMIT_RUNTIME)
             else None
         )
         compile_strict_warning_check(

--- a/python/dev/integration_tests/suites/amalg.py
+++ b/python/dev/integration_tests/suites/amalg.py
@@ -43,6 +43,9 @@ def _dialect_configs(root_dir: Path) -> dict[str, DialectConfig]:
             name="sqlite", mode=AmalgMode.FULL,
             extra_cflags=("-DSYNTAQLITE_OMIT_MACROS",),
         ),
+        "sqliteamalgomitruntime": DialectConfig(
+            name="sqlite", mode=AmalgMode.FULL_OMIT_RUNTIME,
+        ),
         "sqliteamalgruntimeonly": DialectConfig(name="sqlite", mode=AmalgMode.DIALECT_ONLY),
         "perfettoamalgfull": DialectConfig(
             name="perfetto", mode=AmalgMode.FULL,
@@ -105,6 +108,10 @@ def run(ctx: SuiteContext) -> int:
         # consumers to add -Wno-* suppressions.
         for key in sorted(needed):
             config = configs[key]
+            if config.mode == AmalgMode.FULL_OMIT_RUNTIME:
+                # Same source file as the FULL variant, only with some bodies
+                # stripped by the preprocessor — strict-check is transitive.
+                continue
             if ctx.verbose >= 1:
                 print(f"Strict-warning C++ compile check: {config.name} ({config.mode.value})...")
             try:

--- a/syntaqlite-buildtools/src/parser_tools/amalgamate.rs
+++ b/syntaqlite-buildtools/src/parser_tools/amalgamate.rs
@@ -20,6 +20,11 @@ use std::collections::{BTreeMap, HashSet};
 use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
+use std::sync::OnceLock;
+
+/// Empty runtime-keys set reused by `Emitter::new` for modes that don't
+/// wrap any files in the `SYNTAQLITE_OMIT_RUNTIME` guard.
+static EMPTY_KEYS: OnceLock<HashSet<String>> = OnceLock::new();
 
 // ---------------------------------------------------------------------------
 // Warning suppressions emitted into the amalgamation .c file
@@ -176,6 +181,11 @@ pub fn amalgamate_dialect(
 /// the amalgamation header and source, compiling out all macro expansion
 /// code.
 ///
+/// The generated `.c` wraps runtime-origin sources (from `runtime_dir`) in
+/// an `#ifndef SYNTAQLITE_OMIT_RUNTIME` guard so callers loading the output
+/// as a plugin (`cdylib`) can compile with `-DSYNTAQLITE_OMIT_RUNTIME` to
+/// exclude runtime implementations and rely on the host binary's copy.
+///
 /// # Errors
 ///
 /// Returns an error if reading source files from `runtime_dir` or `dialect_dir` fails.
@@ -185,13 +195,65 @@ pub fn amalgamate_full(
     dialect_dir: &Path,
     omit_macros: bool,
 ) -> Result<AmalgamateOutput, String> {
-    let files = collect_files(&[
-        &runtime_dir.join("csrc"),
-        &runtime_dir.join("include"),
-        &dialect_dir.join("csrc"),
-        &dialect_dir.join("include"),
-    ])?;
-    Ok(emit(&files, EmitMode::Full(dialect), omit_macros))
+    let runtime_files =
+        collect_files(&[&runtime_dir.join("csrc"), &runtime_dir.join("include")])?;
+    let dialect_files =
+        collect_files(&[&dialect_dir.join("csrc"), &dialect_dir.join("include")])?;
+
+    let mut files = FileMap::new();
+    for (k, v) in &runtime_files {
+        files.insert(k.clone(), v.clone());
+    }
+    for (k, v) in &dialect_files {
+        files.insert(k.clone(), v.clone());
+    }
+
+    let runtime_keys: HashSet<String> = files
+        .keys()
+        .filter(|k| is_runtime_origin(k, dialect, &runtime_files, &dialect_files))
+        .filter(|k| matches!(classify(k), FileKind::InternalHeader | FileKind::Source))
+        .cloned()
+        .collect();
+
+    Ok(emit(
+        &files,
+        EmitMode::Full {
+            dialect,
+            runtime_keys: &runtime_keys,
+        },
+        omit_macros,
+    ))
+}
+
+/// Classify a file's origin.
+///
+/// Primary signal: which collection the key was found in.
+///   - only in runtime     → runtime origin
+///   - only in dialect     → dialect origin
+///   - in both (overlap)   → path-based fallback (happens when the caller
+///     passes the same on-disk tree for both runtime and dialect dirs,
+///     e.g. `tools/build-amalgamation` reading the source checkout).
+///
+/// Path-based fallback: keys under `csrc/<dialect>/` or `syntaqlite_<dialect>/`
+/// are dialect; everything else is runtime.
+fn is_runtime_origin(
+    key: &str,
+    dialect: &str,
+    runtime_files: &FileMap,
+    dialect_files: &FileMap,
+) -> bool {
+    let in_rt = runtime_files.contains_key(key);
+    let in_dl = dialect_files.contains_key(key);
+    match (in_rt, in_dl) {
+        (true, false) => true,
+        (false, true) => false,
+        (true, true) => {
+            let dialect_csrc = format!("csrc/{dialect}/");
+            let dialect_pub = format!("syntaqlite_{dialect}/");
+            !(key.starts_with(&dialect_csrc) || key.starts_with(&dialect_pub))
+        }
+        (false, false) => false,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -323,7 +385,15 @@ enum EmitMode<'a> {
         ext_header: &'a str,
     },
     /// Full: runtime + dialect inlined into `syntaqlite_<name>.{h,c}`.
-    Full(&'a str),
+    ///
+    /// `runtime_keys` identifies files that originate from the runtime tree.
+    /// Runtime-origin sources are wrapped in an `#ifndef SYNTAQLITE_OMIT_RUNTIME`
+    /// guard; runtime-origin headers are emitted before dialect-origin headers
+    /// so dialect declarations can reference runtime types.
+    Full {
+        dialect: &'a str,
+        runtime_keys: &'a HashSet<String>,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -354,21 +424,46 @@ enum Section {
     Source,
 }
 
+fn section_expands(section: Section, kind: FileKind) -> bool {
+    match section {
+        Section::Header => kind == FileKind::PublicHeader,
+        Section::ExtHeader => kind == FileKind::ExtHeader,
+        Section::Source => matches!(kind, FileKind::InternalHeader | FileKind::ExtHeader),
+    }
+}
+
 struct Emitter<'a> {
     files: &'a FileMap,
     seen: HashSet<String>,
+    /// Keys that should have their emitted content wrapped in
+    /// `#ifndef SYNTAQLITE_OMIT_RUNTIME`. Empty means no wrapping (used by
+    /// all modes except `Full`).
+    runtime_keys: &'a HashSet<String>,
 }
 
 impl<'a> Emitter<'a> {
     fn new(files: &'a FileMap) -> Self {
+        Self::with_runtime_keys(files, EMPTY_KEYS.get_or_init(HashSet::new))
+    }
+
+    fn with_runtime_keys(files: &'a FileMap, runtime_keys: &'a HashSet<String>) -> Self {
         Self {
             files,
             seen: HashSet::new(),
+            runtime_keys,
         }
     }
 
-    /// Emit one file, recursively expanding local `#include "..."` directives
-    /// according to `section`. Already-seen files are skipped (deduplication).
+    /// Emit one file. Children (locally-included files allowed by `section`)
+    /// are emitted first in post-order DFS, each via this same function.
+    /// Then the file's own body is emitted, with resolved local includes
+    /// suppressed (their content was written earlier).
+    ///
+    /// If the file's key is in `runtime_keys`, its own body — but *not* its
+    /// hoisted children — is wrapped in `#ifndef SYNTAQLITE_OMIT_RUNTIME`.
+    /// Shared headers (like extension SPI) reached from both runtime and
+    /// dialect files thus land outside any wrap, so dedup never traps their
+    /// declarations inside a stripped region.
     fn emit_file(&mut self, key: &str, out: &mut String, section: Section) {
         if !self.seen.insert(key.to_string()) {
             return;
@@ -378,7 +473,22 @@ impl<'a> Emitter<'a> {
             None => return,
         };
 
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if let Some(IncludeDirective::Quoted(path)) = parse_include_directive(trimmed)
+                && self.files.contains_key(path)
+                && section_expands(section, classify(path))
+            {
+                self.emit_file(path, out, section);
+            }
+        }
+
+        let wrap_runtime = self.runtime_keys.contains(key);
+
         let _ = writeln!(out, "/* ======== begin: {key} ======== */");
+        if wrap_runtime {
+            out.push_str("#ifndef SYNTAQLITE_OMIT_RUNTIME\n");
+        }
 
         let guard = detect_include_guard(&content);
         if let Some(ref g) = guard {
@@ -387,8 +497,6 @@ impl<'a> Emitter<'a> {
 
         let mut lines: Vec<&str> = content.lines().collect();
 
-        // Strip the trailing `#endif` of the original guard so we can re-emit
-        // our own below (prevents the guard from spanning the end-marker comment).
         if guard.is_some() {
             for i in (0..lines.len()).rev() {
                 let t = lines[i].trim();
@@ -409,8 +517,6 @@ impl<'a> Emitter<'a> {
         for line in &lines {
             let trimmed = line.trim();
 
-            // Strip the original `#ifndef GUARD` / `#define GUARD` pair — we
-            // re-emitted them above, before the content block.
             if let Some(ref g) = guard {
                 if !guard_ifndef_seen {
                     if let Some(rest) = trimmed.strip_prefix("#ifndef")
@@ -432,30 +538,15 @@ impl<'a> Emitter<'a> {
                 match directive {
                     IncludeDirective::Quoted(path) => {
                         if self.files.contains_key(path) {
-                            // Resolved: inline it if appropriate for this section,
-                            // otherwise silently drop the directive.
-                            let kind = classify(path);
-                            let should_expand = match section {
-                                Section::Header => kind == FileKind::PublicHeader,
-                                Section::ExtHeader => kind == FileKind::ExtHeader,
-                                Section::Source => {
-                                    matches!(kind, FileKind::InternalHeader | FileKind::ExtHeader)
-                                }
-                            };
-                            if should_expand {
-                                self.emit_file(path, out, section);
-                            }
+                            // Resolved locally — children were hoisted above,
+                            // so drop the directive regardless of whether it
+                            // expanded.
                             continue;
                         }
-                        // Unresolved: strip runtime-style paths in all sections.
-                        // In Full/RuntimeOnly modes these never arise (all runtime
-                        // files are in the map). In DialectOnly mode they must be
-                        // stripped since the runtime header is included explicitly.
                         if is_runtime_path(path) {
                             continue;
                         }
                     }
-                    // System includes (`<...>`) and macro includes are always kept.
                     IncludeDirective::System | IncludeDirective::Other => {}
                 }
             }
@@ -466,6 +557,9 @@ impl<'a> Emitter<'a> {
 
         if let Some(ref g) = guard {
             let _ = writeln!(out, "#endif  /* {g} */");
+        }
+        if wrap_runtime {
+            out.push_str("#endif /* !SYNTAQLITE_OMIT_RUNTIME */\n");
         }
         let _ = write!(out, "/* ======== end: {key} ======== */\n\n");
     }
@@ -563,7 +657,7 @@ fn detect_include_guard(content: &str) -> Option<String> {
 )]
 fn emit(files: &FileMap, mode: EmitMode, omit_macros: bool) -> AmalgamateOutput {
     let (guard, header_filename) = match &mode {
-        EmitMode::DialectOnly { dialect: d, .. } | EmitMode::Full(d) => (
+        EmitMode::DialectOnly { dialect: d, .. } | EmitMode::Full { dialect: d, .. } => (
             format!("SYNTAQLITE_{}_H", d.to_uppercase()),
             format!("syntaqlite_{d}.h"),
         ),
@@ -601,13 +695,13 @@ fn emit(files: &FileMap, mode: EmitMode, omit_macros: bool) -> AmalgamateOutput 
             header.push_str("#endif\n");
             header.push_str("#include SYNTAQLITE_RUNTIME_HEADER\n\n");
         }
-        EmitMode::Full(dialect) if *dialect != "sqlite" => {
+        EmitMode::Full { dialect, .. } if *dialect != "sqlite" => {
             emit_omit_define(&mut header, "SYNTAQLITE_OMIT_SQLITE_API");
             if omit_macros {
                 emit_omit_define(&mut header, "SYNTAQLITE_OMIT_MACROS");
             }
         }
-        EmitMode::Full(_) if omit_macros => {
+        EmitMode::Full { .. } if omit_macros => {
             emit_omit_define(&mut header, "SYNTAQLITE_OMIT_MACROS");
         }
         _ => {}
@@ -677,7 +771,7 @@ fn emit(files: &FileMap, mode: EmitMode, omit_macros: bool) -> AmalgamateOutput 
         let _ = writeln!(source, "#define SYNTAQLITE_EXT_HEADER \"{ext_header}\"");
         source.push_str("#endif\n");
         source.push_str("#include SYNTAQLITE_EXT_HEADER\n\n");
-    } else if let EmitMode::Full(dialect) = &mode
+    } else if let EmitMode::Full { dialect, .. } = &mode
         && *dialect != "sqlite"
     {
         emit_omit_define(&mut source, "SYNTAQLITE_OMIT_SQLITE_API");
@@ -689,9 +783,10 @@ fn emit(files: &FileMap, mode: EmitMode, omit_macros: bool) -> AmalgamateOutput 
     }
     let _ = write!(source, "#include \"{header_filename}\"\n\n");
 
-    // Emit sources. They recursively pull in their internal and ext-header
-    // dependencies in encounter order (driven by the include graph).
-    let mut s_emitter = Emitter::new(files);
+    let mut s_emitter = match &mode {
+        EmitMode::Full { runtime_keys, .. } => Emitter::with_runtime_keys(files, runtime_keys),
+        _ => Emitter::new(files),
+    };
     s_emitter.emit_kind(FileKind::Source, &mut source, Section::Source);
 
     emit_diagnostic_pop(&mut source);
@@ -828,5 +923,201 @@ mod tests {
         assert!(is_runtime_path("syntaqlite_dialect/arena.h"));
         assert!(is_runtime_path("csrc/dialect_dispatch.h"));
         assert!(!is_runtime_path("vendor/custom.h"));
+    }
+
+    fn runtime_set(keys: &[&str]) -> HashSet<String> {
+        keys.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn full_mode_wraps_each_runtime_source_individually() {
+        let mut files = FileMap::new();
+        files.insert(
+            "csrc/parser.c".to_string(),
+            "void runtime_api(void) {}\n".to_string(),
+        );
+        files.insert(
+            "csrc/tokenizer.c".to_string(),
+            "void runtime_tok(void) {}\n".to_string(),
+        );
+        files.insert(
+            "csrc/sqlite/dialect.c".to_string(),
+            "void sqlite_dialect_fn(void) {}\n".to_string(),
+        );
+
+        let runtime_keys = runtime_set(&["csrc/parser.c", "csrc/tokenizer.c"]);
+
+        let out = emit(
+            &files,
+            EmitMode::Full {
+                dialect: "sqlite",
+                runtime_keys: &runtime_keys,
+            },
+            false,
+        );
+
+        let src = &out.source;
+
+        fn block_for<'a>(src: &'a str, key: &str) -> &'a str {
+            let begin = src.find(&format!("begin: {key}")).expect("missing begin");
+            let end = src.find(&format!("end: {key}")).expect("missing end");
+            &src[begin..end]
+        }
+
+        let parser_block = block_for(src, "csrc/parser.c");
+        let tok_block = block_for(src, "csrc/tokenizer.c");
+        let dialect_block = block_for(src, "csrc/sqlite/dialect.c");
+
+        assert!(
+            parser_block.contains("#ifndef SYNTAQLITE_OMIT_RUNTIME"),
+            "runtime parser.c block should open the OMIT_RUNTIME guard"
+        );
+        assert!(
+            parser_block.contains("#endif /* !SYNTAQLITE_OMIT_RUNTIME */"),
+            "runtime parser.c block should close the OMIT_RUNTIME guard"
+        );
+        assert!(
+            tok_block.contains("#ifndef SYNTAQLITE_OMIT_RUNTIME"),
+            "runtime tokenizer.c block should open the OMIT_RUNTIME guard"
+        );
+        assert!(
+            !dialect_block.contains("#ifndef SYNTAQLITE_OMIT_RUNTIME"),
+            "dialect source block must not be wrapped"
+        );
+    }
+
+    #[test]
+    fn full_mode_shared_ext_header_survives_omit_runtime() {
+        // Regression: when a runtime source and a dialect source both include
+        // the same extension SPI header, dedup must not trap the header's
+        // declarations inside the runtime source's OMIT_RUNTIME guard — the
+        // dialect source needs those declarations after the guard strips the
+        // runtime body.
+        let mut files = FileMap::new();
+        files.insert(
+            "syntaqlite_dialect/shared.h".to_string(),
+            "#ifndef SYNTAQLITE_DIALECT_SHARED_H\n\
+             #define SYNTAQLITE_DIALECT_SHARED_H\n\
+             typedef int shared_type;\n\
+             #endif\n"
+                .to_string(),
+        );
+        files.insert(
+            "csrc/parser.c".to_string(),
+            "#include \"syntaqlite_dialect/shared.h\"\n\
+             void runtime_fn(shared_type x) { (void)x; }\n"
+                .to_string(),
+        );
+        files.insert(
+            "csrc/sqlite/dialect.c".to_string(),
+            "#include \"syntaqlite_dialect/shared.h\"\n\
+             void dialect_fn(shared_type x) { (void)x; }\n"
+                .to_string(),
+        );
+
+        let runtime_keys = runtime_set(&["csrc/parser.c"]);
+
+        let out = emit(
+            &files,
+            EmitMode::Full {
+                dialect: "sqlite",
+                runtime_keys: &runtime_keys,
+            },
+            false,
+        );
+
+        let src = &out.source;
+
+        // Emitted exactly once (dedup).
+        assert_eq!(
+            src.matches("begin: syntaqlite_dialect/shared.h").count(),
+            1,
+            "shared header should be emitted exactly once"
+        );
+
+        // Simulate the preprocessor with OMIT_RUNTIME defined: every
+        // `#ifndef SYNTAQLITE_OMIT_RUNTIME` block is stripped. The shared
+        // header's declarations must survive.
+        let stripped = strip_omit_runtime_blocks(src);
+        assert!(
+            stripped.contains("typedef int shared_type"),
+            "shared header declarations must survive OMIT_RUNTIME; stripped output:\n{stripped}"
+        );
+        // Dialect function definition still present (it was never wrapped).
+        assert!(
+            stripped.contains("void dialect_fn("),
+            "dialect source must survive OMIT_RUNTIME"
+        );
+        // Runtime implementation removed.
+        assert!(
+            !stripped.contains("void runtime_fn("),
+            "runtime source must be stripped under OMIT_RUNTIME"
+        );
+    }
+
+    /// Strip every `#ifndef SYNTAQLITE_OMIT_RUNTIME` ... `#endif /* !SYNTAQLITE_OMIT_RUNTIME */`
+    /// block from `src`, simulating what the C preprocessor does when
+    /// `SYNTAQLITE_OMIT_RUNTIME` is defined at compile time.
+    fn strip_omit_runtime_blocks(src: &str) -> String {
+        let mut out = String::new();
+        let mut inside = false;
+        for line in src.lines() {
+            let t = line.trim();
+            if !inside && t == "#ifndef SYNTAQLITE_OMIT_RUNTIME" {
+                inside = true;
+                continue;
+            }
+            if inside && t == "#endif /* !SYNTAQLITE_OMIT_RUNTIME */" {
+                inside = false;
+                continue;
+            }
+            if !inside {
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn is_runtime_origin_prefers_collection_membership() {
+        let mut rt = FileMap::new();
+        rt.insert("csrc/parser.c".to_string(), String::new());
+        let mut dl = FileMap::new();
+        dl.insert("csrc/dialect.c".to_string(), String::new());
+
+        assert!(is_runtime_origin("csrc/parser.c", "sqlite", &rt, &dl));
+        assert!(!is_runtime_origin("csrc/dialect.c", "sqlite", &rt, &dl));
+    }
+
+    #[test]
+    fn is_runtime_origin_falls_back_to_path_when_dirs_overlap() {
+        // Both collections contain the same keys — simulates the caller
+        // passing the same on-disk tree for both runtime_dir and dialect_dir.
+        let mut both = FileMap::new();
+        both.insert("csrc/parser.c".to_string(), String::new());
+        both.insert("csrc/sqlite/dialect.c".to_string(), String::new());
+        both.insert("syntaqlite_sqlite/node.h".to_string(), String::new());
+        both.insert("syntaqlite_dialect/arena.h".to_string(), String::new());
+
+        assert!(is_runtime_origin("csrc/parser.c", "sqlite", &both, &both));
+        assert!(!is_runtime_origin(
+            "csrc/sqlite/dialect.c",
+            "sqlite",
+            &both,
+            &both
+        ));
+        assert!(!is_runtime_origin(
+            "syntaqlite_sqlite/node.h",
+            "sqlite",
+            &both,
+            &both
+        ));
+        assert!(is_runtime_origin(
+            "syntaqlite_dialect/arena.h",
+            "sqlite",
+            &both,
+            &both
+        ));
     }
 }

--- a/tests/amalg_tests/sqlite_omit_runtime.py
+++ b/tests/amalg_tests/sqlite_omit_runtime.py
@@ -1,0 +1,127 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Amalgamation tests with SYNTAQLITE_OMIT_RUNTIME defined.
+
+Verifies that the full amalgamation compiled with `-DSYNTAQLITE_OMIT_RUNTIME`
+and linked against a separately-built runtime-only .c produces a working
+parser — matching the `cdylib` dialect-plugin use case from issue #166
+where the host binary already contains the runtime.
+"""
+
+from python.dev.diff_tests.testing import DiffTestBlueprint, TestSuite
+
+
+class SqliteAmalgOmitRuntime(TestSuite):
+    """Parsing through full amalgamation with runtime stripped and linked externally."""
+
+    def test_select_literal(self):
+        return DiffTestBlueprint(
+            sql="SELECT 1",
+            out="""\
+            SelectStmt
+              flags: (none)
+              columns:
+                ResultColumnList [1 items]
+                  ResultColumn
+                    flags: (none)
+                    alias: (none)
+                    expr:
+                      Literal
+                        literal_type: INTEGER
+                        source: "1"
+              from_clause: (none)
+              where_clause: (none)
+              groupby: (none)
+              having: (none)
+              orderby: (none)
+              limit_clause: (none)
+              window_clause: (none)
+""",
+        )
+
+    def test_select_from_where(self):
+        return DiffTestBlueprint(
+            sql="SELECT a FROM t WHERE x = 1",
+            out="""\
+            SelectStmt
+              flags: (none)
+              columns:
+                ResultColumnList [1 items]
+                  ResultColumn
+                    flags: (none)
+                    alias: (none)
+                    expr:
+                      ColumnRef
+                        column: "a"
+                        table: (none)
+                        schema: (none)
+              from_clause:
+                TableRef
+                  table_name: "t"
+                  schema: (none)
+                  alias: (none)
+                  args: (none)
+              where_clause:
+                BinaryExpr
+                  op: EQ
+                  left:
+                    ColumnRef
+                      column: "x"
+                      table: (none)
+                      schema: (none)
+                  right:
+                    Literal
+                      literal_type: INTEGER
+                      source: "1"
+              groupby: (none)
+              having: (none)
+              orderby: (none)
+              limit_clause: (none)
+              window_clause: (none)
+""",
+        )
+
+    def test_multiple_statements(self):
+        return DiffTestBlueprint(
+            sql="SELECT 1; SELECT 2",
+            out="""\
+            SelectStmt
+              flags: (none)
+              columns:
+                ResultColumnList [1 items]
+                  ResultColumn
+                    flags: (none)
+                    alias: (none)
+                    expr:
+                      Literal
+                        literal_type: INTEGER
+                        source: "1"
+              from_clause: (none)
+              where_clause: (none)
+              groupby: (none)
+              having: (none)
+              orderby: (none)
+              limit_clause: (none)
+              window_clause: (none)
+            ----
+            SelectStmt
+              flags: (none)
+              columns:
+                ResultColumnList [1 items]
+                  ResultColumn
+                    flags: (none)
+                    alias: (none)
+                    expr:
+                      Literal
+                        literal_type: INTEGER
+                        source: "2"
+              from_clause: (none)
+              where_clause: (none)
+              groupby: (none)
+              having: (none)
+              orderby: (none)
+              limit_clause: (none)
+              window_clause: (none)
+""",
+        )


### PR DESCRIPTION
## Motivation

Closes #166.

When a dialect is compiled as a `cdylib` to be loaded by a host binary (e.g. `syntaqlite fmt --dialect-path`), the host already contains the runtime. The `--output-type full` amalgamation duplicates ~670 KB of runtime code inside the `.so`. The ask: a preprocessor flag that lets a single checked-in `syntaqlite_<dialect>.c` serve both the statically-linked-into-host and loaded-as-plugin use cases.

## Changes

- **Amalgamator**: in `EmitMode::Full`, each runtime-origin file's own body is wrapped in `#ifndef SYNTAQLITE_OMIT_RUNTIME` / `#endif`. Emission is restructured to a post-order DFS: each file's children (typically shared ext SPI headers like `syntaqlite_dialect/*`) are emitted before the file's wrap opens, so a header reached via a runtime source is not trapped inside its wrap.
- **Origin tagging**: prefers collection membership when `runtime_dir` and `dialect_dir` differ (the `syntaqlite dialect --output-type full` CLI path) and falls back to path classification when both point at the same source tree (`tools/build-amalgamation`). Ext headers (`syntaqlite_dialect/*`) are excluded from the wrap because dialect code consumes those declarations.
- **Integration test**: new `AmalgMode.FULL_OMIT_RUNTIME` flavour in `python/dev/diff_tests/amalg_executor.py` compiles the full amalgamation with `-DSYNTAQLITE_OMIT_RUNTIME` and links against a separately-built `syntaqlite_runtime.c`. New `SqliteAmalgOmitRuntime` AST diff suite in `tests/amalg_tests/sqlite_omit_runtime.py` runs end-to-end under `tools/run-integration-tests --suite amalg` (compile → link → parse → verify AST).
- **Unit tests**: added to `amalgamate.rs` — per-file wrap placement, shared ext-header survival when OMIT_RUNTIME strips a neighbouring runtime body, and origin classification behaviour with distinct vs. overlapping directory collections.

Verified: `cargo test -p syntaqlite-buildtools` (144 unit tests) and `tools/run-integration-tests --suite amalg` (31 amalgamation tests, including the 3 new OMIT_RUNTIME ones) both pass.