### PR TITLE
synq: add tokenize subcommand + refactor dialect as subcommand group

### DIFF
--- a/python/dev/diff_tests/amalg_executor.py
+++ b/python/dev/diff_tests/amalg_executor.py
@@ -57,7 +57,7 @@ class DialectConfig:
 # ---------------------------------------------------------------------------
 
 def _build_full(cli_binary: Path, dialect: DialectConfig, output_dir: Path) -> None:
-    cmd = [str(cli_binary), "dialect", "--name", dialect.name]
+    cmd = [str(cli_binary), "dialect", "generate", "--name", dialect.name]
     if dialect.actions_dir:
         cmd += ["--actions-dir", dialect.actions_dir]
     if dialect.nodes_dir:
@@ -73,7 +73,7 @@ def _build_full(cli_binary: Path, dialect: DialectConfig, output_dir: Path) -> N
 def _build_dialect_only(
     cli_binary: Path, dialect: DialectConfig, output_dir: Path
 ) -> None:
-    cmd = [str(cli_binary), "dialect", "--name", dialect.name]
+    cmd = [str(cli_binary), "dialect", "generate", "--name", dialect.name]
     if dialect.actions_dir:
         cmd += ["--actions-dir", dialect.actions_dir]
     if dialect.nodes_dir:
@@ -87,7 +87,7 @@ def _build_dialect_only(
 
 
 def _build_runtime_only(cli_binary: Path, output_dir: Path) -> None:
-    cmd = [str(cli_binary), "dialect", "--name", "sqlite",
+    cmd = [str(cli_binary), "dialect", "generate", "--name", "sqlite",
            "--output-type", "runtime-only", "--output-dir", str(output_dir)]
     proc = subprocess.run(cmd, capture_output=True, text=True)
     if proc.returncode != 0:

--- a/python/dev/diff_tests/perfetto_common.py
+++ b/python/dev/diff_tests/perfetto_common.py
@@ -78,6 +78,7 @@ def _compile_perfetto_dialect(cli_binary: Path, work_dir: Path) -> Path:
         [
             str(cli_binary),
             "dialect",
+            "generate",
             "--name",
             "perfetto",
             "--actions-dir",

--- a/python/dev/integration_tests/runner.py
+++ b/python/dev/integration_tests/runner.py
@@ -40,6 +40,7 @@ _SUITE_MODULES = [
     "python.dev.integration_tests.suites.lsp",
     "python.dev.integration_tests.suites.validate",
     "python.dev.integration_tests.suites.lineage",
+    "python.dev.integration_tests.suites.introspect",
 ]
 
 _BLUE = "\033[1;34m"

--- a/python/dev/integration_tests/suites/grammar.py
+++ b/python/dev/integration_tests/suites/grammar.py
@@ -45,7 +45,7 @@ def _generate_full_amalg(
     actions_dir: str | None = None,
     nodes_dir: str | None = None,
 ) -> None:
-    cmd = [str(binary), "dialect", "--name", name]
+    cmd = [str(binary), "dialect", "generate", "--name", name]
     if actions_dir:
         cmd += ["--actions-dir", actions_dir]
     if nodes_dir:

--- a/python/dev/integration_tests/suites/introspect.py
+++ b/python/dev/integration_tests/suites/introspect.py
@@ -1,0 +1,145 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""CLI introspection suite: tokenize."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from python.dev.integration_tests.suite import SuiteContext
+
+NAME = "introspect"
+DESCRIPTION = "CLI introspection commands (tokenize + dialect codegen group)"
+
+_GREEN = "\033[32m"
+_RED = "\033[31m"
+_RESET = "\033[0m"
+
+
+def _pass(name: str) -> None:
+    print(f"  {_GREEN}PASS{_RESET}  {name}")
+
+
+def _fail(name: str, detail: str) -> None:
+    print(f"  {_RED}FAIL{_RESET}  {name}: {detail}")
+
+
+def _run(
+    binary: Path,
+    *args: str,
+    stdin: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(binary), *args],
+        input=stdin,
+        capture_output=True,
+        text=True,
+    )
+
+
+# ── tokenize ─────────────────────────────────────────────────────────────
+
+
+def _test_tokenize_text_output(ctx: SuiteContext) -> bool:
+    """`tokenize` default (text) emits one line per token."""
+    result = _run(ctx.binary, "tokenize", "-e", "SELECT 1;")
+    if result.returncode != 0:
+        _fail("tokenize_text_output", f"exit {result.returncode}: {result.stderr}")
+        return False
+    lines = [l for l in result.stdout.splitlines() if l.strip()]
+    if not lines:
+        _fail("tokenize_text_output", f"no output: {result.stdout!r}")
+        return False
+    joined = "\n".join(lines)
+    if "SELECT" not in joined:
+        _fail("tokenize_text_output", f"expected SELECT token, got: {joined}")
+        return False
+    _pass("tokenize_text_output")
+    return True
+
+
+def _test_tokenize_json_output(ctx: SuiteContext) -> bool:
+    """`tokenize -o json` emits ndjson with text/offset/length/type fields."""
+    result = _run(ctx.binary, "tokenize", "-o", "json", "-e", "SELECT 1;")
+    if result.returncode != 0:
+        _fail("tokenize_json_output", f"exit {result.returncode}: {result.stderr}")
+        return False
+    records = [
+        json.loads(l) for l in result.stdout.splitlines() if l.strip()
+    ]
+    if not records:
+        _fail("tokenize_json_output", "no records")
+        return False
+    for field in ("kind", "schema_version", "text", "offset", "length", "type"):
+        if field not in records[0]:
+            _fail("tokenize_json_output", f"missing {field!r} in {records[0]}")
+            return False
+    if records[0]["kind"] != "token":
+        _fail("tokenize_json_output", f"wrong kind: {records[0]}")
+        return False
+    select = next((r for r in records if r["text"] == "SELECT"), None)
+    if select is None:
+        _fail("tokenize_json_output", f"no SELECT token in {records}")
+        return False
+    _pass("tokenize_json_output")
+    return True
+
+
+def _test_tokenize_stdin(ctx: SuiteContext) -> bool:
+    """`tokenize` reads stdin when no files / -e given."""
+    result = _run(ctx.binary, "tokenize", "-o", "json", stdin="SELECT 1;\n")
+    if result.returncode != 0:
+        _fail("tokenize_stdin", f"exit {result.returncode}: {result.stderr}")
+        return False
+    records = [json.loads(l) for l in result.stdout.splitlines() if l.strip()]
+    if not any(r["text"] == "SELECT" for r in records):
+        _fail("tokenize_stdin", f"no SELECT in stdin tokens: {records}")
+        return False
+    _pass("tokenize_stdin")
+    return True
+
+
+# ── dialect codegen group refactor ───────────────────────────────────────
+
+
+def _test_dialect_generate_still_works(ctx: SuiteContext) -> bool:
+    """After the refactor, `dialect generate --name X` still produces files."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        result = _run(
+            ctx.binary, "dialect", "generate",
+            "--name", "sqlite",
+            "--output-dir", tmp,
+            "--output-type", "runtime-only",
+        )
+        if result.returncode != 0:
+            _fail("dialect_generate_still_works",
+                  f"exit {result.returncode}: {result.stderr}")
+            return False
+        produced = list(Path(tmp).iterdir())
+        if not produced:
+            _fail("dialect_generate_still_works",
+                  "expected files in output dir, found none")
+            return False
+    _pass("dialect_generate_still_works")
+    return True
+
+
+# ── Suite entry point ────────────────────────────────────────────────────
+
+
+def run(ctx: SuiteContext) -> int:
+    tests = [
+        _test_tokenize_text_output,
+        _test_tokenize_json_output,
+        _test_tokenize_stdin,
+        _test_dialect_generate_still_works,
+    ]
+    results = [t(ctx) for t in tests]
+    passed = sum(results)
+    total = len(results)
+    print(f"\n  {passed}/{total} introspect tests passed.")
+    return 0 if all(results) else 1

--- a/python/tools/build_web_playground.py
+++ b/python/tools/build_web_playground.py
@@ -246,7 +246,7 @@ def main() -> int:
         [
             sys.executable, cargo, *cargo_flags,
             "run", "-p", "syntaqlite-cli", "--",
-            "dialect", "--name", "perfetto",
+            "dialect", "generate", "--name", "perfetto",
             "--actions-dir", os.path.join(ROOT_DIR, "dialects", "perfetto", "actions"),
             "--nodes-dir", os.path.join(ROOT_DIR, "dialects", "perfetto", "nodes"),
             "--macro-style", "rust",

--- a/syntaqlite-cli/src/introspect.rs
+++ b/syntaqlite-cli/src/introspect.rs
@@ -1,0 +1,141 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+//! CLI introspection commands. Currently just `tokenize`.
+
+use std::io::{self, IsTerminal, Read};
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+use syntaqlite::any::{AnyDialect, AnyTokenizer};
+
+use crate::IntrospectOutput;
+
+const SCHEMA_VERSION: u32 = 0;
+
+// ---------------------------------------------------------------------------
+// tokenize
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct TokenRecord<'a> {
+    kind: &'static str,
+    schema_version: u32,
+    file: &'a str,
+    text: &'a str,
+    offset: usize,
+    length: usize,
+    #[serde(rename = "type")]
+    token_type: u32,
+    category: &'static str,
+}
+
+pub(crate) fn cmd_tokenize(
+    dialect: &AnyDialect,
+    files: &[String],
+    expression: Option<&str>,
+    output: IntrospectOutput,
+) -> Result<(), String> {
+    let tokenizer = AnyTokenizer::new((**dialect).clone());
+
+    let emit = |source: &str, file: &str| {
+        let base = source.as_ptr() as usize;
+        for tok in tokenizer.tokenize(source) {
+            let text = tok.text();
+            let offset = (text.as_ptr() as usize).saturating_sub(base);
+            let length = text.len();
+            let tt = tok.token_type();
+            let category = category_name(dialect.token_category(tt));
+            match output {
+                IntrospectOutput::Text => {
+                    println!(
+                        "{offset:>6}..{end:<6} {category:<12} {text}",
+                        end = offset + length,
+                    );
+                }
+                IntrospectOutput::Json => {
+                    let rec = TokenRecord {
+                        kind: "token",
+                        schema_version: SCHEMA_VERSION,
+                        file,
+                        text,
+                        offset,
+                        length,
+                        token_type: tt.into(),
+                        category,
+                    };
+                    match serde_json::to_string(&rec) {
+                        Ok(s) => println!("{s}"),
+                        Err(e) => eprintln!("error serializing token: {e}"),
+                    }
+                }
+            }
+        }
+    };
+
+    if let Some(expr) = expression {
+        emit(expr, "<expression>");
+        return Ok(());
+    }
+
+    if files.is_empty() {
+        let source = read_stdin()?;
+        emit(&source, "<stdin>");
+        return Ok(());
+    }
+
+    let mut paths: Vec<PathBuf> = Vec::new();
+    for pat in files {
+        let matches: Vec<_> = glob::glob(pat)
+            .map_err(|e| format!("bad glob pattern {pat:?}: {e}"))?
+            .collect();
+        if matches.is_empty() {
+            return Err(format!("no files matched: {pat}"));
+        }
+        for entry in matches {
+            let path = entry.map_err(|e| format!("glob error: {e}"))?;
+            if path.is_file() {
+                paths.push(path);
+            }
+        }
+    }
+    let multi = paths.len() > 1;
+    for path in &paths {
+        let file = path.display().to_string();
+        if multi && matches!(output, IntrospectOutput::Text) {
+            println!("==> {file} <==");
+        }
+        let source = std::fs::read_to_string(path).map_err(|e| format!("{file}: {e}"))?;
+        emit(&source, &file);
+    }
+    Ok(())
+}
+
+fn category_name(c: syntaqlite_syntax::any::TokenCategory) -> &'static str {
+    use syntaqlite_syntax::any::TokenCategory as T;
+    match c {
+        T::Keyword => "keyword",
+        T::Identifier => "identifier",
+        T::String => "string",
+        T::Number => "number",
+        T::Operator => "operator",
+        T::Punctuation => "punctuation",
+        T::Comment => "comment",
+        T::Parameter => "parameter",
+        T::Function => "function",
+        T::Type => "type",
+        T::Other => "other",
+    }
+}
+
+fn read_stdin() -> Result<String, String> {
+    if io::stdin().is_terminal() {
+        eprintln!("reading from stdin; paste SQL then press Ctrl-D");
+    }
+    let mut buf = String::new();
+    io::stdin()
+        .read_to_string(&mut buf)
+        .map_err(|e| format!("reading stdin: {e}"))?;
+    Ok(buf)
+}

--- a/syntaqlite-cli/src/lib.rs
+++ b/syntaqlite-cli/src/lib.rs
@@ -17,6 +17,8 @@ mod runtime;
 #[cfg(feature = "codegen")]
 mod codegen;
 
+mod introspect;
+
 mod lineage_output;
 
 mod validate_output;
@@ -109,6 +111,15 @@ pub(crate) enum ValidateOutput {
     #[default]
     Text,
     /// Newline-delimited JSON, one record per diagnostic
+    Json,
+}
+
+#[derive(Clone, Copy, Default, ValueEnum)]
+pub(crate) enum IntrospectOutput {
+    /// Human-readable text (default)
+    #[default]
+    Text,
+    /// JSON or newline-delimited JSON
     Json,
 }
 
@@ -247,14 +258,35 @@ pub(crate) enum Command {
     /// Start the MCP server (stdio)
     #[cfg(feature = "mcp")]
     Mcp,
-    /// Generate dialect C sources and Rust bindings for external dialects.
+    /// Tokenize SQL and print the token stream
+    Tokenize {
+        /// SQL files or glob patterns (reads stdin if omitted)
+        files: Vec<String>,
+        /// SQL expression to tokenize directly (instead of files or stdin)
+        #[arg(short = 'e', long = "expression", conflicts_with = "files")]
+        expression: Option<String>,
+        /// Output format
+        #[arg(short, long, value_enum, default_value_t = IntrospectOutput::Text)]
+        output: IntrospectOutput,
+    },
+    /// Dialect codegen (generate C + Rust sources for custom dialects)
     #[cfg(feature = "codegen")]
-    Dialect(codegen::DialectArgs),
+    Dialect {
+        #[command(subcommand)]
+        command: DialectSubcommand,
+    },
     /// Print version information
     Version,
     #[cfg(feature = "codegen")]
     #[command(flatten)]
     DialectTool(codegen::ToolCommand),
+}
+
+#[cfg(feature = "codegen")]
+#[derive(Subcommand)]
+pub(crate) enum DialectSubcommand {
+    /// Generate dialect C sources and Rust bindings for external dialects
+    Generate(codegen::DialectArgs),
 }
 
 /// Build the [`clap::Command`] for the given app, applying runtime visibility

--- a/syntaqlite-cli/src/runtime.rs
+++ b/syntaqlite-cli/src/runtime.rs
@@ -176,32 +176,18 @@ fn dispatch_commands(
             deny,
             lang,
             output,
-        } => require_dialect(dialect).and_then(|d| {
-            let file_config = discover_config_for_paths(&files, config);
-            // If --schema is given, use it directly. Otherwise, resolve from config file.
-            let resolved_schemas = if schema.is_empty() {
-                resolve_schemas_from_config_with(&files, file_config.as_ref())
-            } else {
-                schema
-            };
-            let has_schema = !resolved_schemas.is_empty();
-            let checks = build_check_config(
-                has_schema,
-                file_config.as_ref().map(|(c, _)| &c.checks),
-                &allow,
-                &warn,
-                &deny,
-            )?;
-            cmd_validate(
-                &d,
-                &files,
-                expression.as_deref(),
-                &resolved_schemas,
-                lang,
-                checks,
-                output,
-            )
-        }),
+        } => dispatch_validate(
+            dialect,
+            config,
+            &files,
+            expression.as_deref(),
+            schema,
+            &allow,
+            &warn,
+            &deny,
+            lang,
+            output,
+        ),
         Command::Lineage {
             files,
             expression,
@@ -255,11 +241,62 @@ fn dispatch_commands(
             println!("syntaqlite {}", env!("CARGO_PKG_VERSION"));
             Ok(())
         }
+        Command::Tokenize {
+            files,
+            expression,
+            output,
+        } => require_dialect(dialect).and_then(|d| {
+            crate::introspect::cmd_tokenize(&d, &files, expression.as_deref(), output)
+        }),
         #[cfg(feature = "codegen")]
-        Command::Dialect(args) => crate::codegen::dispatch_dialect(&args),
+        Command::Dialect { command } => match command {
+            crate::DialectSubcommand::Generate(args) => crate::codegen::dispatch_dialect(&args),
+        },
         #[cfg(feature = "codegen")]
         Command::DialectTool(cmd) => crate::codegen::dispatch_tool(cmd),
     }
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "split out to keep dispatch_commands under the line limit"
+)]
+fn dispatch_validate(
+    dialect: Option<AnyDialect>,
+    config: &ConfigMode<'_>,
+    files: &[String],
+    expression: Option<&str>,
+    schema: Vec<String>,
+    allow: &[String],
+    warn: &[String],
+    deny: &[String],
+    lang: Option<HostLanguage>,
+    output: ValidateOutput,
+) -> Result<(), String> {
+    let d = require_dialect(dialect)?;
+    let file_config = discover_config_for_paths(files, config);
+    let resolved_schemas = if schema.is_empty() {
+        resolve_schemas_from_config_with(files, file_config.as_ref())
+    } else {
+        schema
+    };
+    let has_schema = !resolved_schemas.is_empty();
+    let checks = build_check_config(
+        has_schema,
+        file_config.as_ref().map(|(c, _)| &c.checks),
+        allow,
+        warn,
+        deny,
+    )?;
+    cmd_validate(
+        &d,
+        files,
+        expression,
+        &resolved_schemas,
+        lang,
+        checks,
+        output,
+    )
 }
 
 fn read_stdin() -> Result<String, String> {

--- a/web/docs/content/guides/custom-dialects.md
+++ b/web/docs/content/guides/custom-dialects.md
@@ -48,11 +48,11 @@ node CreatePerfettoMacroStmt {
 
 ## Building a dialect
 
-Use the `syntaqlite dialect` command to generate C sources and Rust bindings
-from your `.synq` definitions:
+Use the `syntaqlite dialect generate` command to generate C sources and Rust
+bindings from your `.synq` definitions:
 
 ```bash
-syntaqlite dialect --name mydialect --nodes-dir path/to/nodes --output-dir generated/
+syntaqlite dialect generate --name mydialect --nodes-dir path/to/nodes --output-dir generated/
 ```
 
 Then compile the generated sources into a shared library. See the


### PR DESCRIPTION
- **`syntaqlite tokenize [files] [-e EXPR] [-o text|json]`** emits one record per token with source text, byte offset, length, raw token-type id, and a category name (`keyword`/`identifier`/`number`/…). Reads files, `-e` expression, or stdin.
- **`syntaqlite dialect generate …`** replaces `syntaqlite dialect …`. New `DialectSubcommand` enum (feature-gated under `codegen`) so future subcommands slot in without breakage. Updates the 6 internal callers (grammar suite, amalg executor, perfetto common, playground builder) and the custom-dialects guide.