### PR TITLE
synq: thread offset/text newtypes through parser public API

### DIFF
--- a/syntaqlite-cli/src/commands/fmt.rs
+++ b/syntaqlite-cli/src/commands/fmt.rs
@@ -155,11 +155,9 @@ impl<'a> FmtRun<'a> {
 }
 
 fn render_format_error(e: &FormatError, source: &str, file: &str) {
-    let start = e.offset().unwrap_or(0);
-    let end = start + e.length().unwrap_or(0);
+    let range = e.range().unwrap_or_default();
     let diag = Diagnostic::new(
-        start,
-        end,
+        range,
         DiagnosticMessage::ParseError(e.message().to_owned()),
         Severity::Error,
         None,

--- a/syntaqlite-cli/src/commands/parse.rs
+++ b/syntaqlite-cli/src/commands/parse.rs
@@ -9,6 +9,7 @@ use std::ops::Deref;
 use syntaqlite::Diagnostic;
 use syntaqlite::any::{AnyDialect, AnyParser, ParseOutcome};
 use syntaqlite::semantic::{DiagnosticMessage, Severity};
+use syntaqlite::source::StmtRange;
 use syntaqlite::util::DiagnosticRenderer;
 use syntaqlite_syntax::any::AnyDialect as SyntaxAnyDialect;
 use syntaqlite_syntax::typed::TypedParsedStatement;
@@ -54,11 +55,11 @@ fn parse_source(dialect: &AnyDialect, src: &Source, sink: &mut dyn Sink) -> Vec<
         match session.next() {
             ParseOutcome::Ok(stmt) => sink.on_stmt(StmtView { inner: stmt }),
             ParseOutcome::Err(err) => {
-                let start = err.offset().unwrap_or(0);
-                let end = start + err.length().unwrap_or(0);
+                let start = err.offset().unwrap_or_default();
+                let length = err.length().unwrap_or_default();
+                let range = StmtRange::from_offset_len(start, length).to_doc(err.statement_base());
                 errors.push(Diagnostic::new(
-                    start,
-                    end,
+                    range,
                     DiagnosticMessage::ParseError(err.message().to_string()),
                     Severity::Error,
                     None,

--- a/syntaqlite-cli/src/commands/validate.rs
+++ b/syntaqlite-cli/src/commands/validate.rs
@@ -300,8 +300,8 @@ impl<'a> DiagnosticRecord<'a> {
             file,
             severity: diag.severity().into(),
             message: diag.message().to_string(),
-            start_offset: diag.start_offset(),
-            end_offset: diag.end_offset(),
+            start_offset: diag.start().as_usize(),
+            end_offset: diag.end().as_usize(),
             help,
         }
     }

--- a/syntaqlite-common/src/lib.rs
+++ b/syntaqlite-common/src/lib.rs
@@ -10,9 +10,6 @@
 //! Use the [`syntaqlite`](https://crates.io/crates/syntaqlite) crate instead.
 
 #[doc(hidden)]
-pub mod offsets;
-
-#[doc(hidden)]
 /// Semantic role types shared between the codegen tool and the runtime.
 ///
 /// `SemanticRole` is `#[repr(C, u8)]` so the Rust in-memory layout

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -32,7 +32,8 @@ pub use parser::{
 #[cfg(feature = "sqlite-minimal")]
 #[doc(inline)]
 pub use parser::{
-    Comment, CommentKind, CommentSide, CommentSpan, CompletionContext, ParserTokenFlags,
+    Comment, CommentKind, CommentSide, CommentSpan, CompletionContext, MACRO_BODY_CALL_ARG_INTERNAL,
+    ParserTokenFlags,
 };
 
 // Top-level tokenizer types.
@@ -173,6 +174,7 @@ pub(crate) mod ast;
 mod dialect;
 #[cfg(feature = "sqlite-minimal")]
 pub(crate) mod parser;
+pub mod source;
 #[cfg(feature = "sqlite-minimal")]
 pub(crate) mod tokenizer;
 

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -32,8 +32,8 @@ pub use parser::{
 #[cfg(feature = "sqlite-minimal")]
 #[doc(inline)]
 pub use parser::{
-    Comment, CommentKind, CommentSide, CommentSpan, CompletionContext, MACRO_BODY_CALL_ARG_INTERNAL,
-    ParserTokenFlags,
+    Comment, CommentKind, CommentSide, CommentSpan, CompletionContext,
+    MACRO_BODY_CALL_ARG_INTERNAL, ParserTokenFlags,
 };
 
 // Top-level tokenizer types.

--- a/syntaqlite-syntax/src/parser/incremental.rs
+++ b/syntaqlite-syntax/src/parser/incremental.rs
@@ -9,6 +9,7 @@ use std::rc::Rc;
 
 use crate::ast::GrammarTokenType;
 use crate::dialect::{AnyDialect, TypedDialect};
+use crate::source::DocOffset;
 
 use super::{
     AnyParsedStatement, CParser, CompletionContext, ParserInner, TypedParseError,
@@ -116,28 +117,29 @@ impl<G: TypedDialect> TypedIncrementalParseSession<G> {
     /// # Examples
     ///
     /// ```rust
+    /// use syntaqlite_syntax::source::DocOffset;
     /// use syntaqlite_syntax::typed::{dialect, TypedParser};
     /// use syntaqlite_syntax::TokenType;
     ///
     /// let parser = TypedParser::new(dialect());
     /// let mut session = parser.incremental_parse("SELECT 1");
     ///
-    /// assert!(session.feed_token(TokenType::Select, 0..6).is_none());
-    /// assert!(session.feed_token(TokenType::Integer, 7..8).is_none());
+    /// assert!(session.feed_token(TokenType::Select, DocOffset::from_raw(0)..DocOffset::from_raw(6)).is_none());
+    /// assert!(session.feed_token(TokenType::Integer, DocOffset::from_raw(7)..DocOffset::from_raw(8)).is_none());
     /// assert!(session.finish().is_some());
     /// ```
     pub fn feed_token(
         &mut self,
         token_type: G::Token,
-        span: Range<usize>,
+        span: Range<DocOffset>,
     ) -> Option<Result<TypedParsedStatement<'_, G>, TypedParseError<'_, G>>> {
         self.assert_not_finished();
         // SAFETY: c_text_ptr is valid for the source length; raw is valid.
         let rc = unsafe {
-            let c_text = self.c_text_ptr.as_ptr().add(span.start);
+            let c_text = self.c_text_ptr.as_ptr().add(span.start.as_usize());
             let raw_token_type: u32 = token_type.into();
-            #[expect(clippy::cast_possible_truncation)]
-            (*self.raw_ptr()).feed_token(raw_token_type, c_text as *const _, span.len() as u32)
+            let length = (span.end - span.start).as_u32();
+            (*self.raw_ptr()).feed_token(raw_token_type, c_text as *const _, length)
         };
         self.result_from_rc(rc)
     }
@@ -168,12 +170,13 @@ impl<G: TypedDialect> TypedIncrementalParseSession<G> {
     /// # Examples
     ///
     /// ```rust
+    /// use syntaqlite_syntax::source::DocOffset;
     /// use syntaqlite_syntax::typed::{dialect, TypedParser};
     /// use syntaqlite_syntax::TokenType;
     ///
     /// let parser = TypedParser::new(dialect());
     /// let mut session = parser.incremental_parse("SELECT x FROM t");
-    /// let _ = session.feed_token(TokenType::Select, 0..6);
+    /// let _ = session.feed_token(TokenType::Select, DocOffset::from_raw(0)..DocOffset::from_raw(6));
     ///
     /// let expected: Vec<_> = session.expected_tokens().collect();
     /// assert!(!expected.is_empty());
@@ -265,18 +268,19 @@ impl IncrementalParseSession {
     /// # Examples
     ///
     /// ```rust
+    /// use syntaqlite_syntax::source::DocOffset;
     /// use syntaqlite_syntax::{Parser, TokenType};
     ///
     /// let parser = Parser::new();
     /// let mut session = parser.incremental_parse("SELECT 1");
     ///
-    /// assert!(session.feed_token(TokenType::Select, 0..6).is_none());
-    /// assert!(session.feed_token(TokenType::Integer, 7..8).is_none());
+    /// assert!(session.feed_token(TokenType::Select, DocOffset::from_raw(0)..DocOffset::from_raw(6)).is_none());
+    /// assert!(session.feed_token(TokenType::Integer, DocOffset::from_raw(7)..DocOffset::from_raw(8)).is_none());
     /// ```
     pub fn feed_token(
         &mut self,
         token_type: crate::sqlite::tokens::TokenType,
-        span: Range<usize>,
+        span: Range<DocOffset>,
     ) -> Option<Result<ParsedStatement<'_>, ParseError<'_>>> {
         Some(match self.0.feed_token(token_type, span)? {
             Ok(result) => Ok(ParsedStatement(result)),
@@ -297,12 +301,13 @@ impl IncrementalParseSession {
     /// # Examples
     ///
     /// ```rust
+    /// use syntaqlite_syntax::source::DocOffset;
     /// use syntaqlite_syntax::{Parser, TokenType};
     ///
     /// let parser = Parser::new();
     /// let mut session = parser.incremental_parse("SELECT 1");
-    /// let _ = session.feed_token(TokenType::Select, 0..6);
-    /// let _ = session.feed_token(TokenType::Integer, 7..8);
+    /// let _ = session.feed_token(TokenType::Select, DocOffset::from_raw(0)..DocOffset::from_raw(6));
+    /// let _ = session.feed_token(TokenType::Integer, DocOffset::from_raw(7)..DocOffset::from_raw(8));
     ///
     /// let stmt = session.finish().and_then(Result::ok).unwrap();
     /// let _ = stmt.root();

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -904,7 +904,7 @@ impl<'a> AnyParsedStatement<'a> {
     /// that need full-source positions.
     pub fn span_text_abs(&self, span: crate::ast::TextSpan) -> (&'a str, DocRange) {
         let (text, off) = self.span_text(span);
-        let start = self.statement_base().to_doc(off);
+        let start = off.to_doc(self.statement_base());
         let end = start + DocLen::from_raw(u32::try_from(text.len()).unwrap_or(u32::MAX));
         (text, DocRange { start, end })
     }
@@ -1233,22 +1233,26 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
         }
     }
 
-    /// Byte offset of the error token, or `None` if unknown.
-    pub(crate) fn error_offset(&self) -> Option<usize> {
+    /// Statement-relative byte offset of the error token, or `None` if unknown.
+    pub(crate) fn error_offset(&self) -> Option<StmtOffset> {
         // SAFETY: self.any.raw is a valid, non-null parser pointer for lifetime 'a.
         let v = unsafe { self.any.raw.as_ref().result_error_offset() };
         if v == 0xFFFF_FFFF {
             None
         } else {
-            Some(v as usize)
+            Some(StmtOffset::from_raw(v))
         }
     }
 
     /// Byte length of the error token, or `None` if unknown.
-    pub(crate) fn error_length(&self) -> Option<usize> {
+    pub(crate) fn error_length(&self) -> Option<StmtLen> {
         // SAFETY: self.any.raw is a valid, non-null parser pointer for lifetime 'a.
         let v = unsafe { self.any.raw.as_ref().result_error_length() };
-        if v == 0 { None } else { Some(v as usize) }
+        if v == 0 {
+            None
+        } else {
+            Some(StmtLen::from_raw(v))
+        }
     }
 
     /// Error classification for the current result.
@@ -1373,12 +1377,12 @@ impl<'a, G: TypedDialect> TypedParseError<'a, G> {
     pub fn message(&self) -> &str {
         self.0.error_msg().unwrap_or("parse error")
     }
-    /// Returns the byte offset of the error token, or `None` if unknown.
-    pub fn offset(&self) -> Option<usize> {
+    /// Statement-relative byte offset of the error token, or `None` if unknown.
+    pub fn offset(&self) -> Option<StmtOffset> {
         self.0.error_offset()
     }
-    /// Returns the byte length of the error token, or `None` if unknown.
-    pub fn length(&self) -> Option<usize> {
+    /// Byte length of the error token, or `None` if unknown.
+    pub fn length(&self) -> Option<StmtLen> {
         self.0.error_length()
     }
     /// The partial recovery tree, if error recovery produced one.

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -9,6 +9,11 @@ use std::rc::Rc;
 
 use std::ffi::c_void;
 
+use crate::source::{
+    ColumnNumber, DocLen, DocOffset, DocRange, DocText, LayerLen, LayerOffset, LayerText,
+    LineNumber, StatementBase, StmtLen, StmtOffset, StmtRange, StmtText, TokenIdx,
+};
+
 use crate::any::{AnyNodeTag, AnyTokenType};
 use crate::ast::{AnyNodeId, ArenaNode, GrammarNodeType, GrammarTokenType, RawNodeList};
 use crate::dialect::{AnyDialect, TypedDialect};
@@ -30,8 +35,8 @@ pub use incremental::{AnyIncrementalParseSession, TypedIncrementalParseSession};
 pub use session::{ParseError, ParseSession, ParsedStatement, Parser, ParserToken};
 pub use types::{
     AnyParserToken, ArgOrigin, Comment, CommentKind, CommentSide, CommentSpan, CompletionContext,
-    MacroArgSegment, MacroRewrite, ParseOutcome, ParserTokenFlags, TracebackFrame,
-    TypedParserToken,
+    MACRO_BODY_CALL_ARG_INTERNAL, MacroArgSegment, MacroRewrite, ParseOutcome, ParserTokenFlags,
+    TracebackFrame, TypedParserToken,
 };
 
 /// A single macro argument as presented to the lookup callback.
@@ -668,19 +673,20 @@ impl<'a> AnyParsedStatement<'a> {
             // `expansion` and `name` borrow from parser memory valid for
             // 'a (until the next parser_next / reset / destroy, which
             // requires ending the 'a-tied statement borrow).
-            let expansion: &'a str = if r.expansion.is_null() {
-                ""
+            let expansion: &'a LayerText = if r.expansion.is_null() {
+                LayerText::new("")
             } else {
                 // SAFETY: `expansion` points to `expansion_len` bytes
                 // owned by the parser, valid for 'a.  Parser buffers are
                 // UTF-8 by construction (source text or expansion text
                 // produced by the callback, which accepts a &str body).
-                unsafe {
+                let s = unsafe {
                     std::str::from_utf8_unchecked(std::slice::from_raw_parts(
                         r.expansion,
                         r.expansion_len as usize,
                     ))
-                }
+                };
+                LayerText::new(s)
             };
             let name: &'a str = if r.name.is_null() {
                 ""
@@ -702,14 +708,14 @@ impl<'a> AnyParsedStatement<'a> {
             MacroRewrite {
                 parent,
                 rewrite_idx: i,
-                call_offset: r.call_offset,
-                call_length: r.call_length,
+                call_offset: LayerOffset::from_raw(r.call_offset),
+                call_length: LayerLen::from_raw(r.call_length),
                 expansion,
                 name,
-                def_line: r.def_line,
-                def_col: r.def_col,
-                body_call_offset: r.body_call_offset,
-                body_call_length: r.body_call_length,
+                def_line: LineNumber::from_raw(r.def_line),
+                def_col: ColumnNumber::from_raw(r.def_col),
+                body_call_offset: LayerOffset::from_raw(r.body_call_offset),
+                body_call_length: LayerLen::from_raw(r.body_call_length),
                 parser: self.raw,
                 _lifetime: PhantomData,
             }
@@ -762,22 +768,23 @@ impl<'a> AnyParsedStatement<'a> {
                     ))
                 })
             },
-            line: f.line,
-            col: f.col,
+            line: LineNumber::from_raw(f.line),
+            col: ColumnNumber::from_raw(f.col),
             snippet: if f.snippet.is_null() || f.snippet_len == 0 {
-                ""
+                LayerText::new("")
             } else {
                 // SAFETY: C guarantees snippet points to snippet_len bytes
                 // of valid UTF-8 in a parser-owned buffer valid for 'a.
-                unsafe {
+                let s = unsafe {
                     std::str::from_utf8_unchecked(std::slice::from_raw_parts(
                         f.snippet,
                         f.snippet_len as usize,
                     ))
-                }
+                };
+                LayerText::new(s)
             },
-            offset_in_snippet: f.offset_in_snippet as usize,
-            length_in_snippet: f.length_in_snippet as usize,
+            offset_in_snippet: LayerOffset::from_raw(f.offset_in_snippet),
+            length_in_snippet: LayerLen::from_raw(f.length_in_snippet),
         })
     }
 
@@ -813,7 +820,7 @@ impl<'a> AnyParsedStatement<'a> {
     /// the caller's source; otherwise it collapses to the outermost
     /// `name!(...)` call site.  Always a direct slice — no allocation.
     /// Returns `("", 0)` for empty or invalid spans.
-    pub fn span_text(&self, span: crate::ast::TextSpan) -> (&'a str, u32) {
+    pub fn span_text(&self, span: crate::ast::TextSpan) -> (&'a str, StmtOffset) {
         let mut out_len: u32 = 0;
         let mut out_offset: u32 = 0;
         // SAFETY: self.raw is valid for 'a; span is a copy of an arena value.
@@ -823,14 +830,14 @@ impl<'a> AnyParsedStatement<'a> {
                 .span_text(span, &raw mut out_len, &raw mut out_offset)
         };
         if ptr.is_null() || out_len == 0 {
-            return ("", 0);
+            return ("", StmtOffset::default());
         }
         // SAFETY: C guarantees ptr points to out_len bytes of valid UTF-8
         // in a parser-owned buffer valid for 'a.
         let text = unsafe {
             std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize))
         };
-        (text, out_offset)
+        (text, StmtOffset::from_raw(out_offset))
     }
 
     pub(crate) fn field_span(
@@ -857,10 +864,14 @@ impl<'a> AnyParsedStatement<'a> {
     /// Full SQL source bound to the parse session — the whole input
     /// for multi-statement parses.  Use [`Self::text`] for just this
     /// statement.
-    pub fn full_text(&self) -> &'a str {
+    ///
+    /// Returned as a [`DocText`], which can be indexed by [`DocRange`]
+    /// for type-safe slicing.  Call [`DocText::as_str`] for interop with
+    /// `std::str` APIs.
+    pub fn full_text(&self) -> &'a DocText {
         // SAFETY: self.raw is valid for 'a; the returned slice borrows
         // from the parser's source buffer which outlives 'a.
-        unsafe { self.raw.as_ref().full_text() }
+        DocText::new(unsafe { self.raw.as_ref().full_text() })
     }
 
     /// Source slice for just this statement, including any attached
@@ -868,40 +879,47 @@ impl<'a> AnyParsedStatement<'a> {
     /// this statement — tokens, comments, spans, node extents, error
     /// offsets, macro rewrite call offsets — is relative to this slice.
     /// Empty if no statement was produced.
-    pub fn text(&self) -> &'a str {
+    ///
+    /// Returned as a [`StmtText`], which can be indexed by [`StmtRange`]
+    /// for type-safe slicing.  Call [`StmtText::as_str`] for interop
+    /// with `std::str` APIs.
+    pub fn text(&self) -> &'a StmtText {
         // SAFETY: self.raw is valid for 'a; the returned slice borrows
         // from the parser's source buffer which outlives 'a.
         let (s, _) = unsafe { self.raw.as_ref().text() };
-        s
+        StmtText::new(s)
     }
 
-    /// Byte offset of this statement's start within [`Self::full_text`].
-    /// Add to any statement-relative offset to get an absolute position.
-    pub fn statement_base_offset(&self) -> u32 {
+    /// Document-absolute offset of this statement's start within
+    /// [`Self::full_text`].  Use [`StatementBase::to_doc`] to convert any
+    /// statement-relative offset into an absolute one.
+    pub fn statement_base(&self) -> StatementBase {
         // SAFETY: self.raw is valid for 'a.
         let (_, off) = unsafe { self.raw.as_ref().text() };
-        off
+        StatementBase::new(DocOffset::from_raw(off))
     }
 
-    /// Resolve a span to `(text, abs_start, abs_end)` in
+    /// Resolve a span to its document-absolute `(text, range)` in
     /// [`Self::full_text`].  Convenience for diagnostic emission sites
     /// that need full-source positions.
-    pub fn span_text_abs(&self, span: crate::ast::TextSpan) -> (&'a str, usize, usize) {
+    pub fn span_text_abs(&self, span: crate::ast::TextSpan) -> (&'a str, DocRange) {
         let (text, off) = self.span_text(span);
-        let base = self.statement_base_offset() as usize;
-        let start = base + off as usize;
-        (text, start, start + text.len())
+        let start = self.statement_base().to_doc(off);
+        let end = start + DocLen::from_raw(u32::try_from(text.len()).unwrap_or(u32::MAX));
+        (text, DocRange { start, end })
     }
 
-    /// Raw token spans `(offset, length)` for all collected tokens.
+    /// Statement-relative byte ranges for all collected tokens.
     ///
     /// Returns an empty iterator if `collect_tokens` was not enabled.
     /// Always non-empty when the result comes from [`TypedParser::incremental_parse`],
     /// which unconditionally enables token collection.
-    pub fn token_spans(&self) -> impl Iterator<Item = (u32, u32)> + use<'_> {
+    pub fn token_spans(&self) -> impl Iterator<Item = StmtRange> + use<'_> {
         // SAFETY: self.raw is valid for 'a; the returned slice lives for 'a.
         let raw: &[ffi::CParserToken] = unsafe { self.raw.as_ref().result_tokens() };
-        raw.iter().map(|t| (t.offset, t.length))
+        raw.iter().map(|t| {
+            StmtRange::from_offset_len(StmtOffset::from_raw(t.offset), StmtLen::from_raw(t.length))
+        })
     }
 
     /// Lightweight comment descriptors without source text borrows.
@@ -919,7 +937,13 @@ impl<'a> AnyParsedStatement<'a> {
                 ffi::CCommentSide::Leading => CommentSide::Leading,
                 ffi::CCommentSide::Trailing => CommentSide::Trailing,
             };
-            CommentSpan::new(c.offset, c.length, kind, c.token_idx, side)
+            CommentSpan::new(
+                StmtOffset::from_raw(c.offset),
+                StmtLen::from_raw(c.length),
+                kind,
+                TokenIdx::from_raw(c.token_idx),
+                side,
+            )
         })
     }
 
@@ -1107,18 +1131,18 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
     }
 
     /// See [`AnyParsedStatement::text`].
-    pub fn text(&self) -> &'a str {
+    pub fn text(&self) -> &'a StmtText {
         self.any.text()
     }
 
     /// See [`AnyParsedStatement::full_text`].
-    pub fn full_text(&self) -> &'a str {
+    pub fn full_text(&self) -> &'a DocText {
         self.any.full_text()
     }
 
-    /// See [`AnyParsedStatement::statement_base_offset`].
-    pub fn statement_base_offset(&self) -> u32 {
-        self.any.statement_base_offset()
+    /// See [`AnyParsedStatement::statement_base`].
+    pub fn statement_base(&self) -> StatementBase {
+        self.any.statement_base()
     }
 
     /// Post-expansion source — the bound source with every currently-
@@ -1147,13 +1171,15 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
         let raw: &'a [ffi::CParserToken] = unsafe { self.any.raw.as_ref().result_tokens() };
         raw.iter().filter_map(move |t| {
             let token_type = G::Token::from_token_type(AnyTokenType(t.type_))?;
-            let text = &source[t.offset as usize..(t.offset + t.length) as usize];
+            let offset = StmtOffset::from_raw(t.offset);
+            let length = StmtLen::from_raw(t.length);
+            let text = &source[StmtRange::from_offset_len(offset, length)];
             Some(TypedParserToken::new(
                 text,
                 token_type,
                 ParserTokenFlags::from_raw(t.flags),
-                t.offset,
-                t.length,
+                offset,
+                length,
             ))
         })
     }
@@ -1248,9 +1274,11 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
 }
 
 /// Build a public [`Comment`] from an FFI [`ffi::CComment`] borrowing into
-/// `source`.
-fn ffi_comment<'a>(source: &'a str, c: &ffi::CComment) -> Comment<'a> {
-    let text = &source[c.offset as usize..(c.offset + c.length) as usize];
+/// the statement's source text.
+fn ffi_comment<'a>(source: &'a StmtText, c: &ffi::CComment) -> Comment<'a> {
+    let offset = StmtOffset::from_raw(c.offset);
+    let length = StmtLen::from_raw(c.length);
+    let text = &source[StmtRange::from_offset_len(offset, length)];
     let kind = match c.kind {
         ffi::CCommentKind::LineComment => CommentKind::Line,
         ffi::CCommentKind::BlockComment => CommentKind::Block,
@@ -1259,7 +1287,14 @@ fn ffi_comment<'a>(source: &'a str, c: &ffi::CComment) -> Comment<'a> {
         ffi::CCommentSide::Leading => CommentSide::Leading,
         ffi::CCommentSide::Trailing => CommentSide::Trailing,
     };
-    Comment::new(text, kind, c.offset, c.length, c.token_idx, side)
+    Comment::new(
+        text,
+        kind,
+        offset,
+        length,
+        TokenIdx::from_raw(c.token_idx),
+        side,
+    )
 }
 
 /// Extract a single [`crate::ast::FieldValue`] from a raw arena node pointer.
@@ -1351,13 +1386,13 @@ impl<'a, G: TypedDialect> TypedParseError<'a, G> {
         self.0.recovery_root()
     }
 
-    /// See [`AnyParsedStatement::statement_base_offset`].
-    pub fn statement_base_offset(&self) -> u32 {
-        self.0.any.statement_base_offset()
+    /// See [`AnyParsedStatement::statement_base`].
+    pub fn statement_base(&self) -> StatementBase {
+        self.0.any.statement_base()
     }
 
     /// The source text bound to this result.
-    pub fn text(&self) -> &'a str {
+    pub fn text(&self) -> &'a StmtText {
         self.0.text()
     }
 

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -94,13 +94,14 @@ impl Parser {
     /// # Examples
     ///
     /// ```rust
+    /// use syntaqlite_syntax::source::DocOffset;
     /// use syntaqlite_syntax::{Parser, TokenType};
     ///
     /// let parser = Parser::new();
     /// let mut session = parser.incremental_parse("SELECT 1");
     ///
-    /// assert!(session.feed_token(TokenType::Select, 0..6).is_none());
-    /// assert!(session.feed_token(TokenType::Integer, 7..8).is_none());
+    /// assert!(session.feed_token(TokenType::Select, DocOffset::from_raw(0)..DocOffset::from_raw(6)).is_none());
+    /// assert!(session.feed_token(TokenType::Integer, DocOffset::from_raw(7)..DocOffset::from_raw(8)).is_none());
     ///
     /// let stmt = session.finish().and_then(Result::ok).unwrap();
     /// let _ = stmt.root();
@@ -424,14 +425,21 @@ impl<'a> ParseError<'a> {
         self.0.message()
     }
 
-    /// Byte offset in the original source, if known.
-    pub fn offset(&self) -> Option<usize> {
+    /// Statement-relative byte offset of the error token, if known.
+    pub fn offset(&self) -> Option<StmtOffset> {
         self.0.offset()
     }
 
     /// Byte length of the offending range, if known.
-    pub fn length(&self) -> Option<usize> {
+    pub fn length(&self) -> Option<StmtLen> {
         self.0.length()
+    }
+
+    /// Document-absolute offset of the failing statement's first byte.
+    /// Combine with [`Self::offset`] / [`Self::length`] to produce a
+    /// document-absolute range.
+    pub fn statement_base(&self) -> StatementBase {
+        self.0.statement_base()
     }
 
     /// Partial AST recovered from invalid input, if available.
@@ -1166,10 +1174,8 @@ mod tests {
         let outer = &rewrites[0];
         assert_eq!(outer.parent(), None);
         assert_eq!(outer.name(), "mwrap");
-        let outer_range = crate::source::LayerRange::from_offset_len(
-            outer.call_offset(),
-            outer.call_length(),
-        );
+        let outer_range =
+            crate::source::LayerRange::from_offset_len(outer.call_offset(), outer.call_length());
         let outer_call = &source[outer_range.start.as_usize()..outer_range.end.as_usize()];
         assert_eq!(outer_call, "mwrap!(42)");
         assert_eq!(outer.expansion(), "mpass!(42)");
@@ -1181,10 +1187,8 @@ mod tests {
         assert_eq!(inner.parent(), Some(0));
         assert_eq!(inner.name(), "mpass");
         let outer_exp = outer.expansion();
-        let inner_range = crate::source::LayerRange::from_offset_len(
-            inner.call_offset(),
-            inner.call_length(),
-        );
+        let inner_range =
+            crate::source::LayerRange::from_offset_len(inner.call_offset(), inner.call_length());
         let inner_call = &outer_exp[inner_range];
         assert_eq!(inner_call, "mpass!(42)");
         assert_eq!(inner.expansion(), "42");
@@ -1278,10 +1282,7 @@ mod tests {
             inner.body_call_offset(),
             crate::MACRO_BODY_CALL_ARG_INTERNAL
         );
-        assert_eq!(
-            inner.body_call_length(),
-            LayerLen::from_raw(u32::MAX)
-        );
+        assert_eq!(inner.body_call_length(), LayerLen::from_raw(u32::MAX));
     }
 
     #[test]

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0.
 
 #[cfg(feature = "sqlite")]
+use crate::source::{DocText, StatementBase, StmtLen, StmtOffset, StmtText};
+
+#[cfg(feature = "sqlite")]
 use super::{
     AnyParsedStatement, Comment, IncrementalParseSession, ParseErrorKind, ParseOutcome,
     ParserConfig, ParserTokenFlags, TypedParseError, TypedParseSession, TypedParsedStatement,
@@ -240,13 +243,13 @@ impl<'a> ParserToken<'a> {
         self.0.flags()
     }
 
-    /// Byte offset of the token start within the statement source.
-    pub fn offset(&self) -> u32 {
+    /// Statement-relative byte offset of the token start.
+    pub fn offset(&self) -> StmtOffset {
         self.0.offset()
     }
 
     /// Byte length of the token text.
-    pub fn length(&self) -> u32 {
+    pub fn length(&self) -> StmtLen {
         self.0.length()
     }
 }
@@ -290,18 +293,18 @@ impl<'a> ParsedStatement<'a> {
     }
 
     /// See [`AnyParsedStatement::text`](super::AnyParsedStatement::text).
-    pub fn text(&self) -> &'a str {
+    pub fn text(&self) -> &'a StmtText {
         self.0.text()
     }
 
     /// See [`AnyParsedStatement::full_text`](super::AnyParsedStatement::full_text).
-    pub fn full_text(&self) -> &'a str {
+    pub fn full_text(&self) -> &'a DocText {
         self.0.full_text()
     }
 
-    /// See [`AnyParsedStatement::statement_base_offset`](super::AnyParsedStatement::statement_base_offset).
-    pub fn statement_base_offset(&self) -> u32 {
-        self.0.statement_base_offset()
+    /// See [`AnyParsedStatement::statement_base`](super::AnyParsedStatement::statement_base).
+    pub fn statement_base(&self) -> StatementBase {
+        self.0.statement_base()
     }
 
     /// Post-expansion source — the bound source with every currently-
@@ -439,12 +442,12 @@ impl<'a> ParseError<'a> {
     }
 
     /// Source slice for just the failing statement.
-    pub fn text(&self) -> &'a str {
+    pub fn text(&self) -> &'a StmtText {
         self.0.0.text()
     }
 
     /// Full SQL source bound to the parse session.
-    pub fn full_text(&self) -> &'a str {
+    pub fn full_text(&self) -> &'a DocText {
         self.0.0.full_text()
     }
 
@@ -482,6 +485,8 @@ mod tests {
     use std::collections::HashMap;
     use std::panic::{self, AssertUnwindSafe};
     use std::rc::Rc;
+
+    use crate::source::{LayerLen, LayerOffset};
 
     use super::{ParseErrorKind, ParseOutcome, Parser, ParserConfig, ParserToken};
     use crate::parser::{MacroArg, MacroLookup, MacroOutput};
@@ -536,14 +541,14 @@ mod tests {
             panic!("first statement should parse");
         };
         assert_eq!(first.text(), "CREATE TABLE t(x);");
-        assert_eq!(first.statement_base_offset(), 0);
+        assert_eq!(first.statement_base().as_doc_offset().as_u32(), 0);
         assert_eq!(first.full_text(), "CREATE TABLE t(x);\n  SELECT * FROM t;");
 
         let ParseOutcome::Ok(second) = session.next() else {
             panic!("second statement should parse");
         };
         assert_eq!(second.text(), "SELECT * FROM t;");
-        assert_eq!(second.statement_base_offset(), 21);
+        assert_eq!(second.statement_base().as_doc_offset().as_u32(), 21);
         assert_eq!(second.full_text(), "CREATE TABLE t(x);\n  SELECT * FROM t;");
     }
 
@@ -555,7 +560,7 @@ mod tests {
             panic!("should parse");
         };
         assert_eq!(stmt.text(), "/* hi */ SELECT 1;");
-        assert_eq!(stmt.statement_base_offset(), 0);
+        assert_eq!(stmt.statement_base().as_doc_offset().as_u32(), 0);
     }
 
     #[test]
@@ -1122,9 +1127,15 @@ mod tests {
         assert_eq!(r.name(), "id");
         assert_eq!(r.expansion(), "42");
         // call_offset is relative to stmt.text() for source-parent rewrites.
+        // call_offset is a LayerOffset (generic "byte offset in parent's
+        // text"); at the top level the parent is the statement, so the
+        // pair reinterprets as a StmtRange.
         let stmt_text = stmt.text();
-        let call_text =
-            &stmt_text[r.call_offset() as usize..(r.call_offset() + r.call_length()) as usize];
+        let call_range = crate::source::StmtRange::from_offset_len(
+            crate::source::StmtOffset::from_raw(r.call_offset().as_u32()),
+            crate::source::StmtLen::from_raw(r.call_length().as_u32()),
+        );
+        let call_text = &stmt_text[call_range];
         assert_eq!(call_text, "id!(42)");
     }
 
@@ -1155,19 +1166,26 @@ mod tests {
         let outer = &rewrites[0];
         assert_eq!(outer.parent(), None);
         assert_eq!(outer.name(), "mwrap");
-        let outer_call = &source
-            [outer.call_offset() as usize..(outer.call_offset() + outer.call_length()) as usize];
+        let outer_range = crate::source::LayerRange::from_offset_len(
+            outer.call_offset(),
+            outer.call_length(),
+        );
+        let outer_call = &source[outer_range.start.as_usize()..outer_range.end.as_usize()];
         assert_eq!(outer_call, "mwrap!(42)");
         assert_eq!(outer.expansion(), "mpass!(42)");
 
         // mpass is nested inside mwrap; call_offset/call_length are into
-        // outer.expansion().
+        // outer.expansion() — the nested-rewrite case where parent is a
+        // LayerText, and the Index<LayerRange> impl slices directly.
         let inner = &rewrites[1];
         assert_eq!(inner.parent(), Some(0));
         assert_eq!(inner.name(), "mpass");
         let outer_exp = outer.expansion();
-        let inner_call = &outer_exp
-            [inner.call_offset() as usize..(inner.call_offset() + inner.call_length()) as usize];
+        let inner_range = crate::source::LayerRange::from_offset_len(
+            inner.call_offset(),
+            inner.call_length(),
+        );
+        let inner_call = &outer_exp[inner_range];
         assert_eq!(inner_call, "mpass!(42)");
         assert_eq!(inner.expansion(), "42");
     }
@@ -1199,15 +1217,16 @@ mod tests {
         assert_eq!(segs.len(), 1, "$x is the only substitution in ($x)");
         let seg = &segs[0];
         // Authored body is "($x)" — $x sits at offset 1, length 2.
-        assert_eq!(seg.body_offset(), 1);
-        assert_eq!(seg.body_length(), 2);
+        assert_eq!(seg.body_offset(), LayerOffset::from_raw(1));
+        assert_eq!(seg.body_length(), LayerLen::from_raw(2));
         // Expansion buffer is "(42)" — arg text sits at offset 1, length 2.
-        assert_eq!(seg.expansion_offset(), 1);
-        assert_eq!(seg.expansion_length(), 2);
+        assert_eq!(seg.expansion_offset(), LayerOffset::from_raw(1));
+        assert_eq!(seg.expansion_length(), LayerLen::from_raw(2));
         // Origin is the authored source.
         assert_eq!(seg.origin_parent(), None);
-        let origin_text = &source
-            [seg.origin_offset() as usize..(seg.origin_offset() + seg.origin_length()) as usize];
+        let off = seg.origin_offset().as_usize();
+        let len = seg.origin_length().as_usize();
+        let origin_text = &source[off..off + len];
         assert_eq!(origin_text, "42");
     }
 
@@ -1254,9 +1273,15 @@ mod tests {
         // The nested n!(42) call lives entirely inside m's substituted
         // $x arg — call_offset/length are in the post-substitution
         // expansion buffer, but there's no clean position in m's
-        // authored body "($x)".  u32::MAX is the arg-internal sentinel.
-        assert_eq!(inner.body_call_offset(), u32::MAX);
-        assert_eq!(inner.body_call_length(), u32::MAX);
+        // authored body "($x)".  The arg-internal sentinel signals this.
+        assert_eq!(
+            inner.body_call_offset(),
+            crate::MACRO_BODY_CALL_ARG_INTERNAL
+        );
+        assert_eq!(
+            inner.body_call_length(),
+            LayerLen::from_raw(u32::MAX)
+        );
     }
 
     #[test]
@@ -1287,8 +1312,8 @@ mod tests {
         assert_eq!(inner.name(), "leaf");
         assert_eq!(inner.parent(), Some(0));
         // `leaf!(7)` sits at offset 5 in the authored body "$a + leaf!(7)".
-        assert_eq!(inner.body_call_offset(), 5);
-        assert_eq!(inner.body_call_length(), 8);
+        assert_eq!(inner.body_call_offset(), LayerOffset::from_raw(5));
+        assert_eq!(inner.body_call_length(), LayerLen::from_raw(8));
     }
 
     #[test]
@@ -1321,8 +1346,8 @@ mod tests {
         let inner = &rewrites[1];
         assert_eq!(inner.name(), "leaf");
         assert_eq!(inner.parent(), Some(0));
-        assert_eq!(inner.body_call_offset(), 5);
-        assert_eq!(inner.body_call_length(), 13);
+        assert_eq!(inner.body_call_offset(), LayerOffset::from_raw(5));
+        assert_eq!(inner.body_call_length(), LayerLen::from_raw(13));
     }
 
     #[test]
@@ -1364,8 +1389,13 @@ mod tests {
         let m_segs: Vec<_> = rewrites[0].arg_segments().collect();
         assert_eq!(m_segs.len(), 1);
         assert_eq!(m_segs[0].origin(), ArgOrigin::Source);
-        let m_arg_text = &stmt_text[m_segs[0].origin_offset() as usize
-            ..(m_segs[0].origin_offset() + m_segs[0].origin_length()) as usize];
+        // Arg-segment origin_offset is a LayerOffset; at Source origin
+        // the "layer" is the statement, so reinterpret as StmtRange.
+        let m_arg_range = crate::source::StmtRange::from_offset_len(
+            crate::source::StmtOffset::from_raw(m_segs[0].origin_offset().as_u32()),
+            crate::source::StmtLen::from_raw(m_segs[0].origin_length().as_u32()),
+        );
+        let m_arg_text = &stmt_text[m_arg_range];
         assert_eq!(m_arg_text, "n!(nonexistent_col)");
 
         // n's arg segment origin is m's expansion buffer — one link in
@@ -1375,8 +1405,11 @@ mod tests {
         assert_eq!(n_segs.len(), 1);
         assert_eq!(n_segs[0].origin(), ArgOrigin::Rewrite(0));
         let m_expansion = rewrites[0].expansion();
-        let n_arg_in_m_expansion = &m_expansion[n_segs[0].origin_offset() as usize
-            ..(n_segs[0].origin_offset() + n_segs[0].origin_length()) as usize];
+        let n_arg_range = crate::source::LayerRange::from_offset_len(
+            n_segs[0].origin_offset(),
+            n_segs[0].origin_length(),
+        );
+        let n_arg_in_m_expansion = &m_expansion[n_arg_range];
         assert_eq!(n_arg_in_m_expansion, "nonexistent_col");
 
         // Walk the chain: n's arg inside m's expansion, intersected with
@@ -1392,7 +1425,9 @@ mod tests {
         let delta = n_arg_off_in_m - m_seg.expansion_offset();
         let source_off = m_seg.origin_offset() + delta;
         let source_len = n_segs[0].origin_length();
-        let authored = &source[source_off as usize..(source_off + source_len) as usize];
+        let off = source_off.as_usize();
+        let len = source_len.as_usize();
+        let authored = &source[off..off + len];
         assert_eq!(authored, "nonexistent_col");
     }
 
@@ -1692,8 +1727,8 @@ mod tests {
         let f = &frames[0];
         assert_eq!(f.name, None, "root frame has no macro name");
         assert_eq!(f.snippet, source, "root snippet is the authored source");
-        // Offset points somewhere inside source.
-        assert!(f.offset_in_snippet < source.len());
+        // Offset points somewhere inside the snippet.
+        assert!(f.offset_in_snippet < f.snippet.as_range().end);
     }
 
     #[test]
@@ -1725,7 +1760,7 @@ mod tests {
         // Innermost = macro expansion
         assert_eq!(frames[1].name, Some("idmac"));
         assert_eq!(frames[1].snippet, "inner");
-        assert_eq!(frames[1].offset_in_snippet, 0);
+        assert_eq!(frames[1].offset_in_snippet, LayerOffset::default());
     }
 
     #[test]
@@ -1754,9 +1789,11 @@ mod tests {
         );
         assert_eq!(frames[0].name, None, "root frame after drill");
         assert_eq!(frames[0].snippet, source);
-        let off = frames[0].offset_in_snippet;
-        let end = off + "authored".len();
-        assert_eq!(&source[off..end], "authored");
+        let range = crate::source::LayerRange::from_offset_len(
+            frames[0].offset_in_snippet,
+            LayerLen::from_raw(u32::try_from("authored".len()).unwrap()),
+        );
+        assert_eq!(&frames[0].snippet[range], "authored");
     }
 
     #[test]

--- a/syntaqlite-syntax/src/parser/types.rs
+++ b/syntaqlite-syntax/src/parser/types.rs
@@ -1,6 +1,10 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+use crate::source::{
+    ColumnNumber, LayerLen, LayerOffset, LayerText, LineNumber, StmtLen, StmtOffset, TokenIdx,
+};
+
 use crate::dialect::TypedDialect;
 
 /// Tri-state parse result for statement-oriented parser APIs.
@@ -85,9 +89,9 @@ pub enum CommentSide {
 pub struct Comment<'a> {
     text: &'a str,
     kind: CommentKind,
-    offset: u32,
-    length: u32,
-    token_idx: u32,
+    offset: StmtOffset,
+    length: StmtLen,
+    token_idx: TokenIdx,
     side: CommentSide,
 }
 
@@ -95,9 +99,9 @@ impl<'a> Comment<'a> {
     pub(super) fn new(
         text: &'a str,
         kind: CommentKind,
-        offset: u32,
-        length: u32,
-        token_idx: u32,
+        offset: StmtOffset,
+        length: StmtLen,
+        token_idx: TokenIdx,
         side: CommentSide,
     ) -> Self {
         Comment {
@@ -120,20 +124,20 @@ impl<'a> Comment<'a> {
         self.kind
     }
 
-    /// Byte offset of the comment start within the statement source.
-    pub fn offset(&self) -> u32 {
+    /// Statement-relative byte offset of the comment start.
+    pub fn offset(&self) -> StmtOffset {
         self.offset
     }
 
     /// Byte length of the comment text.
-    pub fn length(&self) -> u32 {
+    pub fn length(&self) -> StmtLen {
         self.length
     }
 
     /// Index of the owning token in the statement's token stream.
     /// May equal the token count when the comment trails the last token
     /// of the statement and no following statement exists.
-    pub fn token_idx(&self) -> u32 {
+    pub fn token_idx(&self) -> TokenIdx {
         self.token_idx
     }
 
@@ -149,21 +153,21 @@ impl<'a> Comment<'a> {
 /// Use this when you only need position and kind, not the text.
 #[derive(Debug, Clone, Copy)]
 pub struct CommentSpan {
-    offset: u32,
-    length: u32,
+    offset: StmtOffset,
+    length: StmtLen,
     kind: CommentKind,
-    token_idx: u32,
+    token_idx: TokenIdx,
     side: CommentSide,
 }
 
 impl CommentSpan {
-    /// Byte offset of the comment start within the statement source.
-    pub fn offset(&self) -> u32 {
+    /// Statement-relative byte offset of the comment start.
+    pub fn offset(&self) -> StmtOffset {
         self.offset
     }
 
     /// Byte length of the comment text.
-    pub fn length(&self) -> u32 {
+    pub fn length(&self) -> StmtLen {
         self.length
     }
 
@@ -174,7 +178,7 @@ impl CommentSpan {
 
     /// Index of the owning token in the statement's token stream.
     /// See [`Comment::token_idx`] for attachment semantics.
-    pub fn token_idx(&self) -> u32 {
+    pub fn token_idx(&self) -> TokenIdx {
         self.token_idx
     }
 
@@ -184,10 +188,10 @@ impl CommentSpan {
     }
 
     pub(super) fn new(
-        offset: u32,
-        length: u32,
+        offset: StmtOffset,
+        length: StmtLen,
         kind: CommentKind,
-        token_idx: u32,
+        token_idx: TokenIdx,
         side: CommentSide,
     ) -> Self {
         CommentSpan {
@@ -211,8 +215,8 @@ pub struct TypedParserToken<'a, G: TypedDialect> {
     text: &'a str,
     token_type: G::Token,
     flags: ParserTokenFlags,
-    offset: u32,
-    length: u32,
+    offset: StmtOffset,
+    length: StmtLen,
 }
 
 impl<'a, G: TypedDialect> TypedParserToken<'a, G> {
@@ -220,8 +224,8 @@ impl<'a, G: TypedDialect> TypedParserToken<'a, G> {
         text: &'a str,
         token_type: G::Token,
         flags: ParserTokenFlags,
-        offset: u32,
-        length: u32,
+        offset: StmtOffset,
+        length: StmtLen,
     ) -> Self {
         TypedParserToken {
             text,
@@ -247,13 +251,13 @@ impl<'a, G: TypedDialect> TypedParserToken<'a, G> {
         self.flags
     }
 
-    /// Byte offset of the token start within the statement source.
-    pub fn offset(&self) -> u32 {
+    /// Statement-relative byte offset of the token start.
+    pub fn offset(&self) -> StmtOffset {
         self.offset
     }
 
     /// Byte length of the token text.
-    pub fn length(&self) -> u32 {
+    pub fn length(&self) -> StmtLen {
         self.length
     }
 }
@@ -282,17 +286,23 @@ pub type AnyParserToken<'a> = TypedParserToken<'a, crate::dialect::AnyDialect>;
 pub struct MacroRewrite<'a> {
     pub(crate) parent: Option<u32>,
     pub(crate) rewrite_idx: u32,
-    pub(crate) call_offset: u32,
-    pub(crate) call_length: u32,
-    pub(crate) expansion: &'a str,
+    pub(crate) call_offset: LayerOffset,
+    pub(crate) call_length: LayerLen,
+    pub(crate) expansion: &'a LayerText,
     pub(crate) name: &'a str,
-    pub(crate) def_line: u32,
-    pub(crate) def_col: u32,
-    pub(crate) body_call_offset: u32,
-    pub(crate) body_call_length: u32,
+    pub(crate) def_line: LineNumber,
+    pub(crate) def_col: ColumnNumber,
+    pub(crate) body_call_offset: LayerOffset,
+    pub(crate) body_call_length: LayerLen,
     pub(crate) parser: std::ptr::NonNull<crate::parser::ffi::CParser>,
     pub(crate) _lifetime: std::marker::PhantomData<&'a ()>,
 }
+
+/// Sentinel value for [`MacroRewrite::body_call_offset`] /
+/// [`MacroRewrite::body_call_length`] meaning "this call was tokenized
+/// from a `$param` substitution; descend through the matching arg
+/// segment instead of indexing into the parent's body."
+pub const MACRO_BODY_CALL_ARG_INTERNAL: LayerOffset = LayerOffset::from_raw(u32::MAX);
 
 impl<'a> MacroRewrite<'a> {
     /// Index of the parent rewrite, or `None` if this rewrite applies
@@ -301,17 +311,25 @@ impl<'a> MacroRewrite<'a> {
         self.parent
     }
     /// Byte offset of the macro call in the parent's text.
-    pub fn call_offset(&self) -> u32 {
+    pub fn call_offset(&self) -> LayerOffset {
         self.call_offset
     }
     /// Byte length of the entire macro call in the parent's text.
-    pub fn call_length(&self) -> u32 {
+    pub fn call_length(&self) -> LayerLen {
         self.call_length
     }
     /// The replacement text for the macro call.  Nested macro calls that
     /// appear in this buffer are reported as separate [`MacroRewrite`]
     /// entries whose [`parent`](Self::parent) refers back to this one.
-    pub fn expansion(&self) -> &'a str {
+    ///
+    /// Returned as a [`LayerText`], slicable by [`LayerRange`] for
+    /// type-safe slicing.  Offsets from nested rewrites ([`call_offset`],
+    /// [`call_length`]) are measured into this buffer.
+    ///
+    /// [`LayerRange`]: crate::source::LayerRange
+    /// [`call_offset`]: Self::call_offset
+    /// [`call_length`]: Self::call_length
+    pub fn expansion(&self) -> &'a LayerText {
         self.expansion
     }
     /// The macro name as it appears at the call site.
@@ -319,11 +337,11 @@ impl<'a> MacroRewrite<'a> {
         self.name
     }
     /// 1-based line of the macro definition (0 if unknown).
-    pub fn def_line(&self) -> u32 {
+    pub fn def_line(&self) -> LineNumber {
         self.def_line
     }
     /// 1-based column of the macro definition (0 if unknown).
-    pub fn def_col(&self) -> u32 {
+    pub fn def_col(&self) -> ColumnNumber {
         self.def_col
     }
     /// Byte offset of this call in the parent's *authored* body, computed
@@ -331,15 +349,15 @@ impl<'a> MacroRewrite<'a> {
     /// introduced.  For top-level rewrites the parent is the authored
     /// source, so this equals [`call_offset`](Self::call_offset).
     ///
-    /// Returns [`u32::MAX`] (the arg-internal sentinel) when the call was
+    /// Returns [`MACRO_BODY_CALL_ARG_INTERNAL`] when the call was
     /// tokenized from a `$param` substitution — consumers should descend
     /// through the matching arg segment instead of rewriting in the body.
     /// [`body_call_length`](Self::body_call_length) mirrors the sentinel.
-    pub fn body_call_offset(&self) -> u32 {
+    pub fn body_call_offset(&self) -> LayerOffset {
         self.body_call_offset
     }
     /// Length counterpart of [`body_call_offset`](Self::body_call_offset).
-    pub fn body_call_length(&self) -> u32 {
+    pub fn body_call_length(&self) -> LayerLen {
         self.body_call_length
     }
     /// Iterator over the `$param` substitutions recorded on this rewrite.
@@ -363,13 +381,13 @@ impl<'a> MacroRewrite<'a> {
                 ArgOrigin::Rewrite(s.origin_parent_idx)
             };
             MacroArgSegment {
-                body_offset: s.body_offset,
-                body_length: s.body_length,
-                expansion_offset: s.expansion_offset,
-                expansion_length: s.expansion_length,
+                body_offset: LayerOffset::from_raw(s.body_offset),
+                body_length: LayerLen::from_raw(s.body_length),
+                expansion_offset: LayerOffset::from_raw(s.expansion_offset),
+                expansion_length: LayerLen::from_raw(s.expansion_length),
                 origin,
-                origin_offset: s.origin_offset,
-                origin_length: s.origin_length,
+                origin_offset: LayerOffset::from_raw(s.origin_offset),
+                origin_length: LayerLen::from_raw(s.origin_length),
                 _lifetime: std::marker::PhantomData,
             }
         })
@@ -392,13 +410,13 @@ pub enum ArgOrigin {
 /// authored source, possibly via a chain of earlier substitutions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MacroArgSegment<'a> {
-    pub(crate) body_offset: u32,
-    pub(crate) body_length: u32,
-    pub(crate) expansion_offset: u32,
-    pub(crate) expansion_length: u32,
+    pub(crate) body_offset: LayerOffset,
+    pub(crate) body_length: LayerLen,
+    pub(crate) expansion_offset: LayerOffset,
+    pub(crate) expansion_length: LayerLen,
     pub(crate) origin: ArgOrigin,
-    pub(crate) origin_offset: u32,
-    pub(crate) origin_length: u32,
+    pub(crate) origin_offset: LayerOffset,
+    pub(crate) origin_length: LayerLen,
     pub(crate) _lifetime: std::marker::PhantomData<&'a ()>,
 }
 
@@ -406,20 +424,20 @@ impl MacroArgSegment<'_> {
     /// Byte offset of the `$param` token in the macro's authored body.
     /// Zero when the rewrite was registered via the raw arg-map API
     /// (which doesn't supply authored-body positions).
-    pub fn body_offset(&self) -> u32 {
+    pub fn body_offset(&self) -> LayerOffset {
         self.body_offset
     }
     /// Byte length of the `$param` token in the authored body.
-    pub fn body_length(&self) -> u32 {
+    pub fn body_length(&self) -> LayerLen {
         self.body_length
     }
     /// Byte offset of the substituted arg text in the rewrite's
     /// [`expansion`](MacroRewrite::expansion) buffer.
-    pub fn expansion_offset(&self) -> u32 {
+    pub fn expansion_offset(&self) -> LayerOffset {
         self.expansion_offset
     }
     /// Byte length of the substituted arg text in the expansion buffer.
-    pub fn expansion_length(&self) -> u32 {
+    pub fn expansion_length(&self) -> LayerLen {
         self.expansion_length
     }
     /// Where the arg text was authored — the source, or another rewrite's
@@ -436,11 +454,11 @@ impl MacroArgSegment<'_> {
         }
     }
     /// Byte offset of the arg text in its origin.
-    pub fn origin_offset(&self) -> u32 {
+    pub fn origin_offset(&self) -> LayerOffset {
         self.origin_offset
     }
     /// Byte length of the arg text in its origin.
-    pub fn origin_length(&self) -> u32 {
+    pub fn origin_length(&self) -> LayerLen {
         self.origin_length
     }
 }
@@ -465,15 +483,20 @@ pub struct TracebackFrame<'a> {
     /// registered name.
     pub name: Option<&'a str>,
     /// 1-based line number of `offset_in_snippet` within `snippet`.
-    pub line: u32,
+    pub line: LineNumber,
     /// 1-based column number of `offset_in_snippet` within `snippet`.
-    pub col: u32,
-    /// Buffer to render the caret against.
-    pub snippet: &'a str,
+    pub col: ColumnNumber,
+    /// Buffer to render the caret against — the original source for the
+    /// root frame, or an expansion layer's buffer for macro frames.
+    /// Typed as [`LayerText`] so it can be sliced directly by a
+    /// [`LayerRange`] built from `offset_in_snippet` / `length_in_snippet`.
+    ///
+    /// [`LayerRange`]: crate::source::LayerRange
+    pub snippet: &'a LayerText,
     /// Byte offset of the frame's position within `snippet`.
-    pub offset_in_snippet: usize,
+    pub offset_in_snippet: LayerOffset,
     /// Byte length of the frame's position within `snippet`.
-    pub length_in_snippet: usize,
+    pub length_in_snippet: LayerLen,
 }
 
 /// Parser's best guess about what kind of token fits next.

--- a/syntaqlite-syntax/src/source.rs
+++ b/syntaqlite-syntax/src/source.rs
@@ -1,7 +1,8 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-//! Newtypes for source positions, lengths, ranges, and indices.
+//! Typed source coordinates — positions, lengths, ranges, token indices,
+//! line/column numbers, and source-text wrappers.
 //!
 //! Every position-like value crossing the syntaqlite API surface lives in one
 //! of a small number of distinct *kinds*:
@@ -15,6 +16,10 @@
 //!   the first byte of the full bound source
 //!   (`AnyParsedStatement::full_text()`).  The semantic layer and LSP
 //!   protocol use these.
+//! * **Layer-relative byte offsets** ([`LayerOffset`]) — measured from
+//!   the start of an unspecified-but-contextual buffer (a macro expansion
+//!   layer, a traceback snippet, a parent rewrite's expansion).  Used by
+//!   APIs where the buffer is identified by a sibling field.
 //! * **Token indices** ([`TokenIdx`]) — 0-based index into a statement's
 //!   token stream.
 //! * **1-based line / column** ([`LineNumber`], [`ColumnNumber`]) — as
@@ -39,9 +44,28 @@
 //! positions and line/UTF-16 positions requires the source text and lives
 //! on a separate `SourceMap` type (added in a later change); these are not
 //! `From` impls because they are not free.
+//!
+//! ## Typed source text
+//!
+//! Paired with the offset newtypes are three wrappers around `str` that
+//! model the buffer each offset kind measures into:
+//!
+//! | Offset        | Corresponding text   |
+//! |---------------|----------------------|
+//! | [`StmtOffset`]  | [`StmtText`]         |
+//! | [`DocOffset`]   | [`DocText`]          |
+//! | [`LayerOffset`] | [`LayerText`]        |
+//!
+//! Each is `#[repr(transparent)]` over `str`, so wrapping a `&str` is
+//! zero-cost.  They implement `Index<Range>` for their matching
+//! range newtype, so `&stmt_text[stmt_range]` compiles but
+//! `&stmt_text[doc_range]` does not — the type system rules out slicing
+//! a statement-relative buffer with a document-absolute range.  Use
+//! [`StmtText::as_str`] (and its peers) as the escape hatch when
+//! interoperating with `std::str` APIs.
 
 use core::fmt;
-use core::ops::{Add, AddAssign, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Index, Sub, SubAssign};
 
 // ── Macro: define a u32 newtype with the standard set of impls ──────────────
 
@@ -216,6 +240,7 @@ impl StmtRange {
     pub const fn is_empty(self) -> bool {
         self.start.0 == self.end.0
     }
+
 }
 
 // ── Document-absolute byte position / length ────────────────────────────────
@@ -265,6 +290,60 @@ impl DocRange {
     pub const fn is_empty(self) -> bool {
         self.start.0 == self.end.0
     }
+
+}
+
+// ── Layer-relative byte position / length ──────────────────────────────────
+
+define_u32_newtype! {
+    /// A byte offset measured from the start of an unspecified-but-contextual
+    /// buffer — typically a macro expansion layer's buffer, a traceback
+    /// snippet, or a parent rewrite's expansion text.
+    ///
+    /// Used by APIs whose offsets are interpreted relative to a buffer
+    /// identified by a sibling field (e.g. `MacroRewrite`'s `parent`,
+    /// `MacroArgSegment`'s `origin`).  Distinct from [`StmtOffset`] and
+    /// [`DocOffset`] at the type level so callers can't accidentally use
+    /// one in place of another.
+    LayerOffset
+}
+
+define_u32_newtype! {
+    /// A byte length, paired with [`LayerOffset`].  See [`StmtLen`] for the
+    /// arithmetic rationale.
+    LayerLen
+}
+
+impl_pos_len_arith!(pos: LayerOffset, len: LayerLen);
+
+/// A half-open range of layer-relative byte offsets `[start, end)`.
+#[derive(Copy, Clone, Default, PartialEq, Eq, Hash, Debug)]
+pub struct LayerRange {
+    /// Inclusive start of the range.
+    pub start: LayerOffset,
+    /// Exclusive end of the range.
+    pub end: LayerOffset,
+}
+
+impl LayerRange {
+    /// Construct a range from `(offset, length)`.
+    pub const fn from_offset_len(start: LayerOffset, len: LayerLen) -> Self {
+        Self {
+            start,
+            end: LayerOffset(start.0 + len.0),
+        }
+    }
+
+    /// The length of this range.
+    pub const fn len(self) -> LayerLen {
+        LayerLen(self.end.0 - self.start.0)
+    }
+
+    /// Whether this range covers zero bytes.
+    pub const fn is_empty(self) -> bool {
+        self.start.0 == self.end.0
+    }
+
 }
 
 // ── Statement base offset ───────────────────────────────────────────────────
@@ -359,6 +438,149 @@ define_u32_newtype! {
     /// A 0-based column number in UTF-16 code units, per the LSP
     /// protocol's `Position.character` field.  See [`Utf16Line`].
     Utf16Col
+}
+
+// ── Typed source text ──────────────────────────────────────────────────────
+
+macro_rules! define_text_newtype {
+    (
+        $(#[$meta:meta])*
+        $name:ident,
+        offset = $offset:ident,
+        len = $len:ident,
+        range = $range:ident,
+    ) => {
+        $(#[$meta])*
+        #[repr(transparent)]
+        pub struct $name(str);
+
+        impl $name {
+            /// Wrap a `&str` as a reference to this typed text.
+            ///
+            /// The caller asserts that positions into the string are in
+            /// the coordinate system this newtype represents (e.g. for
+            /// [`StmtText`], offsets are statement-relative).
+            pub fn new(s: &str) -> &$name {
+                // SAFETY: $name is `#[repr(transparent)]` over `str`, so
+                // the layouts of `&str` and `&$name` are identical.
+                unsafe { &*(std::ptr::from_ref(s) as *const $name) }
+            }
+
+            /// Underlying `&str` — use when interoperating with `std::str`
+            /// APIs that don't understand the newtype.
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            /// Byte length, as a typed length.  Returns `u32::MAX` if the
+            /// underlying string is longer than `u32::MAX` bytes (not
+            /// possible for any syntaqlite-managed buffer).
+            pub fn byte_len(&self) -> $len {
+                $len::from_raw(u32::try_from(self.0.len()).unwrap_or(u32::MAX))
+            }
+
+            /// Whether the text is empty.
+            pub fn is_empty(&self) -> bool {
+                self.0.is_empty()
+            }
+
+            /// Range spanning the whole text `[0, byte_len())`.
+            pub fn as_range(&self) -> $range {
+                $range::from_offset_len($offset::default(), self.byte_len())
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt::Debug::fmt(&self.0, f)
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt::Display::fmt(&self.0, f)
+            }
+        }
+
+        impl PartialEq<str> for $name {
+            fn eq(&self, other: &str) -> bool {
+                &self.0 == other
+            }
+        }
+
+        impl PartialEq<&str> for $name {
+            fn eq(&self, other: &&str) -> bool {
+                &self.0 == *other
+            }
+        }
+
+        impl PartialEq<$name> for str {
+            fn eq(&self, other: &$name) -> bool {
+                self == &other.0
+            }
+        }
+
+        impl PartialEq for $name {
+            fn eq(&self, other: &Self) -> bool {
+                self.0 == other.0
+            }
+        }
+
+        impl Eq for $name {}
+
+        impl core::hash::Hash for $name {
+            fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+                self.0.hash(state);
+            }
+        }
+
+        impl Index<$range> for $name {
+            type Output = str;
+            fn index(&self, r: $range) -> &str {
+                &self.0[r.start.as_usize()..r.end.as_usize()]
+            }
+        }
+    };
+}
+
+define_text_newtype! {
+    /// Source text for a single statement — the slice returned by
+    /// `AnyParsedStatement::text()`.  Positions into a `StmtText` are
+    /// measured in [`StmtOffset`] / [`StmtLen`] / [`StmtRange`].
+    ///
+    /// Slicing uses the typed range: `&stmt_text[range]` where
+    /// `range: StmtRange`.  Indexing with a [`DocRange`] is a type error.
+    StmtText,
+    offset = StmtOffset,
+    len = StmtLen,
+    range = StmtRange,
+}
+
+define_text_newtype! {
+    /// Full document source — the slice returned by
+    /// `AnyParsedStatement::full_text()`.  Positions into a `DocText`
+    /// are measured in [`DocOffset`] / [`DocLen`] / [`DocRange`].
+    DocText,
+    offset = DocOffset,
+    len = DocLen,
+    range = DocRange,
+}
+
+define_text_newtype! {
+    /// Source text in an unspecified contextual buffer — typically a
+    /// macro expansion layer, traceback snippet, or parent rewrite's
+    /// expansion text.  Positions into a `LayerText` are measured in
+    /// [`LayerOffset`] / [`LayerLen`] / [`LayerRange`].
+    LayerText,
+    offset = LayerOffset,
+    len = LayerLen,
+    range = LayerRange,
 }
 
 #[cfg(test)]
@@ -461,11 +683,62 @@ mod tests {
     }
 
     #[test]
+    fn stmt_text_slice_by_range_returns_str() {
+        let t = StmtText::new("SELECT 1");
+        let r = StmtRange::from_offset_len(StmtOffset::from_raw(0), StmtLen::from_raw(6));
+        let s: &str = &t[r];
+        assert_eq!(s, "SELECT");
+    }
+
+    #[test]
+    fn stmt_text_basic_queries() {
+        let t = StmtText::new("SELECT 1");
+        assert_eq!(t.byte_len().as_u32(), 8);
+        assert!(!t.is_empty());
+        assert_eq!(t.as_range().start.as_u32(), 0);
+        assert_eq!(t.as_range().end.as_u32(), 8);
+    }
+
+    #[test]
+    fn doc_text_slice_by_doc_range() {
+        let d = DocText::new("create table t; select 1");
+        let r = DocRange::from_offset_len(DocOffset::from_raw(16), DocLen::from_raw(8));
+        assert_eq!(&d[r], "select 1");
+    }
+
+    #[test]
+    fn layer_text_slice_by_layer_range() {
+        let l = LayerText::new("(inner)");
+        let r = LayerRange::from_offset_len(LayerOffset::from_raw(1), LayerLen::from_raw(5));
+        assert_eq!(&l[r], "inner");
+    }
+
+    #[test]
+    fn text_wrapping_is_zero_cost() {
+        let s = "SELECT 1";
+        let t = StmtText::new(s);
+        // `#[repr(transparent)]`: pointer-identical.
+        assert_eq!(
+            std::ptr::from_ref::<str>(s).cast::<u8>(),
+            std::ptr::from_ref::<StmtText>(t).cast::<u8>(),
+        );
+    }
+
+    #[test]
+    fn text_equality_with_str() {
+        let t = StmtText::new("SELECT 1");
+        assert_eq!(t, "SELECT 1");
+        assert_eq!("SELECT 1", t.as_str());
+    }
+
+    #[test]
     fn types_are_expected_size() {
         assert_eq!(size_of::<StmtOffset>(), 4);
         assert_eq!(size_of::<StmtLen>(), 4);
         assert_eq!(size_of::<DocOffset>(), 4);
         assert_eq!(size_of::<DocLen>(), 4);
+        assert_eq!(size_of::<LayerOffset>(), 4);
+        assert_eq!(size_of::<LayerLen>(), 4);
         assert_eq!(size_of::<TokenIdx>(), 4);
         assert_eq!(size_of::<LineNumber>(), 4);
         assert_eq!(size_of::<ColumnNumber>(), 4);
@@ -473,6 +746,7 @@ mod tests {
         assert_eq!(size_of::<Utf16Col>(), 4);
         assert_eq!(size_of::<StmtRange>(), 8);
         assert_eq!(size_of::<DocRange>(), 8);
+        assert_eq!(size_of::<LayerRange>(), 8);
         assert_eq!(size_of::<StatementBase>(), 4);
     }
 

--- a/syntaqlite-syntax/src/source.rs
+++ b/syntaqlite-syntax/src/source.rs
@@ -240,7 +240,6 @@ impl StmtRange {
     pub const fn is_empty(self) -> bool {
         self.start.0 == self.end.0
     }
-
 }
 
 // ── Document-absolute byte position / length ────────────────────────────────
@@ -290,7 +289,6 @@ impl DocRange {
     pub const fn is_empty(self) -> bool {
         self.start.0 == self.end.0
     }
-
 }
 
 // ── Layer-relative byte position / length ──────────────────────────────────
@@ -315,6 +313,31 @@ define_u32_newtype! {
 }
 
 impl_pos_len_arith!(pos: LayerOffset, len: LayerLen);
+
+// ── Length inter-convertibility ────────────────────────────────────────────
+//
+// A byte length is a context-free quantity — 10 bytes is 10 bytes regardless
+// of which buffer it was measured in.  Only *offsets* carry a coordinate
+// system.  These `From` impls let callers move a length across boundaries
+// without a named-argument round-trip, while keeping the offset distinctions
+// intact.
+
+macro_rules! impl_len_from {
+    ($from:ident => $to:ident) => {
+        impl From<$from> for $to {
+            fn from(v: $from) -> $to {
+                $to(v.0)
+            }
+        }
+    };
+}
+
+impl_len_from!(StmtLen => DocLen);
+impl_len_from!(StmtLen => LayerLen);
+impl_len_from!(DocLen => StmtLen);
+impl_len_from!(DocLen => LayerLen);
+impl_len_from!(LayerLen => StmtLen);
+impl_len_from!(LayerLen => DocLen);
 
 /// A half-open range of layer-relative byte offsets `[start, end)`.
 #[derive(Copy, Clone, Default, PartialEq, Eq, Hash, Debug)]
@@ -343,7 +366,6 @@ impl LayerRange {
     pub const fn is_empty(self) -> bool {
         self.start.0 == self.end.0
     }
-
 }
 
 // ── Statement base offset ───────────────────────────────────────────────────
@@ -366,29 +388,41 @@ impl StatementBase {
     pub const fn as_doc_offset(self) -> DocOffset {
         self.0
     }
+}
 
-    /// Convert a statement-relative offset to a document-absolute offset.
-    pub const fn to_doc(self, off: StmtOffset) -> DocOffset {
-        DocOffset(self.0.0 + off.0)
+// ── Cross-coordinate conversions ────────────────────────────────────────────
+//
+// The receiver is the value being converted; the `StatementBase` is passed
+// in.  Reads naturally: `off.to_doc(base)` ("this offset, expressed in
+// document coordinates given this statement's base").
+
+impl StmtOffset {
+    /// Convert to a document-absolute offset given the statement's base.
+    pub const fn to_doc(self, base: StatementBase) -> DocOffset {
+        DocOffset(base.0.0 + self.0)
     }
+}
 
-    /// Convert a statement-relative range to a document-absolute range.
-    pub const fn to_doc_range(self, range: StmtRange) -> DocRange {
+impl StmtRange {
+    /// Convert to a document-absolute range given the statement's base.
+    pub const fn to_doc(self, base: StatementBase) -> DocRange {
         DocRange {
-            start: self.to_doc(range.start),
-            end: self.to_doc(range.end),
+            start: self.start.to_doc(base),
+            end: self.end.to_doc(base),
         }
     }
+}
 
-    /// Convert a document-absolute offset to a statement-relative offset.
+impl DocOffset {
+    /// Convert to a statement-relative offset given the statement's base.
     ///
-    /// Returns `None` if `off` precedes the statement's start, in which
-    /// case the offset cannot be expressed as statement-relative.
-    pub const fn from_doc(self, off: DocOffset) -> Option<StmtOffset> {
-        if off.0 < self.0.0 {
+    /// Returns `None` if this offset precedes the statement's start, in
+    /// which case the value cannot be expressed as statement-relative.
+    pub const fn to_stmt(self, base: StatementBase) -> Option<StmtOffset> {
+        if self.0 < base.0.0 {
             None
         } else {
-            Some(StmtOffset(off.0 - self.0.0))
+            Some(StmtOffset(self.0 - base.0.0))
         }
     }
 }
@@ -620,10 +654,7 @@ mod tests {
 
     #[test]
     fn stmt_range_from_offset_len() {
-        let r = StmtRange::from_offset_len(
-            StmtOffset::from_raw(10),
-            StmtLen::from_raw(5),
-        );
+        let r = StmtRange::from_offset_len(StmtOffset::from_raw(10), StmtLen::from_raw(5));
         assert_eq!(r.start.as_u32(), 10);
         assert_eq!(r.end.as_u32(), 15);
         assert_eq!(r.len().as_u32(), 5);
@@ -632,45 +663,39 @@ mod tests {
 
     #[test]
     fn empty_range() {
-        let r = StmtRange::from_offset_len(
-            StmtOffset::from_raw(10),
-            StmtLen::from_raw(0),
-        );
+        let r = StmtRange::from_offset_len(StmtOffset::from_raw(10), StmtLen::from_raw(0));
         assert!(r.is_empty());
     }
 
     #[test]
-    fn statement_base_to_doc() {
+    fn stmt_offset_to_doc() {
         let base = StatementBase::new(DocOffset::from_raw(100));
         let off = StmtOffset::from_raw(7);
-        let doc: DocOffset = base.to_doc(off);
+        let doc: DocOffset = off.to_doc(base);
         assert_eq!(doc.as_u32(), 107);
     }
 
     #[test]
-    fn statement_base_to_doc_range() {
+    fn stmt_range_to_doc() {
         let base = StatementBase::new(DocOffset::from_raw(100));
-        let r = StmtRange::from_offset_len(
-            StmtOffset::from_raw(5),
-            StmtLen::from_raw(3),
-        );
-        let doc = base.to_doc_range(r);
+        let r = StmtRange::from_offset_len(StmtOffset::from_raw(5), StmtLen::from_raw(3));
+        let doc = r.to_doc(base);
         assert_eq!(doc.start.as_u32(), 105);
         assert_eq!(doc.end.as_u32(), 108);
     }
 
     #[test]
-    fn statement_base_from_doc_in_range() {
+    fn doc_offset_to_stmt_in_range() {
         let base = StatementBase::new(DocOffset::from_raw(100));
         let doc = DocOffset::from_raw(107);
-        assert_eq!(base.from_doc(doc).map(StmtOffset::as_u32), Some(7));
+        assert_eq!(doc.to_stmt(base).map(StmtOffset::as_u32), Some(7));
     }
 
     #[test]
-    fn statement_base_from_doc_before_base() {
+    fn doc_offset_to_stmt_before_base() {
         let base = StatementBase::new(DocOffset::from_raw(100));
         let doc = DocOffset::from_raw(50);
-        assert!(base.from_doc(doc).is_none());
+        assert!(doc.to_stmt(base).is_none());
     }
 
     #[test]

--- a/syntaqlite-wasm/src/main.rs
+++ b/syntaqlite-wasm/src/main.rs
@@ -11,6 +11,7 @@ use serde::Serialize;
 use syntaqlite::any::AnyDialect;
 use syntaqlite::fmt::KeywordCase;
 use syntaqlite::lsp::LspHost;
+use syntaqlite::source::{DocLen, DocOffset, DocRange};
 use syntaqlite::util::{SqliteFlag, SqliteFlags, SqliteVersion};
 use syntaqlite::{FormatConfig, Formatter, ValidationConfig};
 
@@ -390,7 +391,10 @@ fn run_semantic_tokens(ptr: u32, len: u32, range_start: u32, range_end: u32, ver
     let range = if range_start == 0 && range_end == 0xFFFF_FFFF {
         None
     } else {
-        Some((range_start as usize, range_end as usize))
+        Some(DocRange::from_offset_len(
+            DocOffset::from_raw(range_start),
+            DocLen::from_raw(range_end.saturating_sub(range_start)),
+        ))
     };
     let encoded = lsp.semantic_tokens_encoded(WASM_DOC_URI, range);
     let token_count = i32::try_from(encoded.len() / 5).expect("token count fits i32");
@@ -409,7 +413,7 @@ fn run_completions(ptr: u32, len: u32, offset: u32, version: u32) -> i32 {
     let source = try_wasm!(decode_input(ptr, len), -1);
     let mut lsp = try_wasm!(take_or_create_lsp_host(), -1);
     lsp.update_document(WASM_DOC_URI, version.cast_signed(), source);
-    let entries = lsp.completion_items(WASM_DOC_URI, offset as usize);
+    let entries = lsp.completion_items(WASM_DOC_URI, DocOffset::from_raw(offset));
     let count = i32::try_from(entries.len()).expect("completion count fits i32");
     let items: Vec<CompletionItem> = entries
         .into_iter()

--- a/syntaqlite/src/embedded/mod.rs
+++ b/syntaqlite/src/embedded/mod.rs
@@ -30,6 +30,7 @@ pub use typescript::extract_typescript;
 use std::ops::Range;
 
 use syntaqlite_syntax::any::TokenCategory;
+use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange};
 
 use crate::dialect::AnyDialect;
 use crate::semantic::ValidationConfig;
@@ -246,12 +247,11 @@ impl EmbeddedAnalyzer {
             let offset_map = OffsetMap::new(fragment);
 
             for mut d in diags {
-                let Some(start) = offset_map.to_host(d.start_offset()) else {
+                let Some(start) = offset_map.to_host(d.range.start) else {
                     continue;
                 };
-                let end = offset_map.to_host(d.end_offset()).unwrap_or(start);
-                d.start_offset = start;
-                d.end_offset = end;
+                let end = offset_map.to_host(d.range.end).unwrap_or(start);
+                d.range = DocRange { start, end };
                 all_diags.push(d);
             }
         }
@@ -267,7 +267,7 @@ impl EmbeddedAnalyzer {
     pub(crate) fn fragment_semantic_tokens(
         &self,
         fragment: &EmbeddedFragment,
-    ) -> Vec<(usize, usize, TokenCategory)> {
+    ) -> Vec<(DocOffset, DocLen, TokenCategory)> {
         let mut analyzer = self.make_analyzer();
         let model = analyzer.analyze(fragment.sql_text(), &self.catalog, &self.config);
         model
@@ -292,9 +292,10 @@ impl EmbeddedAnalyzer {
         source: &str,
     ) -> Vec<u32> {
         let source_bytes = source.as_bytes();
+        let source_end = DocOffset::from_raw(u32::try_from(source.len()).unwrap_or(u32::MAX));
 
         // Collect (host_offset, length, legend_idx) for all fragments.
-        let mut all_tokens: Vec<(usize, usize, u32)> = Vec::new();
+        let mut all_tokens: Vec<(DocOffset, DocLen, u32)> = Vec::new();
         for fragment in fragments {
             let offset_map = OffsetMap::new(fragment);
             for (sql_offset, length, cat) in self.fragment_semantic_tokens(fragment) {
@@ -305,8 +306,13 @@ impl EmbeddedAnalyzer {
                 let Some(host_offset) = offset_map.to_host(sql_offset) else {
                     continue;
                 };
-                let host_len = length.min(source.len().saturating_sub(host_offset));
-                if host_len == 0 {
+                let remaining: DocLen = if host_offset >= source_end {
+                    DocLen::default()
+                } else {
+                    source_end - host_offset
+                };
+                let host_len = std::cmp::min(length, remaining);
+                if host_len == DocLen::default() {
                     continue;
                 }
                 all_tokens.push((host_offset, host_len, legend_idx));
@@ -322,17 +328,18 @@ impl EmbeddedAnalyzer {
         let mut prev_col: u32 = 0;
         let mut cur_line: u32 = 0;
         let mut cur_col: u32 = 0;
-        let mut src_pos: usize = 0;
+        let mut src_pos = DocOffset::default();
+        let one = DocLen::from_raw(1);
 
         for (host_offset, host_len, legend_idx) in all_tokens {
-            while src_pos < host_offset && src_pos < source_bytes.len() {
-                if source_bytes[src_pos] == b'\n' {
+            while src_pos < host_offset && src_pos < source_end {
+                if source_bytes[src_pos.as_usize()] == b'\n' {
                     cur_line += 1;
                     cur_col = 0;
                 } else {
                     cur_col += 1;
                 }
-                src_pos += 1;
+                src_pos += one;
             }
             let delta_line = cur_line - prev_line;
             let delta_start = if delta_line == 0 {
@@ -342,7 +349,7 @@ impl EmbeddedAnalyzer {
             };
             result.push(delta_line);
             result.push(delta_start);
-            result.push(u32::try_from(host_len).expect("host token length fits u32"));
+            result.push(host_len.as_u32());
             result.push(legend_idx);
             result.push(0); // modifiers
             prev_line = cur_line;
@@ -374,6 +381,7 @@ mod tests {
     use super::*;
     use crate::embedded::{python::extract_python, typescript::extract_typescript};
     use crate::semantic::diagnostics::{DiagnosticMessage, Severity};
+    use syntaqlite_syntax::source::DocText;
 
     fn analyzer() -> EmbeddedAnalyzer {
         EmbeddedAnalyzer::new(crate::sqlite::dialect::dialect())
@@ -439,9 +447,9 @@ mod tests {
         assert!(!parse_diags.is_empty(), "expected parse error");
         let fstring_start = source.find("SELECT").unwrap();
         assert!(
-            parse_diags[0].start_offset >= fstring_start,
+            parse_diags[0].start().as_usize() >= fstring_start,
             "expected offset >= {fstring_start}, got {}",
-            parse_diags[0].start_offset,
+            parse_diags[0].start(),
         );
     }
 
@@ -457,9 +465,9 @@ mod tests {
         let second_select = source.rfind("SELECT").unwrap();
         for d in &diags {
             assert!(
-                d.start_offset >= second_select,
+                d.start().as_usize() >= second_select,
                 "error at offset {} is before second fragment start {second_select}",
-                d.start_offset,
+                d.start(),
             );
         }
     }
@@ -540,14 +548,16 @@ mod tests {
         let valus_start = source.find("VALUS").unwrap();
         let valus_end = valus_start + "VALUS".len();
         assert_eq!(
-            parse_diags[0].start_offset, valus_start,
+            parse_diags[0].start().as_usize(),
+            valus_start,
             "error start should point to VALUS (offset {valus_start}), got {}",
-            parse_diags[0].start_offset,
+            parse_diags[0].start(),
         );
         assert_eq!(
-            parse_diags[0].end_offset, valus_end,
+            parse_diags[0].end().as_usize(),
+            valus_end,
             "error end should span VALUS (offset {valus_end}), got {}",
-            parse_diags[0].end_offset,
+            parse_diags[0].end(),
         );
     }
 
@@ -574,7 +584,10 @@ mod tests {
             .fragment_semantic_tokens(&fragments[0]);
         let datetime_tokens: Vec<_> = tokens
             .iter()
-            .filter(|(off, len, _)| &fragments[0].sql_text()[*off..*off + *len] == "datetime")
+            .filter(|(off, len, _)| {
+                let sql = DocText::new(fragments[0].sql_text());
+                &sql[DocRange::from_offset_len(*off, *len)] == "datetime"
+            })
             .collect();
         assert_eq!(
             datetime_tokens.len(),

--- a/syntaqlite/src/embedded/offset_map.rs
+++ b/syntaqlite/src/embedded/offset_map.rs
@@ -7,6 +7,8 @@
 //! offsets shift because `{some_long_expr}` might become `__hole_0__` (or
 //! vice-versa). The `OffsetMap` handles this translation.
 
+use syntaqlite_syntax::source::DocOffset;
+
 use super::{EmbeddedFragment, HOLE_PLACEHOLDER};
 
 /// An entry in the offset map: a region where the SQL text and host text differ.
@@ -51,15 +53,16 @@ impl OffsetMap {
     ///
     /// Returns `None` if the offset falls inside a hole placeholder, since
     /// those regions correspond to host-language expressions, not SQL.
-    pub(crate) fn to_host(&self, sql_offset: usize) -> Option<usize> {
+    pub(crate) fn to_host(&self, sql_offset: DocOffset) -> Option<DocOffset> {
         // Walk through segments to compute the cumulative drift.
         let mut drift: isize = 0;
+        let sql = sql_offset.as_usize();
 
         for seg in &self.segments {
-            if sql_offset < seg.sql_start {
+            if sql < seg.sql_start {
                 break;
             }
-            if sql_offset < seg.sql_start + seg.sql_len {
+            if sql < seg.sql_start + seg.sql_len {
                 // Inside a hole placeholder — no meaningful host mapping.
                 return None;
             }
@@ -68,7 +71,8 @@ impl OffsetMap {
         }
 
         // Apply base offset and accumulated drift.
-        Some((sql_offset.cast_signed() + self.base_offset.cast_signed() + drift).cast_unsigned())
+        let host = (sql.cast_signed() + self.base_offset.cast_signed() + drift).cast_unsigned();
+        Some(DocOffset::from_raw(u32::try_from(host).ok()?))
     }
 }
 
@@ -86,8 +90,14 @@ mod tests {
         };
         let map = OffsetMap::new(&fragment);
         // Offset 0 in SQL → offset 10 in host.
-        assert_eq!(map.to_host(0), Some(10));
-        assert_eq!(map.to_host(7), Some(17));
+        assert_eq!(
+            map.to_host(DocOffset::from_raw(0)),
+            Some(DocOffset::from_raw(10))
+        );
+        assert_eq!(
+            map.to_host(DocOffset::from_raw(7)),
+            Some(DocOffset::from_raw(17))
+        );
     }
 
     #[test]
@@ -108,12 +118,18 @@ mod tests {
         let map = OffsetMap::new(&fragment);
 
         // Before hole: offset 0 → 10, offset 13 → 23.
-        assert_eq!(map.to_host(0), Some(10));
-        assert_eq!(map.to_host(13), Some(23));
+        assert_eq!(
+            map.to_host(DocOffset::from_raw(0)),
+            Some(DocOffset::from_raw(10))
+        );
+        assert_eq!(
+            map.to_host(DocOffset::from_raw(13)),
+            Some(DocOffset::from_raw(23))
+        );
 
         // Inside hole: returns None (host-language expression, not SQL).
-        assert_eq!(map.to_host(14), None);
-        assert_eq!(map.to_host(18), None);
+        assert_eq!(map.to_host(DocOffset::from_raw(14)), None);
+        assert_eq!(map.to_host(DocOffset::from_raw(18)), None);
     }
 
     #[test]
@@ -148,17 +164,29 @@ mod tests {
         let map = OffsetMap::new(&fragment);
 
         // Inside holes: must return None so no semantic token is emitted.
-        assert_eq!(map.to_host(8), None, "first placeholder start");
-        assert_eq!(map.to_host(18), None, "second placeholder start");
-        assert_eq!(map.to_host(22), None, "second placeholder mid");
+        assert_eq!(
+            map.to_host(DocOffset::from_raw(8)),
+            None,
+            "first placeholder start"
+        );
+        assert_eq!(
+            map.to_host(DocOffset::from_raw(18)),
+            None,
+            "second placeholder start"
+        );
+        assert_eq!(
+            map.to_host(DocOffset::from_raw(22)),
+            None,
+            "second placeholder mid"
+        );
 
         // `datetime` sits after both placeholders in SQL text.
         // sql_offset of "datetime" = 8 + 8 + 2 + 8 + 2 = 28
-        let datetime_sql_offset = 28;
+        let datetime_sql_offset = DocOffset::from_raw(28);
         let datetime_host = map.to_host(datetime_sql_offset);
         assert_eq!(
             datetime_host,
-            Some(36),
+            Some(DocOffset::from_raw(36)),
             "datetime must map to host offset 36"
         );
     }

--- a/syntaqlite/src/fmt/formatter.rs
+++ b/syntaqlite/src/fmt/formatter.rs
@@ -131,21 +131,21 @@ impl Formatter {
         self.comment_entries.clear();
         self.comment_entries
             .extend(erased.comment_spans().map(|c| CommentEntry {
-                offset: c.offset(),
-                length: c.length(),
+                offset: c.offset().as_u32(),
+                length: c.length().as_u32(),
                 kind: c.kind(),
                 side: c.side(),
             }));
         self.token_entries.clear();
-        self.token_entries.extend(
-            erased
-                .token_spans()
-                .map(|(offset, length)| TokenEntry { offset, length }),
-        );
+        self.token_entries
+            .extend(erased.token_spans().map(|range| TokenEntry {
+                offset: range.start.as_u32(),
+                length: range.len().as_u32(),
+            }));
         self.macro_rewrites.extend(
             erased
                 .macro_rewrites()
-                .map(|r| (r.call_offset(), r.call_length())),
+                .map(|r| (r.call_offset().as_u32(), r.call_length().as_u32())),
         );
     }
 
@@ -195,7 +195,7 @@ impl Formatter {
 
             let erased = stmt.erase();
             self.collect_side_channels(&erased);
-            let stmt_source = erased.text();
+            let stmt_source = erased.text().as_str();
 
             let root_id = erased.root_id();
             let semicolons = self.config.semicolons;
@@ -461,7 +461,7 @@ impl Formatter {
             let mut arena = DocArena::recycle(prev_arena);
             self.parts.clear();
 
-            let stmt_source = erased.text();
+            let stmt_source = erased.text().as_str();
             if stmt_num > 0 {
                 emit_stmt_separator(
                     comment_ctx.as_ref(),

--- a/syntaqlite/src/fmt/formatter.rs
+++ b/syntaqlite/src/fmt/formatter.rs
@@ -3,8 +3,9 @@
 
 use syntaqlite_syntax::ParserConfig;
 use syntaqlite_syntax::any::{
-    AnyNodeId, AnyParsedStatement, AnyParser, AnyTokenizer, ParseOutcome,
+    AnyNodeId, AnyParseError, AnyParsedStatement, AnyParser, AnyTokenizer, ParseOutcome,
 };
+use syntaqlite_syntax::source::{DocLen, DocRange};
 
 use super::FormatConfig;
 use super::FormatError;
@@ -12,6 +13,21 @@ use super::comment::{CommentCtx, CommentEntry, TokenEntry};
 use super::doc::{DocArena, DocId, NIL_DOC, RenderBuffers};
 use super::interpret::{FmtCtx, InterpretScratch};
 use crate::dialect::AnyDialect;
+
+/// Convert a parse error (statement-relative offsets) to a
+/// [`FormatError`] with a document-absolute range.
+fn parse_error_to_format_error(e: &AnyParseError<'_>) -> FormatError {
+    let base = e.statement_base();
+    let range = match (e.offset(), e.length()) {
+        (Some(off), Some(len)) => Some(DocRange::from_offset_len(off.to_doc(base), len.into())),
+        (Some(off), None) => Some(DocRange::from_offset_len(
+            off.to_doc(base),
+            DocLen::default(),
+        )),
+        _ => None,
+    };
+    FormatError::new(e.message().to_owned(), range)
+}
 
 /// High-level SQL formatter that pretty-prints SQL source text.
 ///
@@ -185,11 +201,7 @@ impl Formatter {
                 ParseOutcome::Done => break,
                 ParseOutcome::Ok(stmt) => stmt,
                 ParseOutcome::Err(e) => {
-                    return Err(FormatError {
-                        message: e.message().to_owned(),
-                        offset: e.offset(),
-                        length: e.length(),
-                    });
+                    return Err(parse_error_to_format_error(&e));
                 }
             };
 
@@ -306,11 +318,7 @@ impl Formatter {
                 ParseOutcome::Done => break,
                 ParseOutcome::Ok(stmt) => stmt,
                 ParseOutcome::Err(e) => {
-                    return Err(FormatError {
-                        message: e.message().to_owned(),
-                        offset: e.offset(),
-                        length: e.length(),
-                    });
+                    return Err(parse_error_to_format_error(&e));
                 }
             };
 
@@ -427,11 +435,7 @@ impl Formatter {
                 ParseOutcome::Done => break,
                 ParseOutcome::Ok(stmt) => stmt,
                 ParseOutcome::Err(e) => {
-                    return Err(FormatError {
-                        message: e.message().to_owned(),
-                        offset: e.offset(),
-                        length: e.length(),
-                    });
+                    return Err(parse_error_to_format_error(&e));
                 }
             };
 

--- a/syntaqlite/src/fmt/interpret.rs
+++ b/syntaqlite/src/fmt/interpret.rs
@@ -231,9 +231,8 @@ impl Formatter {
                             // For quoted spans, the original token in source
                             // starts one byte earlier (the opening quote) and
                             // extends one byte past (the closing quote).
-                            let span_len = StmtLen::from_raw(
-                                u32::try_from(s.len()).unwrap_or(u32::MAX),
-                            );
+                            let span_len =
+                                StmtLen::from_raw(u32::try_from(s.len()).unwrap_or(u32::MAX));
                             let drain_offset = if quoted {
                                 span_start - StmtLen::from_raw(1)
                             } else {
@@ -244,8 +243,7 @@ impl Formatter {
                             } else {
                                 span_len
                             };
-                            let drain =
-                                cctx.drain_before(drain_offset.as_u32(), source, arena);
+                            let drain = cctx.drain_before(drain_offset.as_u32(), source, arena);
                             flush_drain(&drain, &mut pending, &mut running, arena);
                             cctx.advance_past((drain_offset + token_len).as_u32());
                         }

--- a/syntaqlite/src/fmt/interpret.rs
+++ b/syntaqlite/src/fmt/interpret.rs
@@ -23,7 +23,7 @@ pub(crate) struct FmtCtx<'a> {
 
 impl<'a> FmtCtx<'a> {
     pub(crate) fn text(&self) -> &'a str {
-        self.reader.text()
+        self.reader.text().as_str()
     }
 }
 
@@ -227,15 +227,27 @@ impl Formatter {
                     // real `""` token and must round-trip as `""`.
                     if quoted || !s.is_empty() {
                         if let Some(ref cctx) = ctx.comment_ctx {
+                            use syntaqlite_syntax::source::StmtLen;
                             // For quoted spans, the original token in source
                             // starts one byte earlier (the opening quote) and
                             // extends one byte past (the closing quote).
-                            let span_len = u32::try_from(s.len()).unwrap_or(u32::MAX);
-                            let drain_offset = if quoted { span_start - 1 } else { span_start };
-                            let token_len = span_len + if quoted { 2 } else { 0 };
-                            let drain = cctx.drain_before(drain_offset, source, arena);
+                            let span_len = StmtLen::from_raw(
+                                u32::try_from(s.len()).unwrap_or(u32::MAX),
+                            );
+                            let drain_offset = if quoted {
+                                span_start - StmtLen::from_raw(1)
+                            } else {
+                                span_start
+                            };
+                            let token_len = if quoted {
+                                span_len + StmtLen::from_raw(2)
+                            } else {
+                                span_len
+                            };
+                            let drain =
+                                cctx.drain_before(drain_offset.as_u32(), source, arena);
                             flush_drain(&drain, &mut pending, &mut running, arena);
-                            cctx.advance_past(drain_offset + token_len);
+                            cctx.advance_past((drain_offset + token_len).as_u32());
                         }
                         if quoted {
                             let q = arena.text("\"");

--- a/syntaqlite/src/fmt/mod.rs
+++ b/syntaqlite/src/fmt/mod.rs
@@ -37,6 +37,8 @@ mod interpret;
 #[doc(inline)]
 pub use formatter::Formatter;
 
+use crate::source::DocRange;
+
 // ── Config types (formerly config.rs) ────────────────────────────────────
 
 /// Controls how SQL keywords are cased in formatted output.
@@ -152,24 +154,22 @@ impl FormatConfig {
 #[derive(Debug, Clone)]
 pub struct FormatError {
     message: String,
-    offset: Option<usize>,
-    length: Option<usize>,
+    range: Option<DocRange>,
 }
 
 impl FormatError {
+    pub(crate) fn new(message: String, range: Option<DocRange>) -> Self {
+        Self { message, range }
+    }
+
     /// Human-readable error message.
     pub fn message(&self) -> &str {
         &self.message
     }
 
-    /// Byte offset of the error token in the source, if known.
-    pub fn offset(&self) -> Option<usize> {
-        self.offset
-    }
-
-    /// Byte length of the error token, if known.
-    pub fn length(&self) -> Option<usize> {
-        self.length
+    /// Document-absolute byte range of the error token, if known.
+    pub fn range(&self) -> Option<DocRange> {
+        self.range
     }
 }
 

--- a/syntaqlite/src/lib.rs
+++ b/syntaqlite/src/lib.rs
@@ -159,6 +159,14 @@ pub use syntaqlite_syntax::ParseOutcome;
 #[cfg(feature = "sqlite")]
 pub use syntaqlite_syntax::Parser;
 
+/// Typed source coordinates — offsets, lengths, ranges, and source-text
+/// wrappers.  Every position-like value the parser emits is modeled by a
+/// newtype in this module so coordinate-system confusion is caught at
+/// compile time rather than surfacing as a runtime bug.
+pub mod source {
+    pub use syntaqlite_syntax::source::*;
+}
+
 // Formatting — the formatter and its config.
 #[doc(inline)]
 #[cfg(feature = "fmt")]

--- a/syntaqlite/src/lsp/completion.rs
+++ b/syntaqlite/src/lsp/completion.rs
@@ -11,6 +11,7 @@ use std::collections::HashSet;
 
 use syntaqlite_syntax::ParserConfig;
 use syntaqlite_syntax::any::{AnyParser, AnyTokenType, TokenCategory};
+use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange, DocText};
 
 use crate::dialect::AnyDialect;
 use crate::semantic::model::{CompletionContext, CompletionInfo, SemanticModel, StoredToken};
@@ -19,18 +20,23 @@ use crate::semantic::model::{CompletionContext, CompletionInfo, SemanticModel, S
 pub(crate) fn completion_info(
     dialect: &AnyDialect,
     model: &SemanticModel,
-    offset: usize,
+    offset: DocOffset,
 ) -> CompletionInfo {
-    let source = model.source();
+    let source = DocText::new(model.source());
     let tokens = &model.tokens;
-    let cursor = offset.min(source.len());
+    let end_of_doc = source.byte_len();
+    let cursor = if offset.as_usize() > end_of_doc.as_usize() {
+        DocOffset::default() + end_of_doc
+    } else {
+        offset
+    };
     let (boundary, backtracked) = completion_boundary(source, tokens, cursor);
     let start = statement_token_start(tokens, boundary);
     let stmt_tokens = &tokens[start..boundary];
 
     let syntax = (**dialect).clone();
     let parser = AnyParser::with_config(syntax, &ParserConfig::default());
-    let mut cursor_p = parser.incremental_parse(source);
+    let mut cursor_p = parser.incremental_parse(source.as_str());
     // Do not call expected_tokens() before feeding any tokens: the C parser
     // returns a garbage `total` count when no tokens have been fed yet,
     // which would trigger a multi-GiB allocation and SIGKILL.
@@ -74,14 +80,20 @@ pub(crate) fn completion_info(
 /// If the last two tokens are `Identifier` then `.`, return the identifier
 /// text as the qualifier (used to detect `table.` prefixes for qualified
 /// column completion).
-fn detect_qualifier(source: &str, tokens: &[StoredToken], dialect: &AnyDialect) -> Option<String> {
+fn detect_qualifier(
+    source: &DocText,
+    tokens: &[StoredToken],
+    dialect: &AnyDialect,
+) -> Option<String> {
     if tokens.len() < 2 {
         return None;
     }
     let dot_tok = &tokens[tokens.len() - 1];
     let ident_tok = &tokens[tokens.len() - 2];
 
-    if dot_tok.length != 1 || source.as_bytes().get(dot_tok.offset) != Some(&b'.') {
+    if dot_tok.length != DocLen::from_raw(1)
+        || source.as_str().as_bytes().get(dot_tok.offset.as_usize()) != Some(&b'.')
+    {
         return None;
     }
 
@@ -90,20 +102,20 @@ fn detect_qualifier(source: &str, tokens: &[StoredToken], dialect: &AnyDialect) 
         return None;
     }
 
-    let name = &source[ident_tok.offset..ident_tok.offset + ident_tok.length];
+    let name = &source[DocRange::from_offset_len(ident_tok.offset, ident_tok.length)];
     Some(name.to_string())
 }
 
 fn completion_boundary(
-    source: &str,
+    source: &DocText,
     tokens: &[StoredToken],
-    cursor_offset: usize,
+    cursor_offset: DocOffset,
 ) -> (usize, bool) {
     let mut boundary = tokens.partition_point(|t| t.offset + t.length <= cursor_offset);
 
     while boundary > 0 {
         let tok = &tokens[boundary - 1];
-        if tok.length == 0 && tok.offset == cursor_offset {
+        if tok.length == DocLen::default() && tok.offset == cursor_offset {
             boundary -= 1;
         } else {
             break;
@@ -113,9 +125,9 @@ fn completion_boundary(
     let mut backtracked = false;
     if boundary > 0
         && tokens[boundary - 1].offset + tokens[boundary - 1].length == cursor_offset
-        && cursor_offset > 0
+        && cursor_offset > DocOffset::default()
     {
-        let prev = source.as_bytes()[cursor_offset - 1];
+        let prev = source.as_str().as_bytes()[cursor_offset.as_usize() - 1];
         if prev.is_ascii_alphanumeric() || prev == b'_' {
             boundary -= 1;
             backtracked = true;
@@ -154,20 +166,20 @@ mod tests {
     #[test]
     fn detect_qualifier_basic() {
         let dialect = crate::sqlite::dialect::dialect();
-        let source = "SELECT t1.";
+        let source = DocText::new("SELECT t1.");
         let id_type = AnyTokenType::from(syntaqlite_syntax::TokenType::Id);
         let dot_type = AnyTokenType::from(syntaqlite_syntax::TokenType::Dot);
 
         let tokens = vec![
             StoredToken {
-                offset: 7,
-                length: 2,
+                offset: DocOffset::from_raw(7),
+                length: DocLen::from_raw(2),
                 token_type: id_type,
                 flags: ParserTokenFlags::default(),
             },
             StoredToken {
-                offset: 9,
-                length: 1,
+                offset: DocOffset::from_raw(9),
+                length: DocLen::from_raw(1),
                 token_type: dot_type,
                 flags: ParserTokenFlags::default(),
             },

--- a/syntaqlite/src/lsp/host.rs
+++ b/syntaqlite/src/lsp/host.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use syntaqlite_syntax::any::TokenCategory;
+use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange, DocText};
 use syntaqlite_syntax::util::is_suggestable_keyword;
 
 use crate::dialect::AnyDialect;
@@ -165,6 +166,7 @@ fn ensure_model_for(
 ///
 /// ```
 /// use syntaqlite::lsp::LspHost;
+/// use syntaqlite::source::DocOffset;
 ///
 /// let mut host = LspHost::new(); // SQLite dialect by default
 ///
@@ -175,7 +177,7 @@ fn ensure_model_for(
 /// let tokens = host.semantic_tokens_encoded("file:///query.sql", None);
 ///
 /// // Retrieve completions at a cursor position.
-/// let items = host.completion_items("file:///query.sql", 9);
+/// let items = host.completion_items("file:///query.sql", DocOffset::from_raw(9));
 /// ```
 pub struct LspHost {
     dialect: AnyDialect,
@@ -339,11 +341,7 @@ impl LspHost {
     /// # Panics
     /// Panics if the internal model or token cache is in an inconsistent state
     /// (this indicates a bug in `ensure_model`).
-    pub fn semantic_tokens_encoded(
-        &mut self,
-        uri: &str,
-        range: Option<(usize, usize)>,
-    ) -> Vec<u32> {
+    pub fn semantic_tokens_encoded(&mut self, uri: &str, range: Option<DocRange>) -> Vec<u32> {
         if !ensure_model_for(
             uri,
             &mut self.documents,
@@ -374,7 +372,11 @@ impl LspHost {
     }
 
     /// Expected parser tokens and semantic context at a byte offset.
-    pub(crate) fn completion_info_at_offset(&mut self, uri: &str, offset: usize) -> CompletionInfo {
+    pub(crate) fn completion_info_at_offset(
+        &mut self,
+        uri: &str,
+        offset: DocOffset,
+    ) -> CompletionInfo {
         if !ensure_model_for(
             uri,
             &mut self.documents,
@@ -401,7 +403,7 @@ impl LspHost {
     }
 
     /// Completion items (keywords + functions) at a byte offset.
-    pub fn completion_items(&mut self, uri: &str, offset: usize) -> Vec<CompletionEntry> {
+    pub fn completion_items(&mut self, uri: &str, offset: DocOffset) -> Vec<CompletionEntry> {
         use std::collections::HashSet;
 
         let info = self.completion_info_at_offset(uri, offset);
@@ -545,12 +547,12 @@ impl LspHost {
 
     // ── Hover ──────────────────────────────────────────────────────────────────
 
-    /// Hover information at a byte offset: returns (`hover_text`, `token_offset`, `token_length`).
+    /// Hover information at a byte offset: returns (`hover_text`, `token_range`).
     pub(crate) fn hover_info(
         &mut self,
         uri: &str,
-        offset: usize,
-    ) -> Option<(String, usize, usize)> {
+        offset: DocOffset,
+    ) -> Option<(String, DocRange)> {
         ensure_model_for(
             uri,
             &mut self.documents,
@@ -563,20 +565,24 @@ impl LspHost {
         let model = doc.model.as_ref().expect("ensure_model sets model");
 
         let resolution = model.resolution_at(offset)?;
-        let (start, end) = model
+        let range = model
             .resolutions
             .iter()
-            .find(|r| offset >= r.start && offset < r.end)
-            .map(|r| (r.start, r.end))?;
+            .find(|r| offset >= r.range.start && offset < r.range.end)
+            .map(|r| r.range)?;
 
         let hover = format_resolved_hover(resolution);
-        Some((hover, start, end - start))
+        Some((hover, range))
     }
 
     // ── Go-to-definition ───────────────────────────────────────────────────
 
     /// Return the definition location for the symbol at `offset`.
-    pub(crate) fn definition_info(&mut self, uri: &str, offset: usize) -> Option<DefinitionResult> {
+    pub(crate) fn definition_info(
+        &mut self,
+        uri: &str,
+        offset: DocOffset,
+    ) -> Option<DefinitionResult> {
         ensure_model_for(
             uri,
             &mut self.documents,
@@ -594,14 +600,14 @@ impl LspHost {
 
     /// Find all references to the symbol at `offset` across all open documents.
     ///
-    /// Returns a list of `(uri, start, end)` tuples. When `include_declaration`
+    /// Returns a list of `(uri, range)` tuples. When `include_declaration`
     /// is true, the definition site (if known) is included in the results.
     pub(crate) fn find_references(
         &mut self,
         uri: &str,
-        offset: usize,
+        offset: DocOffset,
         include_declaration: bool,
-    ) -> Vec<(String, usize, usize)> {
+    ) -> Vec<(String, DocRange)> {
         // Identify the symbol at the cursor.
         let identity = self.symbol_identity_at(uri, offset);
         let Some(identity) = identity else {
@@ -626,18 +632,16 @@ impl LspHost {
                 .get(doc_uri.as_str())
                 .expect("doc_uri came from keys()");
             let model = doc.model.as_ref().expect("ensure_model sets model");
-            for (start, end) in model.references_matching(&identity) {
-                results.push((doc_uri.clone(), start, end));
+            for range in model.references_matching(&identity) {
+                results.push((doc_uri.clone(), range));
             }
             if include_declaration {
                 let key = identity.definition_key();
-                if let Some(&(start, end)) = model.definition_offsets.get(&key) {
+                if let Some(&range) = model.definition_offsets.get(&key) {
                     // Avoid duplicates (definition might also be in resolutions).
-                    let already = results
-                        .iter()
-                        .any(|(u, s, e)| u == doc_uri && *s == start && *e == end);
+                    let already = results.iter().any(|(u, r)| u == doc_uri && *r == range);
                     if !already {
-                        results.push((doc_uri.clone(), start, end));
+                        results.push((doc_uri.clone(), range));
                     }
                 }
             }
@@ -647,7 +651,7 @@ impl LspHost {
         if include_declaration && let Some(def_site) = self.external_definition_site(&identity) {
             let already = results
                 .iter()
-                .any(|(u, s, e)| *u == def_site.0 && *s == def_site.1 && *e == def_site.2);
+                .any(|(u, r)| *u == def_site.0 && *r == def_site.1);
             if !already {
                 results.push(def_site);
             }
@@ -658,12 +662,12 @@ impl LspHost {
 
     // ── Rename ──────────────────────────────────────────────────────────────
 
-    /// Check if the symbol at `offset` is renameable, returning `(start, end, current_name)`.
+    /// Check if the symbol at `offset` is renameable, returning `(range, current_name)`.
     pub(crate) fn prepare_rename(
         &mut self,
         uri: &str,
-        offset: usize,
-    ) -> Option<(usize, usize, String)> {
+        offset: DocOffset,
+    ) -> Option<(DocRange, String)> {
         ensure_model_for(
             uri,
             &mut self.documents,
@@ -677,31 +681,31 @@ impl LspHost {
         let res = model
             .resolutions
             .iter()
-            .find(|r| offset >= r.start && offset < r.end)?;
+            .find(|r| offset >= r.range.start && offset < r.range.end)?;
         let name = match &res.symbol {
             ResolvedSymbol::Table { name, .. } => name.clone(),
             ResolvedSymbol::Column { column, .. } => column.clone(),
             ResolvedSymbol::Function { .. } => return None,
         };
-        Some((res.start, res.end, name))
+        Some((res.range, name))
     }
 
     /// Rename the symbol at `offset` to `new_name` across all open documents.
     ///
-    /// Returns a map of `uri -> Vec<(start, end, new_text)>` edits.
+    /// Returns a map of `uri -> Vec<(range, new_text)>` edits.
     pub(crate) fn rename(
         &mut self,
         uri: &str,
-        offset: usize,
+        offset: DocOffset,
         new_name: &str,
-    ) -> HashMap<String, Vec<(usize, usize, String)>> {
+    ) -> HashMap<String, Vec<(DocRange, String)>> {
         let refs = self.find_references(uri, offset, true);
-        let mut edits: HashMap<String, Vec<(usize, usize, String)>> = HashMap::new();
-        for (ref_uri, start, end) in refs {
+        let mut edits: HashMap<String, Vec<(DocRange, String)>> = HashMap::new();
+        for (ref_uri, range) in refs {
             edits
                 .entry(ref_uri)
                 .or_default()
-                .push((start, end, new_name.to_string()));
+                .push((range, new_name.to_string()));
         }
         edits
     }
@@ -710,7 +714,7 @@ impl LspHost {
 
     /// Determine the symbol identity at `offset` — either from a resolution or
     /// from a definition site (CREATE TABLE / column-def).
-    fn symbol_identity_at(&mut self, uri: &str, offset: usize) -> Option<SymbolIdentity> {
+    fn symbol_identity_at(&mut self, uri: &str, offset: DocOffset) -> Option<SymbolIdentity> {
         ensure_model_for(
             uri,
             &mut self.documents,
@@ -728,8 +732,8 @@ impl LspHost {
         }
 
         // Fall back to definition_offsets (cursor on a CREATE TABLE name, etc).
-        for (key, &(start, end)) in &model.definition_offsets {
-            if offset >= start && offset < end {
+        for (key, &range) in &model.definition_offsets {
+            if offset >= range.start && offset < range.end {
                 return if let Some((table, col)) = key.split_once('.') {
                     Some(SymbolIdentity::Column {
                         table: table.to_string(),
@@ -744,18 +748,15 @@ impl LspHost {
     }
 
     /// Look up an external (schema-file) definition site for a symbol from the catalog.
-    fn external_definition_site(
-        &self,
-        identity: &SymbolIdentity,
-    ) -> Option<(String, usize, usize)> {
+    fn external_definition_site(&self, identity: &SymbolIdentity) -> Option<(String, DocRange)> {
         match identity {
             SymbolIdentity::Table(name) => {
                 let site = self.user_catalog.relation_definition_site(name)?;
-                Some((site.file_uri.clone(), site.start, site.end))
+                Some((site.file_uri.clone(), site.range))
             }
             SymbolIdentity::Column { table, column } => {
                 let site = self.user_catalog.column_definition_site(table, column)?;
-                Some((site.file_uri.clone(), site.start, site.end))
+                Some((site.file_uri.clone(), site.range))
             }
         }
     }
@@ -764,7 +765,11 @@ impl LspHost {
 
     /// Signature help at a byte offset: finds enclosing function call and returns
     /// (`function_name`, `active_parameter`, overloads).
-    pub(crate) fn signature_help(&mut self, uri: &str, offset: usize) -> Option<SignatureHelpInfo> {
+    pub(crate) fn signature_help(
+        &mut self,
+        uri: &str,
+        offset: DocOffset,
+    ) -> Option<SignatureHelpInfo> {
         ensure_model_for(
             uri,
             &mut self.documents,
@@ -778,7 +783,8 @@ impl LspHost {
         let source = model.source();
 
         // Walk backwards from offset to find enclosing `name(` and count commas.
-        let before = &source[..offset.min(source.len())];
+        let cursor_byte = std::cmp::min(offset.as_usize(), source.len());
+        let before = &source[..cursor_byte];
         let (func_name, active_param) = find_enclosing_call(before, &model.tokens, &self.dialect)?;
 
         let (_category, arities) = self.user_catalog.function_signature(&func_name)?;
@@ -849,28 +855,36 @@ impl LspHost {
 fn encode_semantic_tokens(
     source: &str,
     semantic_tokens: &[SemanticToken],
-    range: Option<(usize, usize)>,
+    range: Option<DocRange>,
 ) -> Vec<u32> {
     let src = source.as_bytes();
-    let (range_start, range_end) = range.unwrap_or((0, src.len()));
+    let src_end = DocOffset::from_raw(u32::try_from(src.len()).unwrap_or(u32::MAX));
+    let DocRange {
+        start: range_start,
+        end: range_end,
+    } = range.unwrap_or(DocRange {
+        start: DocOffset::default(),
+        end: src_end,
+    });
 
     let mut result = Vec::with_capacity(semantic_tokens.len() * 5);
     let mut prev_line: u32 = 0;
     let mut prev_col: u32 = 0;
     let mut cur_line: u32 = 0;
     let mut cur_col: u32 = 0;
-    let mut src_pos: usize = 0;
+    let mut src_pos = DocOffset::default();
 
     for tok in semantic_tokens {
-        while src_pos < tok.offset && src_pos < src.len() {
-            if src[src_pos] == b'\n' {
+        while src_pos < tok.offset && src_pos < src_end {
+            let i = src_pos.as_usize();
+            if src[i] == b'\n' {
                 cur_line += 1;
                 cur_col = 0;
-                src_pos += 1;
+                src_pos += DocLen::from_raw(1);
             } else {
-                let char_len = utf8_char_len(src[src_pos]);
+                let char_len = utf8_char_len(src[i]);
                 cur_col += if char_len == 4 { 2 } else { 1 };
-                src_pos += char_len;
+                src_pos += DocLen::from_raw(u32::try_from(char_len).unwrap_or(1));
             }
         }
 
@@ -893,8 +907,8 @@ fn encode_semantic_tokens(
         };
 
         // Compute token length in UTF-16 code units.
-        let tok_end = (tok.offset + tok.length).min(src.len());
-        let length_utf16 = utf16_len(&src[tok.offset..tok_end]);
+        let tok_end = std::cmp::min(tok.offset + tok.length, src_end);
+        let length_utf16 = utf16_len(&src[tok.offset.as_usize()..tok_end.as_usize()]);
 
         result.push(delta_line);
         result.push(delta_start);
@@ -973,6 +987,7 @@ fn find_enclosing_call(
     tokens: &[StoredToken],
     dialect: &AnyDialect,
 ) -> Option<(String, u32)> {
+    let before_doc = DocText::new(before);
     let bytes = before.as_bytes();
     let mut depth: i32 = 0;
     let mut commas: u32 = 0;
@@ -986,7 +1001,7 @@ fn find_enclosing_call(
             b'(' => {
                 if depth == 0 {
                     // Found the opening paren — look for the function name token before it.
-                    let paren_offset = pos;
+                    let paren_offset = DocOffset::from_raw(u32::try_from(pos).unwrap_or(u32::MAX));
                     let func_token = tokens.iter().rev().find(|t| {
                         t.offset + t.length <= paren_offset
                             && dialect.classify_token(t.token_type, t.flags)
@@ -994,10 +1009,15 @@ fn find_enclosing_call(
                     })?;
                     // Make sure the function token is immediately before the paren
                     // (only whitespace between).
-                    let between = &before[func_token.offset + func_token.length..paren_offset];
+                    let tok_end = func_token.offset + func_token.length;
+                    let between = &before_doc[DocRange {
+                        start: tok_end,
+                        end: paren_offset,
+                    }];
                     if between.trim().is_empty() {
-                        let name = before[func_token.offset..func_token.offset + func_token.length]
-                            .to_string();
+                        let name = before_doc
+                            [DocRange::from_offset_len(func_token.offset, func_token.length)]
+                        .to_string();
                         return Some((name, commas));
                     }
                     return None;
@@ -1038,7 +1058,7 @@ impl std::error::Error for FormatError {}
 #[cfg(test)]
 impl LspHost {
     /// Expected terminal token IDs (as `u32` ordinals) at a byte offset.
-    pub(crate) fn expected_tokens_at_offset(&mut self, uri: &str, offset: usize) -> Vec<u32> {
+    pub(crate) fn expected_tokens_at_offset(&mut self, uri: &str, offset: DocOffset) -> Vec<u32> {
         self.completion_info_at_offset(uri, offset)
             .tokens
             .iter()
@@ -1051,6 +1071,7 @@ impl LspHost {
 #[cfg(feature = "sqlite")]
 mod tests {
     use syntaqlite_syntax::TokenType;
+    use syntaqlite_syntax::source::DocOffset;
 
     use super::LspHost;
     use crate::lsp::CompletionKind;
@@ -1065,7 +1086,8 @@ mod tests {
         let uri = "file:///test.sql";
         let sql = "SELECT * FR";
         host.open_document(uri, 1, sql.to_string());
-        let expected = host.expected_tokens_at_offset(uri, sql.len());
+        let expected = host
+            .expected_tokens_at_offset(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
         assert!(
             expected.contains(&(TokenType::From as u32)),
             "expected From after SELECT *, got {expected:?}"
@@ -1078,7 +1100,8 @@ mod tests {
         let uri = "file:///test.sql";
         let sql = "SELEC 1; SELECT * FR";
         host.open_document(uri, 1, sql.to_string());
-        let expected = host.expected_tokens_at_offset(uri, sql.len());
+        let expected = host
+            .expected_tokens_at_offset(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
         assert!(
             expected.contains(&(TokenType::From as u32)),
             "expected From in second statement context, got {expected:?}"
@@ -1091,7 +1114,8 @@ mod tests {
         let uri = "file:///test.sql";
         let sql = "SELECT * FROM s AS x J";
         host.open_document(uri, 1, sql.to_string());
-        let expected = host.expected_tokens_at_offset(uri, sql.len());
+        let expected = host
+            .expected_tokens_at_offset(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
         assert!(
             expected.contains(&(TokenType::JoinKw as u32)),
             "expected JoinKw after FROM alias, got {expected:?}"
@@ -1104,7 +1128,8 @@ mod tests {
         let uri = "file:///test.sql";
         let sql = "SELECT * FROM slice ";
         host.open_document(uri, 1, sql.to_string());
-        let expected = host.expected_tokens_at_offset(uri, sql.len());
+        let expected = host
+            .expected_tokens_at_offset(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
         assert!(
             expected.contains(&(TokenType::Join as u32)),
             "expected Join"
@@ -1154,7 +1179,8 @@ mod tests {
         let uri = "file:///test.sql";
         let sql = "SELECT acos() as foo FROM ";
         host.open_document(uri, 1, sql.to_string());
-        let info = host.completion_info_at_offset(uri, sql.len());
+        let info = host
+            .completion_info_at_offset(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
         assert_eq!(info.context, super::super::CompletionContext::TableRef);
     }
 
@@ -1164,7 +1190,8 @@ mod tests {
         let uri = "file:///test.sql";
         let sql = "SELECT ";
         host.open_document(uri, 1, sql.to_string());
-        let info = host.completion_info_at_offset(uri, sql.len());
+        let info = host
+            .completion_info_at_offset(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
         assert_ne!(info.context, super::super::CompletionContext::TableRef);
     }
 
@@ -1174,7 +1201,8 @@ mod tests {
         let uri = "file:///test.sql";
         let sql = "SELECT * FROM t WHERE ";
         host.open_document(uri, 1, sql.to_string());
-        let info = host.completion_info_at_offset(uri, sql.len());
+        let info = host
+            .completion_info_at_offset(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
         assert_eq!(info.context, super::super::CompletionContext::Expression);
     }
 
@@ -1184,7 +1212,8 @@ mod tests {
         let uri = "file:///test.sql";
         let sql = "SELECT * FROM slice";
         host.open_document(uri, 1, sql.to_string());
-        let expected = host.expected_tokens_at_offset(uri, sql.len());
+        let expected = host
+            .expected_tokens_at_offset(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
         assert!(expected.contains(&(TokenType::Join as u32)));
     }
 
@@ -1320,12 +1349,13 @@ mod tests {
         let diag = &diags[0];
         assert_eq!(diag.severity, Severity::Error);
         let second_where = sql[31..].find("where").map(|i| i + 31).unwrap();
+        let start = diag.start().as_usize();
         assert_eq!(
-            diag.start_offset,
+            start,
             second_where,
             "got '{}' at {}",
-            &sql[diag.start_offset..=diag.start_offset],
-            diag.start_offset
+            &sql[start..=start],
+            start
         );
     }
 
@@ -1379,13 +1409,17 @@ mod tests {
         host.open_document(uri, 1, "SELECT * FROM orders".to_string());
 
         let ref_offset = "SELECT * FROM ".len();
-        let result = host.definition_info(uri, ref_offset);
+        let result =
+            host.definition_info(uri, DocOffset::from_raw(u32::try_from(ref_offset).unwrap()));
         assert!(result.is_some(), "expected definition for schema table");
         let def = result.unwrap();
         assert_eq!(def.target.file_uri.as_deref(), Some(file_uri));
         let schema_offset = schema.find("orders").unwrap();
-        assert_eq!(def.target.start, schema_offset);
-        assert_eq!(def.target.end, schema_offset + "orders".len());
+        assert_eq!(def.target.range.start.as_usize(), schema_offset);
+        assert_eq!(
+            def.target.range.end.as_usize(),
+            schema_offset + "orders".len()
+        );
     }
 
     #[test]
@@ -1400,13 +1434,17 @@ mod tests {
         host.open_document(uri, 1, "SELECT total FROM orders".to_string());
 
         let ref_offset = "SELECT ".len(); // points to "total"
-        let result = host.definition_info(uri, ref_offset);
+        let result =
+            host.definition_info(uri, DocOffset::from_raw(u32::try_from(ref_offset).unwrap()));
         assert!(result.is_some(), "expected definition for schema column");
         let def = result.unwrap();
         assert_eq!(def.target.file_uri.as_deref(), Some(file_uri));
         let schema_offset = schema.find("total").unwrap();
-        assert_eq!(def.target.start, schema_offset);
-        assert_eq!(def.target.end, schema_offset + "total".len());
+        assert_eq!(def.target.range.start.as_usize(), schema_offset);
+        assert_eq!(
+            def.target.range.end.as_usize(),
+            schema_offset + "total".len()
+        );
     }
 
     #[test]
@@ -1436,7 +1474,11 @@ mod tests {
 
         // Click on "users" in the SELECT statement.
         let offset = sql.find("SELECT").unwrap() + "SELECT * FROM ".len();
-        let refs = host.find_references(uri, offset, false);
+        let refs = host.find_references(
+            uri,
+            DocOffset::from_raw(u32::try_from(offset).unwrap()),
+            false,
+        );
         // Should find the two DML references (SELECT + DELETE), not the CREATE.
         assert_eq!(refs.len(), 2, "expected 2 refs, got: {refs:?}");
     }
@@ -1449,7 +1491,11 @@ mod tests {
         host.open_document(uri, 1, sql.to_string());
 
         let offset = sql.find("SELECT").unwrap() + "SELECT * FROM ".len();
-        let refs = host.find_references(uri, offset, true);
+        let refs = host.find_references(
+            uri,
+            DocOffset::from_raw(u32::try_from(offset).unwrap()),
+            true,
+        );
         // Should find the two DML references + the CREATE TABLE definition.
         assert_eq!(refs.len(), 3, "expected 3 refs (incl decl), got: {refs:?}");
     }
@@ -1463,7 +1509,11 @@ mod tests {
 
         // Click on "id" in the first SELECT.
         let offset = sql.find("SELECT id").unwrap() + "SELECT ".len();
-        let refs = host.find_references(uri, offset, false);
+        let refs = host.find_references(
+            uri,
+            DocOffset::from_raw(u32::try_from(offset).unwrap()),
+            false,
+        );
         assert_eq!(refs.len(), 2, "expected 2 column refs, got: {refs:?}");
     }
 
@@ -1482,7 +1532,11 @@ mod tests {
 
         // Click on "orders" in a.sql.
         let offset = "SELECT * FROM ".len();
-        let refs = host.find_references(uri1, offset, false);
+        let refs = host.find_references(
+            uri1,
+            DocOffset::from_raw(u32::try_from(offset).unwrap()),
+            false,
+        );
         assert_eq!(refs.len(), 2, "expected refs in both files, got: {refs:?}");
         let ref_uris: Vec<&str> = refs.iter().map(|r| r.0.as_str()).collect();
         assert!(ref_uris.contains(&uri1));
@@ -1498,7 +1552,11 @@ mod tests {
 
         // Click on "users" in CREATE TABLE — should still find the SELECT reference.
         let offset = sql.find("users").unwrap();
-        let refs = host.find_references(uri, offset, false);
+        let refs = host.find_references(
+            uri,
+            DocOffset::from_raw(u32::try_from(offset).unwrap()),
+            false,
+        );
         assert_eq!(
             refs.len(),
             1,
@@ -1514,7 +1572,11 @@ mod tests {
         host.open_document(uri, 1, sql.to_string());
 
         let offset = sql.find("users").unwrap();
-        let refs = host.find_references(uri, offset, true);
+        let refs = host.find_references(
+            uri,
+            DocOffset::from_raw(u32::try_from(offset).unwrap()),
+            true,
+        );
         assert_eq!(refs.len(), 2, "expected 2 refs (incl decl), got: {refs:?}");
     }
 
@@ -1528,11 +1590,11 @@ mod tests {
         host.open_document(uri, 1, sql.to_string());
 
         let offset = sql.find("SELECT").unwrap() + "SELECT * FROM ".len();
-        let result = host.prepare_rename(uri, offset);
+        let result = host.prepare_rename(uri, DocOffset::from_raw(u32::try_from(offset).unwrap()));
         assert!(result.is_some(), "expected rename range");
-        let (start, end, text) = result.unwrap();
+        let (range, text) = result.unwrap();
         assert_eq!(text, "users");
-        assert_eq!(&sql[start..end], "users");
+        assert_eq!(&sql[range.start.as_usize()..range.end.as_usize()], "users");
     }
 
     #[test]
@@ -1543,11 +1605,15 @@ mod tests {
         host.open_document(uri, 1, sql.to_string());
 
         let offset = sql.find("SELECT").unwrap() + "SELECT * FROM ".len();
-        let edits = host.rename(uri, offset, "accounts");
+        let edits = host.rename(
+            uri,
+            DocOffset::from_raw(u32::try_from(offset).unwrap()),
+            "accounts",
+        );
         // Should produce edits for all 3 occurrences (definition + 2 refs).
         let file_edits = edits.get(uri).expect("expected edits for test file");
         assert_eq!(file_edits.len(), 3, "expected 3 edits, got: {file_edits:?}");
-        for (_, _, text) in file_edits {
+        for (_, text) in file_edits {
             assert_eq!(text.as_str(), "accounts");
         }
     }
@@ -1560,7 +1626,11 @@ mod tests {
         host.open_document(uri, 1, sql.to_string());
 
         let offset = sql.find("SELECT id").unwrap() + "SELECT ".len();
-        let edits = host.rename(uri, offset, "user_id");
+        let edits = host.rename(
+            uri,
+            DocOffset::from_raw(u32::try_from(offset).unwrap()),
+            "user_id",
+        );
         let file_edits = edits.get(uri).expect("expected edits for test file");
         // 2 column refs + 1 definition = 3 edits.
         assert_eq!(file_edits.len(), 3, "expected 3 edits, got: {file_edits:?}");
@@ -1580,7 +1650,11 @@ mod tests {
         host.open_document(uri2, 1, "DELETE FROM orders;".to_string());
 
         let offset = "SELECT * FROM ".len();
-        let edits = host.rename(uri1, offset, "invoices");
+        let edits = host.rename(
+            uri1,
+            DocOffset::from_raw(u32::try_from(offset).unwrap()),
+            "invoices",
+        );
         // Should have edits in both open files.
         assert!(edits.contains_key(uri1), "expected edits in a.sql");
         assert!(edits.contains_key(uri2), "expected edits in b.sql");
@@ -1592,7 +1666,8 @@ mod tests {
         let uri = "file:///test.sql";
         let sql = "SELECT * FROM slice JOIN thread ";
         host.open_document(uri, 1, sql.to_string());
-        let items = host.completion_items(uri, sql.len());
+        let items =
+            host.completion_items(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
         let labels: Vec<&str> = items.iter().map(|e| e.label.as_str()).collect();
         assert!(
             labels.contains(&"ON"),
@@ -1606,7 +1681,8 @@ mod tests {
         let uri = "file:///test.sql";
         let sql = "CREATE TABLE t1 (a INT, b TEXT);\nCREATE TABLE t2 (c INT);\nSELECT t1.";
         host.open_document(uri, 1, sql.to_string());
-        let info = host.completion_info_at_offset(uri, sql.len());
+        let info = host
+            .completion_info_at_offset(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
         assert_eq!(
             info.qualifier.as_deref(),
             Some("t1"),
@@ -1621,7 +1697,8 @@ mod tests {
         let uri = "file:///test.sql";
         let sql = "CREATE TABLE t1 (a INT, b TEXT);\nCREATE TABLE t2 (c INT);\nSELECT t1.";
         host.open_document(uri, 1, sql.to_string());
-        let items = host.completion_items(uri, sql.len());
+        let items =
+            host.completion_items(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
         let labels: Vec<&str> = items.iter().map(|e| e.label.as_str()).collect();
         assert!(labels.contains(&"a"), "should suggest column a");
         assert!(labels.contains(&"b"), "should suggest column b");
@@ -1641,7 +1718,8 @@ mod tests {
         let uri = "file:///test.sql";
         let sql = "CREATE TABLE users (id INT);\nSELECT * FROM ";
         host.open_document(uri, 1, sql.to_string());
-        let items = host.completion_items(uri, sql.len());
+        let items =
+            host.completion_items(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
         let labels: Vec<&str> = items.iter().map(|e| e.label.as_str()).collect();
         assert!(
             labels.contains(&"users"),
@@ -1655,7 +1733,8 @@ mod tests {
         let uri = "file:///test.sql";
         let sql = "CREATE TABLE users (id INT, name TEXT);\nSELECT ";
         host.open_document(uri, 1, sql.to_string());
-        let items = host.completion_items(uri, sql.len());
+        let items =
+            host.completion_items(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
         let labels: Vec<&str> = items.iter().map(|e| e.label.as_str()).collect();
         assert!(labels.contains(&"id"), "should suggest column id");
         assert!(labels.contains(&"name"), "should suggest column name");
@@ -1670,7 +1749,8 @@ mod tests {
                    CREATE TABLE thread (tid INT, parent INT);\n\
                    SELECT slice.id, thread.tid\nFROM slice\nJOIN thread ON ";
         host.open_document(uri, 1, sql.to_string());
-        let items = host.completion_items(uri, sql.len());
+        let items =
+            host.completion_items(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
 
         // Find the first column and first function in the list.
         let first_column_pos = items
@@ -1867,10 +1947,15 @@ mod tests {
         host.open_document(uri, 1, src.to_string());
 
         let ref_offset = src.rfind("cte").unwrap();
-        let def = host.definition_info(uri, ref_offset).expect("definition");
+        let def = host
+            .definition_info(uri, DocOffset::from_raw(u32::try_from(ref_offset).unwrap()))
+            .expect("definition");
         let cte_def_offset = src.find("cte").unwrap();
-        assert_eq!(def.target.start, cte_def_offset);
-        assert_eq!(def.target.end, cte_def_offset + "cte".len());
+        assert_eq!(def.target.range.start.as_usize(), cte_def_offset);
+        assert_eq!(
+            def.target.range.end.as_usize(),
+            cte_def_offset + "cte".len()
+        );
     }
 
     #[test]
@@ -1881,10 +1966,12 @@ mod tests {
         host.open_document(uri, 1, src.to_string());
 
         let ref_offset = src.rfind("users").unwrap();
-        let def = host.definition_info(uri, ref_offset).expect("definition");
+        let def = host
+            .definition_info(uri, DocOffset::from_raw(u32::try_from(ref_offset).unwrap()))
+            .expect("definition");
         let ddl_offset = src.find("users").unwrap();
-        assert_eq!(def.target.start, ddl_offset);
-        assert_eq!(def.target.end, ddl_offset + "users".len());
+        assert_eq!(def.target.range.start.as_usize(), ddl_offset);
+        assert_eq!(def.target.range.end.as_usize(), ddl_offset + "users".len());
     }
 
     #[test]
@@ -1896,10 +1983,13 @@ mod tests {
 
         let from_t_offset = src.rfind("FROM t").unwrap() + 5;
         let def = host
-            .definition_info(uri, from_t_offset)
+            .definition_info(
+                uri,
+                DocOffset::from_raw(u32::try_from(from_t_offset).unwrap()),
+            )
             .expect("definition");
         let cte_t_offset = src[29..].find('t').unwrap() + 29;
-        assert_eq!(def.target.start, cte_t_offset);
+        assert_eq!(def.target.range.start.as_usize(), cte_t_offset);
     }
 
     #[test]
@@ -1910,7 +2000,13 @@ mod tests {
         host.open_document(uri, 1, src.to_string());
 
         let from_offset = src.find("nonexistent").unwrap();
-        assert!(host.definition_info(uri, from_offset).is_none());
+        assert!(
+            host.definition_info(
+                uri,
+                DocOffset::from_raw(u32::try_from(from_offset).unwrap())
+            )
+            .is_none()
+        );
     }
 
     #[test]
@@ -1922,10 +2018,13 @@ mod tests {
 
         let select_name_offset = src.rfind("name").unwrap();
         let def = host
-            .definition_info(uri, select_name_offset)
+            .definition_info(
+                uri,
+                DocOffset::from_raw(u32::try_from(select_name_offset).unwrap()),
+            )
             .expect("definition");
         let ddl_name_offset = src.find("name").unwrap();
-        assert_eq!(def.target.start, ddl_name_offset);
+        assert_eq!(def.target.range.start.as_usize(), ddl_name_offset);
     }
 
     #[test]
@@ -1936,7 +2035,10 @@ mod tests {
         host.open_document(uri, 1, src.to_string());
 
         let b_offset = src.find('b').unwrap();
-        assert!(host.definition_info(uri, b_offset).is_none());
+        assert!(
+            host.definition_info(uri, DocOffset::from_raw(u32::try_from(b_offset).unwrap()))
+                .is_none()
+        );
     }
 
     #[test]
@@ -1947,9 +2049,11 @@ mod tests {
         host.open_document(uri, 1, src.to_string());
 
         let a_offset = src.find("SELECT a").unwrap() + "SELECT ".len();
-        let def = host.definition_info(uri, a_offset).expect("definition");
+        let def = host
+            .definition_info(uri, DocOffset::from_raw(u32::try_from(a_offset).unwrap()))
+            .expect("definition");
         let cte_a_offset = src.find("AS a").unwrap() + "AS ".len();
-        assert_eq!(def.target.start, cte_a_offset);
+        assert_eq!(def.target.range.start.as_usize(), cte_a_offset);
     }
 
     #[test]
@@ -1960,9 +2064,11 @@ mod tests {
         host.open_document(uri, 1, src.to_string());
 
         let x_offset = src.find("SELECT x").unwrap() + "SELECT ".len();
-        let def = host.definition_info(uri, x_offset).expect("definition");
+        let def = host
+            .definition_info(uri, DocOffset::from_raw(u32::try_from(x_offset).unwrap()))
+            .expect("definition");
         let decl_x_offset = src.find("(x)").unwrap() + 1;
-        assert_eq!(def.target.start, decl_x_offset);
+        assert_eq!(def.target.range.start.as_usize(), decl_x_offset);
     }
 
     #[test]
@@ -1981,11 +2087,16 @@ mod tests {
         host.open_document(uri, 1, src.to_string());
 
         let ref_offset = src.find("users").unwrap();
-        let def = host.definition_info(uri, ref_offset).expect("definition");
+        let def = host
+            .definition_info(uri, DocOffset::from_raw(u32::try_from(ref_offset).unwrap()))
+            .expect("definition");
         assert_eq!(def.target.file_uri.as_deref(), Some(file_uri));
         let schema_offset = schema.find("users").unwrap();
-        assert_eq!(def.target.start, schema_offset);
-        assert_eq!(def.target.end, schema_offset + "users".len());
+        assert_eq!(def.target.range.start.as_usize(), schema_offset);
+        assert_eq!(
+            def.target.range.end.as_usize(),
+            schema_offset + "users".len()
+        );
     }
 
     #[test]
@@ -2004,8 +2115,10 @@ mod tests {
         host.open_document(uri, 1, src.to_string());
 
         let ref_offset = src.rfind(" t").unwrap() + 1;
-        let def = host.definition_info(uri, ref_offset).expect("definition");
+        let def = host
+            .definition_info(uri, DocOffset::from_raw(u32::try_from(ref_offset).unwrap()))
+            .expect("definition");
         assert!(def.target.file_uri.is_none());
-        assert_eq!(def.target.start, src.find('t').unwrap());
+        assert_eq!(def.target.range.start.as_usize(), src.find('t').unwrap());
     }
 }

--- a/syntaqlite/src/lsp/server.rs
+++ b/syntaqlite/src/lsp/server.rs
@@ -33,6 +33,7 @@ use lsp_types::{
     SignatureInformation, TextDocumentSyncCapability, TextDocumentSyncKind, TextEdit, Uri,
     WorkDoneProgressOptions, WorkspaceEdit,
 };
+use syntaqlite_syntax::source::{DocOffset, DocRange};
 
 use crate::dialect::AnyDialect;
 use crate::fmt::FormatConfig;
@@ -305,12 +306,12 @@ impl LspServer {
         let offset = SourcePositionMap::new(source).position_to_offset(position);
 
         match host.hover_info(uri_str, offset) {
-            Some((text, tok_offset, tok_length)) => {
+            Some((text, tok_range)) => {
                 let source = host
                     .document_source(uri_str)
                     .expect("document must exist for hover");
                 let map = SourcePositionMap::new(source);
-                let positions = map.offsets_to_positions(&[tok_offset, tok_offset + tok_length]);
+                let positions = map.offsets_to_positions(&[tok_range.start, tok_range.end]);
                 let range = Range::new(positions[0], positions[1]);
                 let hover = Hover {
                     contents: HoverContents::Markup(MarkupContent {
@@ -356,7 +357,7 @@ impl LspServer {
             .document_source(uri_str)
             .expect("document must exist")
             .to_string();
-        let origin_range = offsets_to_range(&source, def.origin_start, def.origin_end);
+        let origin_range = offsets_to_range(&source, def.origin);
 
         let (target_uri, target_source) = if let Some(ref file_uri) = def.target.file_uri {
             let target: Uri = file_uri.parse().unwrap_or(uri);
@@ -368,7 +369,7 @@ impl LspServer {
         } else {
             (uri, source.clone())
         };
-        let target_range = offsets_to_range(&target_source, def.target.start, def.target.end);
+        let target_range = offsets_to_range(&target_source, def.target.range);
         let link = lsp_types::LocationLink {
             origin_selection_range: Some(origin_range),
             target_uri,
@@ -548,7 +549,7 @@ impl LspServer {
         let refs = host.find_references(uri_str, offset, true);
         let same_file: Vec<_> = refs
             .into_iter()
-            .filter(|(ref_uri, _, _)| ref_uri == uri_str)
+            .filter(|(ref_uri, _)| ref_uri == uri_str)
             .collect();
         if same_file.is_empty() {
             return Response::new_ok(req.id, Option::<Vec<lsp_types::DocumentHighlight>>::None);
@@ -560,8 +561,8 @@ impl LspServer {
             .to_string();
         let highlights: Vec<lsp_types::DocumentHighlight> = same_file
             .into_iter()
-            .map(|(_, start, end)| lsp_types::DocumentHighlight {
-                range: offsets_to_range(&source, start, end),
+            .map(|(_, range)| lsp_types::DocumentHighlight {
+                range: offsets_to_range(&source, range),
                 kind: Some(lsp_types::DocumentHighlightKind::READ),
             })
             .collect();
@@ -597,7 +598,7 @@ impl LspServer {
 
         let locations: Vec<Location> = refs
             .into_iter()
-            .filter_map(|(ref_uri, start, end)| {
+            .filter_map(|(ref_uri, doc_range)| {
                 let source = if ref_uri == uri_str {
                     host.document_source(&ref_uri)?.to_string()
                 } else if let Some(s) = host.document_source(&ref_uri) {
@@ -606,7 +607,7 @@ impl LspServer {
                     let file_path = ref_uri.strip_prefix("file://")?;
                     std::fs::read_to_string(file_path).ok()?
                 };
-                let range = offsets_to_range(&source, start, end);
+                let range = offsets_to_range(&source, doc_range);
                 let target_uri: Uri = ref_uri.parse().ok()?;
                 Some(Location {
                     uri: target_uri,
@@ -639,7 +640,7 @@ impl LspServer {
         };
         let offset = SourcePositionMap::new(source).position_to_offset(position);
 
-        let Some((start, end, placeholder)) = host.prepare_rename(uri_str, offset) else {
+        let Some((doc_range, placeholder)) = host.prepare_rename(uri_str, offset) else {
             return Response::new_ok(req.id, Option::<PrepareRenameResponse>::None);
         };
 
@@ -647,7 +648,7 @@ impl LspServer {
             .document_source(uri_str)
             .expect("document must exist for prepare_rename")
             .to_string();
-        let range = offsets_to_range(&source, start, end);
+        let range = offsets_to_range(&source, doc_range);
         Response::new_ok(
             req.id,
             PrepareRenameResponse::RangeWithPlaceholder { range, placeholder },
@@ -702,8 +703,8 @@ impl LspServer {
             };
             let text_edits: Vec<TextEdit> = edits
                 .into_iter()
-                .map(|(start, end, text)| TextEdit {
-                    range: offsets_to_range(&source, start, end),
+                .map(|(doc_range, text)| TextEdit {
+                    range: offsets_to_range(&source, doc_range),
                     new_text: text,
                 })
                 .collect();
@@ -854,10 +855,10 @@ impl DiagnosticPublisher {
         };
 
         // Collect all offsets and convert in a single O(n) pass.
-        let mut offsets: Vec<usize> = Vec::with_capacity(diags.len() * 2);
+        let mut offsets: Vec<DocOffset> = Vec::with_capacity(diags.len() * 2);
         for d in &diags {
-            offsets.push(d.start_offset());
-            offsets.push(d.end_offset());
+            offsets.push(d.start());
+            offsets.push(d.end());
         }
         let map = SourcePositionMap::new(&source);
         let positions = map.offsets_to_positions(&offsets);
@@ -897,10 +898,10 @@ impl DiagnosticPublisher {
     }
 }
 
-/// Convert byte offsets to an LSP `Range`.
-fn offsets_to_range(source: &str, start: usize, end: usize) -> Range {
+/// Convert a `DocRange` to an LSP `Range`.
+fn offsets_to_range(source: &str, range: DocRange) -> Range {
     let map = SourcePositionMap::new(source);
-    let positions = map.offsets_to_positions(&[start, end]);
+    let positions = map.offsets_to_positions(&[range.start, range.end]);
     Range::new(positions[0], positions[1])
 }
 
@@ -926,14 +927,14 @@ impl<'a> SourcePositionMap<'a> {
     /// Internally sorts the offsets, walks the source once, then returns
     /// results in the original order. Character offsets are UTF-16 code
     /// units per the LSP specification.
-    pub(crate) fn offsets_to_positions(&self, offsets: &[usize]) -> Vec<Position> {
+    pub(crate) fn offsets_to_positions(&self, offsets: &[DocOffset]) -> Vec<Position> {
         if offsets.is_empty() {
             return Vec::new();
         }
 
         let mut indexed: Vec<(usize, usize)> = offsets
             .iter()
-            .copied()
+            .map(|o| o.as_usize())
             .enumerate()
             .map(|(i, o)| (o, i))
             .collect();
@@ -967,8 +968,8 @@ impl<'a> SourcePositionMap<'a> {
         result
     }
 
-    /// Convert an LSP `Position` (with UTF-16 character offset) to a byte offset.
-    pub(crate) fn position_to_offset(&self, pos: Position) -> usize {
+    /// Convert an LSP `Position` (with UTF-16 character offset) to a document-absolute byte offset.
+    pub(crate) fn position_to_offset(&self, pos: Position) -> DocOffset {
         let len = self.src.len();
         let mut line = 0usize;
         let mut line_start = 0usize;
@@ -979,7 +980,7 @@ impl<'a> SourcePositionMap<'a> {
                     line_start += nl + 1;
                     line += 1;
                 }
-                None => return len,
+                None => return DocOffset::from_raw(u32::try_from(len).unwrap_or(u32::MAX)),
             }
         }
 
@@ -997,7 +998,7 @@ impl<'a> SourcePositionMap<'a> {
             utf16_col += if char_len == 4 { 2 } else { 1 };
             byte_pos += char_len;
         }
-        byte_pos
+        DocOffset::from_raw(u32::try_from(byte_pos).unwrap_or(u32::MAX))
     }
 }
 
@@ -1012,7 +1013,13 @@ mod tests {
     #[test]
     fn ascii_positions() {
         let map = SourcePositionMap::new("ab\ncd");
-        let positions = map.offsets_to_positions(&[0, 1, 2, 3, 4]);
+        let positions = map.offsets_to_positions(&[
+            DocOffset::from_raw(0),
+            DocOffset::from_raw(1),
+            DocOffset::from_raw(2),
+            DocOffset::from_raw(3),
+            DocOffset::from_raw(4),
+        ]);
         assert_eq!(positions[0], Position::new(0, 0)); // 'a'
         assert_eq!(positions[1], Position::new(0, 1)); // 'b'
         assert_eq!(positions[2], Position::new(0, 2)); // '\n'
@@ -1026,7 +1033,11 @@ mod tests {
         let src = "aé b";
         let map = SourcePositionMap::new(src);
         // byte offsets: a=0, é=1..3, ' '=3, 'b'=4
-        let positions = map.offsets_to_positions(&[0, 3, 4]);
+        let positions = map.offsets_to_positions(&[
+            DocOffset::from_raw(0),
+            DocOffset::from_raw(3),
+            DocOffset::from_raw(4),
+        ]);
         assert_eq!(positions[0], Position::new(0, 0)); // 'a'
         assert_eq!(positions[1], Position::new(0, 2)); // ' ' — after 'a' (1) + 'é' (1)
         assert_eq!(positions[2], Position::new(0, 3)); // 'b'
@@ -1038,7 +1049,7 @@ mod tests {
         let src = "a中b";
         let map = SourcePositionMap::new(src);
         // byte offsets: a=0, 中=1..4, b=4
-        let positions = map.offsets_to_positions(&[0, 4]);
+        let positions = map.offsets_to_positions(&[DocOffset::from_raw(0), DocOffset::from_raw(4)]);
         assert_eq!(positions[0], Position::new(0, 0)); // 'a'
         assert_eq!(positions[1], Position::new(0, 2)); // 'b' — after 'a' (1) + '中' (1)
     }
@@ -1049,7 +1060,7 @@ mod tests {
         let src = "a😀b";
         let map = SourcePositionMap::new(src);
         // byte offsets: a=0, 😀=1..5, b=5
-        let positions = map.offsets_to_positions(&[0, 5]);
+        let positions = map.offsets_to_positions(&[DocOffset::from_raw(0), DocOffset::from_raw(5)]);
         assert_eq!(positions[0], Position::new(0, 0)); // 'a'
         assert_eq!(positions[1], Position::new(0, 3)); // 'b' — after 'a' (1) + '😀' (2)
     }
@@ -1059,7 +1070,7 @@ mod tests {
         let src = "x\né";
         let map = SourcePositionMap::new(src);
         // byte offsets: x=0, \n=1, é=2..4
-        let positions = map.offsets_to_positions(&[2, 4]);
+        let positions = map.offsets_to_positions(&[DocOffset::from_raw(2), DocOffset::from_raw(4)]);
         assert_eq!(positions[0], Position::new(1, 0)); // start of 'é'
         assert_eq!(positions[1], Position::new(1, 1)); // after 'é'
     }
@@ -1069,10 +1080,22 @@ mod tests {
     #[test]
     fn ascii_position_to_offset() {
         let map = SourcePositionMap::new("ab\ncd");
-        assert_eq!(map.position_to_offset(Position::new(0, 0)), 0);
-        assert_eq!(map.position_to_offset(Position::new(0, 1)), 1);
-        assert_eq!(map.position_to_offset(Position::new(1, 0)), 3);
-        assert_eq!(map.position_to_offset(Position::new(1, 1)), 4);
+        assert_eq!(
+            map.position_to_offset(Position::new(0, 0)),
+            DocOffset::from_raw(0)
+        );
+        assert_eq!(
+            map.position_to_offset(Position::new(0, 1)),
+            DocOffset::from_raw(1)
+        );
+        assert_eq!(
+            map.position_to_offset(Position::new(1, 0)),
+            DocOffset::from_raw(3)
+        );
+        assert_eq!(
+            map.position_to_offset(Position::new(1, 1)),
+            DocOffset::from_raw(4)
+        );
     }
 
     #[test]
@@ -1084,10 +1107,22 @@ mod tests {
         // UTF-16 col 1 = byte 1 (start of 'é')
         // UTF-16 col 2 = byte 3 (' ')
         // UTF-16 col 3 = byte 4 ('b')
-        assert_eq!(map.position_to_offset(Position::new(0, 0)), 0);
-        assert_eq!(map.position_to_offset(Position::new(0, 1)), 1);
-        assert_eq!(map.position_to_offset(Position::new(0, 2)), 3);
-        assert_eq!(map.position_to_offset(Position::new(0, 3)), 4);
+        assert_eq!(
+            map.position_to_offset(Position::new(0, 0)),
+            DocOffset::from_raw(0)
+        );
+        assert_eq!(
+            map.position_to_offset(Position::new(0, 1)),
+            DocOffset::from_raw(1)
+        );
+        assert_eq!(
+            map.position_to_offset(Position::new(0, 2)),
+            DocOffset::from_raw(3)
+        );
+        assert_eq!(
+            map.position_to_offset(Position::new(0, 3)),
+            DocOffset::from_raw(4)
+        );
     }
 
     #[test]
@@ -1098,8 +1133,17 @@ mod tests {
         // UTF-16 col 0 = byte 0 ('a')
         // UTF-16 col 1 = byte 1 (start of '😀')
         // UTF-16 col 3 = byte 5 ('b')
-        assert_eq!(map.position_to_offset(Position::new(0, 0)), 0);
-        assert_eq!(map.position_to_offset(Position::new(0, 1)), 1);
-        assert_eq!(map.position_to_offset(Position::new(0, 3)), 5);
+        assert_eq!(
+            map.position_to_offset(Position::new(0, 0)),
+            DocOffset::from_raw(0)
+        );
+        assert_eq!(
+            map.position_to_offset(Position::new(0, 1)),
+            DocOffset::from_raw(1)
+        );
+        assert_eq!(
+            map.position_to_offset(Position::new(0, 3)),
+            DocOffset::from_raw(5)
+        );
     }
 }

--- a/syntaqlite/src/semantic/analyzer/helpers.rs
+++ b/syntaqlite/src/semantic/analyzer/helpers.rs
@@ -5,6 +5,9 @@
 //! span lookup, macro registration extraction, rowid aliasing.
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParseError, AnyParsedStatement, FieldValue};
+#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
+use syntaqlite_syntax::source::StatementBase;
+use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange, StmtLen};
 
 use crate::dialect::{FIELD_ABSENT, MacroDef, SemanticRole};
 #[cfg(feature = "lsp")]
@@ -62,14 +65,13 @@ pub(super) fn format_arity(name: &str, arity: AritySpec) -> String {
 #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
 pub(super) fn collect_tokens<'a>(
     iter: impl Iterator<Item = syntaqlite_syntax::any::AnyParserToken<'a>>,
-    stmt_base: syntaqlite_syntax::source::StatementBase,
+    stmt_base: StatementBase,
     tokens: &mut Vec<StoredToken>,
 ) {
-    let base = stmt_base.as_doc_offset().as_usize();
     for tok in iter {
         tokens.push(StoredToken {
-            offset: base + tok.offset().as_usize(),
-            length: tok.length().as_usize(),
+            offset: tok.offset().to_doc(stmt_base),
+            length: tok.length().into(),
             token_type: tok.token_type(),
             flags: tok.flags(),
         });
@@ -79,34 +81,50 @@ pub(super) fn collect_tokens<'a>(
 #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
 pub(super) fn collect_comments<'a>(
     iter: impl Iterator<Item = syntaqlite_syntax::Comment<'a>>,
-    stmt_base: syntaqlite_syntax::source::StatementBase,
+    stmt_base: StatementBase,
     comments: &mut Vec<StoredComment>,
 ) {
-    let base = stmt_base.as_doc_offset().as_usize();
     for c in iter {
         comments.push(StoredComment {
-            offset: base + c.offset().as_usize(),
-            length: c.length().as_usize(),
+            offset: c.offset().to_doc(stmt_base),
+            length: c.length().into(),
         });
     }
 }
 
-pub(super) fn parse_error_span(err: &AnyParseError<'_>, source: &str) -> (usize, usize) {
-    let base = err.statement_base().as_doc_offset().as_usize();
+pub(super) fn parse_error_span(err: &AnyParseError<'_>, source: &str) -> DocRange {
+    let base = err.statement_base();
+    let source_end = DocOffset::from_raw(u32::try_from(source.len()).unwrap_or(u32::MAX));
     match (err.offset(), err.length()) {
-        (Some(off), Some(len)) if len > 0 => (base + off, base + off + len),
+        (Some(off), Some(len)) if len > StmtLen::default() => {
+            let start = off.to_doc(base);
+            DocRange::from_offset_len(start, len.into())
+        }
         (Some(off), _) => {
-            let abs = base + off;
-            if abs >= source.len() && !source.is_empty() {
-                (source.len() - 1, source.len())
+            let abs = off.to_doc(base);
+            if abs >= source_end && !source.is_empty() {
+                DocRange {
+                    start: source_end - DocLen::from_raw(1),
+                    end: source_end,
+                }
             } else {
-                (abs, (abs + 1).min(source.len()))
+                DocRange {
+                    start: abs,
+                    end: std::cmp::min(abs + DocLen::from_raw(1), source_end),
+                }
             }
         }
         _ => {
-            let end = source.len();
-            let start = if end > 0 { end - 1 } else { 0 };
-            (start, end)
+            let one = DocLen::from_raw(1);
+            let start = if source_end > DocOffset::default() {
+                source_end - one
+            } else {
+                DocOffset::default()
+            };
+            DocRange {
+                start,
+                end: source_end,
+            }
         }
     }
 }

--- a/syntaqlite/src/semantic/analyzer/helpers.rs
+++ b/syntaqlite/src/semantic/analyzer/helpers.rs
@@ -62,14 +62,14 @@ pub(super) fn format_arity(name: &str, arity: AritySpec) -> String {
 #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
 pub(super) fn collect_tokens<'a>(
     iter: impl Iterator<Item = syntaqlite_syntax::any::AnyParserToken<'a>>,
-    stmt_base: u32,
+    stmt_base: syntaqlite_syntax::source::StatementBase,
     tokens: &mut Vec<StoredToken>,
 ) {
-    let base = stmt_base as usize;
+    let base = stmt_base.as_doc_offset().as_usize();
     for tok in iter {
         tokens.push(StoredToken {
-            offset: base + tok.offset() as usize,
-            length: tok.length() as usize,
+            offset: base + tok.offset().as_usize(),
+            length: tok.length().as_usize(),
             token_type: tok.token_type(),
             flags: tok.flags(),
         });
@@ -79,20 +79,20 @@ pub(super) fn collect_tokens<'a>(
 #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
 pub(super) fn collect_comments<'a>(
     iter: impl Iterator<Item = syntaqlite_syntax::Comment<'a>>,
-    stmt_base: u32,
+    stmt_base: syntaqlite_syntax::source::StatementBase,
     comments: &mut Vec<StoredComment>,
 ) {
-    let base = stmt_base as usize;
+    let base = stmt_base.as_doc_offset().as_usize();
     for c in iter {
         comments.push(StoredComment {
-            offset: base + c.offset() as usize,
-            length: c.length() as usize,
+            offset: base + c.offset().as_usize(),
+            length: c.length().as_usize(),
         });
     }
 }
 
 pub(super) fn parse_error_span(err: &AnyParseError<'_>, source: &str) -> (usize, usize) {
-    let base = err.statement_base_offset() as usize;
+    let base = err.statement_base().as_doc_offset().as_usize();
     match (err.offset(), err.length()) {
         (Some(off), Some(len)) if len > 0 => (base + off, base + off + len),
         (Some(off), _) => {

--- a/syntaqlite/src/semantic/analyzer/mod.rs
+++ b/syntaqlite/src/semantic/analyzer/mod.rs
@@ -289,7 +289,7 @@ impl SemanticAnalyzer {
                     }
                     #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
                     {
-                        let base = e.statement_base_offset();
+                        let base = e.statement_base();
                         collect_tokens(e.tokens(), base, &mut tokens);
                         collect_comments(e.comments(), base, &mut comments);
                     }
@@ -299,7 +299,7 @@ impl SemanticAnalyzer {
 
             #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
             {
-                let base = stmt.statement_base_offset();
+                let base = stmt.statement_base();
                 collect_tokens(stmt.tokens(), base, &mut tokens);
                 collect_comments(stmt.comments(), base, &mut comments);
             }
@@ -397,7 +397,7 @@ impl SemanticAnalyzer {
         let defined_relations = extract_defined_relations(erased, root_id, self.dialect.roles());
 
         StatementModel::new(
-            erased.text().to_owned(),
+            erased.text().as_str().to_owned(),
             diagnostics,
             lineage,
             defined_relations,
@@ -440,8 +440,8 @@ impl SemanticAnalyzer {
         let Some(source) = self.resolver.as_ref().and_then(|r| r.resolve(&module_name)) else {
             let (start, end) = match fields[module as usize] {
                 FieldValue::Span(sp) => {
-                    let (_, start, end) = erased.span_text_abs(sp);
-                    (start, end)
+                    let (_, range) = erased.span_text_abs(sp);
+                    (range.start.as_usize(), range.end.as_usize())
                 }
                 _ => (0, 0),
             };

--- a/syntaqlite/src/semantic/analyzer/mod.rs
+++ b/syntaqlite/src/semantic/analyzer/mod.rs
@@ -9,6 +9,7 @@ use std::rc::Rc;
 
 use syntaqlite_syntax::ParserConfig;
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, AnyParser, FieldValue, ParseOutcome};
+use syntaqlite_syntax::source::DocRange;
 use syntaqlite_syntax::{MacroArg, MacroLookup, MacroOutput};
 
 use crate::dialect::AnyDialect;
@@ -260,7 +261,7 @@ impl SemanticAnalyzer {
         let mut comments: Vec<StoredComment> = Vec::new();
         let mut statements: Vec<StatementModel> = Vec::new();
         #[cfg(feature = "lsp")]
-        let mut definition_offsets: HashMap<String, (usize, usize)> = HashMap::new();
+        let mut definition_offsets: HashMap<String, DocRange> = HashMap::new();
         #[cfg(feature = "lsp")]
         let mut resolutions: Vec<Resolution> = Vec::new();
 
@@ -271,10 +272,9 @@ impl SemanticAnalyzer {
                 ParseOutcome::Err(e) => {
                     let message = DiagnosticMessage::ParseError(e.message().to_owned());
                     if let Some(severity) = config.checks().level_for(&message).to_severity() {
-                        let (start, end) = parse_error_span(&e, source);
+                        let range = parse_error_span(&e, source);
                         let diag = Diagnostic {
-                            start_offset: start,
-                            end_offset: end,
+                            range,
                             message,
                             severity,
                             help: None,
@@ -354,7 +354,7 @@ impl SemanticAnalyzer {
         erased: &mut AnyParsedStatement<'_>,
         config: &ValidationConfig,
         #[cfg(feature = "lsp")] resolutions: &mut Vec<Resolution>,
-        #[cfg(feature = "lsp")] definition_offsets: &mut HashMap<String, (usize, usize)>,
+        #[cfg(feature = "lsp")] definition_offsets: &mut HashMap<String, DocRange>,
     ) -> StatementModel {
         let root_id = erased.root_id();
         let mut diagnostics: Vec<Diagnostic> = Vec::new();
@@ -369,12 +369,12 @@ impl SemanticAnalyzer {
         #[cfg(feature = "lsp")]
         {
             let reader = DdlReader::new(erased, self.dialect.roles());
-            if let Some((table_name, start, end)) = reader.name_span(root_id) {
-                for (col_name, col_start, col_end) in reader.column_spans(root_id) {
+            if let Some((table_name, table_range)) = reader.name_span(root_id) {
+                for (col_name, col_range) in reader.column_spans(root_id) {
                     let key = format!("{table_name}.{col_name}");
-                    definition_offsets.insert(key, (col_start, col_end));
+                    definition_offsets.insert(key, col_range);
                 }
-                definition_offsets.insert(table_name, (start, end));
+                definition_offsets.insert(table_name, table_range);
             }
         }
 
@@ -438,16 +438,13 @@ impl SemanticAnalyzer {
         }
 
         let Some(source) = self.resolver.as_ref().and_then(|r| r.resolve(&module_name)) else {
-            let (start, end) = match fields[module as usize] {
-                FieldValue::Span(sp) => {
-                    let (_, range) = erased.span_text_abs(sp);
-                    (range.start.as_usize(), range.end.as_usize())
-                }
-                _ => (0, 0),
+            let range = match fields[module as usize] {
+                FieldValue::Span(sp) => erased.span_text_abs(sp).1,
+                _ => DocRange::default(),
             };
             let message = DiagnosticMessage::UnknownModule { name: module_name };
             if let Some(severity) = config.checks().level_for(&message).to_severity() {
-                diagnostics.push(Diagnostic::new(start, end, message, severity, None));
+                diagnostics.push(Diagnostic::new(range, message, severity, None));
             }
             return;
         };

--- a/syntaqlite/src/semantic/analyzer/pass/cte.rs
+++ b/syntaqlite/src/semantic/analyzer/pass/cte.rs
@@ -186,8 +186,8 @@ impl ValidationPass<'_> {
         let (name, name_range) = match fields[name_idx as usize] {
             FieldValue::Span(sp) => {
                 let name = stmt.span_expanded_text(sp);
-                let (_, start, end) = stmt.span_text_abs(sp);
-                (name, (start, end))
+                let (_, range) = stmt.span_text_abs(sp);
+                (name, (range.start.as_usize(), range.end.as_usize()))
             }
             _ => ("", (0, 0)),
         };

--- a/syntaqlite/src/semantic/analyzer/pass/cte.rs
+++ b/syntaqlite/src/semantic/analyzer/pass/cte.rs
@@ -9,6 +9,7 @@
 //! definition offsets — so it lives in its own file.
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue, NodeFields};
+use syntaqlite_syntax::source::DocRange;
 
 use crate::dialect::{FIELD_ABSENT, SemanticRole};
 use crate::semantic::ddl::DdlReader;
@@ -19,12 +20,12 @@ use super::ValidationPass;
 /// Extracted info for a single CTE binding.
 struct CteBindingInfo<'a> {
     name: &'a str,
-    /// Source-level byte range of the CTE name (start, end).  For CTEs
-    /// inside a macro expansion, points at the macro call site.
-    name_range: (usize, usize),
+    /// Document-absolute byte range of the CTE name.  For CTEs inside a
+    /// macro expansion, points at the macro call site.
+    name_range: DocRange,
     body_id: Option<AnyNodeId>,
-    /// Each declared column: text and source-level byte range.
-    declared_cols: Option<Vec<(&'a str, usize, usize)>>,
+    /// Each declared column: text and document-absolute byte range.
+    declared_cols: Option<Vec<(&'a str, DocRange)>>,
 }
 
 impl ValidationPass<'_> {
@@ -57,7 +58,7 @@ impl ValidationPass<'_> {
                 let cols = binding
                     .declared_cols
                     .as_ref()
-                    .map(|v| v.iter().map(|(s, _, _)| s.to_string()).collect());
+                    .map(|v| v.iter().map(|(s, _)| s.to_string()).collect());
                 self.catalog.add_query_table(binding.name, cols);
             }
 
@@ -78,7 +79,7 @@ impl ValidationPass<'_> {
             #[cfg(feature = "lsp")]
             let cte_key = binding.name.to_ascii_lowercase();
             let cols = if let Some(ref declared) = binding.declared_cols {
-                let col_names: Vec<&str> = declared.iter().map(|(s, _, _)| *s).collect();
+                let col_names: Vec<&str> = declared.iter().map(|(s, _)| *s).collect();
                 self.check_cte_column_count(
                     stmt,
                     binding.name,
@@ -87,11 +88,11 @@ impl ValidationPass<'_> {
                     binding.body_id,
                 );
                 #[cfg(feature = "lsp")]
-                for &(col_name, col_start, col_end) in declared {
+                for &(col_name, col_range) in declared {
                     let key = format!("{cte_key}.{}", col_name.to_ascii_lowercase());
-                    self.definition_offsets.insert(key, (col_start, col_end));
+                    self.definition_offsets.insert(key, col_range);
                 }
-                Some(declared.iter().map(|(s, _, _)| s.to_string()).collect())
+                Some(declared.iter().map(|(s, _)| s.to_string()).collect())
             } else {
                 #[cfg(feature = "lsp")]
                 self.record_select_column_offsets(stmt, binding.body_id, &cte_key);
@@ -152,11 +153,10 @@ impl ValidationPass<'_> {
                 continue;
             };
             let alias_node = Self::field_node_id(&child_fields, alias_idx);
-            let (alias_text, alias_start, alias_end) = Self::name_text(stmt, alias_node);
+            let (alias_text, alias_range) = Self::name_text(stmt, alias_node);
             if !alias_text.is_empty() {
                 let key = format!("{table_key}.{}", alias_text.to_ascii_lowercase());
-                self.definition_offsets
-                    .insert(key, (alias_start, alias_end));
+                self.definition_offsets.insert(key, alias_range);
             }
         }
     }
@@ -187,9 +187,9 @@ impl ValidationPass<'_> {
             FieldValue::Span(sp) => {
                 let name = stmt.span_expanded_text(sp);
                 let (_, range) = stmt.span_text_abs(sp);
-                (name, (range.start.as_usize(), range.end.as_usize()))
+                (name, range)
             }
-            _ => ("", (0, 0)),
+            _ => ("", DocRange::default()),
         };
         Some(CteBindingInfo {
             name,
@@ -204,18 +204,18 @@ impl ValidationPass<'_> {
         stmt: &mut AnyParsedStatement<'b>,
         fields: &NodeFields,
         cols_idx: u8,
-    ) -> Option<Vec<(&'b str, usize, usize)>> {
+    ) -> Option<Vec<(&'b str, DocRange)>> {
         if cols_idx == FIELD_ABSENT {
             return None;
         }
         let list_id = Self::field_node_id(fields, cols_idx)?;
         let children = stmt.list_children(list_id)?;
-        let names: Vec<(&'b str, usize, usize)> = children
+        let names: Vec<(&'b str, DocRange)> = children
             .iter()
             .copied()
             .filter(|id| !id.is_null())
             .map(|id| Self::name_text(stmt, Some(id)))
-            .filter(|(s, _, _)| !s.is_empty())
+            .filter(|(s, _)| !s.is_empty())
             .collect();
         if names.is_empty() { None } else { Some(names) }
     }
@@ -225,7 +225,7 @@ impl ValidationPass<'_> {
         &mut self,
         stmt: &mut AnyParsedStatement<'_>,
         cte_name: &str,
-        cte_name_range: (usize, usize),
+        cte_name_range: DocRange,
         declared: &[&str],
         body_id: Option<AnyNodeId>,
     ) {
@@ -233,8 +233,7 @@ impl ValidationPass<'_> {
             && actual != declared.len()
         {
             self.emit_at(
-                cte_name_range.0,
-                cte_name_range.1,
+                cte_name_range,
                 DiagnosticMessage::CteColumnCountMismatch {
                     name: cte_name.to_string(),
                     declared: declared.len(),

--- a/syntaqlite/src/semantic/analyzer/pass/mod.rs
+++ b/syntaqlite/src/semantic/analyzer/pass/mod.rs
@@ -4,12 +4,15 @@
 //! The statement-level validation pass: visits an AST once, emitting
 //! diagnostics and populating LSP resolutions as it goes.
 
+#[cfg(feature = "lsp")]
 use std::collections::HashMap;
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue, NodeFields};
 
 use crate::dialect::{AnyDialect, FIELD_ABSENT, SemanticRole};
-use crate::semantic::catalog::{Catalog, ColumnResolution, FunctionCategory, FunctionCheckResult};
+use crate::semantic::catalog::{Catalog, ColumnResolution, FunctionCheckResult};
+#[cfg(feature = "lsp")]
+use crate::semantic::catalog::FunctionCategory;
 use crate::semantic::ddl::DdlReader;
 use crate::semantic::diagnostics::{Diagnostic, DiagnosticMessage, Help};
 use crate::semantic::fuzzy::best_suggestion;
@@ -73,10 +76,14 @@ impl<'a> ValidationPass<'a> {
         };
         let frames = stmt
             .traceback(node_id, field_idx)
-            .map(|f| crate::semantic::diagnostics::DiagnosticFrame {
-                buffer: f.snippet.to_string(),
-                start: f.offset_in_snippet,
-                end: f.offset_in_snippet + f.length_in_snippet,
+            .map(|f| {
+                let start = f.offset_in_snippet.as_usize();
+                let end = start + f.length_in_snippet.as_usize();
+                crate::semantic::diagnostics::DiagnosticFrame {
+                    buffer: f.snippet.to_string(),
+                    start,
+                    end,
+                }
             })
             .collect::<Vec<_>>();
         // Only attach if there's actual expansion (more than 1 frame).
@@ -282,8 +289,8 @@ impl<'a> ValidationPass<'a> {
                 // Identifier spelling uses the post-expansion bytes;
                 // source position uses the authored byte range.
                 let name = stmt.span_expanded_text(sp);
-                let (_, start, end) = stmt.span_text_abs(sp);
-                (name, start, end)
+                let (_, range) = stmt.span_text_abs(sp);
+                (name, range.start.as_usize(), range.end.as_usize())
             }
             _ => ("", 0, 0),
         }
@@ -311,7 +318,9 @@ impl<'a> ValidationPass<'a> {
         // to the authored byte range so diagnostics anchor at the macro
         // call site.
         let name = stmt.span_expanded_text(sp);
-        let (_, start, end) = stmt.span_text_abs(sp);
+        let (_, range) = stmt.span_text_abs(sp);
+        let start = range.start.as_usize();
+        let end = range.end.as_usize();
 
         let is_known =
             self.catalog.resolve_relation(name) || self.catalog.resolve_table_function(name);
@@ -381,7 +390,9 @@ impl<'a> ValidationPass<'a> {
             && !sp.is_empty()
         {
             let name = stmt.span_expanded_text(sp);
-            let (_, start, end) = stmt.span_text_abs(sp);
+            let (_, range) = stmt.span_text_abs(sp);
+            let start = range.start.as_usize();
+            let end = range.end.as_usize();
             let args_id = Self::field_node_id(fields, args_idx);
             let arg_count = args_id
                 .and_then(|id| stmt.list_children(id))
@@ -465,7 +476,9 @@ impl<'a> ValidationPass<'a> {
             FieldValue::Span(sp) if !sp.is_empty() => Some(stmt.span_expanded_text(sp)),
             _ => None,
         };
-        let (_, start, end) = stmt.span_text_abs(col_sp);
+        let (_, range) = stmt.span_text_abs(col_sp);
+        let start = range.start.as_usize();
+        let end = range.end.as_usize();
 
         match self.scope.resolve_column(table, column) {
             ColumnResolution::Found {

--- a/syntaqlite/src/semantic/analyzer/pass/mod.rs
+++ b/syntaqlite/src/semantic/analyzer/pass/mod.rs
@@ -8,11 +8,12 @@
 use std::collections::HashMap;
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue, NodeFields};
+use syntaqlite_syntax::source::{DocRange, LayerRange};
 
 use crate::dialect::{AnyDialect, FIELD_ABSENT, SemanticRole};
-use crate::semantic::catalog::{Catalog, ColumnResolution, FunctionCheckResult};
 #[cfg(feature = "lsp")]
 use crate::semantic::catalog::FunctionCategory;
+use crate::semantic::catalog::{Catalog, ColumnResolution, FunctionCheckResult};
 use crate::semantic::ddl::DdlReader;
 use crate::semantic::diagnostics::{Diagnostic, DiagnosticMessage, Help};
 use crate::semantic::fuzzy::best_suggestion;
@@ -37,7 +38,7 @@ pub(super) struct ValidationPass<'a> {
     /// Maps `lowercase(name)` → `(start_offset, end_offset)` for definition sites.
     /// Populated from DDL (per-document) and CTE bindings (per-WITH scope).
     #[cfg(feature = "lsp")]
-    definition_offsets: &'a mut HashMap<String, (usize, usize)>,
+    definition_offsets: &'a mut HashMap<String, DocRange>,
 }
 
 impl CheckConfig {
@@ -67,7 +68,7 @@ impl<'a> ValidationPass<'a> {
         stmt: &mut AnyParsedStatement<'_>,
         node_id: AnyNodeId,
         field_idx: u8,
-        text_range: (usize, usize),
+        range: DocRange,
         message: DiagnosticMessage,
         help: Option<Help>,
     ) {
@@ -76,21 +77,15 @@ impl<'a> ValidationPass<'a> {
         };
         let frames = stmt
             .traceback(node_id, field_idx)
-            .map(|f| {
-                let start = f.offset_in_snippet.as_usize();
-                let end = start + f.length_in_snippet.as_usize();
-                crate::semantic::diagnostics::DiagnosticFrame {
-                    buffer: f.snippet.to_string(),
-                    start,
-                    end,
-                }
+            .map(|f| crate::semantic::diagnostics::DiagnosticFrame {
+                buffer: f.snippet.as_str().to_string(),
+                range: LayerRange::from_offset_len(f.offset_in_snippet, f.length_in_snippet),
             })
             .collect::<Vec<_>>();
         // Only attach if there's actual expansion (more than 1 frame).
         let expansion_frames = if frames.len() > 1 { frames } else { Vec::new() };
         self.diagnostics.push(Diagnostic {
-            start_offset: text_range.0,
-            end_offset: text_range.1,
+            range,
             message,
             severity,
             help,
@@ -98,20 +93,13 @@ impl<'a> ValidationPass<'a> {
         });
     }
 
-    /// Push a diagnostic with explicit source offsets and no expansion
+    /// Push a diagnostic with an explicit source range and no expansion
     /// traceback.  Use only when there is no associated span field
     /// (e.g. computed-from-tokens locations).
-    fn emit_at(
-        &mut self,
-        start_offset: usize,
-        end_offset: usize,
-        message: DiagnosticMessage,
-        help: Option<Help>,
-    ) {
+    fn emit_at(&mut self, range: DocRange, message: DiagnosticMessage, help: Option<Help>) {
         if let Some(severity) = self.config.checks().level_for(&message).to_severity() {
             self.diagnostics.push(Diagnostic {
-                start_offset,
-                end_offset,
+                range,
                 message,
                 severity,
                 help,
@@ -129,7 +117,7 @@ impl<'a> ValidationPass<'a> {
         config: &'a ValidationConfig,
         diagnostics: &'a mut Vec<Diagnostic>,
         #[cfg(feature = "lsp")] resolutions: &'a mut Vec<Resolution>,
-        #[cfg(feature = "lsp")] definition_offsets: &'a mut HashMap<String, (usize, usize)>,
+        #[cfg(feature = "lsp")] definition_offsets: &'a mut HashMap<String, DocRange>,
     ) {
         let roles = dialect.roles();
         let mut pass = ValidationPass {
@@ -269,20 +257,20 @@ impl<'a> ValidationPass<'a> {
 
     /// Extract source text and source-level byte range from a `Name` node
     /// (`IdentName` or `Error`).  Both node kinds store their span at field 0.
-    /// Returns `(text, source_start, source_end)`.  For spans inside a macro
-    /// expansion, the source range points at the macro call site.
+    /// For spans inside a macro expansion, the returned range points at the
+    /// macro call site.
     fn name_text<'b>(
         stmt: &AnyParsedStatement<'b>,
         node_id: Option<AnyNodeId>,
-    ) -> (&'b str, usize, usize) {
+    ) -> (&'b str, DocRange) {
         let Some(node_id) = node_id else {
-            return ("", 0, 0);
+            return ("", DocRange::default());
         };
         let Some((_, fields)) = stmt.extract_fields(node_id) else {
-            return ("", 0, 0);
+            return ("", DocRange::default());
         };
         if fields.is_empty() {
-            return ("", 0, 0);
+            return ("", DocRange::default());
         }
         match fields[0] {
             FieldValue::Span(sp) => {
@@ -290,9 +278,9 @@ impl<'a> ValidationPass<'a> {
                 // source position uses the authored byte range.
                 let name = stmt.span_expanded_text(sp);
                 let (_, range) = stmt.span_text_abs(sp);
-                (name, range.start.as_usize(), range.end.as_usize())
+                (name, range)
             }
-            _ => ("", 0, 0),
+            _ => ("", DocRange::default()),
         }
     }
 
@@ -319,8 +307,6 @@ impl<'a> ValidationPass<'a> {
         // call site.
         let name = stmt.span_expanded_text(sp);
         let (_, range) = stmt.span_text_abs(sp);
-        let start = range.start.as_usize();
-        let end = range.end.as_usize();
 
         let is_known =
             self.catalog.resolve_relation(name) || self.catalog.resolve_table_function(name);
@@ -332,7 +318,7 @@ impl<'a> ValidationPass<'a> {
                 stmt,
                 node_id,
                 name_idx,
-                (start, end),
+                range,
                 DiagnosticMessage::UnknownTable {
                     name: name.to_string(),
                 },
@@ -340,7 +326,7 @@ impl<'a> ValidationPass<'a> {
             );
         }
 
-        let (alias, _, _) = Self::name_text(stmt, Self::field_node_id(fields, alias_idx));
+        let (alias, _) = Self::name_text(stmt, Self::field_node_id(fields, alias_idx));
         let scope_name = if alias.is_empty() { name } else { alias };
         let (columns, without_rowid) = self.catalog.table_source_info(name);
 
@@ -349,23 +335,20 @@ impl<'a> ValidationPass<'a> {
             let definition = self
                 .definition_offsets
                 .get(&name.to_ascii_lowercase())
-                .map(|&(start, end)| DefinitionLocation {
-                    start,
-                    end,
+                .map(|&range| DefinitionLocation {
+                    range,
                     file_uri: None,
                 })
                 .or_else(|| {
                     self.catalog
                         .relation_definition_site(name)
                         .map(|site| DefinitionLocation {
-                            start: site.start,
-                            end: site.end,
+                            range: site.range,
                             file_uri: Some(site.file_uri.clone()),
                         })
                 });
             self.resolutions.push(Resolution {
-                start,
-                end,
+                range,
                 symbol: ResolvedSymbol::Table {
                     name: name.to_string(),
                     columns: columns.clone(),
@@ -391,8 +374,6 @@ impl<'a> ValidationPass<'a> {
         {
             let name = stmt.span_expanded_text(sp);
             let (_, range) = stmt.span_text_abs(sp);
-            let start = range.start.as_usize();
-            let end = range.end.as_usize();
             let args_id = Self::field_node_id(fields, args_idx);
             let arg_count = args_id
                 .and_then(|id| stmt.list_children(id))
@@ -409,8 +390,7 @@ impl<'a> ValidationPass<'a> {
                         let arity_strs: Vec<String> =
                             arities.iter().map(|a| format_arity(name, *a)).collect();
                         self.resolutions.push(Resolution {
-                            start,
-                            end,
+                            range,
                             symbol: ResolvedSymbol::Function {
                                 category: cat_str.to_string(),
                                 arities: arity_strs,
@@ -426,7 +406,7 @@ impl<'a> ValidationPass<'a> {
                         stmt,
                         node_id,
                         name_idx,
-                        (start, end),
+                        range,
                         DiagnosticMessage::UnknownFunction {
                             name: name.to_string(),
                         },
@@ -438,7 +418,7 @@ impl<'a> ValidationPass<'a> {
                         stmt,
                         node_id,
                         name_idx,
-                        (start, end),
+                        range,
                         DiagnosticMessage::FunctionArity {
                             name: name.to_string(),
                             expected,
@@ -477,8 +457,6 @@ impl<'a> ValidationPass<'a> {
             _ => None,
         };
         let (_, range) = stmt.span_text_abs(col_sp);
-        let start = range.start.as_usize();
-        let end = range.end.as_usize();
 
         match self.scope.resolve_column(table, column) {
             ColumnResolution::Found {
@@ -486,7 +464,7 @@ impl<'a> ValidationPass<'a> {
                 all_columns,
             } => {
                 #[cfg(feature = "lsp")]
-                self.record_column_resolution(start, end, column, resolved_table, all_columns);
+                self.record_column_resolution(range, column, resolved_table, all_columns);
                 #[cfg(not(feature = "lsp"))]
                 let _ = (resolved_table, all_columns);
             }
@@ -500,7 +478,7 @@ impl<'a> ValidationPass<'a> {
                     stmt,
                     node_id,
                     column_idx,
-                    (start, end),
+                    range,
                     DiagnosticMessage::UnknownColumn {
                         column: column.to_string(),
                         table: Some(tbl.to_string()),
@@ -522,7 +500,7 @@ impl<'a> ValidationPass<'a> {
                     stmt,
                     node_id,
                     column_idx,
-                    (start, end),
+                    range,
                     DiagnosticMessage::UnknownColumn {
                         column: column.to_string(),
                         table: None,
@@ -538,8 +516,7 @@ impl<'a> ValidationPass<'a> {
     #[cfg(feature = "lsp")]
     fn record_column_resolution(
         &mut self,
-        start: usize,
-        end: usize,
+        range: DocRange,
         column: &str,
         resolved_table: String,
         all_columns: Vec<String>,
@@ -555,23 +532,20 @@ impl<'a> ValidationPass<'a> {
         let definition = self
             .definition_offsets
             .get(&def_key)
-            .map(|&(start, end)| DefinitionLocation {
-                start,
-                end,
+            .map(|&range| DefinitionLocation {
+                range,
                 file_uri: None,
             })
             .or_else(|| {
                 self.catalog
                     .column_definition_site(&resolved_table, column)
                     .map(|site| DefinitionLocation {
-                        start: site.start,
-                        end: site.end,
+                        range: site.range,
                         file_uri: Some(site.file_uri.clone()),
                     })
             });
         self.resolutions.push(Resolution {
-            start,
-            end,
+            range,
             symbol: ResolvedSymbol::Column {
                 column: column.to_string(),
                 table: resolved_table,
@@ -592,7 +566,7 @@ impl<'a> ValidationPass<'a> {
         self.visit_opt(stmt, Self::field_node_id(fields, body_idx));
         self.scope.pop();
 
-        let (alias, _, _) = Self::name_text(stmt, Self::field_node_id(fields, alias_idx));
+        let (alias, _) = Self::name_text(stmt, Self::field_node_id(fields, alias_idx));
         let cols = Self::field_node_id(fields, body_idx)
             .and_then(|id| DdlReader::new(stmt, self.roles).columns_from_select(id));
         if alias.is_empty() {
@@ -671,7 +645,7 @@ impl<'a> ValidationPass<'a> {
                 continue;
             };
             let alias_node = Self::field_node_id(&child_fields, alias_idx);
-            let (alias_text, _, _) = Self::name_text(stmt, alias_node);
+            let (alias_text, _) = Self::name_text(stmt, alias_node);
             if !alias_text.is_empty() {
                 aliases.push(alias_text.to_string());
             }

--- a/syntaqlite/src/semantic/catalog.rs
+++ b/syntaqlite/src/semantic/catalog.rs
@@ -8,6 +8,8 @@
 use std::collections::{HashMap, HashSet};
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue};
+#[cfg(feature = "lsp")]
+use syntaqlite_syntax::source::DocRange;
 
 use super::ddl::DdlReader;
 use crate::dialect::AnyDialect;
@@ -103,10 +105,8 @@ impl From<DialectFunctionCategory> for FunctionCategory {
 pub(crate) struct DefinitionSite {
     /// File URI (e.g. `"file:///path/to/schema.sql"`).
     pub file_uri: String,
-    /// Byte offset of the start of the name in the source file.
-    pub start: usize,
-    /// Byte offset of the end of the name in the source file.
-    pub end: usize,
+    /// Document-absolute byte range of the name in the source file.
+    pub range: DocRange,
 }
 
 #[derive(Debug, Clone)]
@@ -876,7 +876,7 @@ impl Catalog {
     ) {
         let Some(uri) = file_uri else { return };
         let reader = DdlReader::new(stmt, dialect.roles());
-        let Some((name, start, end)) = reader.name_span(root) else {
+        let Some((name, range)) = reader.name_span(root) else {
             return;
         };
         let Some(entry) = self.layers[CatalogLayer::Database.index()]
@@ -887,16 +887,14 @@ impl Catalog {
         };
         entry.definition_site = Some(DefinitionSite {
             file_uri: uri.to_string(),
-            start,
-            end,
+            range,
         });
-        for (col_name, col_start, col_end) in reader.column_spans(root) {
+        for (col_name, col_range) in reader.column_spans(root) {
             entry.column_definition_sites.insert(
                 col_name,
                 DefinitionSite {
                     file_uri: uri.to_string(),
-                    start: col_start,
-                    end: col_end,
+                    range: col_range,
                 },
             );
         }

--- a/syntaqlite/src/semantic/ddl.rs
+++ b/syntaqlite/src/semantic/ddl.rs
@@ -9,6 +9,9 @@
 //! grouped on a single [`DdlReader`] handle.
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue, NodeFields};
+#[cfg(feature = "lsp")]
+use syntaqlite_syntax::source::DocRange;
+use syntaqlite_syntax::source::{StmtLen, StmtOffset, StmtRange};
 
 use crate::dialect::{FIELD_ABSENT, SemanticRole};
 use crate::semantic::catalog::AritySpec;
@@ -45,10 +48,10 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
 
     // ── DDL definition spans (LSP go-to-definition) ───────────────────────
 
-    /// `(lowercase_name, start, end)` for `CREATE TABLE` / `CREATE VIEW`.
+    /// `(lowercase_name, range)` for `CREATE TABLE` / `CREATE VIEW`.
     /// Returns `None` for non-DDL statements.
     #[cfg(feature = "lsp")]
-    pub(super) fn name_span(&self, root: AnyNodeId) -> Option<(String, usize, usize)> {
+    pub(super) fn name_span(&self, root: AnyNodeId) -> Option<(String, DocRange)> {
         let (tag, fields) = self.stmt.extract_fields(root)?;
         let (SemanticRole::DefineTable { name: name_idx, .. }
         | SemanticRole::DefineView { name: name_idx, .. }) = self.role_for(tag)?
@@ -62,12 +65,12 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
             return None;
         }
         let (s, range) = self.stmt.span_text_abs(sp);
-        Some((s.to_ascii_lowercase(), range.start.as_usize(), range.end.as_usize()))
+        Some((s.to_ascii_lowercase(), range))
     }
 
-    /// Per-column `(lowercase_name, start, end)` triples for a `CREATE TABLE`.
+    /// Per-column `(lowercase_name, range)` pairs for a `CREATE TABLE`.
     #[cfg(feature = "lsp")]
-    pub(super) fn column_spans(&self, root: AnyNodeId) -> Vec<(String, usize, usize)> {
+    pub(super) fn column_spans(&self, root: AnyNodeId) -> Vec<(String, DocRange)> {
         let mut out = Vec::new();
         let Some((tag, fields)) = self.stmt.extract_fields(root) else {
             return out;
@@ -91,15 +94,15 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
             if child_id.is_null() {
                 continue;
             }
-            if let Some((name, start, end)) = self.column_def_name_span(child_id) {
-                out.push((name.to_ascii_lowercase(), start, end));
+            if let Some((name, range)) = self.column_def_name_span(child_id) {
+                out.push((name.to_ascii_lowercase(), range));
             }
         }
         out
     }
 
     #[cfg(feature = "lsp")]
-    fn column_def_name_span(&self, node_id: AnyNodeId) -> Option<(&'stmt str, usize, usize)> {
+    fn column_def_name_span(&self, node_id: AnyNodeId) -> Option<(&'stmt str, DocRange)> {
         let (tag, fields) = self.stmt.extract_fields(node_id)?;
         let SemanticRole::ColumnDef { name: name_idx, .. } = self.role_for(tag)? else {
             return None;
@@ -116,7 +119,7 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
                 && !sp.is_empty()
             {
                 let (s, range) = self.stmt.span_text_abs(sp);
-                return Some((s, range.start.as_usize(), range.end.as_usize()));
+                return Some((s, range));
             }
         }
         None
@@ -332,24 +335,22 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
 
     /// Source slice spanning every byte covered by `id`'s subtree.
     pub(crate) fn expr_source_text(&self, id: AnyNodeId) -> Option<&'stmt str> {
-        use syntaqlite_syntax::source::{StmtOffset, StmtRange};
         let mut min = StmtOffset::from_raw(u32::MAX);
         let mut max = StmtOffset::default();
         self.collect_spans(id, &mut min, &mut max);
         if min < max {
-            Some(&self.stmt.text()[StmtRange { start: min, end: max }])
+            Some(
+                &self.stmt.text()[StmtRange {
+                    start: min,
+                    end: max,
+                }],
+            )
         } else {
             None
         }
     }
 
-    fn collect_spans(
-        &self,
-        id: AnyNodeId,
-        min: &mut syntaqlite_syntax::source::StmtOffset,
-        max: &mut syntaqlite_syntax::source::StmtOffset,
-    ) {
-        use syntaqlite_syntax::source::StmtLen;
+    fn collect_spans(&self, id: AnyNodeId, min: &mut StmtOffset, max: &mut StmtOffset) {
         if id.is_null() {
             return;
         }

--- a/syntaqlite/src/semantic/ddl.rs
+++ b/syntaqlite/src/semantic/ddl.rs
@@ -61,8 +61,8 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
         if sp.is_empty() {
             return None;
         }
-        let (s, start, end) = self.stmt.span_text_abs(sp);
-        Some((s.to_ascii_lowercase(), start, end))
+        let (s, range) = self.stmt.span_text_abs(sp);
+        Some((s.to_ascii_lowercase(), range.start.as_usize(), range.end.as_usize()))
     }
 
     /// Per-column `(lowercase_name, start, end)` triples for a `CREATE TABLE`.
@@ -115,8 +115,8 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
             if let FieldValue::Span(sp) = name_fields[j]
                 && !sp.is_empty()
             {
-                let (s, start, end) = self.stmt.span_text_abs(sp);
-                return Some((s, start, end));
+                let (s, range) = self.stmt.span_text_abs(sp);
+                return Some((s, range.start.as_usize(), range.end.as_usize()));
             }
         }
         None
@@ -332,17 +332,24 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
 
     /// Source slice spanning every byte covered by `id`'s subtree.
     pub(crate) fn expr_source_text(&self, id: AnyNodeId) -> Option<&'stmt str> {
-        let mut min = usize::MAX;
-        let mut max = 0usize;
+        use syntaqlite_syntax::source::{StmtOffset, StmtRange};
+        let mut min = StmtOffset::from_raw(u32::MAX);
+        let mut max = StmtOffset::default();
         self.collect_spans(id, &mut min, &mut max);
         if min < max {
-            Some(&self.stmt.text()[min..max])
+            Some(&self.stmt.text()[StmtRange { start: min, end: max }])
         } else {
             None
         }
     }
 
-    fn collect_spans(&self, id: AnyNodeId, min: &mut usize, max: &mut usize) {
+    fn collect_spans(
+        &self,
+        id: AnyNodeId,
+        min: &mut syntaqlite_syntax::source::StmtOffset,
+        max: &mut syntaqlite_syntax::source::StmtOffset,
+    ) {
+        use syntaqlite_syntax::source::StmtLen;
         if id.is_null() {
             return;
         }
@@ -351,8 +358,9 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
                 match fields[i] {
                     FieldValue::Span(sp) if !sp.is_empty() => {
                         let (text, off) = self.stmt.span_text(sp);
-                        let start = off as usize;
-                        let end = start + text.len();
+                        let start = off;
+                        let end = start
+                            + StmtLen::from_raw(u32::try_from(text.len()).unwrap_or(u32::MAX));
                         if start < *min {
                             *min = start;
                         }

--- a/syntaqlite/src/semantic/diagnostics.rs
+++ b/syntaqlite/src/semantic/diagnostics.rs
@@ -7,6 +7,8 @@
 //! optional "did you mean?" suggestions. Both parse errors and semantic
 //! issues (unknown table, wrong arity, etc.) are represented uniformly.
 
+use crate::source::{DocOffset, DocRange, LayerRange};
+
 /// A diagnostic produced by parsing or semantic analysis.
 ///
 /// Every diagnostic carries a byte-offset range into the source text,
@@ -33,8 +35,8 @@
 ///     println!(
 ///         "[{:?}] bytes {}..{}: {}",
 ///         diag.severity(),
-///         diag.start_offset(),
-///         diag.end_offset(),
+///         diag.range().start,
+///         diag.range().end,
 ///         diag.message(),
 ///     );
 ///     if let Some(help) = diag.help() {
@@ -52,18 +54,15 @@ pub struct DiagnosticFrame {
     /// Buffer text — the original source for the outermost frame, or an
     /// expansion buffer for inner frames.
     pub buffer: String,
-    /// Byte offset of this frame's span within `buffer`.
-    pub start: usize,
-    /// Byte offset of the end of this frame's span within `buffer`.
-    pub end: usize,
+    /// Byte range within `buffer` for this frame's span.
+    pub range: LayerRange,
 }
 
 /// A semantic diagnostic produced by validation, with location, message,
 /// severity, optional help, and an optional macro expansion traceback.
 #[derive(Debug, Clone)]
 pub struct Diagnostic {
-    pub(crate) start_offset: usize,
-    pub(crate) end_offset: usize,
+    pub(crate) range: DocRange,
     pub(crate) message: DiagnosticMessage,
     pub(crate) severity: Severity,
     pub(crate) help: Option<Help>,
@@ -76,15 +75,13 @@ pub struct Diagnostic {
 impl Diagnostic {
     /// Create a new diagnostic.
     pub fn new(
-        start_offset: usize,
-        end_offset: usize,
+        range: DocRange,
         message: DiagnosticMessage,
         severity: Severity,
         help: Option<Help>,
     ) -> Self {
         Self {
-            start_offset,
-            end_offset,
+            range,
             message,
             severity,
             help,
@@ -92,13 +89,17 @@ impl Diagnostic {
         }
     }
 
-    /// Byte offset of the start of the diagnostic range.
-    pub fn start_offset(&self) -> usize {
-        self.start_offset
+    /// Document-absolute byte range of the diagnostic.
+    pub fn range(&self) -> DocRange {
+        self.range
     }
-    /// Byte offset of the end of the diagnostic range.
-    pub fn end_offset(&self) -> usize {
-        self.end_offset
+    /// Document-absolute byte offset of the start of the diagnostic range.
+    pub fn start(&self) -> DocOffset {
+        self.range.start
+    }
+    /// Document-absolute byte offset of the end of the diagnostic range.
+    pub fn end(&self) -> DocOffset {
+        self.range.end
     }
     /// Structured diagnostic message.
     pub fn message(&self) -> &DiagnosticMessage {
@@ -391,8 +392,8 @@ impl serde::Serialize for Diagnostic {
         use serde::ser::SerializeMap;
         let len = if self.help.is_some() { 7 } else { 5 };
         let mut m = serializer.serialize_map(Some(len))?;
-        m.serialize_entry("startOffset", &self.start_offset)?;
-        m.serialize_entry("endOffset", &self.end_offset)?;
+        m.serialize_entry("startOffset", &self.range.start.as_u32())?;
+        m.serialize_entry("endOffset", &self.range.end.as_u32())?;
         m.serialize_entry("message", &self.message.to_string())?;
         m.serialize_entry("detail", &self.message)?;
         m.serialize_entry("severity", &self.severity)?;

--- a/syntaqlite/src/semantic/ffi/analyze.rs
+++ b/syntaqlite/src/semantic/ffi/analyze.rs
@@ -63,8 +63,8 @@ pub unsafe extern "C" fn syntaqlite_validator_analyze(
         state.c_diagnostics.push(SyntaqliteDiagnostic {
             severity: severity_to_c(d.severity()),
             message: msg.as_ptr(),
-            start_offset: d.start_offset() as u32,
-            end_offset: d.end_offset() as u32,
+            start_offset: d.range().start.as_u32(),
+            end_offset: d.range().end.as_u32(),
             kind_code: diagnostic_code_to_c(d.message()),
         });
     }

--- a/syntaqlite/src/semantic/ffi/statement.rs
+++ b/syntaqlite/src/semantic/ffi/statement.rs
@@ -38,8 +38,8 @@ fn ensure_diagnostics<'a>(
             diags.push(SyntaqliteDiagnostic {
                 severity: severity_to_c(d.severity()),
                 message: msg.as_ptr(),
-                start_offset: d.start_offset() as u32,
-                end_offset: d.end_offset() as u32,
+                start_offset: d.range().start.as_u32(),
+                end_offset: d.range().end.as_u32(),
                 kind_code: diagnostic_code_to_c(d.message()),
             });
         }

--- a/syntaqlite/src/semantic/model.rs
+++ b/syntaqlite/src/semantic/model.rs
@@ -7,6 +7,8 @@
 use syntaqlite_syntax::ParserTokenFlags;
 #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
 use syntaqlite_syntax::any::{AnyTokenType, TokenCategory};
+#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
+use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange};
 
 #[cfg(feature = "lsp")]
 use std::collections::HashMap;
@@ -25,8 +27,8 @@ use super::lineage::{
 #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
 #[derive(Debug, Clone)]
 pub(crate) struct StoredToken {
-    pub(crate) offset: usize,
-    pub(crate) length: usize,
+    pub(crate) offset: DocOffset,
+    pub(crate) length: DocLen,
     pub(crate) token_type: AnyTokenType,
     pub(crate) flags: ParserTokenFlags,
 }
@@ -35,8 +37,8 @@ pub(crate) struct StoredToken {
 #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
 #[derive(Debug, Clone)]
 pub(crate) struct StoredComment {
-    pub(crate) offset: usize,
-    pub(crate) length: usize,
+    pub(crate) offset: DocOffset,
+    pub(crate) length: DocLen,
 }
 
 // ── Output types ──────────────────────────────────────────────────────────────
@@ -45,10 +47,10 @@ pub(crate) struct StoredComment {
 #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
 #[derive(Debug, Clone)]
 pub(crate) struct SemanticToken {
-    /// Byte offset in the source text.
-    pub offset: usize,
+    /// Document-absolute byte offset in the source text.
+    pub offset: DocOffset,
     /// Length in bytes.
-    pub length: usize,
+    pub length: DocLen,
     /// Token category for highlighting.
     pub category: TokenCategory,
 }
@@ -95,8 +97,7 @@ pub(crate) struct CompletionInfo {
 #[cfg(feature = "lsp")]
 #[derive(Debug, Clone)]
 pub(crate) struct DefinitionLocation {
-    pub start: usize,
-    pub end: usize,
+    pub range: DocRange,
     /// If `Some`, the definition is in a different file (e.g. an external schema).
     pub file_uri: Option<String>,
 }
@@ -106,10 +107,8 @@ pub(crate) struct DefinitionLocation {
 #[cfg(feature = "lsp")]
 #[derive(Debug, Clone)]
 pub(crate) struct DefinitionResult {
-    /// Byte offset of the start of the reference token.
-    pub origin_start: usize,
-    /// Byte offset of the end of the reference token.
-    pub origin_end: usize,
+    /// Document-absolute byte range of the reference token.
+    pub origin: DocRange,
     /// The definition site this reference resolves to.
     pub target: DefinitionLocation,
 }
@@ -144,8 +143,7 @@ pub(crate) enum ResolvedSymbol {
 #[cfg(feature = "lsp")]
 #[derive(Debug, Clone)]
 pub(crate) struct Resolution {
-    pub start: usize,
-    pub end: usize,
+    pub range: DocRange,
     pub symbol: ResolvedSymbol,
 }
 
@@ -302,7 +300,7 @@ pub struct SemanticModel {
     /// `table.column` (column). Used by find-references and rename to
     /// locate definition sites within the document.
     #[cfg(feature = "lsp")]
-    pub(crate) definition_offsets: HashMap<String, (usize, usize)>,
+    pub(crate) definition_offsets: HashMap<String, DocRange>,
 }
 
 impl SemanticModel {
@@ -381,24 +379,23 @@ impl SemanticModel {
 #[cfg(feature = "lsp")]
 impl SemanticModel {
     /// Find the resolved symbol at a byte offset, if any.
-    pub(crate) fn resolution_at(&self, offset: usize) -> Option<&ResolvedSymbol> {
+    pub(crate) fn resolution_at(&self, offset: DocOffset) -> Option<&ResolvedSymbol> {
         self.resolutions
             .iter()
-            .find(|r| offset >= r.start && offset < r.end)
+            .find(|r| offset >= r.range.start && offset < r.range.end)
             .map(|r| &r.symbol)
     }
 
     /// Find the definition location for the symbol at a byte offset, if any.
-    pub(crate) fn definition_at(&self, offset: usize) -> Option<DefinitionResult> {
+    pub(crate) fn definition_at(&self, offset: DocOffset) -> Option<DefinitionResult> {
         self.resolutions
             .iter()
-            .find(|r| offset >= r.start && offset < r.end)
+            .find(|r| offset >= r.range.start && offset < r.range.end)
             .and_then(|r| match &r.symbol {
                 ResolvedSymbol::Table { definition, .. }
                 | ResolvedSymbol::Column { definition, .. } => {
                     definition.as_ref().map(|d| DefinitionResult {
-                        origin_start: r.start,
-                        origin_end: r.end,
+                        origin: r.range,
                         target: d.clone(),
                     })
                 }
@@ -407,11 +404,11 @@ impl SemanticModel {
     }
 
     /// Find all resolutions in this model that match the given symbol identity.
-    pub(crate) fn references_matching(&self, kind: &SymbolIdentity) -> Vec<(usize, usize)> {
+    pub(crate) fn references_matching(&self, kind: &SymbolIdentity) -> Vec<DocRange> {
         self.resolutions
             .iter()
             .filter(|r| kind.matches(&r.symbol))
-            .map(|r| (r.start, r.end))
+            .map(|r| r.range)
             .collect()
     }
 }

--- a/syntaqlite/src/semantic/render.rs
+++ b/syntaqlite/src/semantic/render.rs
@@ -81,8 +81,8 @@ impl<'a> DiagnosticRenderer<'a> {
                 file: self.file,
                 severity,
                 message: &message,
-                start_offset: diag.start_offset(),
-                end_offset: diag.end_offset(),
+                start_offset: diag.range().start.as_usize(),
+                end_offset: diag.range().end.as_usize(),
                 help: help.as_deref(),
             },
         )?;
@@ -99,8 +99,8 @@ impl<'a> DiagnosticRenderer<'a> {
                     file: "<macro expansion>",
                     severity: "note",
                     message: "in macro expansion",
-                    start_offset: frame.start,
-                    end_offset: frame.end,
+                    start_offset: frame.range.start.as_usize(),
+                    end_offset: frame.range.end.as_usize(),
                     help: None,
                 },
             )?;

--- a/syntaqlite/tests/cursor_coexistence.rs
+++ b/syntaqlite/tests/cursor_coexistence.rs
@@ -9,6 +9,7 @@
 
 use syntaqlite::parse::Tokenizer;
 use syntaqlite::parse::{IncrementalParseSession, ParseSession};
+use syntaqlite::source::DocOffset;
 use syntaqlite::{ParseOutcome, Parser};
 
 // ── Parser + ParseSession coexistence ────────────────────────────────────
@@ -60,8 +61,14 @@ fn parser_and_incremental_session_coexist() {
         session,
     };
 
-    s.session.feed_token(TokenType::Select, 0..6);
-    s.session.feed_token(TokenType::Integer, 7..8);
+    s.session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(0)..DocOffset::from_raw(6),
+    );
+    s.session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(7)..DocOffset::from_raw(8),
+    );
     assert!(s.session.finish().is_some());
 }
 
@@ -72,14 +79,26 @@ fn parser_incremental_reuse_after_session_drop() {
     let parser = Parser::new();
     {
         let mut s = parser.incremental_parse("SELECT 1");
-        s.feed_token(TokenType::Select, 0..6);
-        s.feed_token(TokenType::Integer, 7..8);
+        s.feed_token(
+            TokenType::Select,
+            DocOffset::from_raw(0)..DocOffset::from_raw(6),
+        );
+        s.feed_token(
+            TokenType::Integer,
+            DocOffset::from_raw(7)..DocOffset::from_raw(8),
+        );
         assert!(s.finish().is_some());
     }
     {
         let mut s = parser.incremental_parse("SELECT 2");
-        s.feed_token(TokenType::Select, 0..6);
-        s.feed_token(TokenType::Integer, 7..8);
+        s.feed_token(
+            TokenType::Select,
+            DocOffset::from_raw(0)..DocOffset::from_raw(6),
+        );
+        s.feed_token(
+            TokenType::Integer,
+            DocOffset::from_raw(7)..DocOffset::from_raw(8),
+        );
         assert!(s.finish().is_some());
     }
 }

--- a/syntaqlite/tests/embedded.rs
+++ b/syntaqlite/tests/embedded.rs
@@ -149,7 +149,7 @@ fn validate_offsets_mapped_to_host_file() {
     if let Some(d) = table_diag {
         // The word "nonexistent" starts at offset 20 in the host source
         // (after `q = f"SELECT * FROM `).
-        let referenced = &source[d.start_offset()..d.end_offset()];
+        let referenced = &source[d.start().as_usize()..d.end().as_usize()];
         assert_eq!(referenced, "nonexistent");
     }
 }
@@ -270,7 +270,7 @@ fn ts_validate_offsets_mapped_to_host_file() {
         .iter()
         .find(|d| d.message().to_string().contains("nonexistent"));
     if let Some(d) = table_diag {
-        let referenced = &source[d.start_offset()..d.end_offset()];
+        let referenced = &source[d.start().as_usize()..d.end().as_usize()];
         assert_eq!(referenced, "nonexistent");
     }
 }

--- a/syntaqlite/tests/fmt_comments.rs
+++ b/syntaqlite/tests/fmt_comments.rs
@@ -71,12 +71,13 @@ fn debug_comment_token_offsets() {
                 let stmt_text = stmt.text();
                 eprintln!("  Comments ({}):", comments.len());
                 for c in &comments {
-                    let end = c.offset() as usize + c.length() as usize;
+                    let range =
+                        syntaqlite::source::StmtRange::from_offset_len(c.offset(), c.length());
                     eprintln!(
                         "    offset={} len={} text={:?}",
                         c.offset(),
                         c.length(),
-                        &stmt_text[c.offset() as usize..end]
+                        &stmt_text[range]
                     );
                 }
                 let tokens: Vec<_> = stmt.tokens().collect();

--- a/syntaqlite/tests/generated.rs
+++ b/syntaqlite/tests/generated.rs
@@ -191,7 +191,8 @@ fn debug_multi_stmt_comments() {
             eprintln!("stmt {stmt_num}: source={stmt_text:?}");
             eprintln!("  {} comment(s):", comments.len());
             for c in &comments {
-                let text = &stmt_text[c.offset() as usize..(c.offset() + c.length()) as usize];
+                let range = syntaqlite::source::StmtRange::from_offset_len(c.offset(), c.length());
+                let text = &stmt_text[range];
                 eprintln!(
                     "    offset={} kind={:?} text={text:?}",
                     c.offset(),

--- a/syntaqlite/tests/low_level.rs
+++ b/syntaqlite/tests/low_level.rs
@@ -115,7 +115,7 @@ fn feed_token_records_comment() {
 
     let comments: Vec<_> = stmt.comments().collect();
     assert_eq!(comments.len(), 1);
-    assert_eq!(comments[0].length(), 8);
+    assert_eq!(comments[0].length(), syntaqlite_syntax::source::StmtLen::from_raw(8));
 }
 
 /// Leading `TK_SPACE` fed via `feed_token` should NOT open the statement:
@@ -139,9 +139,9 @@ fn feed_token_leading_whitespace_does_not_open_statement() {
 
     // Statement opens at `SELECT`, not at byte 0 — matches parser_next.
     assert_eq!(stmt.text(), "SELECT 1");
-    assert_eq!(stmt.statement_base_offset(), 3);
+    assert_eq!(stmt.statement_base().as_doc_offset().as_u32(), 3);
     let tokens: Vec<_> = stmt.tokens().collect();
-    assert_eq!(tokens[0].offset(), 0);
+    assert_eq!(tokens[0].offset(), syntaqlite_syntax::source::StmtOffset::default());
     assert_eq!(tokens[0].text(), "SELECT");
 }
 
@@ -428,10 +428,11 @@ fn sqlite_type_tokens_are_marked_as_type() {
                 let stmt_text = stmt.text();
                 for t in stmt.tokens() {
                     if t.flags().used_as_type() {
-                        marked.push(
-                            stmt_text[t.offset() as usize..(t.offset() + t.length()) as usize]
-                                .to_string(),
+                        let range = syntaqlite_syntax::source::StmtRange::from_offset_len(
+                            t.offset(),
+                            t.length(),
                         );
+                        marked.push(stmt_text[range].to_string());
                     }
                 }
             }
@@ -460,7 +461,7 @@ fn collect_span_ranges(
             match fields[idx] {
                 FieldValue::Span(sp) => {
                     let (text, off) = erased.span_text(sp);
-                    let start = off as usize;
+                    let start = off.as_usize();
                     spans.push((field_idx, start, start + text.len()));
                 }
                 FieldValue::NodeId(child) if !child.is_null() => {

--- a/syntaqlite/tests/low_level.rs
+++ b/syntaqlite/tests/low_level.rs
@@ -6,6 +6,7 @@
 use syntaqlite::nodes::Stmt;
 use syntaqlite::parse::ParserConfig;
 use syntaqlite::parse::TokenType;
+use syntaqlite::source::DocOffset;
 use syntaqlite::{ParseOutcome, Parser};
 use syntaqlite_syntax::{MacroArg, MacroLookup, MacroOutput};
 
@@ -18,10 +19,24 @@ fn feed_tokens_select_1() {
     let mut session = parser.incremental_parse(source);
 
     // Feed SELECT token.
-    assert!(session.feed_token(TokenType::Select, 0..6).is_none());
+    assert!(
+        session
+            .feed_token(
+                TokenType::Select,
+                DocOffset::from_raw(0)..DocOffset::from_raw(6)
+            )
+            .is_none()
+    );
 
     // Feed integer literal token.
-    assert!(session.feed_token(TokenType::Integer, 7..8).is_none());
+    assert!(
+        session
+            .feed_token(
+                TokenType::Integer,
+                DocOffset::from_raw(7)..DocOffset::from_raw(8)
+            )
+            .is_none()
+    );
 
     // finish() synthesizes SEMI + EOF, triggering the ecmd reduction.
     let stmt = session
@@ -39,12 +54,21 @@ fn feed_tokens_with_semicolon() {
     let parser = Parser::new();
     let mut session = parser.incremental_parse(source);
 
-    session.feed_token(TokenType::Select, 0..6);
-    session.feed_token(TokenType::Integer, 7..8);
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(0)..DocOffset::from_raw(6),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(7)..DocOffset::from_raw(8),
+    );
 
     // SEMI completes the statement immediately.
     let stmt = session
-        .feed_token(TokenType::Semi, 8..9)
+        .feed_token(
+            TokenType::Semi,
+            DocOffset::from_raw(8)..DocOffset::from_raw(9),
+        )
         .expect("SEMI should complete the statement")
         .expect("expected Ok");
     assert!(matches!(stmt.root(), Some(Stmt::SelectStmt(_))));
@@ -59,16 +83,31 @@ fn feed_tokens_multi_statement() {
     let mut session = parser.incremental_parse(source);
 
     // First statement: SELECT 1 ;
-    session.feed_token(TokenType::Select, 0..6);
-    session.feed_token(TokenType::Integer, 7..8);
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(0)..DocOffset::from_raw(6),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(7)..DocOffset::from_raw(8),
+    );
 
     // SEMI completes stmt 1 immediately.
-    let stmt1 = session.feed_token(TokenType::Semi, 8..9);
+    let stmt1 = session.feed_token(
+        TokenType::Semi,
+        DocOffset::from_raw(8)..DocOffset::from_raw(9),
+    );
     assert!(stmt1.is_some(), "first statement should complete on SEMI");
 
     // Second statement tokens belong entirely to stmt 2.
-    session.feed_token(TokenType::Select, 10..16);
-    session.feed_token(TokenType::Integer, 17..18);
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(10)..DocOffset::from_raw(16),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(17)..DocOffset::from_raw(18),
+    );
 
     assert!(
         session.finish().is_some(),
@@ -83,12 +122,25 @@ fn feed_token_skips_space() {
     let parser = Parser::new();
     let mut session = parser.incremental_parse(source);
 
-    session.feed_token(TokenType::Select, 0..6);
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(0)..DocOffset::from_raw(6),
+    );
 
     // Feed a space — should be silently skipped.
-    assert!(session.feed_token(TokenType::Space, 6..7).is_none());
+    assert!(
+        session
+            .feed_token(
+                TokenType::Space,
+                DocOffset::from_raw(6)..DocOffset::from_raw(7)
+            )
+            .is_none()
+    );
 
-    session.feed_token(TokenType::Integer, 7..8);
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(7)..DocOffset::from_raw(8),
+    );
 
     let stmt = session
         .finish()
@@ -104,9 +156,18 @@ fn feed_token_records_comment() {
     let parser = Parser::with_config(&ParserConfig::default().with_collect_tokens(true));
     let mut session = parser.incremental_parse(source);
 
-    session.feed_token(TokenType::Select, 0..6);
-    session.feed_token(TokenType::Comment, 7..15);
-    session.feed_token(TokenType::Integer, 16..17);
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(0)..DocOffset::from_raw(6),
+    );
+    session.feed_token(
+        TokenType::Comment,
+        DocOffset::from_raw(7)..DocOffset::from_raw(15),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(16)..DocOffset::from_raw(17),
+    );
 
     let stmt = session
         .finish()
@@ -115,7 +176,10 @@ fn feed_token_records_comment() {
 
     let comments: Vec<_> = stmt.comments().collect();
     assert_eq!(comments.len(), 1);
-    assert_eq!(comments[0].length(), syntaqlite_syntax::source::StmtLen::from_raw(8));
+    assert_eq!(
+        comments[0].length(),
+        syntaqlite_syntax::source::StmtLen::from_raw(8)
+    );
 }
 
 /// Leading `TK_SPACE` fed via `feed_token` should NOT open the statement:
@@ -128,9 +192,18 @@ fn feed_token_leading_whitespace_does_not_open_statement() {
     let parser = Parser::with_config(&ParserConfig::default().with_collect_tokens(true));
     let mut session = parser.incremental_parse(source);
 
-    session.feed_token(TokenType::Space, 0..3);
-    session.feed_token(TokenType::Select, 3..9);
-    session.feed_token(TokenType::Integer, 10..11);
+    session.feed_token(
+        TokenType::Space,
+        DocOffset::from_raw(0)..DocOffset::from_raw(3),
+    );
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(3)..DocOffset::from_raw(9),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(10)..DocOffset::from_raw(11),
+    );
 
     let stmt = session
         .finish()
@@ -141,7 +214,10 @@ fn feed_token_leading_whitespace_does_not_open_statement() {
     assert_eq!(stmt.text(), "SELECT 1");
     assert_eq!(stmt.statement_base().as_doc_offset().as_u32(), 3);
     let tokens: Vec<_> = stmt.tokens().collect();
-    assert_eq!(tokens[0].offset(), syntaqlite_syntax::source::StmtOffset::default());
+    assert_eq!(
+        tokens[0].offset(),
+        syntaqlite_syntax::source::StmtOffset::default()
+    );
     assert_eq!(tokens[0].text(), "SELECT");
 }
 
@@ -153,17 +229,32 @@ fn feed_tokens_multi_statement_both_roots() {
     let mut session = parser.incremental_parse(source);
 
     // First statement.
-    session.feed_token(TokenType::Select, 0..6);
-    session.feed_token(TokenType::Integer, 7..8);
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(0)..DocOffset::from_raw(6),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(7)..DocOffset::from_raw(8),
+    );
     let stmt1 = session
-        .feed_token(TokenType::Semi, 8..9)
+        .feed_token(
+            TokenType::Semi,
+            DocOffset::from_raw(8)..DocOffset::from_raw(9),
+        )
         .expect("stmt 1 should complete")
         .expect("stmt 1 should be Ok");
     assert!(matches!(stmt1.root(), Some(Stmt::SelectStmt(_))));
 
     // Second statement.
-    session.feed_token(TokenType::Select, 10..16);
-    session.feed_token(TokenType::Integer, 17..18);
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(10)..DocOffset::from_raw(16),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(17)..DocOffset::from_raw(18),
+    );
     let stmt2 = session
         .finish()
         .expect("stmt 2 should complete")
@@ -179,18 +270,50 @@ fn feed_tokens_three_statements() {
     let mut session = parser.incremental_parse(source);
 
     // Statement 1.
-    session.feed_token(TokenType::Select, 0..6);
-    session.feed_token(TokenType::Integer, 7..8);
-    assert!(session.feed_token(TokenType::Semi, 8..9).is_some());
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(0)..DocOffset::from_raw(6),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(7)..DocOffset::from_raw(8),
+    );
+    assert!(
+        session
+            .feed_token(
+                TokenType::Semi,
+                DocOffset::from_raw(8)..DocOffset::from_raw(9)
+            )
+            .is_some()
+    );
 
     // Statement 2.
-    session.feed_token(TokenType::Select, 10..16);
-    session.feed_token(TokenType::Integer, 17..18);
-    assert!(session.feed_token(TokenType::Semi, 18..19).is_some());
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(10)..DocOffset::from_raw(16),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(17)..DocOffset::from_raw(18),
+    );
+    assert!(
+        session
+            .feed_token(
+                TokenType::Semi,
+                DocOffset::from_raw(18)..DocOffset::from_raw(19)
+            )
+            .is_some()
+    );
 
     // Statement 3 — completed by finish().
-    session.feed_token(TokenType::Select, 20..26);
-    session.feed_token(TokenType::Integer, 27..28);
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(20)..DocOffset::from_raw(26),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(27)..DocOffset::from_raw(28),
+    );
     let stmt3 = session
         .finish()
         .expect("stmt 3 should complete")
@@ -207,22 +330,41 @@ fn feed_tokens_bare_semicolons() {
 
     // Leading bare semicolon — should not produce a statement.
     assert!(
-        session.feed_token(TokenType::Semi, 0..1).is_none(),
+        session
+            .feed_token(
+                TokenType::Semi,
+                DocOffset::from_raw(0)..DocOffset::from_raw(1)
+            )
+            .is_none(),
         "bare semicolon should not produce a statement"
     );
 
     // Real statement.
-    session.feed_token(TokenType::Select, 2..8);
-    session.feed_token(TokenType::Integer, 9..10);
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(2)..DocOffset::from_raw(8),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(9)..DocOffset::from_raw(10),
+    );
     let stmt = session
-        .feed_token(TokenType::Semi, 10..11)
+        .feed_token(
+            TokenType::Semi,
+            DocOffset::from_raw(10)..DocOffset::from_raw(11),
+        )
         .expect("should complete")
         .expect("should be Ok");
     assert!(matches!(stmt.root(), Some(Stmt::SelectStmt(_))));
 
     // Trailing bare semicolon.
     assert!(
-        session.feed_token(TokenType::Semi, 12..13).is_none(),
+        session
+            .feed_token(
+                TokenType::Semi,
+                DocOffset::from_raw(12)..DocOffset::from_raw(13)
+            )
+            .is_none(),
         "trailing bare semicolon should not produce a statement"
     );
 
@@ -237,11 +379,23 @@ fn feed_tokens_explain_then_normal() {
     let mut session = parser.incremental_parse(source);
 
     // EXPLAIN SELECT 1;
-    session.feed_token(TokenType::Explain, 0..7);
-    session.feed_token(TokenType::Select, 8..14);
-    session.feed_token(TokenType::Integer, 15..16);
+    session.feed_token(
+        TokenType::Explain,
+        DocOffset::from_raw(0)..DocOffset::from_raw(7),
+    );
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(8)..DocOffset::from_raw(14),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(15)..DocOffset::from_raw(16),
+    );
     let stmt1 = session
-        .feed_token(TokenType::Semi, 16..17)
+        .feed_token(
+            TokenType::Semi,
+            DocOffset::from_raw(16)..DocOffset::from_raw(17),
+        )
         .expect("stmt 1 should complete")
         .expect("stmt 1 should be Ok");
     assert!(
@@ -250,8 +404,14 @@ fn feed_tokens_explain_then_normal() {
     );
 
     // SELECT 2 — should NOT be wrapped in EXPLAIN.
-    session.feed_token(TokenType::Select, 18..24);
-    session.feed_token(TokenType::Integer, 25..26);
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(18)..DocOffset::from_raw(24),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(25)..DocOffset::from_raw(26),
+    );
     let stmt2 = session
         .finish()
         .expect("stmt 2 should complete")
@@ -270,18 +430,36 @@ fn feed_tokens_normal_then_explain() {
     let mut session = parser.incremental_parse(source);
 
     // SELECT 1;
-    session.feed_token(TokenType::Select, 0..6);
-    session.feed_token(TokenType::Integer, 7..8);
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(0)..DocOffset::from_raw(6),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(7)..DocOffset::from_raw(8),
+    );
     let stmt1 = session
-        .feed_token(TokenType::Semi, 8..9)
+        .feed_token(
+            TokenType::Semi,
+            DocOffset::from_raw(8)..DocOffset::from_raw(9),
+        )
         .expect("stmt 1 should complete")
         .expect("stmt 1 should be Ok");
     assert!(matches!(stmt1.root(), Some(Stmt::SelectStmt(_))));
 
     // EXPLAIN SELECT 2
-    session.feed_token(TokenType::Explain, 10..17);
-    session.feed_token(TokenType::Select, 18..24);
-    session.feed_token(TokenType::Integer, 25..26);
+    session.feed_token(
+        TokenType::Explain,
+        DocOffset::from_raw(10)..DocOffset::from_raw(17),
+    );
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(18)..DocOffset::from_raw(24),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(25)..DocOffset::from_raw(26),
+    );
     let stmt2 = session
         .finish()
         .expect("stmt 2 should complete")
@@ -299,7 +477,10 @@ fn feed_tokens_incomplete_statement_error() {
     let parser = Parser::new();
     let mut session = parser.incremental_parse(source);
 
-    session.feed_token(TokenType::Select, 0..6);
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(0)..DocOffset::from_raw(6),
+    );
     // finish() synthesizes SEMI + EOF; SELECT alone is incomplete.
     let result = session.finish().expect("should return Some");
     assert!(result.is_err(), "incomplete SELECT should be a parse error");
@@ -313,10 +494,19 @@ fn feed_tokens_comments_between_statements() {
     let mut session = parser.incremental_parse(source);
 
     // Statement 1.
-    session.feed_token(TokenType::Select, 0..6);
-    session.feed_token(TokenType::Integer, 7..8);
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(0)..DocOffset::from_raw(6),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(7)..DocOffset::from_raw(8),
+    );
     let stmt1 = session
-        .feed_token(TokenType::Semi, 8..9)
+        .feed_token(
+            TokenType::Semi,
+            DocOffset::from_raw(8)..DocOffset::from_raw(9),
+        )
         .expect("stmt 1 should complete")
         .expect("stmt 1 should be Ok");
     assert_eq!(
@@ -326,9 +516,18 @@ fn feed_tokens_comments_between_statements() {
     );
 
     // Inter-statement comment belongs to statement 2.
-    session.feed_token(TokenType::Comment, 10..20);
-    session.feed_token(TokenType::Select, 21..27);
-    session.feed_token(TokenType::Integer, 28..29);
+    session.feed_token(
+        TokenType::Comment,
+        DocOffset::from_raw(10)..DocOffset::from_raw(20),
+    );
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(21)..DocOffset::from_raw(27),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(28)..DocOffset::from_raw(29),
+    );
     let stmt2 = session
         .finish()
         .expect("stmt 2 should complete")
@@ -487,8 +686,14 @@ fn field_source_range_direct_span() {
     let parser = Parser::new();
     let mut session = parser.incremental_parse(source);
 
-    session.feed_token(TokenType::Select, 0..6);
-    session.feed_token(TokenType::Integer, 7..8);
+    session.feed_token(
+        TokenType::Select,
+        DocOffset::from_raw(0)..DocOffset::from_raw(6),
+    );
+    session.feed_token(
+        TokenType::Integer,
+        DocOffset::from_raw(7)..DocOffset::from_raw(8),
+    );
 
     let stmt = session
         .finish()

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -8,6 +8,20 @@
 #[repr(transparent)] pub struct syntaqlite_syntax::nodes::FunctionCallFlags(_)
 #[repr(transparent)] pub struct syntaqlite_syntax::nodes::ResultColumnFlags(_)
 #[repr(transparent)] pub struct syntaqlite_syntax::nodes::SelectStmtFlags(_)
+#[repr(transparent)] pub struct syntaqlite_syntax::source::ColumnNumber(_)
+#[repr(transparent)] pub struct syntaqlite_syntax::source::DocLen(_)
+#[repr(transparent)] pub struct syntaqlite_syntax::source::DocOffset(_)
+#[repr(transparent)] pub struct syntaqlite_syntax::source::DocText(_)
+#[repr(transparent)] pub struct syntaqlite_syntax::source::LayerLen(_)
+#[repr(transparent)] pub struct syntaqlite_syntax::source::LayerOffset(_)
+#[repr(transparent)] pub struct syntaqlite_syntax::source::LayerText(_)
+#[repr(transparent)] pub struct syntaqlite_syntax::source::LineNumber(_)
+#[repr(transparent)] pub struct syntaqlite_syntax::source::StmtLen(_)
+#[repr(transparent)] pub struct syntaqlite_syntax::source::StmtOffset(_)
+#[repr(transparent)] pub struct syntaqlite_syntax::source::StmtText(_)
+#[repr(transparent)] pub struct syntaqlite_syntax::source::TokenIdx(_)
+#[repr(transparent)] pub struct syntaqlite_syntax::source::Utf16Col(_)
+#[repr(transparent)] pub struct syntaqlite_syntax::source::Utf16Line(_)
 #[repr(u32)] pub enum syntaqlite_syntax::CompletionContext
 #[repr(u32)] pub enum syntaqlite_syntax::ParseErrorKind
 #[repr(u32)] pub enum syntaqlite_syntax::TokenType
@@ -45,6 +59,24 @@
 #[repr(u32)] pub enum syntaqlite_syntax::nodes::UpsertAction
 #[repr(u32)] pub enum syntaqlite_syntax::util::SqliteSyntaxFlag
 #[repr(u8)] pub enum syntaqlite_syntax::any::FieldKind
+impl core::cmp::Eq for syntaqlite_syntax::source::DocText
+impl core::cmp::Eq for syntaqlite_syntax::source::LayerText
+impl core::cmp::Eq for syntaqlite_syntax::source::StmtText
+impl core::cmp::PartialEq for syntaqlite_syntax::source::DocText
+impl core::cmp::PartialEq for syntaqlite_syntax::source::LayerText
+impl core::cmp::PartialEq for syntaqlite_syntax::source::StmtText
+impl core::cmp::PartialEq<&str> for syntaqlite_syntax::source::DocText
+impl core::cmp::PartialEq<&str> for syntaqlite_syntax::source::LayerText
+impl core::cmp::PartialEq<&str> for syntaqlite_syntax::source::StmtText
+impl core::cmp::PartialEq<str> for syntaqlite_syntax::source::DocText
+impl core::cmp::PartialEq<str> for syntaqlite_syntax::source::LayerText
+impl core::cmp::PartialEq<str> for syntaqlite_syntax::source::StmtText
+impl core::cmp::PartialEq<syntaqlite_syntax::source::DocText> for str
+impl core::cmp::PartialEq<syntaqlite_syntax::source::LayerText> for str
+impl core::cmp::PartialEq<syntaqlite_syntax::source::StmtText> for str
+impl core::convert::AsRef<str> for syntaqlite_syntax::source::DocText
+impl core::convert::AsRef<str> for syntaqlite_syntax::source::LayerText
+impl core::convert::AsRef<str> for syntaqlite_syntax::source::StmtText
 impl core::convert::From<syntaqlite_syntax::CompletionContext> for u32
 impl core::convert::From<syntaqlite_syntax::TokenType> for syntaqlite_syntax::any::AnyTokenType
 impl core::convert::From<syntaqlite_syntax::TokenType> for u32
@@ -207,6 +239,20 @@ impl core::fmt::Debug for syntaqlite_syntax::nodes::ValuesClause<'_>
 impl core::fmt::Debug for syntaqlite_syntax::nodes::Variable<'_>
 impl core::fmt::Debug for syntaqlite_syntax::nodes::WindowDef<'_>
 impl core::fmt::Debug for syntaqlite_syntax::nodes::WithClause<'_>
+impl core::fmt::Debug for syntaqlite_syntax::source::ColumnNumber
+impl core::fmt::Debug for syntaqlite_syntax::source::DocLen
+impl core::fmt::Debug for syntaqlite_syntax::source::DocOffset
+impl core::fmt::Debug for syntaqlite_syntax::source::DocText
+impl core::fmt::Debug for syntaqlite_syntax::source::LayerLen
+impl core::fmt::Debug for syntaqlite_syntax::source::LayerOffset
+impl core::fmt::Debug for syntaqlite_syntax::source::LayerText
+impl core::fmt::Debug for syntaqlite_syntax::source::LineNumber
+impl core::fmt::Debug for syntaqlite_syntax::source::StmtLen
+impl core::fmt::Debug for syntaqlite_syntax::source::StmtOffset
+impl core::fmt::Debug for syntaqlite_syntax::source::StmtText
+impl core::fmt::Debug for syntaqlite_syntax::source::TokenIdx
+impl core::fmt::Debug for syntaqlite_syntax::source::Utf16Col
+impl core::fmt::Debug for syntaqlite_syntax::source::Utf16Line
 impl core::fmt::Display for syntaqlite_syntax::any::AnyNode<'_>
 impl core::fmt::Display for syntaqlite_syntax::nodes::AggregateFunctionCall<'_>
 impl core::fmt::Display for syntaqlite_syntax::nodes::AlterTableStmt<'_>
@@ -272,8 +318,55 @@ impl core::fmt::Display for syntaqlite_syntax::nodes::ValuesClause<'_>
 impl core::fmt::Display for syntaqlite_syntax::nodes::Variable<'_>
 impl core::fmt::Display for syntaqlite_syntax::nodes::WindowDef<'_>
 impl core::fmt::Display for syntaqlite_syntax::nodes::WithClause<'_>
+impl core::fmt::Display for syntaqlite_syntax::source::ColumnNumber
+impl core::fmt::Display for syntaqlite_syntax::source::DocLen
+impl core::fmt::Display for syntaqlite_syntax::source::DocOffset
+impl core::fmt::Display for syntaqlite_syntax::source::DocText
+impl core::fmt::Display for syntaqlite_syntax::source::LayerLen
+impl core::fmt::Display for syntaqlite_syntax::source::LayerOffset
+impl core::fmt::Display for syntaqlite_syntax::source::LayerText
+impl core::fmt::Display for syntaqlite_syntax::source::LineNumber
+impl core::fmt::Display for syntaqlite_syntax::source::StmtLen
+impl core::fmt::Display for syntaqlite_syntax::source::StmtOffset
+impl core::fmt::Display for syntaqlite_syntax::source::StmtText
+impl core::fmt::Display for syntaqlite_syntax::source::TokenIdx
+impl core::fmt::Display for syntaqlite_syntax::source::Utf16Col
+impl core::fmt::Display for syntaqlite_syntax::source::Utf16Line
+impl core::hash::Hash for syntaqlite_syntax::source::DocText
+impl core::hash::Hash for syntaqlite_syntax::source::LayerText
+impl core::hash::Hash for syntaqlite_syntax::source::StmtText
 impl core::marker::Send for syntaqlite_syntax::any::AnyDialect
 impl core::marker::Sync for syntaqlite_syntax::any::AnyDialect
+impl core::ops::arith::Add for syntaqlite_syntax::source::DocLen
+impl core::ops::arith::Add for syntaqlite_syntax::source::LayerLen
+impl core::ops::arith::Add for syntaqlite_syntax::source::StmtLen
+impl core::ops::arith::Add<syntaqlite_syntax::source::DocLen> for syntaqlite_syntax::source::DocOffset
+impl core::ops::arith::Add<syntaqlite_syntax::source::LayerLen> for syntaqlite_syntax::source::LayerOffset
+impl core::ops::arith::Add<syntaqlite_syntax::source::StmtLen> for syntaqlite_syntax::source::StmtOffset
+impl core::ops::arith::AddAssign for syntaqlite_syntax::source::DocLen
+impl core::ops::arith::AddAssign for syntaqlite_syntax::source::LayerLen
+impl core::ops::arith::AddAssign for syntaqlite_syntax::source::StmtLen
+impl core::ops::arith::AddAssign<syntaqlite_syntax::source::DocLen> for syntaqlite_syntax::source::DocOffset
+impl core::ops::arith::AddAssign<syntaqlite_syntax::source::LayerLen> for syntaqlite_syntax::source::LayerOffset
+impl core::ops::arith::AddAssign<syntaqlite_syntax::source::StmtLen> for syntaqlite_syntax::source::StmtOffset
+impl core::ops::arith::Sub for syntaqlite_syntax::source::DocLen
+impl core::ops::arith::Sub for syntaqlite_syntax::source::DocOffset
+impl core::ops::arith::Sub for syntaqlite_syntax::source::LayerLen
+impl core::ops::arith::Sub for syntaqlite_syntax::source::LayerOffset
+impl core::ops::arith::Sub for syntaqlite_syntax::source::StmtLen
+impl core::ops::arith::Sub for syntaqlite_syntax::source::StmtOffset
+impl core::ops::arith::Sub<syntaqlite_syntax::source::DocLen> for syntaqlite_syntax::source::DocOffset
+impl core::ops::arith::Sub<syntaqlite_syntax::source::LayerLen> for syntaqlite_syntax::source::LayerOffset
+impl core::ops::arith::Sub<syntaqlite_syntax::source::StmtLen> for syntaqlite_syntax::source::StmtOffset
+impl core::ops::arith::SubAssign for syntaqlite_syntax::source::DocLen
+impl core::ops::arith::SubAssign for syntaqlite_syntax::source::LayerLen
+impl core::ops::arith::SubAssign for syntaqlite_syntax::source::StmtLen
+impl core::ops::arith::SubAssign<syntaqlite_syntax::source::DocLen> for syntaqlite_syntax::source::DocOffset
+impl core::ops::arith::SubAssign<syntaqlite_syntax::source::LayerLen> for syntaqlite_syntax::source::LayerOffset
+impl core::ops::arith::SubAssign<syntaqlite_syntax::source::StmtLen> for syntaqlite_syntax::source::StmtOffset
+impl core::ops::index::Index<syntaqlite_syntax::source::DocRange> for syntaqlite_syntax::source::DocText
+impl core::ops::index::Index<syntaqlite_syntax::source::LayerRange> for syntaqlite_syntax::source::LayerText
+impl core::ops::index::Index<syntaqlite_syntax::source::StmtRange> for syntaqlite_syntax::source::StmtText
 impl core::ops::index::Index<usize> for syntaqlite_syntax::any::NodeFields
 impl syntaqlite_syntax::CommentSpan
 impl syntaqlite_syntax::CompletionContext
@@ -411,6 +504,24 @@ impl syntaqlite_syntax::nodes::VariableId
 impl syntaqlite_syntax::nodes::WindowDefId
 impl syntaqlite_syntax::nodes::WindowDefListId
 impl syntaqlite_syntax::nodes::WithClauseId
+impl syntaqlite_syntax::source::ColumnNumber
+impl syntaqlite_syntax::source::DocLen
+impl syntaqlite_syntax::source::DocOffset
+impl syntaqlite_syntax::source::DocRange
+impl syntaqlite_syntax::source::DocText
+impl syntaqlite_syntax::source::LayerLen
+impl syntaqlite_syntax::source::LayerOffset
+impl syntaqlite_syntax::source::LayerRange
+impl syntaqlite_syntax::source::LayerText
+impl syntaqlite_syntax::source::LineNumber
+impl syntaqlite_syntax::source::StatementBase
+impl syntaqlite_syntax::source::StmtLen
+impl syntaqlite_syntax::source::StmtOffset
+impl syntaqlite_syntax::source::StmtRange
+impl syntaqlite_syntax::source::StmtText
+impl syntaqlite_syntax::source::TokenIdx
+impl syntaqlite_syntax::source::Utf16Col
+impl syntaqlite_syntax::source::Utf16Line
 impl syntaqlite_syntax::typed::Dialect
 impl syntaqlite_syntax::typed::GrammarTokenType for syntaqlite_syntax::TokenType
 impl syntaqlite_syntax::typed::GrammarTokenType for syntaqlite_syntax::any::AnyTokenType
@@ -755,6 +866,54 @@ impl<G: syntaqlite_syntax::typed::TypedDialect> syntaqlite_syntax::typed::TypedP
 impl<G: syntaqlite_syntax::typed::TypedDialect> syntaqlite_syntax::typed::TypedParser<G>
 impl<G: syntaqlite_syntax::typed::TypedDialect> syntaqlite_syntax::typed::TypedTokenizer<G>
 impl<T, E> syntaqlite_syntax::ParseOutcome<T, E>
+pub const fn syntaqlite_syntax::source::ColumnNumber::as_u32(self) -> u32
+pub const fn syntaqlite_syntax::source::ColumnNumber::as_usize(self) -> usize
+pub const fn syntaqlite_syntax::source::ColumnNumber::from_raw(v: u32) -> Self
+pub const fn syntaqlite_syntax::source::DocLen::as_u32(self) -> u32
+pub const fn syntaqlite_syntax::source::DocLen::as_usize(self) -> usize
+pub const fn syntaqlite_syntax::source::DocLen::from_raw(v: u32) -> Self
+pub const fn syntaqlite_syntax::source::DocOffset::as_u32(self) -> u32
+pub const fn syntaqlite_syntax::source::DocOffset::as_usize(self) -> usize
+pub const fn syntaqlite_syntax::source::DocOffset::from_raw(v: u32) -> Self
+pub const fn syntaqlite_syntax::source::DocRange::from_offset_len(start: syntaqlite_syntax::source::DocOffset, len: syntaqlite_syntax::source::DocLen) -> Self
+pub const fn syntaqlite_syntax::source::DocRange::is_empty(self) -> bool
+pub const fn syntaqlite_syntax::source::DocRange::len(self) -> syntaqlite_syntax::source::DocLen
+pub const fn syntaqlite_syntax::source::LayerLen::as_u32(self) -> u32
+pub const fn syntaqlite_syntax::source::LayerLen::as_usize(self) -> usize
+pub const fn syntaqlite_syntax::source::LayerLen::from_raw(v: u32) -> Self
+pub const fn syntaqlite_syntax::source::LayerOffset::as_u32(self) -> u32
+pub const fn syntaqlite_syntax::source::LayerOffset::as_usize(self) -> usize
+pub const fn syntaqlite_syntax::source::LayerOffset::from_raw(v: u32) -> Self
+pub const fn syntaqlite_syntax::source::LayerRange::from_offset_len(start: syntaqlite_syntax::source::LayerOffset, len: syntaqlite_syntax::source::LayerLen) -> Self
+pub const fn syntaqlite_syntax::source::LayerRange::is_empty(self) -> bool
+pub const fn syntaqlite_syntax::source::LayerRange::len(self) -> syntaqlite_syntax::source::LayerLen
+pub const fn syntaqlite_syntax::source::LineNumber::as_u32(self) -> u32
+pub const fn syntaqlite_syntax::source::LineNumber::as_usize(self) -> usize
+pub const fn syntaqlite_syntax::source::LineNumber::from_raw(v: u32) -> Self
+pub const fn syntaqlite_syntax::source::StatementBase::as_doc_offset(self) -> syntaqlite_syntax::source::DocOffset
+pub const fn syntaqlite_syntax::source::StatementBase::from_doc(self, off: syntaqlite_syntax::source::DocOffset) -> core::option::Option<syntaqlite_syntax::source::StmtOffset>
+pub const fn syntaqlite_syntax::source::StatementBase::new(base: syntaqlite_syntax::source::DocOffset) -> Self
+pub const fn syntaqlite_syntax::source::StatementBase::to_doc(self, off: syntaqlite_syntax::source::StmtOffset) -> syntaqlite_syntax::source::DocOffset
+pub const fn syntaqlite_syntax::source::StatementBase::to_doc_range(self, range: syntaqlite_syntax::source::StmtRange) -> syntaqlite_syntax::source::DocRange
+pub const fn syntaqlite_syntax::source::StmtLen::as_u32(self) -> u32
+pub const fn syntaqlite_syntax::source::StmtLen::as_usize(self) -> usize
+pub const fn syntaqlite_syntax::source::StmtLen::from_raw(v: u32) -> Self
+pub const fn syntaqlite_syntax::source::StmtOffset::as_u32(self) -> u32
+pub const fn syntaqlite_syntax::source::StmtOffset::as_usize(self) -> usize
+pub const fn syntaqlite_syntax::source::StmtOffset::from_raw(v: u32) -> Self
+pub const fn syntaqlite_syntax::source::StmtRange::from_offset_len(start: syntaqlite_syntax::source::StmtOffset, len: syntaqlite_syntax::source::StmtLen) -> Self
+pub const fn syntaqlite_syntax::source::StmtRange::is_empty(self) -> bool
+pub const fn syntaqlite_syntax::source::StmtRange::len(self) -> syntaqlite_syntax::source::StmtLen
+pub const fn syntaqlite_syntax::source::TokenIdx::as_u32(self) -> u32
+pub const fn syntaqlite_syntax::source::TokenIdx::as_usize(self) -> usize
+pub const fn syntaqlite_syntax::source::TokenIdx::from_raw(v: u32) -> Self
+pub const fn syntaqlite_syntax::source::Utf16Col::as_u32(self) -> u32
+pub const fn syntaqlite_syntax::source::Utf16Col::as_usize(self) -> usize
+pub const fn syntaqlite_syntax::source::Utf16Col::from_raw(v: u32) -> Self
+pub const fn syntaqlite_syntax::source::Utf16Line::as_u32(self) -> u32
+pub const fn syntaqlite_syntax::source::Utf16Line::as_usize(self) -> usize
+pub const fn syntaqlite_syntax::source::Utf16Line::from_raw(v: u32) -> Self
+pub const syntaqlite_syntax::MACRO_BODY_CALL_ARG_INTERNAL: syntaqlite_syntax::source::LayerOffset
 pub enum syntaqlite_syntax::CommentKind
 pub enum syntaqlite_syntax::CommentSide
 pub enum syntaqlite_syntax::ParseOutcome<T, E>
@@ -770,17 +929,20 @@ pub enum syntaqlite_syntax::nodes::Select<'a>
 pub enum syntaqlite_syntax::nodes::Stmt<'a>
 pub enum syntaqlite_syntax::nodes::TableSource<'a>
 pub enum syntaqlite_syntax::typed::ParseOutcome<T, E>
+pub fn str::eq(&self, other: &syntaqlite_syntax::source::DocText) -> bool
+pub fn str::eq(&self, other: &syntaqlite_syntax::source::LayerText) -> bool
+pub fn str::eq(&self, other: &syntaqlite_syntax::source::StmtText) -> bool
 pub fn syntaqlite_syntax::Comment<'a>::kind(&self) -> syntaqlite_syntax::CommentKind
-pub fn syntaqlite_syntax::Comment<'a>::length(&self) -> u32
-pub fn syntaqlite_syntax::Comment<'a>::offset(&self) -> u32
+pub fn syntaqlite_syntax::Comment<'a>::length(&self) -> syntaqlite_syntax::source::StmtLen
+pub fn syntaqlite_syntax::Comment<'a>::offset(&self) -> syntaqlite_syntax::source::StmtOffset
 pub fn syntaqlite_syntax::Comment<'a>::side(&self) -> syntaqlite_syntax::CommentSide
 pub fn syntaqlite_syntax::Comment<'a>::text(&self) -> &'a str
-pub fn syntaqlite_syntax::Comment<'a>::token_idx(&self) -> u32
+pub fn syntaqlite_syntax::Comment<'a>::token_idx(&self) -> syntaqlite_syntax::source::TokenIdx
 pub fn syntaqlite_syntax::CommentSpan::kind(&self) -> syntaqlite_syntax::CommentKind
-pub fn syntaqlite_syntax::CommentSpan::length(&self) -> u32
-pub fn syntaqlite_syntax::CommentSpan::offset(&self) -> u32
+pub fn syntaqlite_syntax::CommentSpan::length(&self) -> syntaqlite_syntax::source::StmtLen
+pub fn syntaqlite_syntax::CommentSpan::offset(&self) -> syntaqlite_syntax::source::StmtOffset
 pub fn syntaqlite_syntax::CommentSpan::side(&self) -> syntaqlite_syntax::CommentSide
-pub fn syntaqlite_syntax::CommentSpan::token_idx(&self) -> u32
+pub fn syntaqlite_syntax::CommentSpan::token_idx(&self) -> syntaqlite_syntax::source::TokenIdx
 pub fn syntaqlite_syntax::CompletionContext::from_raw(v: u32) -> Self
 pub fn syntaqlite_syntax::CompletionContext::raw(self) -> u32
 pub fn syntaqlite_syntax::IncrementalParseSession::completion_context(&self) -> syntaqlite_syntax::CompletionContext
@@ -807,8 +969,8 @@ pub fn syntaqlite_syntax::ParserConfig::with_macro_fallback(self, macro_fallback
 pub fn syntaqlite_syntax::ParserConfig::with_trace(self, trace: bool) -> Self
 pub fn syntaqlite_syntax::ParserToken<'_>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn syntaqlite_syntax::ParserToken<'a>::flags(&self) -> syntaqlite_syntax::ParserTokenFlags
-pub fn syntaqlite_syntax::ParserToken<'a>::length(&self) -> u32
-pub fn syntaqlite_syntax::ParserToken<'a>::offset(&self) -> u32
+pub fn syntaqlite_syntax::ParserToken<'a>::length(&self) -> syntaqlite_syntax::source::StmtLen
+pub fn syntaqlite_syntax::ParserToken<'a>::offset(&self) -> syntaqlite_syntax::source::StmtOffset
 pub fn syntaqlite_syntax::ParserToken<'a>::text(&self) -> &'a str
 pub fn syntaqlite_syntax::ParserToken<'a>::token_type(&self) -> syntaqlite_syntax::TokenType
 pub fn syntaqlite_syntax::ParserTokenFlags::bits(self) -> u8
@@ -923,7 +1085,7 @@ pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::child_node_ids(&self, id:
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::comment_spans(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::CommentSpan> + use<'_>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::expanded_text(&self) -> &'a str
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::extract_fields(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(syntaqlite_syntax::any::AnyNodeTag, syntaqlite_syntax::any::NodeFields)>
-pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::full_text(&self) -> &'a str
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::full_text(&self) -> &'a syntaqlite_syntax::source::DocText
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::is_macro_free(&self) -> bool
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::list_children(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a [syntaqlite_syntax::any::AnyNodeId]>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::macro_rewrites(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRewrite<'a>> + use<'_, 'a>
@@ -933,11 +1095,11 @@ pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_text(&self, id: synt
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_id(&self) -> syntaqlite_syntax::any::AnyNodeId
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_node(&self) -> core::option::Option<syntaqlite_syntax::any::AnyNode<'_>>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_expanded_text(&self, span: syntaqlite_syntax::any::TextSpan) -> &'a str
-pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_text(&self, span: syntaqlite_syntax::any::TextSpan) -> (&'a str, u32)
-pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_text_abs(&self, span: syntaqlite_syntax::any::TextSpan) -> (&'a str, usize, usize)
-pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::statement_base_offset(&self) -> u32
-pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::text(&self) -> &'a str
-pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::token_spans(&self) -> impl core::iter::traits::iterator::Iterator<Item = (u32, u32)> + use<'_>
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_text(&self, span: syntaqlite_syntax::any::TextSpan) -> (&'a str, syntaqlite_syntax::source::StmtOffset)
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_text_abs(&self, span: syntaqlite_syntax::any::TextSpan) -> (&'a str, syntaqlite_syntax::source::DocRange)
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::statement_base(&self) -> syntaqlite_syntax::source::StatementBase
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::text(&self) -> &'a syntaqlite_syntax::source::StmtText
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::token_spans(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::source::StmtRange> + use<'_>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::traceback(&mut self, node_id: syntaqlite_syntax::any::AnyNodeId, field_idx: u8) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::TracebackFrame<'a>> + use<'_, 'a>
 pub fn syntaqlite_syntax::any::AnyTokenType::from(t: syntaqlite_syntax::TokenType) -> syntaqlite_syntax::any::AnyTokenType
 pub fn syntaqlite_syntax::any::AnyTokenType::from_raw(v: u32) -> Self
@@ -949,22 +1111,22 @@ pub fn syntaqlite_syntax::any::FieldMeta<'_>::name(&self) -> &'static str
 pub fn syntaqlite_syntax::any::FieldMeta<'_>::offset(&self) -> u16
 pub fn syntaqlite_syntax::any::KeywordEntry::keyword(&self) -> &'static str
 pub fn syntaqlite_syntax::any::KeywordEntry::token_type(&self) -> syntaqlite_syntax::any::AnyTokenType
-pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::body_length(&self) -> u32
-pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::body_offset(&self) -> u32
-pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::expansion_length(&self) -> u32
-pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::expansion_offset(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::body_length(&self) -> syntaqlite_syntax::source::LayerLen
+pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::body_offset(&self) -> syntaqlite_syntax::source::LayerOffset
+pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::expansion_length(&self) -> syntaqlite_syntax::source::LayerLen
+pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::expansion_offset(&self) -> syntaqlite_syntax::source::LayerOffset
 pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin(&self) -> syntaqlite_syntax::any::ArgOrigin
-pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin_length(&self) -> u32
-pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin_offset(&self) -> u32
+pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin_length(&self) -> syntaqlite_syntax::source::LayerLen
+pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin_offset(&self) -> syntaqlite_syntax::source::LayerOffset
 pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin_parent(&self) -> core::option::Option<u32>
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::arg_segments(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroArgSegment<'a>> + use<'_, 'a>
-pub fn syntaqlite_syntax::any::MacroRewrite<'a>::body_call_length(&self) -> u32
-pub fn syntaqlite_syntax::any::MacroRewrite<'a>::body_call_offset(&self) -> u32
-pub fn syntaqlite_syntax::any::MacroRewrite<'a>::call_length(&self) -> u32
-pub fn syntaqlite_syntax::any::MacroRewrite<'a>::call_offset(&self) -> u32
-pub fn syntaqlite_syntax::any::MacroRewrite<'a>::def_col(&self) -> u32
-pub fn syntaqlite_syntax::any::MacroRewrite<'a>::def_line(&self) -> u32
-pub fn syntaqlite_syntax::any::MacroRewrite<'a>::expansion(&self) -> &'a str
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::body_call_length(&self) -> syntaqlite_syntax::source::LayerLen
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::body_call_offset(&self) -> syntaqlite_syntax::source::LayerOffset
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::call_length(&self) -> syntaqlite_syntax::source::LayerLen
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::call_offset(&self) -> syntaqlite_syntax::source::LayerOffset
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::def_col(&self) -> syntaqlite_syntax::source::ColumnNumber
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::def_line(&self) -> syntaqlite_syntax::source::LineNumber
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::expansion(&self) -> &'a syntaqlite_syntax::source::LayerText
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::name(&self) -> &'a str
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::parent(&self) -> core::option::Option<u32>
 pub fn syntaqlite_syntax::any::NodeFields::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1632,6 +1794,80 @@ pub fn syntaqlite_syntax::nodes::WithClause<'a>::recursive(&self) -> bool
 pub fn syntaqlite_syntax::nodes::WithClause<'a>::select(&self) -> core::option::Option<syntaqlite_syntax::nodes::Select<'a>>
 pub fn syntaqlite_syntax::nodes::WithClauseId::from(n: syntaqlite_syntax::nodes::WithClause<'a>) -> Self
 pub fn syntaqlite_syntax::nodes::WithClauseId::into_inner(self) -> syntaqlite_syntax::any::AnyNodeId
+pub fn syntaqlite_syntax::source::ColumnNumber::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::DocLen::add(self, rhs: syntaqlite_syntax::source::DocLen) -> syntaqlite_syntax::source::DocLen
+pub fn syntaqlite_syntax::source::DocLen::add_assign(&mut self, rhs: syntaqlite_syntax::source::DocLen)
+pub fn syntaqlite_syntax::source::DocLen::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::DocLen::sub(self, rhs: syntaqlite_syntax::source::DocLen) -> syntaqlite_syntax::source::DocLen
+pub fn syntaqlite_syntax::source::DocLen::sub_assign(&mut self, rhs: syntaqlite_syntax::source::DocLen)
+pub fn syntaqlite_syntax::source::DocOffset::add(self, rhs: syntaqlite_syntax::source::DocLen) -> syntaqlite_syntax::source::DocOffset
+pub fn syntaqlite_syntax::source::DocOffset::add_assign(&mut self, rhs: syntaqlite_syntax::source::DocLen)
+pub fn syntaqlite_syntax::source::DocOffset::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::DocOffset::sub(self, rhs: syntaqlite_syntax::source::DocLen) -> syntaqlite_syntax::source::DocOffset
+pub fn syntaqlite_syntax::source::DocOffset::sub(self, rhs: syntaqlite_syntax::source::DocOffset) -> syntaqlite_syntax::source::DocLen
+pub fn syntaqlite_syntax::source::DocOffset::sub_assign(&mut self, rhs: syntaqlite_syntax::source::DocLen)
+pub fn syntaqlite_syntax::source::DocText::as_range(&self) -> syntaqlite_syntax::source::DocRange
+pub fn syntaqlite_syntax::source::DocText::as_ref(&self) -> &str
+pub fn syntaqlite_syntax::source::DocText::as_str(&self) -> &str
+pub fn syntaqlite_syntax::source::DocText::byte_len(&self) -> syntaqlite_syntax::source::DocLen
+pub fn syntaqlite_syntax::source::DocText::eq(&self, other: &&str) -> bool
+pub fn syntaqlite_syntax::source::DocText::eq(&self, other: &Self) -> bool
+pub fn syntaqlite_syntax::source::DocText::eq(&self, other: &str) -> bool
+pub fn syntaqlite_syntax::source::DocText::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::DocText::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn syntaqlite_syntax::source::DocText::index(&self, r: syntaqlite_syntax::source::DocRange) -> &str
+pub fn syntaqlite_syntax::source::DocText::is_empty(&self) -> bool
+pub fn syntaqlite_syntax::source::DocText::new(s: &str) -> &syntaqlite_syntax::source::DocText
+pub fn syntaqlite_syntax::source::LayerLen::add(self, rhs: syntaqlite_syntax::source::LayerLen) -> syntaqlite_syntax::source::LayerLen
+pub fn syntaqlite_syntax::source::LayerLen::add_assign(&mut self, rhs: syntaqlite_syntax::source::LayerLen)
+pub fn syntaqlite_syntax::source::LayerLen::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::LayerLen::sub(self, rhs: syntaqlite_syntax::source::LayerLen) -> syntaqlite_syntax::source::LayerLen
+pub fn syntaqlite_syntax::source::LayerLen::sub_assign(&mut self, rhs: syntaqlite_syntax::source::LayerLen)
+pub fn syntaqlite_syntax::source::LayerOffset::add(self, rhs: syntaqlite_syntax::source::LayerLen) -> syntaqlite_syntax::source::LayerOffset
+pub fn syntaqlite_syntax::source::LayerOffset::add_assign(&mut self, rhs: syntaqlite_syntax::source::LayerLen)
+pub fn syntaqlite_syntax::source::LayerOffset::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::LayerOffset::sub(self, rhs: syntaqlite_syntax::source::LayerLen) -> syntaqlite_syntax::source::LayerOffset
+pub fn syntaqlite_syntax::source::LayerOffset::sub(self, rhs: syntaqlite_syntax::source::LayerOffset) -> syntaqlite_syntax::source::LayerLen
+pub fn syntaqlite_syntax::source::LayerOffset::sub_assign(&mut self, rhs: syntaqlite_syntax::source::LayerLen)
+pub fn syntaqlite_syntax::source::LayerText::as_range(&self) -> syntaqlite_syntax::source::LayerRange
+pub fn syntaqlite_syntax::source::LayerText::as_ref(&self) -> &str
+pub fn syntaqlite_syntax::source::LayerText::as_str(&self) -> &str
+pub fn syntaqlite_syntax::source::LayerText::byte_len(&self) -> syntaqlite_syntax::source::LayerLen
+pub fn syntaqlite_syntax::source::LayerText::eq(&self, other: &&str) -> bool
+pub fn syntaqlite_syntax::source::LayerText::eq(&self, other: &Self) -> bool
+pub fn syntaqlite_syntax::source::LayerText::eq(&self, other: &str) -> bool
+pub fn syntaqlite_syntax::source::LayerText::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::LayerText::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn syntaqlite_syntax::source::LayerText::index(&self, r: syntaqlite_syntax::source::LayerRange) -> &str
+pub fn syntaqlite_syntax::source::LayerText::is_empty(&self) -> bool
+pub fn syntaqlite_syntax::source::LayerText::new(s: &str) -> &syntaqlite_syntax::source::LayerText
+pub fn syntaqlite_syntax::source::LineNumber::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::StmtLen::add(self, rhs: syntaqlite_syntax::source::StmtLen) -> syntaqlite_syntax::source::StmtLen
+pub fn syntaqlite_syntax::source::StmtLen::add_assign(&mut self, rhs: syntaqlite_syntax::source::StmtLen)
+pub fn syntaqlite_syntax::source::StmtLen::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::StmtLen::sub(self, rhs: syntaqlite_syntax::source::StmtLen) -> syntaqlite_syntax::source::StmtLen
+pub fn syntaqlite_syntax::source::StmtLen::sub_assign(&mut self, rhs: syntaqlite_syntax::source::StmtLen)
+pub fn syntaqlite_syntax::source::StmtOffset::add(self, rhs: syntaqlite_syntax::source::StmtLen) -> syntaqlite_syntax::source::StmtOffset
+pub fn syntaqlite_syntax::source::StmtOffset::add_assign(&mut self, rhs: syntaqlite_syntax::source::StmtLen)
+pub fn syntaqlite_syntax::source::StmtOffset::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::StmtOffset::sub(self, rhs: syntaqlite_syntax::source::StmtLen) -> syntaqlite_syntax::source::StmtOffset
+pub fn syntaqlite_syntax::source::StmtOffset::sub(self, rhs: syntaqlite_syntax::source::StmtOffset) -> syntaqlite_syntax::source::StmtLen
+pub fn syntaqlite_syntax::source::StmtOffset::sub_assign(&mut self, rhs: syntaqlite_syntax::source::StmtLen)
+pub fn syntaqlite_syntax::source::StmtText::as_range(&self) -> syntaqlite_syntax::source::StmtRange
+pub fn syntaqlite_syntax::source::StmtText::as_ref(&self) -> &str
+pub fn syntaqlite_syntax::source::StmtText::as_str(&self) -> &str
+pub fn syntaqlite_syntax::source::StmtText::byte_len(&self) -> syntaqlite_syntax::source::StmtLen
+pub fn syntaqlite_syntax::source::StmtText::eq(&self, other: &&str) -> bool
+pub fn syntaqlite_syntax::source::StmtText::eq(&self, other: &Self) -> bool
+pub fn syntaqlite_syntax::source::StmtText::eq(&self, other: &str) -> bool
+pub fn syntaqlite_syntax::source::StmtText::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::StmtText::hash<H: core::hash::Hasher>(&self, state: &mut H)
+pub fn syntaqlite_syntax::source::StmtText::index(&self, r: syntaqlite_syntax::source::StmtRange) -> &str
+pub fn syntaqlite_syntax::source::StmtText::is_empty(&self) -> bool
+pub fn syntaqlite_syntax::source::StmtText::new(s: &str) -> &syntaqlite_syntax::source::StmtText
+pub fn syntaqlite_syntax::source::TokenIdx::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::Utf16Col::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::Utf16Line::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn syntaqlite_syntax::typed::Dialect::from_raw(raw: syntaqlite_syntax::any::AnyDialect) -> Self
 pub fn syntaqlite_syntax::typed::Dialect::into_raw(self) -> syntaqlite_syntax::any::AnyDialect
 pub fn syntaqlite_syntax::typed::Dialect::with_cflags(self, cflags: syntaqlite_syntax::util::SqliteSyntaxFlags) -> Self
@@ -1660,8 +1896,8 @@ pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::length(&self) -> core::
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::message(&self) -> &str
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::offset(&self) -> core::option::Option<usize>
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::recovery_root(&'a self) -> core::option::Option<<G as syntaqlite_syntax::typed::TypedDialect>::Node>
-pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::statement_base_offset(&self) -> u32
-pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::text(&self) -> &'a str
+pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::statement_base(&self) -> syntaqlite_syntax::source::StatementBase
+pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::text(&self) -> &'a syntaqlite_syntax::source::StmtText
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::typed::TypedParserToken<'a, G>>
 pub fn syntaqlite_syntax::typed::TypedParseSession<G>::arena_result(&self) -> syntaqlite_syntax::any::AnyParsedStatement<'_>
 pub fn syntaqlite_syntax::typed::TypedParseSession<G>::drop(&mut self)
@@ -1673,12 +1909,12 @@ pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::comments(&self) ->
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::dump(&self, out: &mut alloc::string::String, indent: usize)
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::erase(self) -> syntaqlite_syntax::any::AnyParsedStatement<'a>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::expanded_text(&self) -> &'a str
-pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::full_text(&self) -> &'a str
+pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::full_text(&self) -> &'a syntaqlite_syntax::source::DocText
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::leading_comments(&self, token_idx: u32) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::macro_rewrites(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRewrite<'a>> + use<'_, 'a, G>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::root(&'a self) -> core::option::Option<<G as syntaqlite_syntax::typed::TypedDialect>::Node>
-pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::statement_base_offset(&self) -> u32
-pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::text(&self) -> &'a str
+pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::statement_base(&self) -> syntaqlite_syntax::source::StatementBase
+pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::text(&self) -> &'a syntaqlite_syntax::source::StmtText
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::typed::TypedParserToken<'a, G>>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::trailing_comments(&self, token_idx: u32) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>>
 pub fn syntaqlite_syntax::typed::TypedParser<G>::incremental_parse(&self, source: &str) -> syntaqlite_syntax::typed::TypedIncrementalParseSession<G>
@@ -1687,8 +1923,8 @@ pub fn syntaqlite_syntax::typed::TypedParser<G>::parse(&self, source: &str) -> s
 pub fn syntaqlite_syntax::typed::TypedParser<G>::set_macro_lookup(&mut self, handler: core::option::Option<alloc::boxed::Box<dyn syntaqlite_syntax::MacroLookup>>)
 pub fn syntaqlite_syntax::typed::TypedParser<G>::with_config(dialect: G, config: &syntaqlite_syntax::ParserConfig) -> Self
 pub fn syntaqlite_syntax::typed::TypedParserToken<'a, G>::flags(&self) -> syntaqlite_syntax::ParserTokenFlags
-pub fn syntaqlite_syntax::typed::TypedParserToken<'a, G>::length(&self) -> u32
-pub fn syntaqlite_syntax::typed::TypedParserToken<'a, G>::offset(&self) -> u32
+pub fn syntaqlite_syntax::typed::TypedParserToken<'a, G>::length(&self) -> syntaqlite_syntax::source::StmtLen
+pub fn syntaqlite_syntax::typed::TypedParserToken<'a, G>::offset(&self) -> syntaqlite_syntax::source::StmtOffset
 pub fn syntaqlite_syntax::typed::TypedParserToken<'a, G>::text(&self) -> &'a str
 pub fn syntaqlite_syntax::typed::TypedParserToken<'a, G>::token_type(&self) -> <G as syntaqlite_syntax::typed::TypedDialect>::Token
 pub fn syntaqlite_syntax::typed::TypedToken<'a, G>::text(&self) -> &'a str
@@ -1713,6 +1949,7 @@ pub fn u32::from(v: syntaqlite_syntax::CompletionContext) -> u32
 pub mod syntaqlite_syntax
 pub mod syntaqlite_syntax::any
 pub mod syntaqlite_syntax::nodes
+pub mod syntaqlite_syntax::source
 pub mod syntaqlite_syntax::typed
 pub mod syntaqlite_syntax::util
 pub struct syntaqlite_syntax::Comment<'a>
@@ -1881,6 +2118,10 @@ pub struct syntaqlite_syntax::nodes::WindowDefId(_)
 pub struct syntaqlite_syntax::nodes::WindowDefListId(_)
 pub struct syntaqlite_syntax::nodes::WithClause<'a>
 pub struct syntaqlite_syntax::nodes::WithClauseId(_)
+pub struct syntaqlite_syntax::source::DocRange
+pub struct syntaqlite_syntax::source::LayerRange
+pub struct syntaqlite_syntax::source::StatementBase(_)
+pub struct syntaqlite_syntax::source::StmtRange
 pub struct syntaqlite_syntax::typed::Dialect
 pub struct syntaqlite_syntax::typed::TypedIncrementalParseSession<G: syntaqlite_syntax::typed::TypedDialect>
 pub struct syntaqlite_syntax::typed::TypedNodeList<'a, G: syntaqlite_syntax::typed::TypedDialect, T>
@@ -2119,12 +2360,12 @@ pub syntaqlite_syntax::any::TokenCategory::Parameter
 pub syntaqlite_syntax::any::TokenCategory::Punctuation
 pub syntaqlite_syntax::any::TokenCategory::String
 pub syntaqlite_syntax::any::TokenCategory::Type
-pub syntaqlite_syntax::any::TracebackFrame::col: u32
-pub syntaqlite_syntax::any::TracebackFrame::length_in_snippet: usize
-pub syntaqlite_syntax::any::TracebackFrame::line: u32
+pub syntaqlite_syntax::any::TracebackFrame::col: syntaqlite_syntax::source::ColumnNumber
+pub syntaqlite_syntax::any::TracebackFrame::length_in_snippet: syntaqlite_syntax::source::LayerLen
+pub syntaqlite_syntax::any::TracebackFrame::line: syntaqlite_syntax::source::LineNumber
 pub syntaqlite_syntax::any::TracebackFrame::name: core::option::Option<&'a str>
-pub syntaqlite_syntax::any::TracebackFrame::offset_in_snippet: usize
-pub syntaqlite_syntax::any::TracebackFrame::snippet: &'a str
+pub syntaqlite_syntax::any::TracebackFrame::offset_in_snippet: syntaqlite_syntax::source::LayerOffset
+pub syntaqlite_syntax::any::TracebackFrame::snippet: &'a syntaqlite_syntax::source::LayerText
 pub syntaqlite_syntax::nodes::AlterOp::AddColumn = 3
 pub syntaqlite_syntax::nodes::AlterOp::DropColumn = 2
 pub syntaqlite_syntax::nodes::AlterOp::RenameColumn = 1
@@ -2484,6 +2725,12 @@ pub syntaqlite_syntax::nodes::UnaryOp::Not = 3
 pub syntaqlite_syntax::nodes::UnaryOp::Plus = 1
 pub syntaqlite_syntax::nodes::UpsertAction::Nothing = 0
 pub syntaqlite_syntax::nodes::UpsertAction::Update = 1
+pub syntaqlite_syntax::source::DocRange::end: syntaqlite_syntax::source::DocOffset
+pub syntaqlite_syntax::source::DocRange::start: syntaqlite_syntax::source::DocOffset
+pub syntaqlite_syntax::source::LayerRange::end: syntaqlite_syntax::source::LayerOffset
+pub syntaqlite_syntax::source::LayerRange::start: syntaqlite_syntax::source::LayerOffset
+pub syntaqlite_syntax::source::StmtRange::end: syntaqlite_syntax::source::StmtOffset
+pub syntaqlite_syntax::source::StmtRange::start: syntaqlite_syntax::source::StmtOffset
 pub syntaqlite_syntax::typed::ParseOutcome::Done
 pub syntaqlite_syntax::typed::ParseOutcome::Err(E)
 pub syntaqlite_syntax::typed::ParseOutcome::Ok(T)
@@ -2665,6 +2912,18 @@ pub type syntaqlite_syntax::nodes::WindowDefId::Node<'a> = syntaqlite_syntax::no
 pub type syntaqlite_syntax::nodes::WindowDefList<'a> = syntaqlite_syntax::typed::TypedNodeList<'a, syntaqlite_syntax::typed::Dialect, syntaqlite_syntax::nodes::WindowDef<'a>>
 pub type syntaqlite_syntax::nodes::WindowDefListId::Node<'a> = syntaqlite_syntax::typed::TypedNodeList<'a, syntaqlite_syntax::typed::Dialect, syntaqlite_syntax::nodes::WindowDef<'a>>
 pub type syntaqlite_syntax::nodes::WithClauseId::Node<'a> = syntaqlite_syntax::nodes::WithClause<'a>
+pub type syntaqlite_syntax::source::DocLen::Output = syntaqlite_syntax::source::DocLen
+pub type syntaqlite_syntax::source::DocOffset::Output = syntaqlite_syntax::source::DocLen
+pub type syntaqlite_syntax::source::DocOffset::Output = syntaqlite_syntax::source::DocOffset
+pub type syntaqlite_syntax::source::DocText::Output = str
+pub type syntaqlite_syntax::source::LayerLen::Output = syntaqlite_syntax::source::LayerLen
+pub type syntaqlite_syntax::source::LayerOffset::Output = syntaqlite_syntax::source::LayerLen
+pub type syntaqlite_syntax::source::LayerOffset::Output = syntaqlite_syntax::source::LayerOffset
+pub type syntaqlite_syntax::source::LayerText::Output = str
+pub type syntaqlite_syntax::source::StmtLen::Output = syntaqlite_syntax::source::StmtLen
+pub type syntaqlite_syntax::source::StmtOffset::Output = syntaqlite_syntax::source::StmtLen
+pub type syntaqlite_syntax::source::StmtOffset::Output = syntaqlite_syntax::source::StmtOffset
+pub type syntaqlite_syntax::source::StmtText::Output = str
 pub type syntaqlite_syntax::typed::Dialect::Node<'a> = syntaqlite_syntax::nodes::Stmt<'a>
 pub type syntaqlite_syntax::typed::Dialect::NodeId = syntaqlite_syntax::nodes::NodeId
 pub type syntaqlite_syntax::typed::Dialect::Token = syntaqlite_syntax::TokenType

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -169,6 +169,12 @@ impl core::convert::From<syntaqlite_syntax::nodes::VariableId> for syntaqlite_sy
 impl core::convert::From<syntaqlite_syntax::nodes::WindowDefId> for syntaqlite_syntax::any::AnyNodeId
 impl core::convert::From<syntaqlite_syntax::nodes::WindowDefListId> for syntaqlite_syntax::any::AnyNodeId
 impl core::convert::From<syntaqlite_syntax::nodes::WithClauseId> for syntaqlite_syntax::any::AnyNodeId
+impl core::convert::From<syntaqlite_syntax::source::DocLen> for syntaqlite_syntax::source::LayerLen
+impl core::convert::From<syntaqlite_syntax::source::DocLen> for syntaqlite_syntax::source::StmtLen
+impl core::convert::From<syntaqlite_syntax::source::LayerLen> for syntaqlite_syntax::source::DocLen
+impl core::convert::From<syntaqlite_syntax::source::LayerLen> for syntaqlite_syntax::source::StmtLen
+impl core::convert::From<syntaqlite_syntax::source::StmtLen> for syntaqlite_syntax::source::DocLen
+impl core::convert::From<syntaqlite_syntax::source::StmtLen> for syntaqlite_syntax::source::LayerLen
 impl core::convert::From<syntaqlite_syntax::typed::Dialect> for syntaqlite_syntax::any::AnyDialect
 impl core::convert::From<syntaqlite_syntax::typed::TypedIncrementalParseSession<syntaqlite_syntax::typed::Dialect>> for syntaqlite_syntax::IncrementalParseSession
 impl core::fmt::Debug for syntaqlite_syntax::ParserToken<'_>
@@ -875,6 +881,7 @@ pub const fn syntaqlite_syntax::source::DocLen::from_raw(v: u32) -> Self
 pub const fn syntaqlite_syntax::source::DocOffset::as_u32(self) -> u32
 pub const fn syntaqlite_syntax::source::DocOffset::as_usize(self) -> usize
 pub const fn syntaqlite_syntax::source::DocOffset::from_raw(v: u32) -> Self
+pub const fn syntaqlite_syntax::source::DocOffset::to_stmt(self, base: syntaqlite_syntax::source::StatementBase) -> core::option::Option<syntaqlite_syntax::source::StmtOffset>
 pub const fn syntaqlite_syntax::source::DocRange::from_offset_len(start: syntaqlite_syntax::source::DocOffset, len: syntaqlite_syntax::source::DocLen) -> Self
 pub const fn syntaqlite_syntax::source::DocRange::is_empty(self) -> bool
 pub const fn syntaqlite_syntax::source::DocRange::len(self) -> syntaqlite_syntax::source::DocLen
@@ -891,19 +898,18 @@ pub const fn syntaqlite_syntax::source::LineNumber::as_u32(self) -> u32
 pub const fn syntaqlite_syntax::source::LineNumber::as_usize(self) -> usize
 pub const fn syntaqlite_syntax::source::LineNumber::from_raw(v: u32) -> Self
 pub const fn syntaqlite_syntax::source::StatementBase::as_doc_offset(self) -> syntaqlite_syntax::source::DocOffset
-pub const fn syntaqlite_syntax::source::StatementBase::from_doc(self, off: syntaqlite_syntax::source::DocOffset) -> core::option::Option<syntaqlite_syntax::source::StmtOffset>
 pub const fn syntaqlite_syntax::source::StatementBase::new(base: syntaqlite_syntax::source::DocOffset) -> Self
-pub const fn syntaqlite_syntax::source::StatementBase::to_doc(self, off: syntaqlite_syntax::source::StmtOffset) -> syntaqlite_syntax::source::DocOffset
-pub const fn syntaqlite_syntax::source::StatementBase::to_doc_range(self, range: syntaqlite_syntax::source::StmtRange) -> syntaqlite_syntax::source::DocRange
 pub const fn syntaqlite_syntax::source::StmtLen::as_u32(self) -> u32
 pub const fn syntaqlite_syntax::source::StmtLen::as_usize(self) -> usize
 pub const fn syntaqlite_syntax::source::StmtLen::from_raw(v: u32) -> Self
 pub const fn syntaqlite_syntax::source::StmtOffset::as_u32(self) -> u32
 pub const fn syntaqlite_syntax::source::StmtOffset::as_usize(self) -> usize
 pub const fn syntaqlite_syntax::source::StmtOffset::from_raw(v: u32) -> Self
+pub const fn syntaqlite_syntax::source::StmtOffset::to_doc(self, base: syntaqlite_syntax::source::StatementBase) -> syntaqlite_syntax::source::DocOffset
 pub const fn syntaqlite_syntax::source::StmtRange::from_offset_len(start: syntaqlite_syntax::source::StmtOffset, len: syntaqlite_syntax::source::StmtLen) -> Self
 pub const fn syntaqlite_syntax::source::StmtRange::is_empty(self) -> bool
 pub const fn syntaqlite_syntax::source::StmtRange::len(self) -> syntaqlite_syntax::source::StmtLen
+pub const fn syntaqlite_syntax::source::StmtRange::to_doc(self, base: syntaqlite_syntax::source::StatementBase) -> syntaqlite_syntax::source::DocRange
 pub const fn syntaqlite_syntax::source::TokenIdx::as_u32(self) -> u32
 pub const fn syntaqlite_syntax::source::TokenIdx::as_usize(self) -> usize
 pub const fn syntaqlite_syntax::source::TokenIdx::from_raw(v: u32) -> Self
@@ -947,7 +953,7 @@ pub fn syntaqlite_syntax::CompletionContext::from_raw(v: u32) -> Self
 pub fn syntaqlite_syntax::CompletionContext::raw(self) -> u32
 pub fn syntaqlite_syntax::IncrementalParseSession::completion_context(&self) -> syntaqlite_syntax::CompletionContext
 pub fn syntaqlite_syntax::IncrementalParseSession::expected_tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::TokenType>
-pub fn syntaqlite_syntax::IncrementalParseSession::feed_token(&mut self, token_type: syntaqlite_syntax::TokenType, span: core::ops::range::Range<usize>) -> core::option::Option<core::result::Result<ParsedStatement<'_>, ParseError<'_>>>
+pub fn syntaqlite_syntax::IncrementalParseSession::feed_token(&mut self, token_type: syntaqlite_syntax::TokenType, span: core::ops::range::Range<syntaqlite_syntax::source::DocOffset>) -> core::option::Option<core::result::Result<ParsedStatement<'_>, ParseError<'_>>>
 pub fn syntaqlite_syntax::IncrementalParseSession::finish(&mut self) -> core::option::Option<core::result::Result<ParsedStatement<'_>, ParseError<'_>>>
 pub fn syntaqlite_syntax::IncrementalParseSession::from(inner: syntaqlite_syntax::typed::TypedIncrementalParseSession<syntaqlite_syntax::typed::Dialect>) -> Self
 pub fn syntaqlite_syntax::IncrementalParseSession::node_count(&self) -> u32
@@ -1798,6 +1804,8 @@ pub fn syntaqlite_syntax::source::ColumnNumber::fmt(&self, f: &mut core::fmt::Fo
 pub fn syntaqlite_syntax::source::DocLen::add(self, rhs: syntaqlite_syntax::source::DocLen) -> syntaqlite_syntax::source::DocLen
 pub fn syntaqlite_syntax::source::DocLen::add_assign(&mut self, rhs: syntaqlite_syntax::source::DocLen)
 pub fn syntaqlite_syntax::source::DocLen::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::DocLen::from(v: syntaqlite_syntax::source::LayerLen) -> syntaqlite_syntax::source::DocLen
+pub fn syntaqlite_syntax::source::DocLen::from(v: syntaqlite_syntax::source::StmtLen) -> syntaqlite_syntax::source::DocLen
 pub fn syntaqlite_syntax::source::DocLen::sub(self, rhs: syntaqlite_syntax::source::DocLen) -> syntaqlite_syntax::source::DocLen
 pub fn syntaqlite_syntax::source::DocLen::sub_assign(&mut self, rhs: syntaqlite_syntax::source::DocLen)
 pub fn syntaqlite_syntax::source::DocOffset::add(self, rhs: syntaqlite_syntax::source::DocLen) -> syntaqlite_syntax::source::DocOffset
@@ -1821,6 +1829,8 @@ pub fn syntaqlite_syntax::source::DocText::new(s: &str) -> &syntaqlite_syntax::s
 pub fn syntaqlite_syntax::source::LayerLen::add(self, rhs: syntaqlite_syntax::source::LayerLen) -> syntaqlite_syntax::source::LayerLen
 pub fn syntaqlite_syntax::source::LayerLen::add_assign(&mut self, rhs: syntaqlite_syntax::source::LayerLen)
 pub fn syntaqlite_syntax::source::LayerLen::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::LayerLen::from(v: syntaqlite_syntax::source::DocLen) -> syntaqlite_syntax::source::LayerLen
+pub fn syntaqlite_syntax::source::LayerLen::from(v: syntaqlite_syntax::source::StmtLen) -> syntaqlite_syntax::source::LayerLen
 pub fn syntaqlite_syntax::source::LayerLen::sub(self, rhs: syntaqlite_syntax::source::LayerLen) -> syntaqlite_syntax::source::LayerLen
 pub fn syntaqlite_syntax::source::LayerLen::sub_assign(&mut self, rhs: syntaqlite_syntax::source::LayerLen)
 pub fn syntaqlite_syntax::source::LayerOffset::add(self, rhs: syntaqlite_syntax::source::LayerLen) -> syntaqlite_syntax::source::LayerOffset
@@ -1845,6 +1855,8 @@ pub fn syntaqlite_syntax::source::LineNumber::fmt(&self, f: &mut core::fmt::Form
 pub fn syntaqlite_syntax::source::StmtLen::add(self, rhs: syntaqlite_syntax::source::StmtLen) -> syntaqlite_syntax::source::StmtLen
 pub fn syntaqlite_syntax::source::StmtLen::add_assign(&mut self, rhs: syntaqlite_syntax::source::StmtLen)
 pub fn syntaqlite_syntax::source::StmtLen::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::StmtLen::from(v: syntaqlite_syntax::source::DocLen) -> syntaqlite_syntax::source::StmtLen
+pub fn syntaqlite_syntax::source::StmtLen::from(v: syntaqlite_syntax::source::LayerLen) -> syntaqlite_syntax::source::StmtLen
 pub fn syntaqlite_syntax::source::StmtLen::sub(self, rhs: syntaqlite_syntax::source::StmtLen) -> syntaqlite_syntax::source::StmtLen
 pub fn syntaqlite_syntax::source::StmtLen::sub_assign(&mut self, rhs: syntaqlite_syntax::source::StmtLen)
 pub fn syntaqlite_syntax::source::StmtOffset::add(self, rhs: syntaqlite_syntax::source::StmtLen) -> syntaqlite_syntax::source::StmtOffset
@@ -1877,7 +1889,7 @@ pub fn syntaqlite_syntax::typed::GrammarTokenType::from_token_type(raw: syntaqli
 pub fn syntaqlite_syntax::typed::TypedIncrementalParseSession<G>::completion_context(&self) -> syntaqlite_syntax::CompletionContext
 pub fn syntaqlite_syntax::typed::TypedIncrementalParseSession<G>::drop(&mut self)
 pub fn syntaqlite_syntax::typed::TypedIncrementalParseSession<G>::expected_tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = <G as syntaqlite_syntax::typed::TypedDialect>::Token>
-pub fn syntaqlite_syntax::typed::TypedIncrementalParseSession<G>::feed_token(&mut self, token_type: <G as syntaqlite_syntax::typed::TypedDialect>::Token, span: core::ops::range::Range<usize>) -> core::option::Option<core::result::Result<syntaqlite_syntax::typed::TypedParsedStatement<'_, G>, syntaqlite_syntax::typed::TypedParseError<'_, G>>>
+pub fn syntaqlite_syntax::typed::TypedIncrementalParseSession<G>::feed_token(&mut self, token_type: <G as syntaqlite_syntax::typed::TypedDialect>::Token, span: core::ops::range::Range<syntaqlite_syntax::source::DocOffset>) -> core::option::Option<core::result::Result<syntaqlite_syntax::typed::TypedParsedStatement<'_, G>, syntaqlite_syntax::typed::TypedParseError<'_, G>>>
 pub fn syntaqlite_syntax::typed::TypedIncrementalParseSession<G>::finish(&mut self) -> core::option::Option<core::result::Result<syntaqlite_syntax::typed::TypedParsedStatement<'_, G>, syntaqlite_syntax::typed::TypedParseError<'_, G>>>
 pub fn syntaqlite_syntax::typed::TypedIncrementalParseSession<G>::node_count(&self) -> u32
 pub fn syntaqlite_syntax::typed::TypedNodeList<'_, G, T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1892,9 +1904,9 @@ pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::comments(&self) -> impl
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::is_fatal(&self) -> bool
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::is_recovered(&self) -> bool
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::kind(&self) -> syntaqlite_syntax::ParseErrorKind
-pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::length(&self) -> core::option::Option<usize>
+pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::length(&self) -> core::option::Option<syntaqlite_syntax::source::StmtLen>
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::message(&self) -> &str
-pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::offset(&self) -> core::option::Option<usize>
+pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::offset(&self) -> core::option::Option<syntaqlite_syntax::source::StmtOffset>
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::recovery_root(&'a self) -> core::option::Option<<G as syntaqlite_syntax::typed::TypedDialect>::Node>
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::statement_base(&self) -> syntaqlite_syntax::source::StatementBase
 pub fn syntaqlite_syntax::typed::TypedParseError<'a, G>::text(&self) -> &'a syntaqlite_syntax::source::StmtText

--- a/tests/public-api/syntaqlite.txt
+++ b/tests/public-api/syntaqlite.txt
@@ -241,6 +241,7 @@ pub mod syntaqlite::lsp
 pub mod syntaqlite::nodes
 pub mod syntaqlite::parse
 pub mod syntaqlite::semantic
+pub mod syntaqlite::source
 pub mod syntaqlite::typed
 pub mod syntaqlite::util
 pub struct syntaqlite::Catalog
@@ -405,6 +406,7 @@ pub use syntaqlite::parse::ParserConfig
 pub use syntaqlite::parse::ParserToken
 pub use syntaqlite::parse::ParserTokenFlags
 pub use syntaqlite::parse::TokenType
+pub use syntaqlite::source::<<syntaqlite_syntax::source::*>>
 pub use syntaqlite::typed::<<syntaqlite_syntax::typed::*>>
 pub use syntaqlite::util::SqliteSyntaxFlag
 pub use syntaqlite::util::SqliteSyntaxFlags

--- a/tests/public-api/syntaqlite.txt
+++ b/tests/public-api/syntaqlite.txt
@@ -76,14 +76,15 @@ pub fn syntaqlite::Catalog::new(dialect: impl core::convert::Into<syntaqlite::an
 pub fn syntaqlite::Catalog::new_connection(&mut self)
 pub fn syntaqlite::Catalog::new_database(&mut self)
 pub fn syntaqlite::Catalog::new_document(&mut self)
-pub fn syntaqlite::Diagnostic::end_offset(&self) -> usize
+pub fn syntaqlite::Diagnostic::end(&self) -> syntaqlite_syntax::source::DocOffset
 pub fn syntaqlite::Diagnostic::expansion_frames(&self) -> &[syntaqlite::semantic::diagnostics::DiagnosticFrame]
 pub fn syntaqlite::Diagnostic::help(&self) -> core::option::Option<&syntaqlite::semantic::Help>
 pub fn syntaqlite::Diagnostic::message(&self) -> &syntaqlite::semantic::DiagnosticMessage
-pub fn syntaqlite::Diagnostic::new(start_offset: usize, end_offset: usize, message: syntaqlite::semantic::DiagnosticMessage, severity: syntaqlite::semantic::Severity, help: core::option::Option<syntaqlite::semantic::Help>) -> Self
+pub fn syntaqlite::Diagnostic::new(range: syntaqlite_syntax::source::DocRange, message: syntaqlite::semantic::DiagnosticMessage, severity: syntaqlite::semantic::Severity, help: core::option::Option<syntaqlite::semantic::Help>) -> Self
+pub fn syntaqlite::Diagnostic::range(&self) -> syntaqlite_syntax::source::DocRange
 pub fn syntaqlite::Diagnostic::serialize<S: serde_core::ser::Serializer>(&self, serializer: S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
 pub fn syntaqlite::Diagnostic::severity(&self) -> syntaqlite::semantic::Severity
-pub fn syntaqlite::Diagnostic::start_offset(&self) -> usize
+pub fn syntaqlite::Diagnostic::start(&self) -> syntaqlite_syntax::source::DocOffset
 pub fn syntaqlite::Dialect::default() -> Self
 pub fn syntaqlite::Dialect::deref(&self) -> &syntaqlite::any::AnyDialect
 pub fn syntaqlite::Dialect::deref_mut(&mut self) -> &mut syntaqlite::any::AnyDialect
@@ -138,19 +139,18 @@ pub fn syntaqlite::fmt::FormatConfig::with_keyword_case(self, case: syntaqlite::
 pub fn syntaqlite::fmt::FormatConfig::with_line_width(self, width: usize) -> Self
 pub fn syntaqlite::fmt::FormatConfig::with_semicolons(self, semicolons: bool) -> Self
 pub fn syntaqlite::fmt::FormatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-pub fn syntaqlite::fmt::FormatError::length(&self) -> core::option::Option<usize>
 pub fn syntaqlite::fmt::FormatError::message(&self) -> &str
-pub fn syntaqlite::fmt::FormatError::offset(&self) -> core::option::Option<usize>
+pub fn syntaqlite::fmt::FormatError::range(&self) -> core::option::Option<syntaqlite_syntax::source::DocRange>
 pub fn syntaqlite::lsp::CompletionEntry::kind(&self) -> syntaqlite::lsp::CompletionKind
 pub fn syntaqlite::lsp::CompletionEntry::label(&self) -> &str
 pub fn syntaqlite::lsp::CompletionKind::as_str(self) -> &'static str
 pub fn syntaqlite::lsp::CompletionKind::sort_priority(self) -> u8
 pub fn syntaqlite::lsp::LspHost::all_diagnostics(&mut self, uri: &str, config: &syntaqlite::semantic::ValidationConfig) -> alloc::vec::Vec<syntaqlite::Diagnostic>
 pub fn syntaqlite::lsp::LspHost::available_function_names(&self) -> alloc::vec::Vec<alloc::string::String>
-pub fn syntaqlite::lsp::LspHost::completion_items(&mut self, uri: &str, offset: usize) -> alloc::vec::Vec<syntaqlite::lsp::CompletionEntry>
+pub fn syntaqlite::lsp::LspHost::completion_items(&mut self, uri: &str, offset: syntaqlite_syntax::source::DocOffset) -> alloc::vec::Vec<syntaqlite::lsp::CompletionEntry>
 pub fn syntaqlite::lsp::LspHost::default() -> Self
 pub fn syntaqlite::lsp::LspHost::new() -> Self
-pub fn syntaqlite::lsp::LspHost::semantic_tokens_encoded(&mut self, uri: &str, range: core::option::Option<(usize, usize)>) -> alloc::vec::Vec<u32>
+pub fn syntaqlite::lsp::LspHost::semantic_tokens_encoded(&mut self, uri: &str, range: core::option::Option<syntaqlite_syntax::source::DocRange>) -> alloc::vec::Vec<u32>
 pub fn syntaqlite::lsp::LspHost::set_format_config(&mut self, config: syntaqlite::fmt::FormatConfig)
 pub fn syntaqlite::lsp::LspHost::set_schema_map(&mut self, map: syntaqlite::lsp::SchemaMap)
 pub fn syntaqlite::lsp::LspHost::set_session_context(&mut self, ctx: syntaqlite::Catalog)


### PR DESCRIPTION
Before this change, every position-like value in the parser API was a bare `u32` or `usize`. The parser emits statement-relative offsets; the semantic layer and LSP use document-absolute offsets; macro rewrites use layer-relative offsets into a parent expansion buffer. Nothing at the type level distinguished them, so every call site had to keep the coordinate system in its head, and the compiler stayed silent when a statement-relative offset was handed to an API that wanted an absolute one.

The foundation for fixing this landed in #188 — the offset and length newtypes, arithmetic rules, and `StatementBase` converter — but no API actually used them yet. This PR is the second half: it threads those types through every parser-emitted value and, just as importantly, types the source text too. `stmt.text()` returns `&StmtText`, which can only be sliced by a `StmtRange`; slicing it with a `DocRange` is a type error. The goal is that coordinate-system bugs become impossible to write, not just easier to spot in review.

The semantic layer's diagnostics still hold raw `usize` document offsets. Migrating those is a follow-up — this PR stops at the parser boundary.