### PR TITLE
synq: make every parser-emitted offset statement-relative

### DIFF
--- a/python/csrc/_py_ast_wrap.h
+++ b/python/csrc/_py_ast_wrap.h
@@ -26,7 +26,7 @@ syntaqlite_py_wrap_list(SyntaqliteParser *p, const void *raw) {
 static PyObject *
 syntaqlite_py_wrap_span(SyntaqliteParser *p, SyntaqliteTextSpan span) {
     if (span.length == 0) Py_RETURN_NONE;
-    const char *src = syntaqlite_parser_text(p, NULL);
+    const char *src = syntaqlite_parser_text(p, NULL, NULL);
     return PyUnicode_FromStringAndSize(src + span.offset, span.length);
 }
 

--- a/syntaqlite-buildtools/src/dialect_codegen/python_c_codegen.rs
+++ b/syntaqlite-buildtools/src/dialect_codegen/python_c_codegen.rs
@@ -190,7 +190,7 @@ fn emit_wrap_span_fn(w: &mut CWriter) {
     w.line("syntaqlite_py_wrap_span(SyntaqliteParser *p, SyntaqliteTextSpan span) {");
     w.indent();
     w.line("if (span.length == 0) Py_RETURN_NONE;");
-    w.line("const char *src = syntaqlite_parser_text(p, NULL);");
+    w.line("const char *src = syntaqlite_parser_text(p, NULL, NULL);");
     w.line("return PyUnicode_FromStringAndSize(src + span.offset, span.length);");
     w.dedent();
     w.line("}");

--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -531,8 +531,10 @@ SYNTAQLITE_API int32_t syntaqlite_parser_next(SyntaqliteParser* p) {
       p->had_comment = 1;
       if (p->collect_tokens)
         synq_parser_record_comment(p, cur_offset, (uint32_t)cur_len);
-      cur_len = next_token(p, z, cur_offset + (uint32_t)cur_len, &cur_offset,
-                           &cur_type);
+      // Advance p->offset so this comment is covered by stmt_end_offset
+      // (otherwise text() would not span trailing/comment-only comments).
+      p->offset = cur_offset + (uint32_t)cur_len;
+      cur_len = next_token(p, z, p->offset, &cur_offset, &cur_type);
       continue;
     }
 
@@ -821,26 +823,29 @@ static void append_expanded_range(SyntaqliteParser* p,
 #endif
 
 SYNTAQLITE_API const char* syntaqlite_parser_full_text(SyntaqliteParser* p,
-                                                      uint32_t* out_len) {
+                                                       uint32_t* out_len) {
   if (out_len) {
     *out_len = p->source_len;
   }
   return p->source;
 }
 
-SYNTAQLITE_API const char* syntaqlite_parser_text(
-    SyntaqliteParser* p,
-    uint32_t* out_offset,
-    uint32_t* out_len) {
+SYNTAQLITE_API const char* syntaqlite_parser_text(SyntaqliteParser* p,
+                                                  uint32_t* out_offset,
+                                                  uint32_t* out_len) {
   if (p->stmt_start_offset == UINT32_MAX ||
       p->stmt_end_offset <= p->stmt_start_offset ||
       p->stmt_end_offset > p->source_len) {
-    if (out_offset) *out_offset = 0;
-    if (out_len) *out_len = 0;
+    if (out_offset)
+      *out_offset = 0;
+    if (out_len)
+      *out_len = 0;
     return NULL;
   }
-  if (out_offset) *out_offset = p->stmt_start_offset;
-  if (out_len) *out_len = p->stmt_end_offset - p->stmt_start_offset;
+  if (out_offset)
+    *out_offset = p->stmt_start_offset;
+  if (out_len)
+    *out_len = p->stmt_end_offset - p->stmt_start_offset;
   return p->stmt_source;
 }
 
@@ -897,7 +902,8 @@ SYNTAQLITE_API int32_t syntaqlite_parser_feed_token(SyntaqliteParser* p,
     // parser_next updates it during tokenization but feed_token never
     // touches it otherwise.
     uint32_t tok_end = (uint32_t)(text - p->source) + len;
-    if (tok_end > p->offset) p->offset = tok_end;
+    if (tok_end > p->offset)
+      p->offset = tok_end;
   }
 
   // Skip whitespace and comments without feeding to Lemon.

--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -30,8 +30,27 @@ static void reset_stmt(SyntaqliteParser* p);
 static int32_t stmt_boundary(SyntaqliteParser* p);
 static int finish_input(SyntaqliteParser* p);
 
+// Record the first byte consumed for the current statement and sync
+// the layer-0 macro sentinel so span walkers resolve layer-0 spans
+// against the statement slice.
+static void synq_open_statement(SyntaqliteParser* p, uint32_t offset) {
+  p->stmt_start_offset = offset;
+  p->stmt_source = p->source + offset;
+#ifndef SYNTAQLITE_OMIT_MACROS
+  if (syntaqlite_vec_len(&p->macro.layers) > 0) {
+    SynqExpansionLayer* root = &p->macro.layers.data[0];
+    root->expansion_data = p->stmt_source;
+    root->expansion_len = p->source_len - offset;
+  }
+#endif
+}
+
 int32_t synq_parser_set_result_status(SyntaqliteParser* p, int32_t rc) {
   p->last_status = rc;
+  if (p->stmt_start_offset != UINT32_MAX) {
+    p->stmt_end_offset =
+        p->offset > p->stmt_start_offset ? p->offset : p->stmt_start_offset;
+  }
   return rc;
 }
 
@@ -89,6 +108,9 @@ static void reset_stmt(SyntaqliteParser* p) {
   p->ctx.error_offset = 0xFFFFFFFF;
   p->ctx.error_length = 0;
   p->ctx.tokens = p->collect_tokens ? &p->tokens : NULL;
+  p->stmt_start_offset = UINT32_MAX;
+  p->stmt_end_offset = 0;
+  p->stmt_source = p->source;
 }
 
 // Handle a statement boundary after feed_one_token returns 1.
@@ -160,6 +182,9 @@ SYNTAQLITE_API void syntaqlite_parser_reset(SyntaqliteParser* p,
   p->finished = 0;
   p->pending_reset = 0;
   p->last_status = SYNTAQLITE_PARSE_DONE;
+  p->stmt_start_offset = UINT32_MAX;
+  p->stmt_end_offset = 0;
+  p->stmt_source = source;
 #ifndef SYNTAQLITE_OMIT_MACROS
   p->macro.depth = 0;
   syntaqlite_vec_clear(&p->macro.layers);
@@ -193,12 +218,9 @@ int synq_parser_feed_one_token(SyntaqliteParser* p,
                                const char* text,
                                uint32_t len,
                                uint32_t token_idx) {
-  uint32_t tok_offset = 0;
-  if (text != NULL) {
-    // Compute offset relative to the current buffer (which may be the
-    // original source or a macro expansion buffer during expand_and_feed).
-    tok_offset = (uint32_t)(text - p->ctx.source);
-  }
+  // Only called from layer-0 paths — macro expansion bypasses this —
+  // so the offset Lemon stores into TextSpans is statement-relative.
+  uint32_t tok_offset = text ? (uint32_t)(text - p->stmt_source) : 0;
   SynqParseToken minor = {
       .z = text,
       .n = len,
@@ -214,7 +236,7 @@ int synq_parser_feed_one_token(SyntaqliteParser* p,
     p->had_error = 1;
     if (p->error_msg[0] == '\0') {
       if (text) {
-        p->ctx.error_offset = (uint32_t)(text - p->source);
+        p->ctx.error_offset = (uint32_t)(text - p->stmt_source);
         p->ctx.error_length = (uint32_t)len;
         snprintf(p->error_msg, sizeof(p->error_msg), "syntax error near '%.*s'",
                  len, text);
@@ -282,7 +304,7 @@ static int finish_input(SyntaqliteParser* p) {
   if (p->ctx.error) {
     p->had_error = 1;
     if (p->ctx.error_offset == 0xFFFFFFFF) {
-      p->ctx.error_offset = p->offset;
+      p->ctx.error_offset = p->offset - p->stmt_start_offset;
     }
     if (p->error_msg[0] == '\0') {
       snprintf(p->error_msg, sizeof(p->error_msg), "incomplete SQL statement");
@@ -311,33 +333,31 @@ static int finish_input(SyntaqliteParser* p) {
 
 // Record a token and feed it to Lemon.  Returns 1 if a real statement
 // boundary was reached (caller should return stmt_boundary()), 0 otherwise.
+// Always called at layer 0; stores offsets relative to stmt_source.
 int synq_parser_record_and_feed(SyntaqliteParser* p,
                                 uint32_t cur_type,
                                 uint32_t cur_offset,
                                 uint32_t cur_len) {
   uint32_t tidx = 0xFFFFFFFF;
+  uint32_t cur_offset_rel = cur_offset - p->stmt_start_offset;
   if (p->collect_tokens) {
-    SyntaqliteParserToken tp = {cur_offset, cur_len, cur_type, 0,
+    SyntaqliteParserToken tp = {cur_offset_rel, cur_len, cur_type, 0,
                                 p->ctx.layer_id};
     syntaqlite_vec_push(&p->tokens, tp, p->mem);
     tidx = syntaqlite_vec_len(&p->tokens) - 1;
-    if (p->ctx.layer_id == 0)
-      p->last_layer0_token_end = cur_offset + cur_len;
+    p->last_layer0_token_end = cur_offset + cur_len;
   }
   // Publish the upcoming token's start *before* Lemon processes it so
   // that BEFORE-style empty-marker reductions firing inside feed_one_token
   // see the start of the token about to be shifted (whitespace between
-  // the previous terminal and this one is excluded).  Only track
-  // positions for tokens shifted from the root source layer.
-  if (p->ctx.layer_id == 0)
-    p->ctx.cur_shift_start = cur_offset;
+  // the previous terminal and this one is excluded).
+  p->ctx.cur_shift_start = cur_offset_rel;
   int rc = feed_one_token(p, cur_type, p->source + cur_offset, cur_len, tidx);
   // Advance the "last shifted terminal end" cursor *after* Lemon finishes
   // processing `cur`, so that any empty-rule reductions that fired inside
   // feed_one_token observed the previous shifted token's end.  AFTER-style
   // markers use this to capture the end position of a non-terminal.
-  if (p->ctx.layer_id == 0)
-    p->ctx.last_shifted_end = cur_offset + cur_len;
+  p->ctx.last_shifted_end = cur_offset_rel + cur_len;
   // After parse_failure, Lemon stops reducing — force a boundary on SEMI
   // so errors don't bleed into subsequent statements.
   if (p->had_error && rc == 0 && cur_type == SYNTAQLITE_TK_SEMI)
@@ -371,7 +391,7 @@ void synq_parser_record_comment(SyntaqliteParser* p,
   }
 
   SyntaqliteComment t = {
-      .offset = offset,
+      .offset = offset - p->stmt_start_offset,
       .length = len,
       .token_idx = owner_idx,
       .kind = z[offset] == '-' ? (uint8_t)0 : (uint8_t)1,
@@ -498,6 +518,10 @@ SYNTAQLITE_API int32_t syntaqlite_parser_next(SyntaqliteParser* p) {
   uint32_t cur_type = 0;
   uint32_t cur_offset = 0;
   int64_t cur_len = next_token(p, z, p->offset, &cur_offset, &cur_type);
+
+  if (cur_len > 0 && p->stmt_start_offset == UINT32_MAX) {
+    synq_open_statement(p, cur_offset);
+  }
 
   while (cur_len > 0) {
     // Handle comments: record and advance without feeding to Lemon.
@@ -796,25 +820,48 @@ static void append_expanded_range(SyntaqliteParser* p,
                                   uint32_t end);
 #endif
 
-SYNTAQLITE_API const char* syntaqlite_parser_text(SyntaqliteParser* p,
-                                                  uint32_t* out_len) {
+SYNTAQLITE_API const char* syntaqlite_parser_full_text(SyntaqliteParser* p,
+                                                      uint32_t* out_len) {
   if (out_len) {
     *out_len = p->source_len;
   }
   return p->source;
 }
 
+SYNTAQLITE_API const char* syntaqlite_parser_text(
+    SyntaqliteParser* p,
+    uint32_t* out_offset,
+    uint32_t* out_len) {
+  if (p->stmt_start_offset == UINT32_MAX ||
+      p->stmt_end_offset <= p->stmt_start_offset ||
+      p->stmt_end_offset > p->source_len) {
+    if (out_offset) *out_offset = 0;
+    if (out_len) *out_len = 0;
+    return NULL;
+  }
+  if (out_offset) *out_offset = p->stmt_start_offset;
+  if (out_len) *out_len = p->stmt_end_offset - p->stmt_start_offset;
+  return p->stmt_source;
+}
+
 SYNTAQLITE_API const char* syntaqlite_parser_expanded_text(SyntaqliteParser* p,
                                                            uint32_t* out_len) {
 #ifdef SYNTAQLITE_OMIT_MACROS
-  // Without macros, expanded text == source text.
-  return syntaqlite_parser_text(p, out_len);
+  uint32_t ignored_offset = 0;
+  const char* s = syntaqlite_parser_text(p, &ignored_offset, out_len);
+  return s ? s : "";
 #else
   if (out_len) {
     *out_len = 0;
   }
+  if (p->stmt_start_offset == UINT32_MAX ||
+      p->stmt_end_offset <= p->stmt_start_offset ||
+      p->stmt_end_offset > p->source_len) {
+    return "";
+  }
+  uint32_t stmt_len = p->stmt_end_offset - p->stmt_start_offset;
   syntaqlite_vec_clear(&p->macro.node_expanded_buf);
-  append_expanded_range(p, 0, p->source, p->source_len, 0, p->source_len);
+  append_expanded_range(p, 0, p->stmt_source, stmt_len, 0, stmt_len);
   if (out_len) {
     *out_len = syntaqlite_vec_len(&p->macro.node_expanded_buf);
   }
@@ -838,6 +885,17 @@ SYNTAQLITE_API int32_t syntaqlite_parser_feed_token(SyntaqliteParser* p,
     p->pending_reset = 0;
   }
 
+  if (text) {
+    if (p->stmt_start_offset == UINT32_MAX) {
+      synq_open_statement(p, (uint32_t)(text - p->source));
+    }
+    // Advance p->offset so set_result_status can finalize stmt_end_offset;
+    // parser_next updates it during tokenization but feed_token never
+    // touches it otherwise.
+    uint32_t tok_end = (uint32_t)(text - p->source) + len;
+    if (tok_end > p->offset) p->offset = tok_end;
+  }
+
   // Skip whitespace and comments without feeding to Lemon.
   if (synq_token_is_skip(token_type)) {
     if (token_type == SYNTAQLITE_TK_COMMENT && p->collect_tokens && text) {
@@ -849,13 +907,11 @@ SYNTAQLITE_API int32_t syntaqlite_parser_feed_token(SyntaqliteParser* p,
   // Capture non-whitespace, non-comment token positions.
   uint32_t tidx = 0xFFFFFFFF;
   if (p->collect_tokens && text) {
-    uint32_t tok_offset = (uint32_t)(text - p->source);
-    SyntaqliteParserToken tp = {tok_offset, len, token_type, 0,
-                                p->ctx.layer_id};
+    SyntaqliteParserToken tp = {(uint32_t)(text - p->stmt_source), len,
+                                token_type, 0, p->ctx.layer_id};
     syntaqlite_vec_push(&p->tokens, tp, p->mem);
     tidx = syntaqlite_vec_len(&p->tokens) - 1;
-    if (p->ctx.layer_id == 0)
-      p->last_layer0_token_end = tok_offset + len;
+    p->last_layer0_token_end = (uint32_t)(text - p->source) + len;
   }
 
   int rc = feed_one_token(p, token_type, text, len, tidx);
@@ -980,8 +1036,11 @@ SYNTAQLITE_API const char* syntaqlite_parser_node_text(SyntaqliteParser* p,
     return NULL;
   }
   SynqExtentRange r = syntaqlite_vec_at(&p->ctx.node_extents, node_id);
-  // Sentinel `(UINT32_MAX, 0)` or any out-of-source range → not recorded.
-  if (r.root_start > r.root_end || r.root_end > p->source_len) {
+  // Sentinel `(UINT32_MAX, 0)` → not recorded.
+  uint32_t stmt_len = p->stmt_end_offset > p->stmt_start_offset
+                          ? p->stmt_end_offset - p->stmt_start_offset
+                          : 0;
+  if (r.root_start > r.root_end || r.root_end > stmt_len) {
     return NULL;
   }
   if (out_len) {
@@ -990,7 +1049,7 @@ SYNTAQLITE_API const char* syntaqlite_parser_node_text(SyntaqliteParser* p,
   if (out_offset) {
     *out_offset = r.root_start;
   }
-  return p->source + r.root_start;
+  return p->stmt_source + r.root_start;
 }
 
 #ifndef SYNTAQLITE_OMIT_MACROS
@@ -1065,7 +1124,7 @@ SYNTAQLITE_API const char* syntaqlite_parser_node_expanded_text(
       syntaqlite_vec_at(&p->ctx.node_expanded_extents, node_id);
   if (e.length > 0) {
     const char* buf = e.layer_id == 0
-                          ? p->source
+                          ? p->stmt_source
                           : p->macro.layers.data[e.layer_id].expansion_data;
     if (out_len) {
       *out_len = e.length;
@@ -1077,11 +1136,14 @@ SYNTAQLITE_API const char* syntaqlite_parser_node_expanded_text(
     return NULL;
   }
   SynqExtentRange r = syntaqlite_vec_at(&p->ctx.node_extents, node_id);
-  if (r.root_start > r.root_end || r.root_end > p->source_len) {
+  uint32_t stmt_len = p->stmt_end_offset > p->stmt_start_offset
+                          ? p->stmt_end_offset - p->stmt_start_offset
+                          : 0;
+  if (r.root_start > r.root_end || r.root_end > stmt_len) {
     return NULL;
   }
   syntaqlite_vec_clear(&p->macro.node_expanded_buf);
-  append_expanded_range(p, 0, p->source, p->source_len, r.root_start,
+  append_expanded_range(p, 0, p->stmt_source, stmt_len, r.root_start,
                         r.root_end);
   if (out_len) {
     *out_len = syntaqlite_vec_len(&p->macro.node_expanded_buf);
@@ -1132,14 +1194,17 @@ SYNTAQLITE_API const char* syntaqlite_parser_span_text(
     *out_len = 0;
     return NULL;
   }
-  if (span->offset + span->length > p->source_len) {
+  uint32_t stmt_len = p->stmt_end_offset > p->stmt_start_offset
+                          ? p->stmt_end_offset - p->stmt_start_offset
+                          : 0;
+  if (span->offset + span->length > stmt_len) {
     *out_len = 0;
     return NULL;
   }
   *out_len = span->length;
   if (out_offset)
     *out_offset = span->offset;
-  return p->source + span->offset;
+  return p->stmt_source + span->offset;
 }
 
 SYNTAQLITE_API const char* syntaqlite_parser_span_expanded_text(

--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -886,7 +886,11 @@ SYNTAQLITE_API int32_t syntaqlite_parser_feed_token(SyntaqliteParser* p,
   }
 
   if (text) {
-    if (p->stmt_start_offset == UINT32_MAX) {
+    // Open the statement at the first non-whitespace byte, matching
+    // parser_next (which never sees TK_SPACE because the tokenizer
+    // skips it).  Leading TK_COMMENT still opens a statement.
+    if (p->stmt_start_offset == UINT32_MAX &&
+        token_type != SYNTAQLITE_TK_SPACE) {
       synq_open_statement(p, (uint32_t)(text - p->source));
     }
     // Advance p->offset so set_result_status can finalize stmt_end_offset;

--- a/syntaqlite-syntax/csrc/parser_dump.c
+++ b/syntaqlite-syntax/csrc/parser_dump.c
@@ -115,9 +115,13 @@ static void dump_node_recursive(DumpBuf* b,
           dump_printf(b, mem, "%s: (none)\n", fm->name);
         } else {
           const char* base =
+#ifdef SYNTAQLITE_OMIT_MACROS
+              p->stmt_source;
+#else
               sp._layer_id == 0
                   ? p->stmt_source
                   : p->macro.layers.data[sp._layer_id].expansion_data;
+#endif
           dump_printf(b, mem, "%s: \"%.*s\"\n", fm->name, (int)sp.length,
                       base + sp.offset);
         }

--- a/syntaqlite-syntax/csrc/parser_dump.c
+++ b/syntaqlite-syntax/csrc/parser_dump.c
@@ -114,8 +114,12 @@ static void dump_node_recursive(DumpBuf* b,
         if (sp.length == 0) {
           dump_printf(b, mem, "%s: (none)\n", fm->name);
         } else {
+          const char* base =
+              sp._layer_id == 0
+                  ? p->stmt_source
+                  : p->macro.layers.data[sp._layer_id].expansion_data;
           dump_printf(b, mem, "%s: \"%.*s\"\n", fm->name, (int)sp.length,
-                      p->source + sp.offset);
+                      base + sp.offset);
         }
         break;
       }

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -175,6 +175,18 @@ struct SyntaqliteParser {
   uint32_t had_error;   // Sticky error flag for current result.
   char error_msg[256];  // Error message buffer.
 
+  // Current statement's byte range.  Set by parser_next / feed_token on
+  // the first byte consumed; stmt_end_offset is finalized at statement
+  // completion.  `stmt_start_offset == UINT32_MAX` means no statement
+  // has been produced yet; `stmt_source` then equals `p->source`.
+  //
+  // Every layer-0 offset the parser emits (tokens, comments, node
+  // extents, arena TextSpan.offset, macro rewrite call_offset with
+  // source parent, error_offset) is measured from `stmt_source`.
+  uint32_t stmt_start_offset;
+  uint32_t stmt_end_offset;
+  const char* stmt_source;
+
   // ── Parser-only state (only parser.c) ──────────────────────────────────
   uint32_t last_token_type;  // Last non-whitespace token fed to Lemon.
   uint32_t finished;         // 1 after EOF has been sent to Lemon.

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -251,11 +251,11 @@ SYNTAQLITE_API void syntaqlite_macro_expansion_set_result_with_arg_map(
   const SyntaqliteToken* args = p->macro.expansion_args;
   uint32_t arg_count = p->macro.expansion_arg_count;
   uint32_t origin_layer_id = lyr->parent_layer_id;
-  // For layer 0, arg text lives in source; for nested layers, in
-  // expansion_data.  Both are pointed to by args[i].text.
+  // Origin-layer base: stmt_source for layer 0 (so origin_offset is
+  // statement-relative), expansion buffer otherwise.
   const char* origin_base =
       origin_layer_id == 0
-          ? p->source
+          ? p->stmt_source
           : p->macro.layers.data[origin_layer_id].expansion_data;
 
   SynqArgSegment* segs = p->mem.xMalloc(mapping_count * sizeof(SynqArgSegment));
@@ -482,6 +482,13 @@ static void begin_macro_expansion(SyntaqliteParser* p,
                                   uint32_t call_length,
                                   const char* name,
                                   uint32_t name_len) {
+  // Top-level call_offset is absolute; rebase to statement-relative
+  // so layer call_offset / macro_root_start / body_call_offset match
+  // every other per-statement offset.
+  if (p->ctx.layer_id == 0) {
+    call_offset -= p->stmt_start_offset;
+  }
+
   // Stash the outermost macro call-site range so per-node extent
   // tracking can attribute tokens from inside this (or any nested)
   // expansion back to the authored source.
@@ -775,7 +782,7 @@ SYNTAQLITE_API int syntaqlite_macro_expansion_expand_and_set_result(
     uint32_t origin_layer_id = lyr->parent_layer_id;
     const char* origin_base =
         origin_layer_id == 0
-            ? p->source
+            ? p->stmt_source
             : p->macro.layers.data[origin_layer_id].expansion_data;
 
     SynqArgSegment* segs =

--- a/syntaqlite-syntax/csrc/parser_spans.c
+++ b/syntaqlite-syntax/csrc/parser_spans.c
@@ -112,30 +112,36 @@ SYNTAQLITE_API const char* syntaqlite_parser_span_text(
     *out_len = 0;
     return NULL;
   }
-  // Fast path: spans in the source layer are already authored positions.
+  uint32_t stmt_len = p->stmt_end_offset > p->stmt_start_offset
+                          ? p->stmt_end_offset - p->stmt_start_offset
+                          : 0;
+  // Layer-0 spans are already statement-relative.
   if (span->_layer_id == 0) {
-    if (span->offset + span->length > p->source_len) {
+    if (span->offset + span->length > stmt_len) {
       *out_len = 0;
       return NULL;
     }
     *out_len = span->length;
     if (out_offset)
       *out_offset = span->offset;
-    return p->source + span->offset;
+    return p->stmt_source + span->offset;
   }
-  // Walk the expansion chain to find the authored bytes.
+  // Walk the expansion chain.  call_offsets with parent==layer 0 and
+  // origin_offsets with origin_layer_id==0 are statement-relative, so
+  // a walk that terminates at layer 0 yields a statement-relative
+  // offset; deeper layers yield buffer-local offsets.
   uint32_t off = 0;
   uint32_t len = 0;
   span_walk_to_source(p, span->_layer_id, span->offset, span->length, &off,
                       &len);
-  if (off + len > p->source_len) {
+  if (off + len > stmt_len) {
     *out_len = 0;
     return NULL;
   }
   *out_len = len;
   if (out_offset)
     *out_offset = off;
-  return p->source + off;
+  return p->stmt_source + off;
 }
 
 // ---------------------------------------------------------------------------

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -401,7 +401,7 @@ SYNTAQLITE_API const char* syntaqlite_parser_text(SyntaqliteParser* p,
 // Full SQL source bound by the last reset() call.  For multi-statement
 // input, this is the whole input.
 SYNTAQLITE_API const char* syntaqlite_parser_full_text(SyntaqliteParser* p,
-                                                      uint32_t* out_len);
+                                                       uint32_t* out_len);
 
 // Post-expansion text for the current statement — materializes the
 // statement's source with every currently-active macro call replaced

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -286,9 +286,10 @@ SYNTAQLITE_API const SyntaqliteComment* syntaqlite_token_trailing_comments(
 // in this same flat list (the rewrite replaces a range in that entry's
 // `expansion` buffer).
 //
-// `call_offset` / `call_length` describe the byte range of the macro call
-// inside the parent's text (authored source if `parent_idx` is the
-// sentinel, otherwise the parent entry's `expansion` buffer).
+// `call_offset` / `call_length` describe the byte range of the macro
+// call inside the parent's text: statement-relative when `parent_idx`
+// is the source sentinel, otherwise relative to the parent entry's
+// `expansion` buffer.
 //
 // `expansion` is the replacement text for that range.  It is NOT
 // NUL-terminated; use `expansion_len`.  Nested macro calls appearing
@@ -386,20 +387,27 @@ syntaqlite_macro_rewrite_arg_segment_at(SyntaqliteParser* p,
 SYNTAQLITE_API const void* syntaqlite_parser_node(SyntaqliteParser* p,
                                                   uint32_t node_id);
 
-// Source text bound by the last reset() call.  Writes the byte length
-// to `*out_len` (optional) and returns a direct pointer into the
-// parser's source buffer.
+// Source slice for the last-completed statement.  Writes the
+// statement's absolute byte offset within the bound source to
+// `*out_offset` (optional) and its length to `*out_len` (optional).
+// Every offset the parser emits for this statement — tokens, comments,
+// node extents, spans, error offset, macro rewrite call offsets — is
+// measured from the returned pointer.  Returns NULL / 0 / 0 when no
+// statement has been produced yet.
 SYNTAQLITE_API const char* syntaqlite_parser_text(SyntaqliteParser* p,
+                                                  uint32_t* out_offset,
                                                   uint32_t* out_len);
 
-// Post-expansion text for the whole input — the parser-level
-// analogue of `syntaqlite_parser_node_expanded_text`.  Materializes
-// the source with every currently-active macro call replaced by its
-// expansion into a parser-owned scratch buffer and returns a pointer
-// valid until the next call to `syntaqlite_parser_expanded_text` /
-// `syntaqlite_parser_node_expanded_text` on the same parser or until
-// the parser advances to the next statement.  Writes the byte length
-// to `*out_len` (optional).
+// Full SQL source bound by the last reset() call.  For multi-statement
+// input, this is the whole input.
+SYNTAQLITE_API const char* syntaqlite_parser_full_text(SyntaqliteParser* p,
+                                                      uint32_t* out_len);
+
+// Post-expansion text for the current statement — materializes the
+// statement's source with every currently-active macro call replaced
+// by its expansion into a parser-owned scratch buffer.  The returned
+// pointer is valid until the next `*_expanded_text` call on the same
+// parser or until the parser advances to the next statement.
 SYNTAQLITE_API const char* syntaqlite_parser_expanded_text(SyntaqliteParser* p,
                                                            uint32_t* out_len);
 

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -207,15 +207,43 @@ impl CParser {
         unsafe { syntaqlite_parser_set_collect_node_extents(self, enable) }
     }
 
-    /// Source text bound by the last `reset()` call.
+    /// Source slice for the last-completed statement and its absolute
+    /// offset within the bound source.  Returns `("", 0)` when no
+    /// statement has been produced yet.
     ///
     /// # Safety
     /// The returned slice must not outlive the borrow underlying `self`.
-    pub(crate) unsafe fn text<'a>(&self) -> &'a str {
+    pub(crate) unsafe fn text<'a>(&self) -> (&'a str, u32) {
+        let mut out_offset: u32 = 0;
         let mut out_len: u32 = 0;
         // SAFETY: self is a valid, non-null CParser pointer owned by the caller.
         let ptr = unsafe {
             syntaqlite_parser_text(
+                std::ptr::from_ref::<Self>(self).cast_mut(),
+                &raw mut out_offset,
+                &raw mut out_len,
+            )
+        };
+        if ptr.is_null() || out_len == 0 {
+            return ("", 0);
+        }
+        // SAFETY: C guarantees `ptr` points to `out_len` bytes of valid
+        // UTF-8 within the parser's source buffer.
+        let s = unsafe {
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize))
+        };
+        (s, out_offset)
+    }
+
+    /// Full SQL source bound by the last `reset()` call.
+    ///
+    /// # Safety
+    /// The returned slice must not outlive the borrow underlying `self`.
+    pub(crate) unsafe fn full_text<'a>(&self) -> &'a str {
+        let mut out_len: u32 = 0;
+        // SAFETY: self is a valid, non-null CParser pointer owned by the caller.
+        let ptr = unsafe {
+            syntaqlite_parser_full_text(
                 std::ptr::from_ref::<Self>(self).cast_mut(),
                 &raw mut out_len,
             )
@@ -255,7 +283,7 @@ impl CParser {
     }
 
     /// Source text of AST node `node_id`, returned as `(slice, offset)`
-    /// where `slice` borrows from the parser's source buffer.
+    /// where `offset` is statement-relative (see the C side).
     ///
     /// # Safety
     /// The returned slice must not outlive the borrow underlying `self`.
@@ -675,7 +703,12 @@ unsafe extern "C" {
     fn syntaqlite_parser_set_collect_tokens(p: *mut CParser, enable: u32) -> i32;
     fn syntaqlite_parser_set_macro_fallback(p: *mut CParser, enable: u32) -> i32;
     fn syntaqlite_parser_set_collect_node_extents(p: *mut CParser, enable: u32) -> i32;
-    fn syntaqlite_parser_text(p: *mut CParser, out_len: *mut u32) -> *const u8;
+    fn syntaqlite_parser_text(
+        p: *mut CParser,
+        out_offset: *mut u32,
+        out_len: *mut u32,
+    ) -> *const u8;
+    fn syntaqlite_parser_full_text(p: *mut CParser, out_len: *mut u32) -> *const u8;
     fn syntaqlite_parser_expanded_text(p: *mut CParser, out_len: *mut u32) -> *const u8;
     fn syntaqlite_parser_node_text(
         p: *mut CParser,

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -497,19 +497,19 @@ impl<G: TypedDialect> TypedParseSession<G> {
         }
     }
 
-    /// Original SQL source bound to this session.
+    /// Full SQL source bound to this session.
     ///
     /// # Panics
     ///
     /// Panics only if session invariants were violated.
-    pub fn text(&self) -> &str {
+    pub fn full_text(&self) -> &str {
         let inner = self
             .inner
             .as_ref()
             .expect("inner is Some while session is not finished");
         // SAFETY: inner.raw is valid for `&self`; the returned slice
         // borrows from the parser's source buffer.
-        unsafe { inner.raw.as_ref().text() }
+        unsafe { inner.raw.as_ref().full_text() }
     }
 
     /// Post-expansion source — the bound source with every
@@ -591,7 +591,9 @@ impl<'a> AnyParsedStatement<'a> {
 
     /// Source text of AST node `id` as `(text, offset)`, or `None` when
     /// extent tracking is disabled or no extent was recorded for this
-    /// node.  Requires [`ParserConfig::with_collect_node_extents`].
+    /// node.  `offset` is relative to [`text`](Self::text).
+    ///
+    /// Requires [`ParserConfig::with_collect_node_extents`].
     pub fn node_text(&self, id: AnyNodeId) -> Option<(&'a str, u32)> {
         if id.is_null() {
             return None;
@@ -800,9 +802,9 @@ impl<'a> AnyParsedStatement<'a> {
     }
 
     /// Resolve a [`TextSpan`](crate::ast::TextSpan) to `(authored_text,
-    /// source_offset)` where `authored_text` is a direct slice of the
-    /// user's input source and `source_offset` is its byte offset in
-    /// that source.
+    /// offset)` where `authored_text` is a direct slice of the user's
+    /// input source and `offset` is its byte offset relative to
+    /// [`text`](Self::text).
     ///
     /// For direct (macro-free) spans, this is the span's own bytes and
     /// position.  For spans inside a macro expansion, this walks the
@@ -852,11 +854,43 @@ impl<'a> AnyParsedStatement<'a> {
         })
     }
 
-    /// The source text bound to this result.
+    /// Full SQL source bound to the parse session — the whole input
+    /// for multi-statement parses.  Use [`Self::text`] for just this
+    /// statement.
+    pub fn full_text(&self) -> &'a str {
+        // SAFETY: self.raw is valid for 'a; the returned slice borrows
+        // from the parser's source buffer which outlives 'a.
+        unsafe { self.raw.as_ref().full_text() }
+    }
+
+    /// Source slice for just this statement, including any attached
+    /// leading/trailing comments.  Every offset the parser emits for
+    /// this statement — tokens, comments, spans, node extents, error
+    /// offsets, macro rewrite call offsets — is relative to this slice.
+    /// Empty if no statement was produced.
     pub fn text(&self) -> &'a str {
         // SAFETY: self.raw is valid for 'a; the returned slice borrows
         // from the parser's source buffer which outlives 'a.
-        unsafe { self.raw.as_ref().text() }
+        let (s, _) = unsafe { self.raw.as_ref().text() };
+        s
+    }
+
+    /// Byte offset of this statement's start within [`Self::full_text`].
+    /// Add to any statement-relative offset to get an absolute position.
+    pub fn statement_base_offset(&self) -> u32 {
+        // SAFETY: self.raw is valid for 'a.
+        let (_, off) = unsafe { self.raw.as_ref().text() };
+        off
+    }
+
+    /// Resolve a span to `(text, abs_start, abs_end)` in
+    /// [`Self::full_text`].  Convenience for diagnostic emission sites
+    /// that need full-source positions.
+    pub fn span_text_abs(&self, span: crate::ast::TextSpan) -> (&'a str, usize, usize) {
+        let (text, off) = self.span_text(span);
+        let base = self.statement_base_offset() as usize;
+        let start = base + off as usize;
+        (text, start, start + text.len())
     }
 
     /// Raw token spans `(offset, length)` for all collected tokens.
@@ -1072,9 +1106,19 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
         serde_json::to_string(&self.any.root_node())
     }
 
-    /// The source text bound to this result.
+    /// See [`AnyParsedStatement::text`].
     pub fn text(&self) -> &'a str {
         self.any.text()
+    }
+
+    /// See [`AnyParsedStatement::full_text`].
+    pub fn full_text(&self) -> &'a str {
+        self.any.full_text()
+    }
+
+    /// See [`AnyParsedStatement::statement_base_offset`].
+    pub fn statement_base_offset(&self) -> u32 {
+        self.any.statement_base_offset()
     }
 
     /// Post-expansion source — the bound source with every currently-
@@ -1305,6 +1349,11 @@ impl<'a, G: TypedDialect> TypedParseError<'a, G> {
     /// The partial recovery tree, if error recovery produced one.
     pub fn recovery_root(&'a self) -> Option<G::Node<'a>> {
         self.0.recovery_root()
+    }
+
+    /// See [`AnyParsedStatement::statement_base_offset`].
+    pub fn statement_base_offset(&self) -> u32 {
+        self.0.any.statement_base_offset()
     }
 
     /// The source text bound to this result.

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -143,9 +143,9 @@ impl ParseSession {
         self.0.next().map(ParsedStatement).map_err(ParseError)
     }
 
-    /// Original SQL source bound to this session.
-    pub fn text(&self) -> &str {
-        self.0.text()
+    /// Full SQL source bound to this session.
+    pub fn full_text(&self) -> &str {
+        self.0.full_text()
     }
 
     /// Post-expansion source — the bound source with every currently-
@@ -289,9 +289,19 @@ impl<'a> ParsedStatement<'a> {
         self.0.root()
     }
 
-    /// The source text bound to this result.
+    /// See [`AnyParsedStatement::text`](super::AnyParsedStatement::text).
     pub fn text(&self) -> &'a str {
         self.0.text()
+    }
+
+    /// See [`AnyParsedStatement::full_text`](super::AnyParsedStatement::full_text).
+    pub fn full_text(&self) -> &'a str {
+        self.0.full_text()
+    }
+
+    /// See [`AnyParsedStatement::statement_base_offset`](super::AnyParsedStatement::statement_base_offset).
+    pub fn statement_base_offset(&self) -> u32 {
+        self.0.statement_base_offset()
     }
 
     /// Post-expansion source — the bound source with every currently-
@@ -428,9 +438,14 @@ impl<'a> ParseError<'a> {
         self.0.recovery_root()
     }
 
-    /// The source text bound to this result.
+    /// Source slice for just the failing statement.
     pub fn text(&self) -> &'a str {
         self.0.0.text()
+    }
+
+    /// Full SQL source bound to the parse session.
+    pub fn full_text(&self) -> &'a str {
+        self.0.0.full_text()
     }
 
     /// Tokens collected during the (partial) parse, if `collect_tokens` was enabled.
@@ -510,6 +525,40 @@ mod tests {
         fn lookup(&mut self, name: &str, args: &[MacroArg<'_>], out: &mut MacroOutput) -> bool {
             self.0.borrow_mut().lookup(name, args, out)
         }
+    }
+
+    #[test]
+    fn statement_text_isolates_current_statement() {
+        let parser = Parser::new();
+        let mut session = parser.parse("CREATE TABLE t(x);\n  SELECT * FROM t;");
+
+        let first = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            _ => panic!("first statement should parse"),
+        };
+        assert_eq!(first.text(), "CREATE TABLE t(x);");
+        assert_eq!(first.statement_base_offset(), 0);
+        assert_eq!(first.full_text(), "CREATE TABLE t(x);\n  SELECT * FROM t;");
+
+        let second = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            _ => panic!("second statement should parse"),
+        };
+        assert_eq!(second.text(), "SELECT * FROM t;");
+        assert_eq!(second.statement_base_offset(), 21);
+        assert_eq!(second.full_text(), "CREATE TABLE t(x);\n  SELECT * FROM t;");
+    }
+
+    #[test]
+    fn statement_text_includes_leading_comments() {
+        let parser = Parser::new();
+        let mut session = parser.parse("/* hi */ SELECT 1;");
+        let stmt = match session.next() {
+            ParseOutcome::Ok(s) => s,
+            _ => panic!("should parse"),
+        };
+        assert_eq!(stmt.text(), "/* hi */ SELECT 1;");
+        assert_eq!(stmt.statement_base_offset(), 0);
     }
 
     #[test]
@@ -919,7 +968,7 @@ mod tests {
             ParseOutcome::Err(err) => panic!("statement should parse: {err}"),
         }
 
-        assert_eq!(session.text(), "SELECT id!(42);");
+        assert_eq!(session.full_text(), "SELECT id!(42);");
         assert_eq!(session.expanded_text(), "SELECT 42;");
     }
 

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -532,17 +532,15 @@ mod tests {
         let parser = Parser::new();
         let mut session = parser.parse("CREATE TABLE t(x);\n  SELECT * FROM t;");
 
-        let first = match session.next() {
-            ParseOutcome::Ok(stmt) => stmt,
-            _ => panic!("first statement should parse"),
+        let ParseOutcome::Ok(first) = session.next() else {
+            panic!("first statement should parse");
         };
         assert_eq!(first.text(), "CREATE TABLE t(x);");
         assert_eq!(first.statement_base_offset(), 0);
         assert_eq!(first.full_text(), "CREATE TABLE t(x);\n  SELECT * FROM t;");
 
-        let second = match session.next() {
-            ParseOutcome::Ok(stmt) => stmt,
-            _ => panic!("second statement should parse"),
+        let ParseOutcome::Ok(second) = session.next() else {
+            panic!("second statement should parse");
         };
         assert_eq!(second.text(), "SELECT * FROM t;");
         assert_eq!(second.statement_base_offset(), 21);
@@ -553,9 +551,8 @@ mod tests {
     fn statement_text_includes_leading_comments() {
         let parser = Parser::new();
         let mut session = parser.parse("/* hi */ SELECT 1;");
-        let stmt = match session.next() {
-            ParseOutcome::Ok(s) => s,
-            _ => panic!("should parse"),
+        let ParseOutcome::Ok(stmt) = session.next() else {
+            panic!("should parse");
         };
         assert_eq!(stmt.text(), "/* hi */ SELECT 1;");
         assert_eq!(stmt.statement_base_offset(), 0);
@@ -1126,8 +1123,8 @@ mod tests {
         assert_eq!(r.expansion(), "42");
         // call_offset is relative to stmt.text() for source-parent rewrites.
         let stmt_text = stmt.text();
-        let call_text = &stmt_text
-            [r.call_offset() as usize..(r.call_offset() + r.call_length()) as usize];
+        let call_text =
+            &stmt_text[r.call_offset() as usize..(r.call_offset() + r.call_length()) as usize];
         assert_eq!(call_text, "id!(42)");
     }
 

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -1124,8 +1124,10 @@ mod tests {
         assert_eq!(r.parent(), None, "top-level rewrite");
         assert_eq!(r.name(), "id");
         assert_eq!(r.expansion(), "42");
-        let call_text =
-            &source[r.call_offset() as usize..(r.call_offset() + r.call_length()) as usize];
+        // call_offset is relative to stmt.text() for source-parent rewrites.
+        let stmt_text = stmt.text();
+        let call_text = &stmt_text
+            [r.call_offset() as usize..(r.call_offset() + r.call_length()) as usize];
         assert_eq!(call_text, "id!(42)");
     }
 
@@ -1359,11 +1361,13 @@ mod tests {
         let rewrites: Vec<_> = stmt.macro_rewrites().collect();
         assert_eq!(rewrites.len(), 2);
 
-        // m's arg segment points into the authored source.
+        // m's arg segment points into the authored source; origin_offset
+        // is statement-relative when origin is Source.
+        let stmt_text = stmt.text();
         let m_segs: Vec<_> = rewrites[0].arg_segments().collect();
         assert_eq!(m_segs.len(), 1);
         assert_eq!(m_segs[0].origin(), ArgOrigin::Source);
-        let m_arg_text = &source[m_segs[0].origin_offset() as usize
+        let m_arg_text = &stmt_text[m_segs[0].origin_offset() as usize
             ..(m_segs[0].origin_offset() + m_segs[0].origin_length()) as usize];
         assert_eq!(m_arg_text, "n!(nonexistent_col)");
 

--- a/syntaqlite/README.md
+++ b/syntaqlite/README.md
@@ -51,7 +51,10 @@ loop {
             // stmt.root() returns the typed AST node
         }
         ParseOutcome::Err(err) => {
-            eprintln!("parse error at offset {}: {}", err.offset(), err.message());
+            // `err.offset()` is relative to the failing statement; add
+            // `err.statement_base_offset()` for a position in the full
+            // source.
+            eprintln!("parse error at offset {:?}: {}", err.offset(), err.message());
         }
         ParseOutcome::Done => break,
     }

--- a/syntaqlite/src/semantic/analyzer.rs
+++ b/syntaqlite/src/semantic/analyzer.rs
@@ -371,8 +371,9 @@ impl SemanticAnalyzer {
                     }
                     #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
                     {
-                        collect_tokens(e.tokens(), &mut tokens);
-                        collect_comments(e.comments(), &mut comments);
+                        let base = e.statement_base_offset();
+                        collect_tokens(e.tokens(), base, &mut tokens);
+                        collect_comments(e.comments(), base, &mut comments);
                     }
                     continue;
                 }
@@ -380,8 +381,9 @@ impl SemanticAnalyzer {
 
             #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
             {
-                collect_tokens(stmt.tokens(), &mut tokens);
-                collect_comments(stmt.comments(), &mut comments);
+                let base = stmt.statement_base_offset();
+                collect_tokens(stmt.tokens(), base, &mut tokens);
+                collect_comments(stmt.comments(), base, &mut comments);
             }
 
             // Process the statement and extract macro registration info.
@@ -476,7 +478,7 @@ impl SemanticAnalyzer {
         let defined_relations = extract_defined_relations(erased, root_id, self.dialect.roles());
 
         // Extract the statement source text from token spans.
-        let stmt_source = statement_source(erased);
+        let stmt_source = erased.text().to_string();
 
         StatementModel::new(stmt_source, diagnostics, lineage, defined_relations)
     }
@@ -518,11 +520,10 @@ impl SemanticAnalyzer {
 
         // Resolve the module source.
         let Some(source) = self.resolver.as_ref().and_then(|r| r.resolve(&module_name)) else {
-            // Emit diagnostic for unresolvable module.
             let (start, end) = match fields[module as usize] {
                 FieldValue::Span(sp) => {
-                    let (authored, off) = erased.span_text(sp);
-                    (off as usize, off as usize + authored.len())
+                    let (_, start, end) = erased.span_text_abs(sp);
+                    (start, end)
                 }
                 _ => (0, 0),
             };
@@ -548,28 +549,6 @@ impl Default for SemanticAnalyzer {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-/// Extract the source text for a single parsed statement from its token spans.
-fn statement_source(stmt: &AnyParsedStatement<'_>) -> String {
-    let source = stmt.text();
-    let mut start = usize::MAX;
-    let mut end = 0usize;
-    for (offset, length) in stmt.token_spans() {
-        let o = offset as usize;
-        let l = length as usize;
-        if o < start {
-            start = o;
-        }
-        if o + l > end {
-            end = o + l;
-        }
-    }
-    if start <= end && end <= source.len() {
-        source[start..end].to_string()
-    } else {
-        String::new()
-    }
-}
 
 /// Extract relations defined by a DDL statement (CREATE TABLE / CREATE VIEW).
 fn extract_defined_relations(
@@ -647,11 +626,13 @@ fn format_arity(name: &str, arity: AritySpec) -> String {
 #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
 fn collect_tokens<'a>(
     iter: impl Iterator<Item = syntaqlite_syntax::any::AnyParserToken<'a>>,
+    stmt_base: u32,
     tokens: &mut Vec<StoredToken>,
 ) {
+    let base = stmt_base as usize;
     for tok in iter {
         tokens.push(StoredToken {
-            offset: tok.offset() as usize,
+            offset: base + tok.offset() as usize,
             length: tok.length() as usize,
             token_type: tok.token_type(),
             flags: tok.flags(),
@@ -662,24 +643,28 @@ fn collect_tokens<'a>(
 #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
 fn collect_comments<'a>(
     iter: impl Iterator<Item = syntaqlite_syntax::Comment<'a>>,
+    stmt_base: u32,
     comments: &mut Vec<StoredComment>,
 ) {
+    let base = stmt_base as usize;
     for c in iter {
         comments.push(StoredComment {
-            offset: c.offset() as usize,
+            offset: base + c.offset() as usize,
             length: c.length() as usize,
         });
     }
 }
 
 fn parse_error_span(err: &AnyParseError<'_>, source: &str) -> (usize, usize) {
+    let base = err.statement_base_offset() as usize;
     match (err.offset(), err.length()) {
-        (Some(off), Some(len)) if len > 0 => (off, off + len),
+        (Some(off), Some(len)) if len > 0 => (base + off, base + off + len),
         (Some(off), _) => {
-            if off >= source.len() && !source.is_empty() {
+            let abs = base + off;
+            if abs >= source.len() && !source.is_empty() {
                 (source.len() - 1, source.len())
             } else {
-                (off, (off + 1).min(source.len()))
+                (abs, (abs + 1).min(source.len()))
             }
         }
         _ => {
@@ -961,9 +946,7 @@ fn ddl_name_offset(
         return None;
     }
     let name = stmt.span_expanded_text(sp);
-    let (authored, off) = stmt.span_text(sp);
-    let start = off as usize;
-    let end = start + authored.len();
+    let (_, start, end) = stmt.span_text_abs(sp);
     Some((name.to_ascii_lowercase(), (start, end)))
 }
 
@@ -1305,12 +1288,9 @@ impl<'a> ValidationPass<'a> {
         }
         match fields[0] {
             FieldValue::Span(sp) => {
-                // Identifier spelling uses the post-expansion bytes;
-                // source position uses the authored byte range.
                 let name = stmt.span_expanded_text(sp);
-                let (authored, off) = stmt.span_text(sp);
-                let start = off as usize;
-                (name, start, start + authored.len())
+                let (_, start, end) = stmt.span_text_abs(sp);
+                (name, start, end)
             }
             _ => ("", 0, 0),
         }
@@ -1332,17 +1312,13 @@ impl<'a> ValidationPass<'a> {
         if sp.is_empty() {
             return;
         }
-        // Identifier spelling comes from the post-expansion bytes (what
-        // the tokenizer saw), so a reference produced from a macro body
-        // resolves against the catalog by its expanded name.  Source
-        // position comes from `span_text`, which walks the expansion
-        // chain back to the authored byte range in the user's input —
-        // so diagnostics anchor at the macro call site when the token
-        // lives inside a macro body.
+        // Identifier spelling comes from post-expansion bytes — a
+        // reference produced from a macro body resolves by its expanded
+        // name — while source position walks the expansion chain back
+        // to the authored byte range so diagnostics anchor at the macro
+        // call site.
         let name = stmt.span_expanded_text(sp);
-        let (authored, off) = stmt.span_text(sp);
-        let start = off as usize;
-        let end = start + authored.len();
+        let (_, start, end) = stmt.span_text_abs(sp);
 
         let is_known =
             self.catalog.resolve_relation(name) || self.catalog.resolve_table_function(name);
@@ -1411,13 +1387,8 @@ impl<'a> ValidationPass<'a> {
         if let FieldValue::Span(sp) = fields[name_idx as usize]
             && !sp.is_empty()
         {
-            // Identifier spelling from post-expansion bytes; source
-            // position from `span_text` (walks expansion chain back to
-            // authored byte range).
             let name = stmt.span_expanded_text(sp);
-            let (authored, off) = stmt.span_text(sp);
-            let start = off as usize;
-            let end = start + authored.len();
+            let (_, start, end) = stmt.span_text_abs(sp);
             let args_id = Self::field_node_id(fields, args_idx);
             let arg_count = args_id
                 .and_then(|id| stmt.list_children(id))
@@ -1496,17 +1467,12 @@ impl<'a> ValidationPass<'a> {
         if col_sp.is_empty() {
             return;
         }
-        // Identifier spelling comes from post-expansion bytes; source
-        // position from `span_text` (walks expansion chain back to
-        // authored byte range for diagnostic placement).
         let column = stmt.span_expanded_text(col_sp);
         let table = match fields[table_idx as usize] {
             FieldValue::Span(sp) if !sp.is_empty() => Some(stmt.span_expanded_text(sp)),
             _ => None,
         };
-        let (authored, col_off) = stmt.span_text(col_sp);
-        let start = col_off as usize;
-        let end = start + authored.len();
+        let (_, start, end) = stmt.span_text_abs(col_sp);
 
         match self.scope.resolve_column(table, column) {
             ColumnResolution::Found {
@@ -1870,9 +1836,8 @@ impl<'a> ValidationPass<'a> {
         let (name, name_range) = match fields[name_idx as usize] {
             FieldValue::Span(sp) => {
                 let name = stmt.span_expanded_text(sp);
-                let (authored, off) = stmt.span_text(sp);
-                let start = off as usize;
-                (name, (start, start + authored.len()))
+                let (_, start, end) = stmt.span_text_abs(sp);
+                (name, (start, end))
             }
             _ => ("", (0, 0)),
         };

--- a/syntaqlite/src/semantic/catalog.rs
+++ b/syntaqlite/src/semantic/catalog.rs
@@ -1001,9 +1001,8 @@ fn ddl_name_span(
     if sp.is_empty() {
         return None;
     }
-    let (s, off_u32) = stmt.span_text(sp);
-    let off = off_u32 as usize;
-    Some((s.to_ascii_lowercase(), off, off + s.len()))
+    let (s, start, end) = stmt.span_text_abs(sp);
+    Some((s.to_ascii_lowercase(), start, end))
 }
 
 /// Extract column name spans from a `CREATE TABLE` statement.
@@ -1068,9 +1067,8 @@ fn column_def_name_span<'a>(
         if let FieldValue::Span(sp) = name_fields[j]
             && !sp.is_empty()
         {
-            let (s, off) = stmt.span_text(sp);
-            let start = off as usize;
-            return Some((s, start, start + s.len()));
+            let (s, start, end) = stmt.span_text_abs(sp);
+            return Some((s, start, end));
         }
     }
     None

--- a/syntaqlite/tests/fmt_comments.rs
+++ b/syntaqlite/tests/fmt_comments.rs
@@ -68,6 +68,7 @@ fn debug_comment_token_offsets() {
             ParseOutcome::Ok(stmt) => {
                 eprintln!("=== Statement {stmt_num} ===");
                 let comments: Vec<_> = stmt.comments().collect();
+                let stmt_text = stmt.text();
                 eprintln!("  Comments ({}):", comments.len());
                 for c in &comments {
                     let end = c.offset() as usize + c.length() as usize;
@@ -75,7 +76,7 @@ fn debug_comment_token_offsets() {
                         "    offset={} len={} text={:?}",
                         c.offset(),
                         c.length(),
-                        &input[c.offset() as usize..end]
+                        &stmt_text[c.offset() as usize..end]
                     );
                 }
                 let tokens: Vec<_> = stmt.tokens().collect();

--- a/syntaqlite/tests/generated.rs
+++ b/syntaqlite/tests/generated.rs
@@ -187,10 +187,12 @@ fn debug_multi_stmt_comments() {
                 ParseOutcome::Err(e) => panic!("parse error: {e:?}"),
             };
             let comments: Vec<_> = stmt.comments().collect();
-            eprintln!("stmt {stmt_num}: source={:?}", stmt.text());
+            let stmt_text = stmt.text();
+            eprintln!("stmt {stmt_num}: source={stmt_text:?}");
             eprintln!("  {} comment(s):", comments.len());
             for c in &comments {
-                let text = &source[c.offset() as usize..(c.offset() + c.length()) as usize];
+                let text =
+                    &stmt_text[c.offset() as usize..(c.offset() + c.length()) as usize];
                 eprintln!(
                     "    offset={} kind={:?} text={text:?}",
                     c.offset(),

--- a/syntaqlite/tests/generated.rs
+++ b/syntaqlite/tests/generated.rs
@@ -191,8 +191,7 @@ fn debug_multi_stmt_comments() {
             eprintln!("stmt {stmt_num}: source={stmt_text:?}");
             eprintln!("  {} comment(s):", comments.len());
             for c in &comments {
-                let text =
-                    &stmt_text[c.offset() as usize..(c.offset() + c.length()) as usize];
+                let text = &stmt_text[c.offset() as usize..(c.offset() + c.length()) as usize];
                 eprintln!(
                     "    offset={} kind={:?} text={text:?}",
                     c.offset(),

--- a/syntaqlite/tests/low_level.rs
+++ b/syntaqlite/tests/low_level.rs
@@ -118,6 +118,33 @@ fn feed_token_records_comment() {
     assert_eq!(comments[0].length(), 8);
 }
 
+/// Leading `TK_SPACE` fed via `feed_token` should NOT open the statement:
+/// stmt_start should match parser_next semantics (first significant byte).
+/// This keeps statement-relative offsets consistent between the tokenizer-
+/// driven and incremental paths.
+#[test]
+fn feed_token_leading_whitespace_does_not_open_statement() {
+    let source = "   SELECT 1";
+    let parser = Parser::with_config(&ParserConfig::default().with_collect_tokens(true));
+    let mut session = parser.incremental_parse(source);
+
+    session.feed_token(TokenType::Space, 0..3);
+    session.feed_token(TokenType::Select, 3..9);
+    session.feed_token(TokenType::Integer, 10..11);
+
+    let stmt = session
+        .finish()
+        .expect("expected Some")
+        .expect("expected a statement");
+
+    // Statement opens at `SELECT`, not at byte 0 — matches parser_next.
+    assert_eq!(stmt.text(), "SELECT 1");
+    assert_eq!(stmt.statement_base_offset(), 3);
+    let tokens: Vec<_> = stmt.tokens().collect();
+    assert_eq!(tokens[0].offset(), 0);
+    assert_eq!(tokens[0].text(), "SELECT");
+}
+
 /// Multi-statement via `feed_token`: both statements produce correct AST roots.
 #[test]
 fn feed_tokens_multi_statement_both_roots() {

--- a/syntaqlite/tests/low_level.rs
+++ b/syntaqlite/tests/low_level.rs
@@ -119,7 +119,7 @@ fn feed_token_records_comment() {
 }
 
 /// Leading `TK_SPACE` fed via `feed_token` should NOT open the statement:
-/// stmt_start should match parser_next semantics (first significant byte).
+/// `stmt_start` should match `parser_next` semantics (first significant byte).
 /// This keeps statement-relative offsets consistent between the tokenizer-
 /// driven and incremental paths.
 #[test]

--- a/syntaqlite/tests/low_level.rs
+++ b/syntaqlite/tests/low_level.rs
@@ -398,10 +398,11 @@ fn sqlite_type_tokens_are_marked_as_type() {
     loop {
         match session.next() {
             ParseOutcome::Ok(stmt) => {
+                let stmt_text = stmt.text();
                 for t in stmt.tokens() {
                     if t.flags().used_as_type() {
                         marked.push(
-                            source[t.offset() as usize..(t.offset() + t.length()) as usize]
+                            stmt_text[t.offset() as usize..(t.offset() + t.length()) as usize]
                                 .to_string(),
                         );
                     }

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -923,6 +923,7 @@ pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::child_node_ids(&self, id:
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::comment_spans(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::CommentSpan> + use<'_>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::expanded_text(&self) -> &'a str
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::extract_fields(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(syntaqlite_syntax::any::AnyNodeTag, syntaqlite_syntax::any::NodeFields)>
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::full_text(&self) -> &'a str
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::is_macro_free(&self) -> bool
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::list_children(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a [syntaqlite_syntax::any::AnyNodeId]>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::macro_rewrites(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRewrite<'a>> + use<'_, 'a>
@@ -933,6 +934,8 @@ pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_id(&self) -> syntaql
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_node(&self) -> core::option::Option<syntaqlite_syntax::any::AnyNode<'_>>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_expanded_text(&self, span: syntaqlite_syntax::any::TextSpan) -> &'a str
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_text(&self, span: syntaqlite_syntax::any::TextSpan) -> (&'a str, u32)
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_text_abs(&self, span: syntaqlite_syntax::any::TextSpan) -> (&'a str, usize, usize)
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::statement_base_offset(&self) -> u32
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::text(&self) -> &'a str
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::token_spans(&self) -> impl core::iter::traits::iterator::Iterator<Item = (u32, u32)> + use<'_>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::traceback(&mut self, node_id: syntaqlite_syntax::any::AnyNodeId, field_idx: u8) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::TracebackFrame<'a>> + use<'_, 'a>
@@ -1657,21 +1660,24 @@ pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::length(&self) -> core::
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::message(&self) -> &str
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::offset(&self) -> core::option::Option<usize>
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::recovery_root(&'a self) -> core::option::Option<<G as syntaqlite_syntax::typed::TypedDialect>::Node>
+pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::statement_base_offset(&self) -> u32
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::text(&self) -> &'a str
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::typed::TypedParserToken<'a, G>>
 pub fn syntaqlite_syntax::typed::TypedParseSession<G>::arena_result(&self) -> syntaqlite_syntax::any::AnyParsedStatement<'_>
 pub fn syntaqlite_syntax::typed::TypedParseSession<G>::drop(&mut self)
 pub fn syntaqlite_syntax::typed::TypedParseSession<G>::expanded_text(&self) -> &str
+pub fn syntaqlite_syntax::typed::TypedParseSession<G>::full_text(&self) -> &str
 pub fn syntaqlite_syntax::typed::TypedParseSession<G>::next(&mut self) -> syntaqlite_syntax::ParseOutcome<syntaqlite_syntax::typed::TypedParsedStatement<'_, G>, syntaqlite_syntax::typed::TypedParseError<'_, G>>
 pub fn syntaqlite_syntax::typed::TypedParseSession<G>::set_macro_lookup(&mut self, handler: core::option::Option<alloc::boxed::Box<dyn syntaqlite_syntax::MacroLookup>>)
-pub fn syntaqlite_syntax::typed::TypedParseSession<G>::text(&self) -> &str
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::comments(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::dump(&self, out: &mut alloc::string::String, indent: usize)
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::erase(self) -> syntaqlite_syntax::any::AnyParsedStatement<'a>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::expanded_text(&self) -> &'a str
+pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::full_text(&self) -> &'a str
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::leading_comments(&self, token_idx: u32) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::macro_rewrites(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRewrite<'a>> + use<'_, 'a, G>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::root(&'a self) -> core::option::Option<<G as syntaqlite_syntax::typed::TypedDialect>::Node>
+pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::statement_base_offset(&self) -> u32
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::text(&self) -> &'a str
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::typed::TypedParserToken<'a, G>>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::trailing_comments(&self, token_idx: u32) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>>


### PR DESCRIPTION
All offsets the parser exposes — token/comment spans, arena TextSpan
offsets, node extents, error offsets, macro rewrite call offsets and
arg-segment origin offsets — are now measured from the current
statement's source slice (`stmt.text()`) instead of the full bound
source. Callers that need a full-document position add
`stmt.statement_base_offset()`; this only happens at LSP protocol
boundaries.

- `SyntaqliteParser` grows a `stmt_source` pointer set on the first
  byte of each statement; the layer-0 macro sentinel retargets to
  match so span walking / `span_expanded_text` / `node_expanded_text`
  resolve layer-0 spans against the statement.
- Every layer-0 emission (token vec, comment vec, `minor.offset` fed
  to Lemon, `ctx.cur_shift_start`/`last_shifted_end`, `error_offset`,
  macro layer `call_offset`/`body_call_offset`/`macro_root_*`,
  arg-segment `origin_offset` when origin is source) stores an offset
  relative to `stmt_source`.
- `syntaqlite_parser_text` returns `(ptr, abs_offset, len)` for the
  current statement; `syntaqlite_parser_full_text` returns the whole
  bound source. `feed_token` now advances `p->offset` so
  `stmt_end_offset` is set correctly in the incremental API.
- `AnyParsedStatement` exposes `text`, `full_text`,
  `statement_base_offset`, and a `span_text_abs` convenience that
  returns `(text, abs_start, abs_end)` for callers emitting
  full-source positions. `TypedParseError` also exposes
  `statement_base_offset`.
- Formatter, interpreter and `catalog::expr_source_text` slice against
  `text()` directly. The semantic analyzer keeps LSP-facing
  `Diagnostic`, `Resolution`, `SemanticModel.tokens/comments`, and
  `definition_offsets` in absolute document coordinates by folding the
  statement base in at the emission site (via `span_text_abs` or an
  explicit `base + off`).

