### PR TITLE
synq: thread offset/text newtypes through internal formatter + remaining public API holes

### DIFF
--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -287,7 +287,10 @@ impl CParser {
     ///
     /// # Safety
     /// The returned slice must not outlive the borrow underlying `self`.
-    pub(crate) unsafe fn node_text<'a>(&self, node_id: u32) -> Option<(&'a str, u32)> {
+    pub(crate) unsafe fn node_text<'a>(
+        &self,
+        node_id: u32,
+    ) -> Option<(&'a str, crate::source::StmtOffset)> {
         let mut out_len: u32 = 0;
         let mut out_offset: u32 = 0;
         // SAFETY: self is a valid, non-null CParser pointer owned by the caller.
@@ -307,7 +310,7 @@ impl CParser {
         let text = unsafe {
             std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize))
         };
-        Some((text, out_offset))
+        Some((text, crate::source::StmtOffset::from_raw(out_offset)))
     }
 
     /// Post-expansion text of AST node `node_id` — a slice of whichever
@@ -424,14 +427,17 @@ impl CParser {
         unsafe { std::slice::from_raw_parts(ptr, count as usize) }
     }
 
-    pub(crate) unsafe fn token_leading_comments(&self, token_idx: u32) -> &[CComment] {
+    pub(crate) unsafe fn token_leading_comments(
+        &self,
+        token_idx: crate::source::TokenIdx,
+    ) -> &[CComment] {
         let mut count: u32 = 0;
         // SAFETY: self is a valid, non-null CParser pointer; result
         // accessors are valid after `next()` returns a non-DONE code.
         let ptr = unsafe {
             syntaqlite_token_leading_comments(
                 std::ptr::from_ref::<Self>(self).cast_mut(),
-                token_idx,
+                token_idx.as_u32(),
                 &raw mut count,
             )
         };
@@ -443,14 +449,17 @@ impl CParser {
         unsafe { std::slice::from_raw_parts(ptr, count as usize) }
     }
 
-    pub(crate) unsafe fn token_trailing_comments(&self, token_idx: u32) -> &[CComment] {
+    pub(crate) unsafe fn token_trailing_comments(
+        &self,
+        token_idx: crate::source::TokenIdx,
+    ) -> &[CComment] {
         let mut count: u32 = 0;
         // SAFETY: self is a valid, non-null CParser pointer; result
         // accessors are valid after `next()` returns a non-DONE code.
         let ptr = unsafe {
             syntaqlite_token_trailing_comments(
                 std::ptr::from_ref::<Self>(self).cast_mut(),
-                token_idx,
+                token_idx.as_u32(),
                 &raw mut count,
             )
         };
@@ -535,20 +544,23 @@ impl CParser {
         }
     }
 
-    pub(crate) unsafe fn macro_rewrite_arg_segment_count(&self, rewrite_idx: u32) -> u32 {
+    pub(crate) unsafe fn macro_rewrite_arg_segment_count(
+        &self,
+        rewrite_idx: crate::source::RewriteIdx,
+    ) -> u32 {
         // SAFETY: self is a valid CParser pointer; the C side clamps
         // out-of-range indices to zero.
         unsafe {
             syntaqlite_macro_rewrite_arg_segment_count(
                 std::ptr::from_ref::<Self>(self).cast_mut(),
-                rewrite_idx,
+                rewrite_idx.as_u32(),
             )
         }
     }
 
     pub(crate) unsafe fn macro_rewrite_arg_segment_at(
         &self,
-        rewrite_idx: u32,
+        rewrite_idx: crate::source::RewriteIdx,
         segment_idx: u32,
     ) -> CMacroArgSegment {
         // SAFETY: self is a valid CParser pointer; the C side clamps
@@ -556,7 +568,7 @@ impl CParser {
         unsafe {
             syntaqlite_macro_rewrite_arg_segment_at(
                 std::ptr::from_ref::<Self>(self).cast_mut(),
-                rewrite_idx,
+                rewrite_idx.as_u32(),
                 segment_idx,
             )
         }

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -3,6 +3,8 @@
 
 use std::ffi::{c_char, c_void};
 
+use crate::source::{RewriteIdx, StmtOffset, TokenIdx};
+
 /// Opaque C parser type.
 pub(crate) enum CParser {}
 
@@ -290,7 +292,7 @@ impl CParser {
     pub(crate) unsafe fn node_text<'a>(
         &self,
         node_id: u32,
-    ) -> Option<(&'a str, crate::source::StmtOffset)> {
+    ) -> Option<(&'a str, StmtOffset)> {
         let mut out_len: u32 = 0;
         let mut out_offset: u32 = 0;
         // SAFETY: self is a valid, non-null CParser pointer owned by the caller.
@@ -310,7 +312,7 @@ impl CParser {
         let text = unsafe {
             std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize))
         };
-        Some((text, crate::source::StmtOffset::from_raw(out_offset)))
+        Some((text, StmtOffset::from_raw(out_offset)))
     }
 
     /// Post-expansion text of AST node `node_id` — a slice of whichever
@@ -429,7 +431,7 @@ impl CParser {
 
     pub(crate) unsafe fn token_leading_comments(
         &self,
-        token_idx: crate::source::TokenIdx,
+        token_idx: TokenIdx,
     ) -> &[CComment] {
         let mut count: u32 = 0;
         // SAFETY: self is a valid, non-null CParser pointer; result
@@ -451,7 +453,7 @@ impl CParser {
 
     pub(crate) unsafe fn token_trailing_comments(
         &self,
-        token_idx: crate::source::TokenIdx,
+        token_idx: TokenIdx,
     ) -> &[CComment] {
         let mut count: u32 = 0;
         // SAFETY: self is a valid, non-null CParser pointer; result
@@ -544,10 +546,7 @@ impl CParser {
         }
     }
 
-    pub(crate) unsafe fn macro_rewrite_arg_segment_count(
-        &self,
-        rewrite_idx: crate::source::RewriteIdx,
-    ) -> u32 {
+    pub(crate) unsafe fn macro_rewrite_arg_segment_count(&self, rewrite_idx: RewriteIdx) -> u32 {
         // SAFETY: self is a valid CParser pointer; the C side clamps
         // out-of-range indices to zero.
         unsafe {
@@ -560,7 +559,7 @@ impl CParser {
 
     pub(crate) unsafe fn macro_rewrite_arg_segment_at(
         &self,
-        rewrite_idx: crate::source::RewriteIdx,
+        rewrite_idx: RewriteIdx,
         segment_idx: u32,
     ) -> CMacroArgSegment {
         // SAFETY: self is a valid CParser pointer; the C side clamps

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -11,7 +11,7 @@ use std::ffi::c_void;
 
 use crate::source::{
     ColumnNumber, DocLen, DocOffset, DocRange, DocText, LayerLen, LayerOffset, LayerText,
-    LineNumber, StatementBase, StmtLen, StmtOffset, StmtRange, StmtText, TokenIdx,
+    LineNumber, RewriteIdx, StatementBase, StmtLen, StmtOffset, StmtRange, StmtText, TokenIdx,
 };
 
 use crate::any::{AnyNodeTag, AnyTokenType};
@@ -79,11 +79,19 @@ impl MacroOutput {
     }
 
     /// Set the 1-based line/column of the macro definition for tracebacks.
-    /// Must be called *after* [`write`](Self::write).
-    pub fn set_definition(&mut self, line: u32, col: u32) {
+    /// Must be called *after* [`write`](Self::write).  Use
+    /// [`LineNumber::from_raw`] / [`ColumnNumber::from_raw`] to construct
+    /// the inputs; `0` means "unknown".
+    pub fn set_definition(&mut self, line: LineNumber, col: ColumnNumber) {
         // SAFETY: parser is valid for the duration of the callback.
         unsafe {
-            ffi::syntaqlite_macro_expansion_set_result(self.parser, std::ptr::null(), 0, line, col);
+            ffi::syntaqlite_macro_expansion_set_result(
+                self.parser,
+                std::ptr::null(),
+                0,
+                line.as_u32(),
+                col.as_u32(),
+            );
         }
     }
 
@@ -596,10 +604,10 @@ impl<'a> AnyParsedStatement<'a> {
 
     /// Source text of AST node `id` as `(text, offset)`, or `None` when
     /// extent tracking is disabled or no extent was recorded for this
-    /// node.  `offset` is relative to [`text`](Self::text).
+    /// node.  `offset` is statement-relative.
     ///
     /// Requires [`ParserConfig::with_collect_node_extents`].
-    pub fn node_text(&self, id: AnyNodeId) -> Option<(&'a str, u32)> {
+    pub fn node_text(&self, id: AnyNodeId) -> Option<(&'a str, StmtOffset)> {
         if id.is_null() {
             return None;
         }
@@ -703,11 +711,11 @@ impl<'a> AnyParsedStatement<'a> {
             let parent = if r.parent_idx == u32::MAX {
                 None
             } else {
-                Some(r.parent_idx)
+                Some(RewriteIdx::from_raw(r.parent_idx))
             };
             MacroRewrite {
                 parent,
-                rewrite_idx: i,
+                rewrite_idx: RewriteIdx::from_raw(i),
                 call_offset: LayerOffset::from_raw(r.call_offset),
                 call_length: LayerLen::from_raw(r.call_length),
                 expansion,
@@ -1198,7 +1206,7 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
     /// order.  See [`Comment`] for attachment semantics.
     ///
     /// Requires `collect_tokens: true` in [`ParserConfig`].
-    pub fn leading_comments(&self, token_idx: u32) -> impl Iterator<Item = Comment<'a>> {
+    pub fn leading_comments(&self, token_idx: TokenIdx) -> impl Iterator<Item = Comment<'a>> {
         let source = self.any.text();
         // SAFETY: self.any.raw is valid for 'a; the returned slice lives for 'a.
         let raw: &'a [ffi::CComment] =
@@ -1210,7 +1218,7 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
     /// after it, in source order.  See [`Comment`] for attachment semantics.
     ///
     /// Requires `collect_tokens: true` in [`ParserConfig`].
-    pub fn trailing_comments(&self, token_idx: u32) -> impl Iterator<Item = Comment<'a>> {
+    pub fn trailing_comments(&self, token_idx: TokenIdx) -> impl Iterator<Item = Comment<'a>> {
         let source = self.any.text();
         // SAFETY: self.any.raw is valid for 'a; the returned slice lives for 'a.
         let raw: &'a [ffi::CComment] =

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 #[cfg(feature = "sqlite")]
-use crate::source::{DocText, StatementBase, StmtLen, StmtOffset, StmtText};
+use crate::source::{DocText, StatementBase, StmtLen, StmtOffset, StmtText, TokenIdx};
 
 #[cfg(feature = "sqlite")]
 use super::{
@@ -333,7 +333,7 @@ impl<'a> ParsedStatement<'a> {
     /// Comments that appear immediately before token `token_idx`.
     ///
     /// Requires `collect_tokens: true` in [`ParserConfig`].
-    pub fn leading_comments(&self, token_idx: u32) -> impl Iterator<Item = Comment<'a>> {
+    pub fn leading_comments(&self, token_idx: TokenIdx) -> impl Iterator<Item = Comment<'a>> {
         self.0.leading_comments(token_idx)
     }
 
@@ -341,7 +341,7 @@ impl<'a> ParsedStatement<'a> {
     /// after it.
     ///
     /// Requires `collect_tokens: true` in [`ParserConfig`].
-    pub fn trailing_comments(&self, token_idx: u32) -> impl Iterator<Item = Comment<'a>> {
+    pub fn trailing_comments(&self, token_idx: TokenIdx) -> impl Iterator<Item = Comment<'a>> {
         self.0.trailing_comments(token_idx)
     }
 
@@ -361,7 +361,7 @@ impl<'a> ParsedStatement<'a> {
 
     /// Source text of AST node `id` as `(text, offset)`.  See
     /// [`AnyParsedStatement::node_text`](super::AnyParsedStatement::node_text).
-    pub fn node_text(&self, id: super::AnyNodeId) -> Option<(&'a str, u32)> {
+    pub fn node_text(&self, id: super::AnyNodeId) -> Option<(&'a str, StmtOffset)> {
         self.0.any.node_text(id)
     }
 
@@ -494,7 +494,7 @@ mod tests {
     use std::panic::{self, AssertUnwindSafe};
     use std::rc::Rc;
 
-    use crate::source::{LayerLen, LayerOffset};
+    use crate::source::{LayerLen, LayerOffset, RewriteIdx, StmtLen, StmtOffset, TokenIdx};
 
     use super::{ParseErrorKind, ParseOutcome, Parser, ParserConfig, ParserToken};
     use crate::parser::{MacroArg, MacroLookup, MacroOutput};
@@ -654,7 +654,7 @@ mod tests {
         let one_idx = tokens
             .iter()
             .position(|t| t.text() == "1")
-            .map(|i| u32::try_from(i).unwrap())
+            .map(|i| TokenIdx::from_raw(u32::try_from(i).unwrap()))
             .expect("`1` token");
 
         let trailing: Vec<_> = stmt.trailing_comments(one_idx).collect();
@@ -675,7 +675,7 @@ mod tests {
         let from_idx = tokens
             .iter()
             .position(|t| t.token_type() == TokenType::From)
-            .map(|i| u32::try_from(i).unwrap())
+            .map(|i| TokenIdx::from_raw(u32::try_from(i).unwrap()))
             .expect("FROM token");
 
         let leading: Vec<_> = stmt.leading_comments(from_idx).collect();
@@ -689,7 +689,7 @@ mod tests {
         let mut session = parser.parse("-- header\nSELECT 1;");
         let stmt = ok_stmt!(session);
 
-        let leading: Vec<_> = stmt.leading_comments(0).collect();
+        let leading: Vec<_> = stmt.leading_comments(TokenIdx::default()).collect();
         assert_eq!(leading.len(), 1);
         assert!(leading[0].text().contains("header"));
     }
@@ -704,7 +704,7 @@ mod tests {
         let one_idx = tokens
             .iter()
             .position(|t| t.text() == "1")
-            .map(|i| u32::try_from(i).unwrap())
+            .map(|i| TokenIdx::from_raw(u32::try_from(i).unwrap()))
             .expect("`1` token");
 
         let trailing: Vec<_> = stmt.trailing_comments(one_idx).collect();
@@ -725,7 +725,7 @@ mod tests {
         let semi_idx = tokens1
             .iter()
             .rposition(|t| t.text() == ";")
-            .map(|i| u32::try_from(i).unwrap())
+            .map(|i| TokenIdx::from_raw(u32::try_from(i).unwrap()))
             .expect("`;` token in stmt 1");
 
         let trailing: Vec<_> = stmt1.trailing_comments(semi_idx).collect();
@@ -756,7 +756,7 @@ mod tests {
         drop(stmt1);
 
         let stmt2 = ok_stmt!(session);
-        let leading_first: Vec<_> = stmt2.leading_comments(0).collect();
+        let leading_first: Vec<_> = stmt2.leading_comments(TokenIdx::default()).collect();
         assert_eq!(leading_first.len(), 1);
         assert!(leading_first[0].text().contains("between"));
     }
@@ -780,7 +780,7 @@ mod tests {
             .node_text(root_id)
             .expect("root node should have recorded text");
         assert_eq!(text, "SELECT 1");
-        assert_eq!(offset, 0);
+        assert_eq!(offset, StmtOffset::default());
     }
 
     #[test]
@@ -861,7 +861,7 @@ mod tests {
             .node_text(root_id)
             .expect("root node should have recorded text");
         assert_eq!(text, "SELECT id!(42)");
-        assert_eq!(offset, 0);
+        assert_eq!(offset, StmtOffset::default());
 
         assert_eq!(statement.node_expanded_text(root_id), Some("SELECT 42"));
     }
@@ -1140,8 +1140,8 @@ mod tests {
         // pair reinterprets as a StmtRange.
         let stmt_text = stmt.text();
         let call_range = crate::source::StmtRange::from_offset_len(
-            crate::source::StmtOffset::from_raw(r.call_offset().as_u32()),
-            crate::source::StmtLen::from_raw(r.call_length().as_u32()),
+            StmtOffset::from_raw(r.call_offset().as_u32()),
+            StmtLen::from_raw(r.call_length().as_u32()),
         );
         let call_text = &stmt_text[call_range];
         assert_eq!(call_text, "id!(42)");
@@ -1184,7 +1184,7 @@ mod tests {
         // outer.expansion() — the nested-rewrite case where parent is a
         // LayerText, and the Index<LayerRange> impl slices directly.
         let inner = &rewrites[1];
-        assert_eq!(inner.parent(), Some(0));
+        assert_eq!(inner.parent(), Some(RewriteIdx::from_raw(0)));
         assert_eq!(inner.name(), "mpass");
         let outer_exp = outer.expansion();
         let inner_range =
@@ -1273,7 +1273,7 @@ mod tests {
 
         let inner = &rewrites[1];
         assert_eq!(inner.name(), "n");
-        assert_eq!(inner.parent(), Some(0));
+        assert_eq!(inner.parent(), Some(RewriteIdx::from_raw(0)));
         // The nested n!(42) call lives entirely inside m's substituted
         // $x arg — call_offset/length are in the post-substitution
         // expansion buffer, but there's no clean position in m's
@@ -1311,7 +1311,7 @@ mod tests {
         assert_eq!(rewrites.len(), 2, "wrap + leaf");
         let inner = &rewrites[1];
         assert_eq!(inner.name(), "leaf");
-        assert_eq!(inner.parent(), Some(0));
+        assert_eq!(inner.parent(), Some(RewriteIdx::from_raw(0)));
         // `leaf!(7)` sits at offset 5 in the authored body "$a + leaf!(7)".
         assert_eq!(inner.body_call_offset(), LayerOffset::from_raw(5));
         assert_eq!(inner.body_call_length(), LayerLen::from_raw(8));
@@ -1346,7 +1346,7 @@ mod tests {
         assert_eq!(rewrites.len(), 2, "wrap + leaf");
         let inner = &rewrites[1];
         assert_eq!(inner.name(), "leaf");
-        assert_eq!(inner.parent(), Some(0));
+        assert_eq!(inner.parent(), Some(RewriteIdx::from_raw(0)));
         assert_eq!(inner.body_call_offset(), LayerOffset::from_raw(5));
         assert_eq!(inner.body_call_length(), LayerLen::from_raw(13));
     }
@@ -1393,8 +1393,8 @@ mod tests {
         // Arg-segment origin_offset is a LayerOffset; at Source origin
         // the "layer" is the statement, so reinterpret as StmtRange.
         let m_arg_range = crate::source::StmtRange::from_offset_len(
-            crate::source::StmtOffset::from_raw(m_segs[0].origin_offset().as_u32()),
-            crate::source::StmtLen::from_raw(m_segs[0].origin_length().as_u32()),
+            StmtOffset::from_raw(m_segs[0].origin_offset().as_u32()),
+            StmtLen::from_raw(m_segs[0].origin_length().as_u32()),
         );
         let m_arg_text = &stmt_text[m_arg_range];
         assert_eq!(m_arg_text, "n!(nonexistent_col)");
@@ -1404,7 +1404,7 @@ mod tests {
         // whose expansion range contains n's arg, then recursing.
         let n_segs: Vec<_> = rewrites[1].arg_segments().collect();
         assert_eq!(n_segs.len(), 1);
-        assert_eq!(n_segs[0].origin(), ArgOrigin::Rewrite(0));
+        assert_eq!(n_segs[0].origin(), ArgOrigin::Rewrite(RewriteIdx::from_raw(0)));
         let m_expansion = rewrites[0].expansion();
         let n_arg_range = crate::source::LayerRange::from_offset_len(
             n_segs[0].origin_offset(),

--- a/syntaqlite-syntax/src/parser/types.rs
+++ b/syntaqlite-syntax/src/parser/types.rs
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0.
 
 use crate::source::{
-    ColumnNumber, LayerLen, LayerOffset, LayerText, LineNumber, StmtLen, StmtOffset, TokenIdx,
+    ColumnNumber, LayerLen, LayerOffset, LayerText, LineNumber, RewriteIdx, StmtLen, StmtOffset,
+    TokenIdx,
 };
 
 use crate::dialect::TypedDialect;
@@ -284,8 +285,8 @@ pub type AnyParserToken<'a> = TypedParserToken<'a, crate::dialect::AnyDialect>;
 /// Returned by [`super::AnyParsedStatement::macro_rewrites`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MacroRewrite<'a> {
-    pub(crate) parent: Option<u32>,
-    pub(crate) rewrite_idx: u32,
+    pub(crate) parent: Option<RewriteIdx>,
+    pub(crate) rewrite_idx: RewriteIdx,
     pub(crate) call_offset: LayerOffset,
     pub(crate) call_length: LayerLen,
     pub(crate) expansion: &'a LayerText,
@@ -307,7 +308,7 @@ pub const MACRO_BODY_CALL_ARG_INTERNAL: LayerOffset = LayerOffset::from_raw(u32:
 impl<'a> MacroRewrite<'a> {
     /// Index of the parent rewrite, or `None` if this rewrite applies
     /// directly to the authored source.
-    pub fn parent(&self) -> Option<u32> {
+    pub fn parent(&self) -> Option<RewriteIdx> {
         self.parent
     }
     /// Byte offset of the macro call in the parent's text.
@@ -378,7 +379,7 @@ impl<'a> MacroRewrite<'a> {
             let origin = if s.origin_parent_idx == u32::MAX {
                 ArgOrigin::Source
             } else {
-                ArgOrigin::Rewrite(s.origin_parent_idx)
+                ArgOrigin::Rewrite(RewriteIdx::from_raw(s.origin_parent_idx))
             };
             MacroArgSegment {
                 body_offset: LayerOffset::from_raw(s.body_offset),
@@ -401,7 +402,7 @@ pub enum ArgOrigin {
     Source,
     /// The arg text lives in the expansion buffer of the referenced
     /// rewrite (which in turn may have its own arg segments to descend).
-    Rewrite(u32),
+    Rewrite(RewriteIdx),
 }
 
 /// One `$param` substitution recorded on a [`MacroRewrite`].
@@ -447,7 +448,7 @@ impl MacroArgSegment<'_> {
     }
     /// Convenience: parent rewrite index if the origin is a rewrite,
     /// `None` if the origin is the authored source.
-    pub fn origin_parent(&self) -> Option<u32> {
+    pub fn origin_parent(&self) -> Option<RewriteIdx> {
         match self.origin {
             ArgOrigin::Source => None,
             ArgOrigin::Rewrite(i) => Some(i),

--- a/syntaqlite-syntax/src/source.rs
+++ b/syntaqlite-syntax/src/source.rs
@@ -438,6 +438,15 @@ define_u32_newtype! {
     TokenIdx
 }
 
+define_u32_newtype! {
+    /// A 0-based index into a statement's macro-rewrite list.
+    ///
+    /// Identifies a specific `MacroRewrite` within the flat list emitted by
+    /// `AnyParsedStatement::macro_rewrites`.  Distinct from byte offsets
+    /// and token indices at the type level.
+    RewriteIdx
+}
+
 // ── 1-based line / column (C parser, traceback) ─────────────────────────────
 
 define_u32_newtype! {

--- a/syntaqlite-wasm/src/main.rs
+++ b/syntaqlite-wasm/src/main.rs
@@ -642,15 +642,15 @@ fn run_embedded_extract(lang: u32, ptr: u32, len: u32) -> i32 {
     let items: Vec<WasmFragment> = fragments
         .iter()
         .map(|f| WasmFragment {
-            start: f.sql_range().start,
-            end: f.sql_range().end,
+            start: f.sql_range().start.as_usize(),
+            end: f.sql_range().end.as_usize(),
             sql: f.sql_text().to_string(),
             holes: f
                 .holes()
                 .iter()
                 .map(|h| WasmHole {
-                    start: h.host_range().start,
-                    end: h.host_range().end,
+                    start: h.host_range().start.as_usize(),
+                    end: h.host_range().end.as_usize(),
                 })
                 .collect(),
         })

--- a/syntaqlite/src/embedded/mod.rs
+++ b/syntaqlite/src/embedded/mod.rs
@@ -27,8 +27,6 @@ pub use python::extract_python;
 #[doc(inline)]
 pub use typescript::extract_typescript;
 
-use std::ops::Range;
-
 use syntaqlite_syntax::any::TokenCategory;
 use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange};
 
@@ -58,7 +56,7 @@ use offset_map::OffsetMap;
 #[derive(Debug)]
 pub struct EmbeddedFragment {
     /// Byte range of the SQL content in the host file (excluding quotes).
-    pub(crate) sql_range: Range<usize>,
+    pub(crate) sql_range: DocRange,
     /// SQL text with holes replaced by placeholder identifiers.
     pub(crate) sql_text: String,
     /// Information about each interpolation hole.
@@ -67,8 +65,8 @@ pub struct EmbeddedFragment {
 
 impl EmbeddedFragment {
     /// Byte range of the SQL content in the host file (excluding quotes).
-    pub fn sql_range(&self) -> &Range<usize> {
-        &self.sql_range
+    pub fn sql_range(&self) -> DocRange {
+        self.sql_range
     }
     /// SQL text with holes replaced by placeholder identifiers.
     pub fn sql_text(&self) -> &str {
@@ -88,18 +86,18 @@ impl EmbeddedFragment {
 #[derive(Debug)]
 pub struct Hole {
     /// Byte range of the hole expression in the host file.
-    pub(crate) host_range: Range<usize>,
+    pub(crate) host_range: DocRange,
     /// Byte offset in `sql_text` where the placeholder sits.
-    pub(crate) sql_offset: usize,
+    pub(crate) sql_offset: DocOffset,
 }
 
 impl Hole {
     /// Byte range of the hole expression in the host file.
-    pub fn host_range(&self) -> &Range<usize> {
-        &self.host_range
+    pub fn host_range(&self) -> DocRange {
+        self.host_range
     }
     /// Byte offset in `sql_text` where the placeholder sits.
-    pub fn sql_offset(&self) -> usize {
+    pub fn sql_offset(&self) -> DocOffset {
         self.sql_offset
     }
 }
@@ -109,6 +107,30 @@ impl Hole {
 /// Uses macro-call syntax so the parser's `macro_fallback` mode treats it as a
 /// single identifier token and records a [`MacroRewrite`](syntaqlite_syntax::any::MacroRewrite).
 pub const HOLE_PLACEHOLDER: &str = "__h__!()";
+
+// ── Conversion helpers for extractors ──────────────────────────────────
+
+/// Convert a `usize` byte offset from a host-language scanner into a
+/// [`DocOffset`].  Host files addressable within `u32` are the supported
+/// range; anything larger saturates.
+pub(super) fn doc_offset_from_usize(n: usize) -> DocOffset {
+    DocOffset::from_raw(u32::try_from(n).unwrap_or(u32::MAX))
+}
+
+/// Convert a `usize` byte length into a [`DocLen`] with the same saturation
+/// rule as [`doc_offset_from_usize`].
+pub(super) fn doc_len_from_usize(n: usize) -> DocLen {
+    DocLen::from_raw(u32::try_from(n).unwrap_or(u32::MAX))
+}
+
+/// Construct a [`DocRange`] from a half-open `usize` byte range, as produced
+/// by host-language scanners.
+pub(super) fn doc_range_from_usize(start: usize, end: usize) -> DocRange {
+    DocRange::from_offset_len(
+        doc_offset_from_usize(start),
+        doc_len_from_usize(end.saturating_sub(start)),
+    )
+}
 
 // ── Shared scanner utilities ────────────────────────────────────────────
 

--- a/syntaqlite/src/embedded/offset_map.rs
+++ b/syntaqlite/src/embedded/offset_map.rs
@@ -7,7 +7,7 @@
 //! offsets shift because `{some_long_expr}` might become `__hole_0__` (or
 //! vice-versa). The `OffsetMap` handles this translation.
 
-use syntaqlite_syntax::source::DocOffset;
+use syntaqlite_syntax::source::{DocLen, DocOffset};
 
 use super::{EmbeddedFragment, HOLE_PLACEHOLDER};
 
@@ -15,17 +15,17 @@ use super::{EmbeddedFragment, HOLE_PLACEHOLDER};
 #[derive(Debug)]
 struct Segment {
     /// Start offset in SQL text.
-    sql_start: usize,
+    sql_start: DocOffset,
     /// Length of this segment in SQL text.
-    sql_len: usize,
+    sql_len: DocLen,
     /// Length of this segment in host file.
-    host_len: usize,
+    host_len: DocLen,
 }
 
 /// Maps byte offsets from processed SQL text back to host-file positions.
 pub(crate) struct OffsetMap {
     /// Base offset of the SQL content in the host file.
-    base_offset: usize,
+    base_offset: DocOffset,
     /// Sorted segments where SQL and host offsets diverge (holes).
     segments: Vec<Segment>,
 }
@@ -33,12 +33,15 @@ pub(crate) struct OffsetMap {
 impl OffsetMap {
     /// Build an offset map from an `EmbeddedFragment`.
     pub(crate) fn new(fragment: &EmbeddedFragment) -> Self {
+        let placeholder_len = DocLen::from_raw(
+            u32::try_from(HOLE_PLACEHOLDER.len()).expect("placeholder len fits in u32"),
+        );
         let segments = fragment
             .holes()
             .iter()
             .map(|h| Segment {
                 sql_start: h.sql_offset(),
-                sql_len: HOLE_PLACEHOLDER.len(),
+                sql_len: placeholder_len,
                 host_len: h.host_range().len(),
             })
             .collect();
@@ -54,24 +57,22 @@ impl OffsetMap {
     /// Returns `None` if the offset falls inside a hole placeholder, since
     /// those regions correspond to host-language expressions, not SQL.
     pub(crate) fn to_host(&self, sql_offset: DocOffset) -> Option<DocOffset> {
-        // Walk through segments to compute the cumulative drift.
-        let mut drift: isize = 0;
-        let sql = sql_offset.as_usize();
-
+        // Walk segments accumulating cumulative drift.  Drift can be
+        // negative when a host expression is shorter than the placeholder,
+        // so arithmetic happens in `i64` before projecting back to
+        // `DocOffset`.
+        let mut drift: i64 = 0;
         for seg in &self.segments {
-            if sql < seg.sql_start {
+            if sql_offset < seg.sql_start {
                 break;
             }
-            if sql < seg.sql_start + seg.sql_len {
-                // Inside a hole placeholder — no meaningful host mapping.
+            if sql_offset < seg.sql_start + seg.sql_len {
                 return None;
             }
-            // Past this hole: accumulate the difference in lengths.
-            drift += seg.host_len.cast_signed() - seg.sql_len.cast_signed();
+            drift += i64::from(seg.host_len.as_u32()) - i64::from(seg.sql_len.as_u32());
         }
 
-        // Apply base offset and accumulated drift.
-        let host = (sql.cast_signed() + self.base_offset.cast_signed() + drift).cast_unsigned();
+        let host = i64::from(sql_offset.as_u32()) + i64::from(self.base_offset.as_u32()) + drift;
         Some(DocOffset::from_raw(u32::try_from(host).ok()?))
     }
 }
@@ -80,24 +81,28 @@ impl OffsetMap {
 mod tests {
     use super::*;
     use crate::embedded::{EmbeddedFragment, Hole};
+    use syntaqlite_syntax::source::DocRange;
+
+    fn doc_offset(n: u32) -> DocOffset {
+        DocOffset::from_raw(n)
+    }
+    fn doc_range(start: u32, end: u32) -> DocRange {
+        DocRange {
+            start: doc_offset(start),
+            end: doc_offset(end),
+        }
+    }
 
     #[test]
     fn identity_map_no_holes() {
         let fragment = EmbeddedFragment {
-            sql_range: 10..30,
+            sql_range: doc_range(10, 30),
             sql_text: "SELECT * FROM users".to_string(),
             holes: vec![],
         };
         let map = OffsetMap::new(&fragment);
-        // Offset 0 in SQL → offset 10 in host.
-        assert_eq!(
-            map.to_host(DocOffset::from_raw(0)),
-            Some(DocOffset::from_raw(10))
-        );
-        assert_eq!(
-            map.to_host(DocOffset::from_raw(7)),
-            Some(DocOffset::from_raw(17))
-        );
+        assert_eq!(map.to_host(doc_offset(0)), Some(doc_offset(10)));
+        assert_eq!(map.to_host(doc_offset(7)), Some(doc_offset(17)));
     }
 
     #[test]
@@ -105,31 +110,25 @@ mod tests {
         // Host: "SELECT * FROM {table_name}" (range 10..36)
         // SQL:  "SELECT * FROM __h__!()"
         // Hole: {table_name} at host 24..36 (12 bytes), placeholder at sql offset 14 (8 bytes)
-        let ph = HOLE_PLACEHOLDER; // "__h__!()" = 8 bytes
+        let ph = HOLE_PLACEHOLDER;
         let sql_text = format!("SELECT * FROM {ph}");
         let fragment = EmbeddedFragment {
-            sql_range: 10..36,
+            sql_range: doc_range(10, 36),
             sql_text,
             holes: vec![Hole {
-                host_range: 24..36,
-                sql_offset: 14,
+                host_range: doc_range(24, 36),
+                sql_offset: doc_offset(14),
             }],
         };
         let map = OffsetMap::new(&fragment);
 
         // Before hole: offset 0 → 10, offset 13 → 23.
-        assert_eq!(
-            map.to_host(DocOffset::from_raw(0)),
-            Some(DocOffset::from_raw(10))
-        );
-        assert_eq!(
-            map.to_host(DocOffset::from_raw(13)),
-            Some(DocOffset::from_raw(23))
-        );
+        assert_eq!(map.to_host(doc_offset(0)), Some(doc_offset(10)));
+        assert_eq!(map.to_host(doc_offset(13)), Some(doc_offset(23)));
 
         // Inside hole: returns None (host-language expression, not SQL).
-        assert_eq!(map.to_host(DocOffset::from_raw(14)), None);
-        assert_eq!(map.to_host(DocOffset::from_raw(18)), None);
+        assert_eq!(map.to_host(doc_offset(14)), None);
+        assert_eq!(map.to_host(doc_offset(18)), None);
     }
 
     #[test]
@@ -148,45 +147,36 @@ mod tests {
         let ph = HOLE_PLACEHOLDER;
         let sql_text = format!("VALUES ({ph}, {ph}, datetime('now'))");
         let fragment = EmbeddedFragment {
-            sql_range: 2..50,
+            sql_range: doc_range(2, 50),
             sql_text,
             holes: vec![
                 Hole {
-                    host_range: 10..25, // {customer_id} = 15 bytes
-                    sql_offset: 8,
+                    host_range: doc_range(10, 25), // {customer_id} = 15 bytes
+                    sql_offset: doc_offset(8),
                 },
                 Hole {
-                    host_range: 27..34, // {total} = 7 bytes
-                    sql_offset: 18,     // 8 (offset of first ph) + 8 (ph len) + 2 (", ")
+                    host_range: doc_range(27, 34), // {total} = 7 bytes
+                    sql_offset: doc_offset(18),    // 8 + 8 + 2 ("), "
                 },
             ],
         };
         let map = OffsetMap::new(&fragment);
 
         // Inside holes: must return None so no semantic token is emitted.
+        assert_eq!(map.to_host(doc_offset(8)), None, "first placeholder start");
         assert_eq!(
-            map.to_host(DocOffset::from_raw(8)),
-            None,
-            "first placeholder start"
-        );
-        assert_eq!(
-            map.to_host(DocOffset::from_raw(18)),
+            map.to_host(doc_offset(18)),
             None,
             "second placeholder start"
         );
-        assert_eq!(
-            map.to_host(DocOffset::from_raw(22)),
-            None,
-            "second placeholder mid"
-        );
+        assert_eq!(map.to_host(doc_offset(22)), None, "second placeholder mid");
 
         // `datetime` sits after both placeholders in SQL text.
         // sql_offset of "datetime" = 8 + 8 + 2 + 8 + 2 = 28
-        let datetime_sql_offset = DocOffset::from_raw(28);
-        let datetime_host = map.to_host(datetime_sql_offset);
+        let datetime_host = map.to_host(doc_offset(28));
         assert_eq!(
             datetime_host,
-            Some(DocOffset::from_raw(36)),
+            Some(doc_offset(36)),
             "datetime must map to host offset 36"
         );
     }

--- a/syntaqlite/src/embedded/offset_map.rs
+++ b/syntaqlite/src/embedded/offset_map.rs
@@ -57,11 +57,13 @@ impl OffsetMap {
     /// Returns `None` if the offset falls inside a hole placeholder, since
     /// those regions correspond to host-language expressions, not SQL.
     pub(crate) fn to_host(&self, sql_offset: DocOffset) -> Option<DocOffset> {
-        // Walk segments accumulating cumulative drift.  Drift can be
-        // negative when a host expression is shorter than the placeholder,
-        // so arithmetic happens in `i64` before projecting back to
-        // `DocOffset`.
-        let mut drift: i64 = 0;
+        // Sum the SQL and host widths of every placeholder that
+        // `sql_offset` has passed.  The loop only advances a sum when
+        // `sql_offset >= seg.sql_start + seg.sql_len`, so the invariant
+        // `sql_offset >= sql_sum` holds after the walk — keeping every
+        // subtraction below within unsigned-length arithmetic.
+        let mut host_sum = DocLen::default();
+        let mut sql_sum = DocLen::default();
         for seg in &self.segments {
             if sql_offset < seg.sql_start {
                 break;
@@ -69,11 +71,15 @@ impl OffsetMap {
             if sql_offset < seg.sql_start + seg.sql_len {
                 return None;
             }
-            drift += i64::from(seg.host_len.as_u32()) - i64::from(seg.sql_len.as_u32());
+            host_sum += seg.host_len;
+            sql_sum += seg.sql_len;
         }
 
-        let host = i64::from(sql_offset.as_u32()) + i64::from(self.base_offset.as_u32()) + drift;
-        Some(DocOffset::from_raw(u32::try_from(host).ok()?))
+        // Bytes of non-placeholder SQL content before `sql_offset`.
+        // Re-expressing `sql_offset` as a length from zero lets the final
+        // subtraction stay in `DocLen`.
+        let non_placeholder = (sql_offset - DocOffset::default()) - sql_sum;
+        Some(self.base_offset + host_sum + non_placeholder)
     }
 }
 

--- a/syntaqlite/src/embedded/python.rs
+++ b/syntaqlite/src/embedded/python.rs
@@ -3,7 +3,10 @@
 
 //! Python f-string SQL extraction.
 
-use super::{EmbeddedFragment, HOLE_PLACEHOLDER, Hole, starts_with_sql_keyword};
+use super::{
+    EmbeddedFragment, HOLE_PLACEHOLDER, Hole, doc_offset_from_usize, doc_range_from_usize,
+    starts_with_sql_keyword,
+};
 
 /// Extract SQL fragments from Python source code.
 ///
@@ -157,11 +160,11 @@ fn extract_fstring_fragment(
             let hole_content_end = find_matching_brace(bytes, j + 1, content_end)?;
             let hole_end = hole_content_end + 1;
 
-            let sql_offset = sql_text.len();
+            let sql_offset = doc_offset_from_usize(sql_text.len());
             sql_text.push_str(HOLE_PLACEHOLDER);
 
             holes.push(Hole {
-                host_range: hole_start..hole_end,
+                host_range: doc_range_from_usize(hole_start, hole_end),
                 sql_offset,
             });
             j = hole_end;
@@ -175,7 +178,7 @@ fn extract_fstring_fragment(
     }
 
     Some(EmbeddedFragment {
-        sql_range: content_start..content_end,
+        sql_range: doc_range_from_usize(content_start, content_end),
         sql_text,
         holes,
     })

--- a/syntaqlite/src/embedded/typescript.rs
+++ b/syntaqlite/src/embedded/typescript.rs
@@ -3,7 +3,10 @@
 
 //! TypeScript/JavaScript template literal SQL extraction.
 
-use super::{EmbeddedFragment, HOLE_PLACEHOLDER, Hole, starts_with_sql_keyword};
+use super::{
+    EmbeddedFragment, HOLE_PLACEHOLDER, Hole, doc_offset_from_usize, doc_range_from_usize,
+    starts_with_sql_keyword,
+};
 
 /// Extract SQL fragments from TypeScript/JavaScript source code.
 ///
@@ -118,11 +121,11 @@ fn extract_template_fragment(
             let hole_content_end = find_matching_brace_js(bytes, brace_content, content_end)?;
             let hole_end = hole_content_end + 1;
 
-            let sql_offset = sql_text.len();
+            let sql_offset = doc_offset_from_usize(sql_text.len());
             sql_text.push_str(HOLE_PLACEHOLDER);
 
             holes.push(Hole {
-                host_range: hole_start..hole_end,
+                host_range: doc_range_from_usize(hole_start, hole_end),
                 sql_offset,
             });
             j = hole_end;
@@ -133,7 +136,7 @@ fn extract_template_fragment(
     }
 
     Some(EmbeddedFragment {
-        sql_range: content_start..content_end,
+        sql_range: doc_range_from_usize(content_start, content_end),
         sql_text,
         holes,
     })

--- a/syntaqlite/src/fmt/comment.rs
+++ b/syntaqlite/src/fmt/comment.rs
@@ -3,6 +3,7 @@
 
 use std::cell::Cell;
 
+use syntaqlite_syntax::source::{StmtLen, StmtOffset, StmtRange, StmtText};
 use syntaqlite_syntax::{CommentKind, CommentSide};
 
 use super::doc::{DocArena, DocId, NIL_DOC};
@@ -11,17 +12,37 @@ use super::doc::{DocArena, DocId, NIL_DOC};
 /// parser-supplied attachment (`side` + `token_idx`).
 #[derive(Clone, Copy)]
 pub(crate) struct CommentEntry {
-    pub offset: u32,
-    pub length: u32,
+    pub offset: StmtOffset,
+    pub length: StmtLen,
     pub kind: CommentKind,
     pub side: CommentSide,
+}
+
+impl CommentEntry {
+    fn range(&self) -> StmtRange {
+        StmtRange::from_offset_len(self.offset, self.length)
+    }
+
+    fn end(&self) -> StmtOffset {
+        self.offset + self.length
+    }
 }
 
 /// A collected token entry with pre-computed byte offset and length.
 #[derive(Clone, Copy)]
 pub(crate) struct TokenEntry {
-    pub offset: u32,
-    pub length: u32,
+    pub offset: StmtOffset,
+    pub length: StmtLen,
+}
+
+impl TokenEntry {
+    fn range(&self) -> StmtRange {
+        StmtRange::from_offset_len(self.offset, self.length)
+    }
+
+    fn end(&self) -> StmtOffset {
+        self.offset + self.length
+    }
 }
 
 /// Result of draining comment items. Trailing docs (e.g. `LineSuffix` for
@@ -61,13 +82,12 @@ impl CommentCtx {
 
     /// End offset of the token just before the current token cursor position.
     /// Returns 0 if the cursor is at the start.
-    pub(crate) fn prev_token_end(&self) -> u32 {
+    pub(crate) fn prev_token_end(&self) -> StmtOffset {
         let idx = self.token_cursor.get();
         if idx > 0 {
-            let tp = &self.tokens[idx - 1];
-            tp.offset + tp.length
+            self.tokens[idx - 1].end()
         } else {
-            0
+            StmtOffset::default()
         }
     }
 
@@ -77,8 +97,8 @@ impl CommentCtx {
     /// between a comment and `before`.
     pub(crate) fn drain_before<'a>(
         &self,
-        before: u32,
-        source: &'a str,
+        before: StmtOffset,
+        source: &'a StmtText,
         arena: &mut DocArena<'a>,
     ) -> DrainResult {
         self.drain_impl(before, source, arena, false)
@@ -91,20 +111,19 @@ impl CommentCtx {
     pub(crate) fn drain_keyword_interior<'a>(
         &self,
         word_count: usize,
-        source: &'a str,
+        source: &'a StmtText,
         arena: &mut DocArena<'a>,
     ) -> DrainResult {
         let first_idx = self.token_cursor.get();
-        let last_tok = &self.tokens[first_idx + word_count - 1];
-        let end = last_tok.offset + last_tok.length;
+        let end = self.tokens[first_idx + word_count - 1].end();
         self.drain_impl(end, source, arena, true)
     }
 
     #[expect(clippy::too_many_lines)]
     fn drain_impl<'a>(
         &self,
-        before: u32,
-        source: &'a str,
+        before: StmtOffset,
+        source: &'a StmtText,
         arena: &mut DocArena<'a>,
         skip_text_check: bool,
     ) -> DrainResult {
@@ -112,17 +131,17 @@ impl CommentCtx {
         let mut leading = NIL_DOC;
         let mut cursor = self.cursor.get();
         let mut last_end = self.prev_token_end();
+        let source_end = StmtOffset::default() + source.byte_len();
         while cursor < self.comments.len() && self.comments[cursor].offset < before {
             let t = &self.comments[cursor];
-            let comment_end = (t.offset + t.length) as usize;
 
             if !skip_text_check {
-                let before_usize = (before as usize).min(source.len());
-                if comment_end < before_usize
+                let scan_end = before.min(source_end);
+                if t.end() < scan_end
                     && has_non_comment_text(
                         source,
-                        comment_end,
-                        before_usize,
+                        t.end(),
+                        scan_end,
                         &self.comments,
                         cursor + 1,
                     )
@@ -131,25 +150,23 @@ impl CommentCtx {
                 }
             }
 
-            let text = &source[t.offset as usize..comment_end];
+            let text = &source[t.range()];
 
             // Leading vs trailing is fixed at parse time
             // (see synq_parser_record_comment).  The gap text is still
             // scanned below for blank-line preservation between adjacent
             // leading comments.
-            let gap_start = (last_end as usize).min(source.len());
-            let gap_end = (t.offset as usize).min(source.len());
+            let gap = StmtRange {
+                start: last_end.min(source_end),
+                end: t.offset.min(source_end),
+            };
             let is_leading = matches!(t.side, CommentSide::Leading);
 
             match t.kind {
                 CommentKind::Line => {
                     if is_leading {
                         // Preserve blank lines between separate comment blocks.
-                        let has_blank_line = {
-                            let gs = gap_start.min(source.len());
-                            let ge = gap_end.min(source.len());
-                            gs < ge && source[gs..ge].contains("\n\n")
-                        };
+                        let has_blank_line = !gap.is_empty() && source[gap].contains("\n\n");
                         let hl1 = arena.hardline();
                         let prefix = if has_blank_line && leading != NIL_DOC {
                             let extra = arena.hardline();
@@ -161,16 +178,19 @@ impl CommentCtx {
                         // Only emit a trailing hardline if the next comment
                         // does NOT immediately follow on the next line — that
                         // comment's leading hardline will provide the break.
-                        let next_end = t.offset + t.length;
                         let next_is_contiguous_comment = cursor + 1 < self.comments.len()
                             && self.comments[cursor + 1].offset < before
                             && {
-                                let gap_s = (next_end as usize).min(source.len());
-                                let gap_e =
-                                    (self.comments[cursor + 1].offset as usize).min(source.len());
-                                gap_s < gap_e
-                                    && source[gap_s..gap_e].contains('\n')
-                                    && !source[gap_s..gap_e].contains("\n\n")
+                                let next_gap = StmtRange {
+                                    start: t.end().min(source_end),
+                                    end: self.comments[cursor + 1].offset.min(source_end),
+                                };
+                                if next_gap.is_empty() {
+                                    false
+                                } else {
+                                    let text = &source[next_gap];
+                                    text.contains('\n') && !text.contains("\n\n")
+                                }
                             };
                         let chunk = if next_is_contiguous_comment {
                             arena.cat(prefix, comment_doc)
@@ -221,7 +241,7 @@ impl CommentCtx {
                 }
             }
 
-            last_end = t.offset + t.length;
+            last_end = t.end();
             cursor += 1;
         }
 
@@ -242,7 +262,11 @@ impl CommentCtx {
     /// On match, the token cursor is advanced past any skipped tokens so it
     /// points to the first word of the keyword. Returns `None` if the
     /// keyword is not present in the source (e.g., an inserted `AS`).
-    pub(crate) fn peek_keyword_tokens(&self, kw_text: &str, source: &str) -> Option<(u32, usize)> {
+    pub(crate) fn peek_keyword_tokens(
+        &self,
+        kw_text: &str,
+        source: &StmtText,
+    ) -> Option<(StmtOffset, usize)> {
         const MAX_SCAN: usize = 8;
         let start_idx = self.token_cursor.get();
 
@@ -260,7 +284,7 @@ impl CommentCtx {
                     break;
                 }
                 let tok = &self.tokens[tok_idx];
-                let tok_text = &source[tok.offset as usize..(tok.offset + tok.length) as usize];
+                let tok_text = &source[tok.range()];
                 if !tok_text.eq_ignore_ascii_case(word) {
                     matched = false;
                     break;
@@ -285,7 +309,7 @@ impl CommentCtx {
     }
 
     /// Advance the token cursor past all tokens whose offset is `< end_offset`.
-    pub(crate) fn advance_past(&self, end_offset: u32) {
+    pub(crate) fn advance_past(&self, end_offset: StmtOffset) {
         let mut idx = self.token_cursor.get();
         while idx < self.tokens.len() && self.tokens[idx].offset < end_offset {
             idx += 1;
@@ -308,7 +332,7 @@ impl CommentCtx {
     }
 
     /// Peek at the next token's offset and length without advancing.
-    pub(crate) fn peek_next_token(&self) -> Option<(u32, u32)> {
+    pub(crate) fn peek_next_token(&self) -> Option<(StmtOffset, StmtLen)> {
         let idx = self.token_cursor.get();
         self.tokens.get(idx).map(|tp| (tp.offset, tp.length))
     }
@@ -318,27 +342,31 @@ impl CommentCtx {
     /// is a trailing comment that this statement owns; the guard's check
     /// for "syntax text past the comment" would spuriously fire when the
     /// source text continues into the next statement.
-    pub(crate) fn drain_remaining<'a>(&self, source: &'a str, arena: &mut DocArena<'a>) -> DocId {
-        let drain = self.drain_impl(u32::MAX, source, arena, true);
+    pub(crate) fn drain_remaining<'a>(
+        &self,
+        source: &'a StmtText,
+        arena: &mut DocArena<'a>,
+    ) -> DocId {
+        let drain = self.drain_impl(StmtOffset::from_raw(u32::MAX), source, arena, true);
         arena.cat(drain.trailing, drain.leading)
     }
 }
 
 fn has_non_comment_text(
-    source: &str,
-    start: usize,
-    end: usize,
+    source: &StmtText,
+    start: StmtOffset,
+    end: StmtOffset,
     comments: &[CommentEntry],
     comment_start_idx: usize,
 ) -> bool {
-    let src = source.as_bytes();
+    let src = source.as_str().as_bytes();
     let mut pos = start;
     let mut ci = comment_start_idx;
 
     while pos < end {
         while ci < comments.len() {
-            let c_start = comments[ci].offset as usize;
-            let c_end = (comments[ci].offset + comments[ci].length) as usize;
+            let c_start = comments[ci].offset;
+            let c_end = comments[ci].end();
             if pos >= c_start && pos < c_end {
                 pos = c_end;
                 ci += 1;
@@ -351,10 +379,10 @@ fn has_non_comment_text(
         if pos >= end {
             break;
         }
-        if !src[pos].is_ascii_whitespace() {
+        if !src[pos.as_usize()].is_ascii_whitespace() {
             return true;
         }
-        pos += 1;
+        pos += StmtLen::from_raw(1);
     }
     false
 }

--- a/syntaqlite/src/fmt/formatter.rs
+++ b/syntaqlite/src/fmt/formatter.rs
@@ -5,7 +5,7 @@ use syntaqlite_syntax::ParserConfig;
 use syntaqlite_syntax::any::{
     AnyNodeId, AnyParseError, AnyParsedStatement, AnyParser, AnyTokenizer, ParseOutcome,
 };
-use syntaqlite_syntax::source::{DocLen, DocRange};
+use syntaqlite_syntax::source::{DocLen, DocRange, StmtLen, StmtOffset, StmtRange, StmtText};
 
 use super::FormatConfig;
 use super::FormatError;
@@ -70,7 +70,7 @@ pub struct Formatter {
     /// formatter only needs positions to decide when to emit a call
     /// verbatim; full `MacroRewrite` records would tie this buffer to
     /// the statement lifetime and prevent reuse across statements.
-    pub(super) macro_rewrites: Vec<(u32, u32)>,
+    pub(super) macro_rewrites: Vec<(StmtOffset, StmtLen)>,
     pub(super) comment_entries: Vec<CommentEntry>,
     pub(super) token_entries: Vec<TokenEntry>,
     pub(super) parts: Vec<DocId>,
@@ -147,22 +147,30 @@ impl Formatter {
         self.comment_entries.clear();
         self.comment_entries
             .extend(erased.comment_spans().map(|c| CommentEntry {
-                offset: c.offset().as_u32(),
-                length: c.length().as_u32(),
+                offset: c.offset(),
+                length: c.length(),
                 kind: c.kind(),
                 side: c.side(),
             }));
         self.token_entries.clear();
         self.token_entries
             .extend(erased.token_spans().map(|range| TokenEntry {
-                offset: range.start.as_u32(),
-                length: range.len().as_u32(),
+                offset: range.start,
+                length: range.len(),
             }));
-        self.macro_rewrites.extend(
-            erased
-                .macro_rewrites()
-                .map(|r| (r.call_offset().as_u32(), r.call_length().as_u32())),
-        );
+        // Only top-level rewrites are meaningful here: their `LayerOffset`
+        // coincides with the statement-relative offset the formatter
+        // compares against.  Nested rewrites measure into their parent's
+        // expansion and belong to a different coordinate system.
+        self.macro_rewrites
+            .extend(erased.macro_rewrites().filter(|r| r.parent().is_none()).map(
+                |r| {
+                    (
+                        StmtOffset::from_raw(r.call_offset().as_u32()),
+                        StmtLen::from(r.call_length()),
+                    )
+                },
+            ));
     }
 
     /// Format SQL source text. Handles multiple statements and preserves comments.
@@ -207,7 +215,7 @@ impl Formatter {
 
             let erased = stmt.erase();
             self.collect_side_channels(&erased);
-            let stmt_source = erased.text().as_str();
+            let stmt_source = erased.text();
 
             let root_id = erased.root_id();
             let semicolons = self.config.semicolons;
@@ -465,7 +473,7 @@ impl Formatter {
             let mut arena = DocArena::recycle(prev_arena);
             self.parts.clear();
 
-            let stmt_source = erased.text().as_str();
+            let stmt_source = erased.text();
             if stmt_num > 0 {
                 emit_stmt_separator(
                     comment_ctx.as_ref(),
@@ -517,7 +525,7 @@ impl Formatter {
 
 fn emit_stmt_separator<'a>(
     comment_ctx: Option<&CommentCtx>,
-    source: &'a str,
+    source: &'a StmtText,
     arena: &mut DocArena<'a>,
     parts: &mut Vec<DocId>,
 ) {
@@ -532,13 +540,14 @@ fn emit_stmt_separator<'a>(
 
 fn drain_gap_comments<'a>(
     ctx: &CommentCtx,
-    before: u32,
-    source: &'a str,
+    before: StmtOffset,
+    source: &'a StmtText,
     arena: &mut DocArena<'a>,
     parts: &mut Vec<DocId>,
 ) {
     let mut prev_was_comment = false;
     let mut last_end = ctx.prev_token_end();
+    let source_end = StmtOffset::default() + source.byte_len();
     while let Some(c) = ctx.peek_comment() {
         if c.offset >= before {
             break;
@@ -546,13 +555,15 @@ fn drain_gap_comments<'a>(
         // Preserve blank lines between separate comment blocks
         // (but not between code tokens and the first comment).
         if prev_was_comment {
-            let gap_start = (last_end as usize).min(source.len());
-            let gap_end = (c.offset as usize).min(source.len());
-            if gap_start < gap_end && source[gap_start..gap_end].contains("\n\n") {
+            let gap = StmtRange {
+                start: last_end.min(source_end),
+                end: c.offset.min(source_end),
+            };
+            if !gap.is_empty() && source[gap].contains("\n\n") {
                 parts.push(arena.hardline());
             }
         }
-        let text = &source[c.offset as usize..(c.offset + c.length) as usize];
+        let text = &source[StmtRange::from_offset_len(c.offset, c.length)];
         parts.push(arena.text(text));
         parts.push(arena.hardline());
         last_end = c.offset + c.length;
@@ -586,7 +597,7 @@ fn drain_gap_comments<'a>(
 ///   before a `TableRef`, `AS` before an alias `IdentName`).
 pub(crate) fn try_macro_verbatim<'a>(
     ctx: &FmtCtx<'a>,
-    regions: &[(u32, u32)],
+    regions: &[(StmtOffset, StmtLen)],
     arena: &mut DocArena<'a>,
     consumed: &mut [bool],
     tokenizer: &AnyTokenizer,
@@ -597,8 +608,10 @@ pub(crate) fn try_macro_verbatim<'a>(
     let source = ctx.text();
 
     let (node_text, node_off) = ctx.reader.node_text(child_id)?;
-    let node_len = u32::try_from(node_text.len())
-        .expect("node text length fits in u32; source buffer is addressed via u32 offsets");
+    let node_len = StmtLen::from_raw(
+        u32::try_from(node_text.len())
+            .expect("node text length fits in u32; source buffer is addressed via u32 offsets"),
+    );
     let node_end = node_off + node_len;
 
     for (i, &(r_start, r_len)) in regions.iter().enumerate() {
@@ -609,7 +622,10 @@ pub(crate) fn try_macro_verbatim<'a>(
                 return Some(NIL_DOC);
             }
             consumed[i] = true;
-            let macro_text = &source[r_start as usize..r_end as usize];
+            let macro_text = &source[StmtRange {
+                start: r_start,
+                end: r_end,
+            }];
             return Some(reindent_macro(macro_text, tokenizer, arena));
         }
     }
@@ -755,7 +771,7 @@ mod tests {
 
     #[test]
     fn emit_stmt_separator_without_comments_emits_blank_line() {
-        let source = "SELECT 1";
+        let source = StmtText::new("SELECT 1");
         let mut arena = DocArena::new();
         let mut parts = Vec::new();
         emit_stmt_separator(None, source, &mut arena, &mut parts);
@@ -768,17 +784,17 @@ mod tests {
         // and drains LEADING comments of the next statement.  The
         // statement terminator (`;`) and any TRAILING comments on it are
         // emitted by per-statement processing in `format`, not here.
-        let source = "/*x*/SELECT";
+        let source = StmtText::new("/*x*/SELECT");
         let ctx = CommentCtx::new(
             vec![CommentEntry {
-                offset: 0,
-                length: 5,
+                offset: StmtOffset::from_raw(0),
+                length: StmtLen::from_raw(5),
                 kind: CommentKind::Block,
                 side: CommentSide::Leading,
             }],
             vec![TokenEntry {
-                offset: 5,
-                length: 6,
+                offset: StmtOffset::from_raw(5),
+                length: StmtLen::from_raw(6),
             }],
         );
         let mut arena = DocArena::new();
@@ -789,30 +805,30 @@ mod tests {
 
     #[test]
     fn drain_gap_comments_writes_each_comment_on_own_line() {
-        let source = "--a\n/*b*/SELECT";
+        let source = StmtText::new("--a\n/*b*/SELECT");
         let ctx = CommentCtx::new(
             vec![
                 CommentEntry {
-                    offset: 0,
-                    length: 3,
+                    offset: StmtOffset::from_raw(0),
+                    length: StmtLen::from_raw(3),
                     kind: CommentKind::Line,
                     side: CommentSide::Leading,
                 },
                 CommentEntry {
-                    offset: 4,
-                    length: 5,
+                    offset: StmtOffset::from_raw(4),
+                    length: StmtLen::from_raw(5),
                     kind: CommentKind::Block,
                     side: CommentSide::Leading,
                 },
             ],
             vec![TokenEntry {
-                offset: 9,
-                length: 6,
+                offset: StmtOffset::from_raw(9),
+                length: StmtLen::from_raw(6),
             }],
         );
         let mut arena = DocArena::new();
         let mut parts = Vec::new();
-        drain_gap_comments(&ctx, 9, source, &mut arena, &mut parts);
+        drain_gap_comments(&ctx, StmtOffset::from_raw(9), source, &mut arena, &mut parts);
         assert_eq!(render_parts(&mut arena, &parts), "--a\n/*b*/\n");
     }
 }

--- a/syntaqlite/src/fmt/interpret.rs
+++ b/syntaqlite/src/fmt/interpret.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue};
+use syntaqlite_syntax::source::{StmtLen, StmtOffset, StmtText};
 
 use super::comment::{CommentCtx, DrainResult};
 use super::doc::{DocArena, DocId, NIL_DOC};
@@ -18,12 +19,12 @@ pub(crate) struct FmtCtx<'a> {
     /// `(call_offset, call_length)` for each macro call in the source.
     /// Full `MacroRewrite` records are not needed here since the
     /// formatter only uses positions to decide verbatim emission.
-    pub macro_rewrites: Vec<(u32, u32)>,
+    pub macro_rewrites: Vec<(StmtOffset, StmtLen)>,
 }
 
 impl<'a> FmtCtx<'a> {
-    pub(crate) fn text(&self) -> &'a str {
-        self.reader.text().as_str()
+    pub(crate) fn text(&self) -> &'a StmtText {
+        self.reader.text()
     }
 }
 
@@ -227,7 +228,6 @@ impl Formatter {
                     // real `""` token and must round-trip as `""`.
                     if quoted || !s.is_empty() {
                         if let Some(ref cctx) = ctx.comment_ctx {
-                            use syntaqlite_syntax::source::StmtLen;
                             // For quoted spans, the original token in source
                             // starts one byte earlier (the opening quote) and
                             // extends one byte past (the closing quote).
@@ -243,9 +243,9 @@ impl Formatter {
                             } else {
                                 span_len
                             };
-                            let drain = cctx.drain_before(drain_offset.as_u32(), source, arena);
+                            let drain = cctx.drain_before(drain_offset, source, arena);
                             flush_drain(&drain, &mut pending, &mut running, arena);
-                            cctx.advance_past((drain_offset + token_len).as_u32());
+                            cctx.advance_past(drain_offset + token_len);
                         }
                         if quoted {
                             let q = arena.text("\"");
@@ -848,7 +848,7 @@ fn flush_drain(
 #[inline]
 fn drain_comments_before_child<'a>(
     comment_ctx: Option<&CommentCtx>,
-    source: &'a str,
+    source: &'a StmtText,
     pending: &mut DocId,
     running: &mut DocId,
     arena: &mut DocArena<'a>,

--- a/syntaqlite/src/lsp/completion.rs
+++ b/syntaqlite/src/lsp/completion.rs
@@ -25,11 +25,8 @@ pub(crate) fn completion_info(
     let source = DocText::new(model.source());
     let tokens = &model.tokens;
     let end_of_doc = source.byte_len();
-    let cursor = if offset.as_usize() > end_of_doc.as_usize() {
-        DocOffset::default() + end_of_doc
-    } else {
-        offset
-    };
+    let doc_end = DocOffset::default() + end_of_doc;
+    let cursor = if offset > doc_end { doc_end } else { offset };
     let (boundary, backtracked) = completion_boundary(source, tokens, cursor);
     let start = statement_token_start(tokens, boundary);
     let stmt_tokens = &tokens[start..boundary];
@@ -92,7 +89,7 @@ fn detect_qualifier(
     let ident_tok = &tokens[tokens.len() - 2];
 
     if dot_tok.length != DocLen::from_raw(1)
-        || source.as_str().as_bytes().get(dot_tok.offset.as_usize()) != Some(&b'.')
+        || &source[DocRange::from_offset_len(dot_tok.offset, dot_tok.length)] != "."
     {
         return None;
     }

--- a/syntaqlite/src/lsp/mod.rs
+++ b/syntaqlite/src/lsp/mod.rs
@@ -119,14 +119,6 @@ impl CompletionKind {
 mod completion;
 mod host;
 mod server;
+mod source_map;
 
-/// Length of a UTF-8 character from its leading byte.
-/// Returns 1 for ASCII and for invalid/continuation bytes (defensive).
-fn utf8_char_len(lead: u8) -> usize {
-    match lead {
-        0xC0..=0xDF => 2,
-        0xE0..=0xEF => 3,
-        0xF0..=0xF7 => 4,
-        _ => 1, // ASCII (0x00..=0x7F) and invalid/continuation bytes
-    }
-}
+pub(crate) use source_map::{SourceMap, utf8_char_len};

--- a/syntaqlite/src/lsp/server.rs
+++ b/syntaqlite/src/lsp/server.rs
@@ -33,12 +33,12 @@ use lsp_types::{
     SignatureInformation, TextDocumentSyncCapability, TextDocumentSyncKind, TextEdit, Uri,
     WorkDoneProgressOptions, WorkspaceEdit,
 };
-use syntaqlite_syntax::source::{DocOffset, DocRange};
+use syntaqlite_syntax::source::{DocOffset, DocRange, DocText, Utf16Col, Utf16Line};
 
 use crate::dialect::AnyDialect;
 use crate::fmt::FormatConfig;
 use crate::lsp::host::SchemaMap;
-use crate::lsp::{CompletionKind, LspHost, SEMANTIC_TOKEN_LEGEND};
+use crate::lsp::{CompletionKind, LspHost, SEMANTIC_TOKEN_LEGEND, SourceMap};
 use crate::semantic::Catalog;
 use crate::semantic::diagnostics::Severity;
 
@@ -907,102 +907,35 @@ fn offsets_to_range(source: &str, range: DocRange) -> Range {
 
 // ── SourcePositionMap ─────────────────────────────────────────────────────
 
-/// Converts between byte offsets and LSP `Position` (line/character) values
-/// for a fixed source string.
-///
-/// Both directions use a single O(n) walk over the source bytes.
+/// Thin adapter around [`SourceMap`] that translates to and from
+/// `lsp_types::Position`.  The position-mapping arithmetic lives in
+/// [`SourceMap`]; this adapter only packs/unpacks the LSP wire types.
 pub(super) struct SourcePositionMap<'a> {
-    src: &'a [u8],
+    inner: SourceMap<'a>,
 }
 
 impl<'a> SourcePositionMap<'a> {
     pub(crate) fn new(source: &'a str) -> Self {
         SourcePositionMap {
-            src: source.as_bytes(),
+            inner: SourceMap::new(DocText::new(source)),
         }
     }
 
     /// Convert multiple byte offsets to LSP `Position`s in one O(n) pass.
-    ///
-    /// Internally sorts the offsets, walks the source once, then returns
-    /// results in the original order. Character offsets are UTF-16 code
-    /// units per the LSP specification.
     pub(crate) fn offsets_to_positions(&self, offsets: &[DocOffset]) -> Vec<Position> {
-        if offsets.is_empty() {
-            return Vec::new();
-        }
-
-        let mut indexed: Vec<(usize, usize)> = offsets
-            .iter()
-            .map(|o| o.as_usize())
-            .enumerate()
-            .map(|(i, o)| (o, i))
-            .collect();
-        indexed.sort_unstable_by_key(|&(o, _)| o);
-
-        let mut result = vec![Position::new(0, 0); offsets.len()];
-        let len = self.src.len();
-        let mut line = 0u32;
-        let mut col_utf16 = 0u32;
-        let mut pos = 0usize;
-
-        for (offset, orig_idx) in indexed {
-            let offset = offset.min(len);
-            while pos < offset {
-                if self.src[pos] == b'\n' {
-                    line += 1;
-                    col_utf16 = 0;
-                    pos += 1;
-                } else {
-                    let byte = self.src[pos];
-                    let char_len = utf8_char_len(byte);
-                    // Supplementary characters (4-byte UTF-8) need 2 UTF-16 code units;
-                    // all others need 1.
-                    col_utf16 += if char_len == 4 { 2 } else { 1 };
-                    pos += char_len;
-                }
-            }
-            result[orig_idx] = Position::new(line, col_utf16);
-        }
-
-        result
+        self.inner
+            .byte_offsets_to_utf16(offsets)
+            .into_iter()
+            .map(|(line, col)| Position::new(line.as_u32(), col.as_u32()))
+            .collect()
     }
 
     /// Convert an LSP `Position` (with UTF-16 character offset) to a document-absolute byte offset.
     pub(crate) fn position_to_offset(&self, pos: Position) -> DocOffset {
-        let len = self.src.len();
-        let mut line = 0usize;
-        let mut line_start = 0usize;
-
-        while line < pos.line as usize && line_start < len {
-            match self.src[line_start..].iter().position(|&b| b == b'\n') {
-                Some(nl) => {
-                    line_start += nl + 1;
-                    line += 1;
-                }
-                None => return DocOffset::from_raw(u32::try_from(len).unwrap_or(u32::MAX)),
-            }
-        }
-
-        let line_end = self.src[line_start..]
-            .iter()
-            .position(|&b| b == b'\n')
-            .map_or(len, |rel| line_start + rel);
-
-        // Walk UTF-8 characters, counting UTF-16 code units, until we reach
-        // the requested character offset or end of line.
-        let mut byte_pos = line_start;
-        let mut utf16_col = 0u32;
-        while byte_pos < line_end && utf16_col < pos.character {
-            let char_len = utf8_char_len(self.src[byte_pos]);
-            utf16_col += if char_len == 4 { 2 } else { 1 };
-            byte_pos += char_len;
-        }
-        DocOffset::from_raw(u32::try_from(byte_pos).unwrap_or(u32::MAX))
+        self.inner
+            .utf16_to_byte_offset(Utf16Line::from_raw(pos.line), Utf16Col::from_raw(pos.character))
     }
 }
-
-use super::utf8_char_len;
 
 #[cfg(test)]
 mod tests {

--- a/syntaqlite/src/lsp/source_map.rs
+++ b/syntaqlite/src/lsp/source_map.rs
@@ -1,0 +1,198 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+//! Byte ↔ (line, UTF-16 column) mapping for LSP protocol positions.
+//!
+//! LSP measures positions in UTF-16 code units; the parser emits byte
+//! offsets.  `SourceMap` keeps that translation in one place so every
+//! `didOpen` → `publishDiagnostics` → `hover` round-trip walks the source
+//! bytes the same way.  Each direction is a single O(n) walk.
+
+use syntaqlite_syntax::source::{DocOffset, DocText, Utf16Col, Utf16Line};
+
+/// Converts between document-absolute byte offsets and 0-based
+/// (line, UTF-16 column) positions for a fixed source string.  Zero-cost
+/// to construct — borrows the source.
+#[derive(Copy, Clone)]
+pub(crate) struct SourceMap<'a> {
+    src: &'a DocText,
+}
+
+impl<'a> SourceMap<'a> {
+    /// Wrap `source` as a position map.
+    pub(crate) const fn new(source: &'a DocText) -> Self {
+        Self { src: source }
+    }
+
+    /// Convert a batch of byte offsets to `(line, utf16_col)` positions in
+    /// one O(n) pass, returning results in the same order as `offsets`.
+    ///
+    /// Batching amortizes the source walk: `n` offsets cost
+    /// O(n + source_len), versus O(n × source_len) for single conversions.
+    pub(crate) fn byte_offsets_to_utf16(
+        &self,
+        offsets: &[DocOffset],
+    ) -> Vec<(Utf16Line, Utf16Col)> {
+        if offsets.is_empty() {
+            return Vec::new();
+        }
+
+        let mut indexed: Vec<(usize, usize)> = offsets
+            .iter()
+            .enumerate()
+            .map(|(i, o)| (o.as_usize(), i))
+            .collect();
+        indexed.sort_unstable_by_key(|&(o, _)| o);
+
+        let src = self.src.as_str().as_bytes();
+        let len = src.len();
+        let mut result = vec![(Utf16Line::default(), Utf16Col::default()); offsets.len()];
+        let mut line: u32 = 0;
+        let mut col_utf16: u32 = 0;
+        let mut pos: usize = 0;
+
+        for (offset, orig_idx) in indexed {
+            let offset = offset.min(len);
+            while pos < offset {
+                if src[pos] == b'\n' {
+                    line += 1;
+                    col_utf16 = 0;
+                    pos += 1;
+                } else {
+                    let char_len = utf8_char_len(src[pos]);
+                    // 4-byte UTF-8 chars are a surrogate pair in UTF-16;
+                    // everything else is one UTF-16 code unit.
+                    col_utf16 += if char_len == 4 { 2 } else { 1 };
+                    pos += char_len;
+                }
+            }
+            result[orig_idx] = (Utf16Line::from_raw(line), Utf16Col::from_raw(col_utf16));
+        }
+
+        result
+    }
+
+    /// Convert a 0-based `(line, utf16_col)` position to a document-absolute
+    /// byte offset.  Clamps to end-of-document when `line` is past the last
+    /// line; clamps to end-of-line when `col` is past the line's length.
+    pub(crate) fn utf16_to_byte_offset(&self, line: Utf16Line, col: Utf16Col) -> DocOffset {
+        let src = self.src.as_str().as_bytes();
+        let len = src.len();
+        let target_line = line.as_usize();
+        let mut cur_line: usize = 0;
+        let mut line_start: usize = 0;
+
+        while cur_line < target_line && line_start < len {
+            match src[line_start..].iter().position(|&b| b == b'\n') {
+                Some(nl) => {
+                    line_start += nl + 1;
+                    cur_line += 1;
+                }
+                None => return DocOffset::from_raw(u32::try_from(len).unwrap_or(u32::MAX)),
+            }
+        }
+
+        let line_end = src[line_start..]
+            .iter()
+            .position(|&b| b == b'\n')
+            .map_or(len, |rel| line_start + rel);
+
+        let target_col = col.as_u32();
+        let mut byte_pos = line_start;
+        let mut utf16_col: u32 = 0;
+        while byte_pos < line_end && utf16_col < target_col {
+            let char_len = utf8_char_len(src[byte_pos]);
+            utf16_col += if char_len == 4 { 2 } else { 1 };
+            byte_pos += char_len;
+        }
+        DocOffset::from_raw(u32::try_from(byte_pos).unwrap_or(u32::MAX))
+    }
+}
+
+/// Length of a UTF-8 character from its leading byte.
+/// Returns 1 for ASCII and for invalid/continuation bytes (defensive).
+#[inline]
+pub(crate) const fn utf8_char_len(lead: u8) -> usize {
+    match lead {
+        0xC0..=0xDF => 2,
+        0xE0..=0xEF => 3,
+        0xF0..=0xF7 => 4,
+        _ => 1,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn utf16(line: u32, col: u32) -> (Utf16Line, Utf16Col) {
+        (Utf16Line::from_raw(line), Utf16Col::from_raw(col))
+    }
+
+    #[test]
+    fn ascii_byte_to_utf16() {
+        let src = DocText::new("ab\ncd");
+        let map = SourceMap::new(src);
+        let positions = map.byte_offsets_to_utf16(&[
+            DocOffset::from_raw(0),
+            DocOffset::from_raw(1),
+            DocOffset::from_raw(2),
+            DocOffset::from_raw(3),
+            DocOffset::from_raw(4),
+        ]);
+        assert_eq!(positions[0], utf16(0, 0));
+        assert_eq!(positions[1], utf16(0, 1));
+        assert_eq!(positions[2], utf16(0, 2));
+        assert_eq!(positions[3], utf16(1, 0));
+        assert_eq!(positions[4], utf16(1, 1));
+    }
+
+    #[test]
+    fn two_byte_char_is_one_utf16_unit() {
+        // 'é' = 2 UTF-8 bytes, 1 UTF-16 code unit
+        let src = DocText::new("aé b");
+        let map = SourceMap::new(src);
+        let positions = map.byte_offsets_to_utf16(&[
+            DocOffset::from_raw(0),
+            DocOffset::from_raw(3),
+            DocOffset::from_raw(4),
+        ]);
+        assert_eq!(positions[0], utf16(0, 0));
+        assert_eq!(positions[1], utf16(0, 2));
+        assert_eq!(positions[2], utf16(0, 3));
+    }
+
+    #[test]
+    fn four_byte_char_is_two_utf16_units() {
+        // '😀' = 4 UTF-8 bytes, 2 UTF-16 code units (surrogate pair)
+        let src = DocText::new("a😀b");
+        let map = SourceMap::new(src);
+        let positions =
+            map.byte_offsets_to_utf16(&[DocOffset::from_raw(0), DocOffset::from_raw(5)]);
+        assert_eq!(positions[0], utf16(0, 0));
+        assert_eq!(positions[1], utf16(0, 3));
+    }
+
+    #[test]
+    fn utf16_to_byte_ascii() {
+        let src = DocText::new("ab\ncd");
+        let map = SourceMap::new(src);
+        let (l, c) = utf16(1, 1);
+        assert_eq!(map.utf16_to_byte_offset(l, c), DocOffset::from_raw(4));
+    }
+
+    #[test]
+    fn utf16_to_byte_four_byte_char() {
+        let src = DocText::new("a😀b");
+        let map = SourceMap::new(src);
+        let (l, c) = utf16(0, 3);
+        assert_eq!(map.utf16_to_byte_offset(l, c), DocOffset::from_raw(5));
+    }
+
+    #[test]
+    fn empty_batch() {
+        let src = DocText::new("abc");
+        let map = SourceMap::new(src);
+        assert!(map.byte_offsets_to_utf16(&[]).is_empty());
+    }
+}

--- a/syntaqlite/src/semantic/render.rs
+++ b/syntaqlite/src/semantic/render.rs
@@ -81,17 +81,24 @@ impl<'a> DiagnosticRenderer<'a> {
                 file: self.file,
                 severity,
                 message: &message,
-                start_offset: diag.range().start.as_usize(),
-                end_offset: diag.range().end.as_usize(),
+                range: diag.range(),
                 help: help.as_deref(),
             },
         )?;
 
         // Render macro expansion traceback (Perfetto-style).  Frame 0 is
         // the outermost call site (already shown above), so we render the
-        // inner frames as "in macro expansion" notes.
+        // inner frames as "in macro expansion" notes.  `frame.range` is a
+        // `LayerRange` into the expansion buffer; reinterpret it as a
+        // `DocRange` into `frame.buffer` — each buffer is its own tiny
+        // document for snippet rendering.
         let frames = diag.expansion_frames();
         for frame in frames.iter().skip(1) {
+            use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange};
+            let frame_range = DocRange::from_offset_len(
+                DocOffset::from_raw(frame.range.start.as_u32()),
+                DocLen::from(frame.range.len()),
+            );
             render_source_error(
                 out,
                 &crate::util::SourceError {
@@ -99,8 +106,7 @@ impl<'a> DiagnosticRenderer<'a> {
                     file: "<macro expansion>",
                     severity: "note",
                     message: "in macro expansion",
-                    start_offset: frame.range.start.as_usize(),
-                    end_offset: frame.range.end.as_usize(),
+                    range: frame_range,
                     help: None,
                 },
             )?;

--- a/syntaqlite/src/util.rs
+++ b/syntaqlite/src/util.rs
@@ -5,6 +5,8 @@
 
 use std::io::{self, Write};
 
+use syntaqlite_syntax::source::DocRange;
+
 #[doc(inline)]
 #[cfg(feature = "validation")]
 pub use crate::semantic::render::{DiagnosticRenderer, SourceContext};
@@ -115,13 +117,16 @@ impl From<SqliteSyntaxFlags> for SqliteFlags {
 // ── Rustc-style source error rendering ───────────────────────────────────────
 
 /// Parameters for rendering a rustc-style source error snippet.
+///
+/// `range` is treated as byte offsets into `source` — callers rendering
+/// a span from a macro expansion buffer pass offsets relative to that
+/// buffer (see `DiagnosticRenderer::render_diagnostic`).
 pub(crate) struct SourceError<'a> {
     pub source: &'a str,
     pub file: &'a str,
     pub severity: &'a str,
     pub message: &'a str,
-    pub start_offset: usize,
-    pub end_offset: usize,
+    pub range: DocRange,
     pub help: Option<&'a str>,
 }
 
@@ -142,8 +147,10 @@ pub(crate) struct SourceError<'a> {
 /// # Errors
 /// Returns `Err` if writing to `out` fails.
 pub(crate) fn render_source_error(out: &mut impl Write, err: &SourceError<'_>) -> io::Result<()> {
-    let (line, col) = offset_to_line_col(err.source, err.start_offset);
-    let line_text = source_line_at(err.source, err.start_offset);
+    let start = err.range.start.as_usize();
+    let end = err.range.end.as_usize();
+    let (line, col) = offset_to_line_col(err.source, start);
+    let line_text = source_line_at(err.source, start);
     let gutter_width = line.to_string().len();
 
     writeln!(out, "{}: {}", err.severity, err.message)?;
@@ -151,9 +158,9 @@ pub(crate) fn render_source_error(out: &mut impl Write, err: &SourceError<'_>) -
     writeln!(out, "{:>gutter_width$} |", " ")?;
     writeln!(out, "{line} | {line_text}")?;
 
-    let underline_len = if err.end_offset > err.start_offset {
-        let line_end = err.start_offset + (line_text.len().saturating_sub(col - 1));
-        (err.end_offset.min(line_end) - err.start_offset).max(1)
+    let underline_len = if end > start {
+        let line_end = start + (line_text.len().saturating_sub(col - 1));
+        (end.min(line_end) - start).max(1)
     } else {
         1
     };

--- a/syntaqlite/tests/embedded.rs
+++ b/syntaqlite/tests/embedded.rs
@@ -79,8 +79,9 @@ fn fstring_with_holes_in_multiple_positions() {
     assert_eq!(f.holes().len(), 4);
     // All holes use the same constant placeholder.
     for hole in f.holes() {
-        let end = hole.sql_offset() + HOLE_PLACEHOLDER.len();
-        assert_eq!(&f.sql_text()[hole.sql_offset()..end], HOLE_PLACEHOLDER);
+        let start = hole.sql_offset().as_usize();
+        let end = start + HOLE_PLACEHOLDER.len();
+        assert_eq!(&f.sql_text()[start..end], HOLE_PLACEHOLDER);
     }
 }
 
@@ -208,8 +209,9 @@ fn ts_template_with_multiple_holes() {
     let f = &fragments[0];
     assert_eq!(f.holes().len(), 4);
     for hole in f.holes() {
-        let end = hole.sql_offset() + HOLE_PLACEHOLDER.len();
-        assert_eq!(&f.sql_text()[hole.sql_offset()..end], HOLE_PLACEHOLDER);
+        let start = hole.sql_offset().as_usize();
+        let end = start + HOLE_PLACEHOLDER.len();
+        assert_eq!(&f.sql_text()[start..end], HOLE_PLACEHOLDER);
     }
 }
 

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -16,6 +16,7 @@
 #[repr(transparent)] pub struct syntaqlite_syntax::source::LayerOffset(_)
 #[repr(transparent)] pub struct syntaqlite_syntax::source::LayerText(_)
 #[repr(transparent)] pub struct syntaqlite_syntax::source::LineNumber(_)
+#[repr(transparent)] pub struct syntaqlite_syntax::source::RewriteIdx(_)
 #[repr(transparent)] pub struct syntaqlite_syntax::source::StmtLen(_)
 #[repr(transparent)] pub struct syntaqlite_syntax::source::StmtOffset(_)
 #[repr(transparent)] pub struct syntaqlite_syntax::source::StmtText(_)
@@ -253,6 +254,7 @@ impl core::fmt::Debug for syntaqlite_syntax::source::LayerLen
 impl core::fmt::Debug for syntaqlite_syntax::source::LayerOffset
 impl core::fmt::Debug for syntaqlite_syntax::source::LayerText
 impl core::fmt::Debug for syntaqlite_syntax::source::LineNumber
+impl core::fmt::Debug for syntaqlite_syntax::source::RewriteIdx
 impl core::fmt::Debug for syntaqlite_syntax::source::StmtLen
 impl core::fmt::Debug for syntaqlite_syntax::source::StmtOffset
 impl core::fmt::Debug for syntaqlite_syntax::source::StmtText
@@ -332,6 +334,7 @@ impl core::fmt::Display for syntaqlite_syntax::source::LayerLen
 impl core::fmt::Display for syntaqlite_syntax::source::LayerOffset
 impl core::fmt::Display for syntaqlite_syntax::source::LayerText
 impl core::fmt::Display for syntaqlite_syntax::source::LineNumber
+impl core::fmt::Display for syntaqlite_syntax::source::RewriteIdx
 impl core::fmt::Display for syntaqlite_syntax::source::StmtLen
 impl core::fmt::Display for syntaqlite_syntax::source::StmtOffset
 impl core::fmt::Display for syntaqlite_syntax::source::StmtText
@@ -520,6 +523,7 @@ impl syntaqlite_syntax::source::LayerOffset
 impl syntaqlite_syntax::source::LayerRange
 impl syntaqlite_syntax::source::LayerText
 impl syntaqlite_syntax::source::LineNumber
+impl syntaqlite_syntax::source::RewriteIdx
 impl syntaqlite_syntax::source::StatementBase
 impl syntaqlite_syntax::source::StmtLen
 impl syntaqlite_syntax::source::StmtOffset
@@ -897,6 +901,9 @@ pub const fn syntaqlite_syntax::source::LayerRange::len(self) -> syntaqlite_synt
 pub const fn syntaqlite_syntax::source::LineNumber::as_u32(self) -> u32
 pub const fn syntaqlite_syntax::source::LineNumber::as_usize(self) -> usize
 pub const fn syntaqlite_syntax::source::LineNumber::from_raw(v: u32) -> Self
+pub const fn syntaqlite_syntax::source::RewriteIdx::as_u32(self) -> u32
+pub const fn syntaqlite_syntax::source::RewriteIdx::as_usize(self) -> usize
+pub const fn syntaqlite_syntax::source::RewriteIdx::from_raw(v: u32) -> Self
 pub const fn syntaqlite_syntax::source::StatementBase::as_doc_offset(self) -> syntaqlite_syntax::source::DocOffset
 pub const fn syntaqlite_syntax::source::StatementBase::new(base: syntaqlite_syntax::source::DocOffset) -> Self
 pub const fn syntaqlite_syntax::source::StmtLen::as_u32(self) -> u32
@@ -960,7 +967,7 @@ pub fn syntaqlite_syntax::IncrementalParseSession::node_count(&self) -> u32
 pub fn syntaqlite_syntax::MacroLookup::lookup(&mut self, name: &str, args: &[syntaqlite_syntax::MacroArg<'_>], out: &mut syntaqlite_syntax::MacroOutput) -> bool
 pub fn syntaqlite_syntax::MacroOutput::expand_template(&mut self, body: &str, params: &[alloc::string::String]) -> bool
 pub fn syntaqlite_syntax::MacroOutput::expand_template_permissive(&mut self, body: &str, params: &[alloc::string::String]) -> bool
-pub fn syntaqlite_syntax::MacroOutput::set_definition(&mut self, line: u32, col: u32)
+pub fn syntaqlite_syntax::MacroOutput::set_definition(&mut self, line: syntaqlite_syntax::source::LineNumber, col: syntaqlite_syntax::source::ColumnNumber)
 pub fn syntaqlite_syntax::MacroOutput::write(&mut self, body: &str)
 pub fn syntaqlite_syntax::ParseOutcome<T, E>::map<U>(self, f: impl core::ops::function::FnOnce(T) -> U) -> syntaqlite_syntax::ParseOutcome<U, E>
 pub fn syntaqlite_syntax::ParseOutcome<T, E>::map_err<F>(self, f: impl core::ops::function::FnOnce(E) -> F) -> syntaqlite_syntax::ParseOutcome<T, F>
@@ -1097,7 +1104,7 @@ pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::list_children(&self, id: 
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::macro_rewrites(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRewrite<'a>> + use<'_, 'a>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_expanded_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a str>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_is_macro_free(&self, id: syntaqlite_syntax::any::AnyNodeId) -> bool
-pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(&'a str, u32)>
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(&'a str, syntaqlite_syntax::source::StmtOffset)>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_id(&self) -> syntaqlite_syntax::any::AnyNodeId
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_node(&self) -> core::option::Option<syntaqlite_syntax::any::AnyNode<'_>>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_expanded_text(&self, span: syntaqlite_syntax::any::TextSpan) -> &'a str
@@ -1124,7 +1131,7 @@ pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::expansion_offset(&self) -> s
 pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin(&self) -> syntaqlite_syntax::any::ArgOrigin
 pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin_length(&self) -> syntaqlite_syntax::source::LayerLen
 pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin_offset(&self) -> syntaqlite_syntax::source::LayerOffset
-pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin_parent(&self) -> core::option::Option<u32>
+pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin_parent(&self) -> core::option::Option<syntaqlite_syntax::source::RewriteIdx>
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::arg_segments(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroArgSegment<'a>> + use<'_, 'a>
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::body_call_length(&self) -> syntaqlite_syntax::source::LayerLen
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::body_call_offset(&self) -> syntaqlite_syntax::source::LayerOffset
@@ -1134,7 +1141,7 @@ pub fn syntaqlite_syntax::any::MacroRewrite<'a>::def_col(&self) -> syntaqlite_sy
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::def_line(&self) -> syntaqlite_syntax::source::LineNumber
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::expansion(&self) -> &'a syntaqlite_syntax::source::LayerText
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::name(&self) -> &'a str
-pub fn syntaqlite_syntax::any::MacroRewrite<'a>::parent(&self) -> core::option::Option<u32>
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::parent(&self) -> core::option::Option<syntaqlite_syntax::source::RewriteIdx>
 pub fn syntaqlite_syntax::any::NodeFields::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn syntaqlite_syntax::any::NodeFields::index(&self, idx: usize) -> &syntaqlite_syntax::any::FieldValue
 pub fn syntaqlite_syntax::any::NodeFields::is_empty(&self) -> bool
@@ -1852,6 +1859,7 @@ pub fn syntaqlite_syntax::source::LayerText::index(&self, r: syntaqlite_syntax::
 pub fn syntaqlite_syntax::source::LayerText::is_empty(&self) -> bool
 pub fn syntaqlite_syntax::source::LayerText::new(s: &str) -> &syntaqlite_syntax::source::LayerText
 pub fn syntaqlite_syntax::source::LineNumber::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn syntaqlite_syntax::source::RewriteIdx::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn syntaqlite_syntax::source::StmtLen::add(self, rhs: syntaqlite_syntax::source::StmtLen) -> syntaqlite_syntax::source::StmtLen
 pub fn syntaqlite_syntax::source::StmtLen::add_assign(&mut self, rhs: syntaqlite_syntax::source::StmtLen)
 pub fn syntaqlite_syntax::source::StmtLen::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1922,13 +1930,13 @@ pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::dump(&self, out: &
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::erase(self) -> syntaqlite_syntax::any::AnyParsedStatement<'a>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::expanded_text(&self) -> &'a str
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::full_text(&self) -> &'a syntaqlite_syntax::source::DocText
-pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::leading_comments(&self, token_idx: u32) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>>
+pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::leading_comments(&self, token_idx: syntaqlite_syntax::source::TokenIdx) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::macro_rewrites(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRewrite<'a>> + use<'_, 'a, G>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::root(&'a self) -> core::option::Option<<G as syntaqlite_syntax::typed::TypedDialect>::Node>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::statement_base(&self) -> syntaqlite_syntax::source::StatementBase
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::text(&self) -> &'a syntaqlite_syntax::source::StmtText
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::typed::TypedParserToken<'a, G>>
-pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::trailing_comments(&self, token_idx: u32) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>>
+pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::trailing_comments(&self, token_idx: syntaqlite_syntax::source::TokenIdx) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>>
 pub fn syntaqlite_syntax::typed::TypedParser<G>::incremental_parse(&self, source: &str) -> syntaqlite_syntax::typed::TypedIncrementalParseSession<G>
 pub fn syntaqlite_syntax::typed::TypedParser<G>::new(dialect: G) -> Self
 pub fn syntaqlite_syntax::typed::TypedParser<G>::parse(&self, source: &str) -> syntaqlite_syntax::typed::TypedParseSession<G>
@@ -2346,7 +2354,7 @@ pub syntaqlite_syntax::TokenType::Window = 167
 pub syntaqlite_syntax::TokenType::With = 69
 pub syntaqlite_syntax::TokenType::Within = 86
 pub syntaqlite_syntax::TokenType::Without = 70
-pub syntaqlite_syntax::any::ArgOrigin::Rewrite(u32)
+pub syntaqlite_syntax::any::ArgOrigin::Rewrite(syntaqlite_syntax::source::RewriteIdx)
 pub syntaqlite_syntax::any::ArgOrigin::Source
 pub syntaqlite_syntax::any::FieldKind::Bool = 2
 pub syntaqlite_syntax::any::FieldKind::Enum = 4

--- a/tests/public-api/syntaqlite.txt
+++ b/tests/public-api/syntaqlite.txt
@@ -123,10 +123,10 @@ pub fn syntaqlite::embedded::EmbeddedAnalyzer::validate(&self, fragments: &[synt
 pub fn syntaqlite::embedded::EmbeddedAnalyzer::with_catalog(self, catalog: syntaqlite::Catalog) -> Self
 pub fn syntaqlite::embedded::EmbeddedAnalyzer::with_config(self, config: syntaqlite::semantic::ValidationConfig) -> Self
 pub fn syntaqlite::embedded::EmbeddedFragment::holes(&self) -> &[syntaqlite::embedded::Hole]
-pub fn syntaqlite::embedded::EmbeddedFragment::sql_range(&self) -> &core::ops::range::Range<usize>
+pub fn syntaqlite::embedded::EmbeddedFragment::sql_range(&self) -> syntaqlite_syntax::source::DocRange
 pub fn syntaqlite::embedded::EmbeddedFragment::sql_text(&self) -> &str
-pub fn syntaqlite::embedded::Hole::host_range(&self) -> &core::ops::range::Range<usize>
-pub fn syntaqlite::embedded::Hole::sql_offset(&self) -> usize
+pub fn syntaqlite::embedded::Hole::host_range(&self) -> syntaqlite_syntax::source::DocRange
+pub fn syntaqlite::embedded::Hole::sql_offset(&self) -> syntaqlite_syntax::source::DocOffset
 pub fn syntaqlite::embedded::extract_python(source: &str) -> alloc::vec::Vec<syntaqlite::embedded::EmbeddedFragment>
 pub fn syntaqlite::embedded::extract_typescript(source: &str) -> alloc::vec::Vec<syntaqlite::embedded::EmbeddedFragment>
 pub fn syntaqlite::fmt::FormatConfig::default() -> Self


### PR DESCRIPTION
Builds on PR #190 to eliminate raw u32/usize from the offset surface
both internally (formatter, diagnostic renderer, LSP) and at the few
remaining public-API holes (embedded extraction, parser-API
token/rewrite indices, macro definition line/col).

- fmt: `CommentEntry`/`TokenEntry` hold `StmtOffset`/`StmtLen`; the
  drain/peek/advance APIs take `StmtOffset` and `&StmtText`, slicing
  via `StmtRange` end-to-end — no `.as_u32()`/`.as_usize()` in
  `interpret.rs` hot paths.  `FmtCtx::text()` returns `&StmtText`;
  `try_macro_verbatim` reads typed `node_text` directly.
- util/semantic render: `SourceError` now carries a `DocRange`.  The
  macro-expansion frame branch reinterprets its `LayerRange` as a
  `DocRange` with an explanatory comment.
- lsp: new `pub(crate)` `SourceMap` in `syntaqlite/src/lsp/source_map.rs`
  lifts the byte↔(line, UTF-16 col) walk out of `lsp/server.rs`.
  `SourcePositionMap` is now a thin adapter to `lsp_types::Position`.
- parser public API holes filled:
  - `AnyParsedStatement::node_text` / `TypedParsedStatement::node_text`
    return `Option<(&str, StmtOffset)>` (was `Option<(&str, u32)>`).
  - `leading_comments` / `trailing_comments` take `TokenIdx`
    (was `u32`).
  - `MacroOutput::set_definition` takes `LineNumber` / `ColumnNumber`.
- New `RewriteIdx` newtype; `MacroRewrite::parent`,
  `MacroArgSegment::origin_parent`, and `ArgOrigin::Rewrite` now use
  it (was `Option<u32>` / `u32`).
- embedded: `EmbeddedFragment::sql_range` returns `DocRange`;
  `Hole::host_range` returns `DocRange`, `Hole::sql_offset` returns
  `DocOffset`.  `OffsetMap` carries typed offsets/lengths throughout.
  New `doc_offset_from_usize` / `doc_range_from_usize` helpers (crate
  private) for the host-language scanners.
- Public-API golden files rebaselined (3 sigs in syntaqlite, 4 sigs
  + RewriteIdx in syntaqlite-syntax; all other conversions are
  strictly additive type newtypes).

