### PR TITLE
synq: build + test wasm in npm publish pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,12 @@ jobs:
           export PATH="$PWD/../../third_party/bin/linux-amd64/nodejs/bin:$PATH"
           npm run test:e2e:ci
 
+      - name: Install Playwright browser for syntaqlite-js
+        working-directory: web/syntaqlite-js
+        run: |
+          export PATH="$PWD/../../third_party/bin/linux-amd64/nodejs/bin:$PATH"
+          npx playwright install chromium
+
       - name: Run npm package e2e smoke test
         working-directory: web/syntaqlite-js
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,22 @@ jobs:
           export PATH="$PWD/../../third_party/bin/linux-amd64/nodejs/bin:$PATH"
           npm run test:e2e:ci
 
+      - name: Run npm package e2e smoke test
+        working-directory: web/syntaqlite-js
+        run: |
+          export PATH="$PWD/../../third_party/bin/linux-amd64/nodejs/bin:$PATH"
+          npm run test:package
+
+      - name: Upload npm package test report
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: syntaqlite-js-package-test-report
+          path: |
+            web/syntaqlite-js/playwright-report/
+            web/syntaqlite-js/test-results/
+          retention-days: 14
+
       - name: Upload Playwright report
         uses: actions/upload-artifact@v6
         if: always()

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -27,6 +27,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Cache third_party
+        uses: actions/cache@v5
+        with:
+          path: third_party
+          key: third-party-ui-rust-${{ runner.os }}-${{ hashFiles('python/tools/install_build_deps.py') }}
+
+      - name: Install build dependencies (Rust + Node.js + Emscripten)
+        run: python3 tools/install-build-deps --ui
+
+      - name: Build WASM runtime
+        run: python3 tools/build-web-playground --hermetic
+
       - uses: actions/setup-node@v5
         with:
           node-version: '24'
@@ -39,6 +51,10 @@ jobs:
       - name: Build
         working-directory: web/syntaqlite-js
         run: npm run build
+
+      - name: Verify wasm files are in tarball
+        working-directory: web/syntaqlite-js
+        run: node scripts/verify-tarball.mjs
 
       - name: Publish
         working-directory: web/syntaqlite-js

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -55,6 +55,52 @@ jobs:
           echo "SELECT 1" | syntaqlite fmt
           echo "SELECT 1" | syntaqlite validate
 
+  test-npm:
+    name: npm (browser e2e against registry)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+
+      # npm publishing is async — retry until the registry has the package.
+      - name: Wait for registry availability
+        shell: bash
+        working-directory: web/syntaqlite-js
+        run: |
+          for attempt in 1 2 3 4 5 6; do
+            if npm view syntaqlite@latest version >/dev/null 2>&1; then
+              echo "available: $(npm view syntaqlite@latest version)"
+              break
+            fi
+            echo "Attempt $attempt: not yet, waiting 60s..."
+            sleep 60
+          done
+
+      - name: Install test deps
+        working-directory: web/syntaqlite-js
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: web/syntaqlite-js
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser e2e smoke against published package
+        working-directory: web/syntaqlite-js
+        run: npm run test:package:registry
+
+      - name: Upload Playwright report on failure
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: test-install-npm-report
+          path: |
+            web/syntaqlite-js/playwright-report/
+            web/syntaqlite-js/test-results/
+          retention-days: 30
+
   test-download-script:
     name: Download script (${{ matrix.os }})
     strategy:

--- a/web/syntaqlite-js/.gitignore
+++ b/web/syntaqlite-js/.gitignore
@@ -1,3 +1,8 @@
 dist/
 node_modules/
 wasm/
+*.tgz
+tests/fixture/node_modules/
+tests/fixture/package-lock.json
+test-results/
+playwright-report/

--- a/web/syntaqlite-js/package-lock.json
+++ b/web/syntaqlite-js/package-lock.json
@@ -1,15 +1,79 @@
 {
   "name": "syntaqlite",
-  "version": "0.0.19",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "syntaqlite",
-      "version": "0.0.19",
+      "version": "0.4.2",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/typescript": {

--- a/web/syntaqlite-js/package.json
+++ b/web/syntaqlite-js/package.json
@@ -21,9 +21,13 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "prepublishOnly": "node scripts/verify-tarball.mjs",
+    "test:package": "node tests/setup-fixture.mjs local && playwright test",
+    "test:package:registry": "node tests/setup-fixture.mjs registry && playwright test"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "typescript": "^5.7.2"
   }
 }

--- a/web/syntaqlite-js/playwright.config.ts
+++ b/web/syntaqlite-js/playwright.config.ts
@@ -1,7 +1,7 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-import {defineConfig} from "@playwright/test";
+import {defineConfig, devices} from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests",
@@ -15,7 +15,7 @@ export default defineConfig({
     trace: "retain-on-failure",
   },
   projects: [
-    {name: "chromium", use: {browserName: "chromium"}},
+    {name: "chromium", use: {...devices["Desktop Chrome"]}},
   ],
   webServer: {
     command: "python3 -m http.server 4174 --directory tests/fixture",

--- a/web/syntaqlite-js/playwright.config.ts
+++ b/web/syntaqlite-js/playwright.config.ts
@@ -1,0 +1,27 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import {defineConfig} from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "**/*.spec.ts",
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:4174/",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {name: "chromium", use: {browserName: "chromium"}},
+  ],
+  webServer: {
+    command: "python3 -m http.server 4174 --directory tests/fixture",
+    url: "http://localhost:4174/",
+    reuseExistingServer: !process.env.CI,
+    stdout: "ignore",
+    stderr: "pipe",
+  },
+});

--- a/web/syntaqlite-js/scripts/verify-tarball.mjs
+++ b/web/syntaqlite-js/scripts/verify-tarball.mjs
@@ -1,0 +1,32 @@
+// Verifies that `npm pack` would include the WASM runtime files.
+// Runs as the publish-time safety net (prepublishOnly) and from CI.
+// Fails loudly so a broken tarball like the one reported in issue #189
+// (missing `wasm/` directory) can never be published again.
+
+import {execSync} from "node:child_process";
+
+const REQUIRED = [
+  "wasm/syntaqlite-runtime.js",
+  "wasm/syntaqlite-runtime.wasm",
+  "wasm/syntaqlite-sqlite.wasm",
+  "dist/index.js",
+  "dist/index.d.ts",
+];
+
+const raw = execSync("npm pack --dry-run --json", {encoding: "utf8"});
+const parsed = JSON.parse(raw);
+const entry = Array.isArray(parsed) ? parsed[0] : parsed;
+const files = new Set((entry.files ?? []).map((f) => f.path));
+
+const missing = REQUIRED.filter((p) => !files.has(p));
+if (missing.length > 0) {
+  console.error("ERROR: tarball is missing required files:");
+  for (const p of missing) console.error("  - " + p);
+  console.error("");
+  console.error("Run `python3 tools/build-web-playground` from the repo root,");
+  console.error("then `npm run build` in web/syntaqlite-js before publishing.");
+  process.exit(1);
+}
+
+console.log("tarball verification passed (" + files.size + " files, " +
+  entry.size + " bytes unpacked)");

--- a/web/syntaqlite-js/src/dialect.ts
+++ b/web/syntaqlite-js/src/dialect.ts
@@ -1,8 +1,8 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-import type {DialectBinding} from "./types";
-import type {Engine} from "./engine";
+import type {DialectBinding} from "./types.js";
+import type {Engine} from "./engine.js";
 
 export interface DialectPreset {
   id: string;

--- a/web/syntaqlite-js/src/dialect_config.ts
+++ b/web/syntaqlite-js/src/dialect_config.ts
@@ -1,7 +1,7 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-import type {CflagEntry, Engine} from "./engine";
+import type {CflagEntry, Engine} from "./engine.js";
 
 export const VERSION_OPTIONS = [
   "latest",

--- a/web/syntaqlite-js/src/engine.ts
+++ b/web/syntaqlite-js/src/engine.ts
@@ -15,7 +15,7 @@ import type {
   EmscriptenModuleConfig,
   FormatOptions,
   FormatResult,
-} from "./types";
+} from "./types.js";
 
 export interface CflagEntry {
   name: string;

--- a/web/syntaqlite-js/src/index.ts
+++ b/web/syntaqlite-js/src/index.ts
@@ -1,10 +1,10 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-export { Engine, type EngineConfig, type CflagEntry } from "./engine";
-export { DialectManager, BUILTIN_PRESETS, type DialectPreset, type DialectManagerConfig } from "./dialect";
-export { DialectConfigManager, VERSION_OPTIONS, versionToInt } from "./dialect_config";
-export { SchemaContextManager, parseSimple, type SchemaFormat, type SessionContextPayload } from "./schema";
+export { Engine, type EngineConfig, type CflagEntry } from "./engine.js";
+export { DialectManager, BUILTIN_PRESETS, type DialectPreset, type DialectManagerConfig } from "./dialect.js";
+export { DialectConfigManager, VERSION_OPTIONS, versionToInt } from "./dialect_config.js";
+export { SchemaContextManager, parseSimple, type SchemaFormat, type SessionContextPayload } from "./schema.js";
 export type {
   EmscriptenModule,
   EmscriptenModuleConfig,
@@ -29,4 +29,4 @@ export type {
   EmbeddedHole,
   EmbeddedFragment,
   EmbeddedExtractResult,
-} from "./types";
+} from "./types.js";

--- a/web/syntaqlite-js/src/schema.ts
+++ b/web/syntaqlite-js/src/schema.ts
@@ -1,7 +1,7 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-import type {Engine} from "./engine";
+import type {Engine} from "./engine.js";
 
 export type SchemaFormat = "simple" | "ddl";
 

--- a/web/syntaqlite-js/tests/fixture/index.html
+++ b/web/syntaqlite-js/tests/fixture/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>syntaqlite package smoke test</title>
+</head>
+<body>
+  <div id="status">loading</div>
+  <pre id="log"></pre>
+  <script type="module" src="./smoke.js"></script>
+</body>
+</html>

--- a/web/syntaqlite-js/tests/fixture/package.json
+++ b/web/syntaqlite-js/tests/fixture/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "syntaqlite-package-fixture",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module"
+}

--- a/web/syntaqlite-js/tests/fixture/smoke.js
+++ b/web/syntaqlite-js/tests/fixture/smoke.js
@@ -1,0 +1,52 @@
+// Exercises the installed syntaqlite package in a real browser.
+// Imports are relative to the installed tarball contents under node_modules/,
+// so the path layout (dist/ + wasm/ + root-relative fetches) matches what a
+// real consumer's bundler would produce.
+import {Engine, DialectManager} from "./node_modules/syntaqlite/dist/index.js";
+
+const logEl = document.getElementById("log");
+const statusEl = document.getElementById("status");
+const log = (...args) => {
+  logEl.textContent += args.join(" ") + "\n";
+};
+
+async function main() {
+  const engine = new Engine();
+  await engine.load();
+  log("engine loaded");
+
+  const dm = new DialectManager({
+    presets: [{
+      id: "sqlite",
+      label: "SQLite",
+      wasmUrl: "./node_modules/syntaqlite/wasm/syntaqlite-sqlite.wasm",
+      symbol: "syntaqlite_sqlite_dialect_template",
+    }],
+  });
+  await dm.loadDefault(engine);
+  log("dialect loaded");
+
+  const fmt = engine.runFmt("select a,b from t where a=1", {
+    lineWidth: 80,
+    indentWidth: 2,
+    keywordCase: 1,
+    semicolons: true,
+  });
+  log("fmt:", JSON.stringify(fmt));
+
+  const diag = engine.runDiagnostics("selec 1 frm t");
+  log("diag count:", diag.diagnostics.length);
+
+  window.__syntaqlite_result = {ok: true, fmt, diag};
+  statusEl.textContent = "READY";
+}
+
+main().catch((err) => {
+  window.__syntaqlite_result = {
+    ok: false,
+    error: err?.message ?? String(err),
+    stack: err?.stack,
+  };
+  log("error:", err?.message ?? String(err));
+  statusEl.textContent = "ERROR";
+});

--- a/web/syntaqlite-js/tests/setup-fixture.mjs
+++ b/web/syntaqlite-js/tests/setup-fixture.mjs
@@ -1,0 +1,50 @@
+// Packs the package and installs the tarball into tests/fixture/ so the
+// Playwright smoke test exercises the exact bytes that would be published
+// to npm — catching issue #189 class bugs where required files are missing
+// from the tarball.
+import {execSync} from "node:child_process";
+import {existsSync, rmSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgDir = resolve(__dirname, "..");
+const fixtureDir = join(__dirname, "fixture");
+
+const source = process.argv[2] ?? "local";
+
+let tarball;
+if (source === "local") {
+  console.log("> npm pack (in " + pkgDir + ")");
+  tarball = execSync("npm pack --silent", {cwd: pkgDir, encoding: "utf8"}).trim();
+  tarball = join(pkgDir, tarball);
+} else if (source === "registry") {
+  const version = process.argv[3] ?? "latest";
+  console.log("> npm pack syntaqlite@" + version + " (from registry)");
+  const out = execSync(
+    "npm pack --silent syntaqlite@" + JSON.stringify(version),
+    {cwd: pkgDir, encoding: "utf8"},
+  ).trim();
+  tarball = join(pkgDir, out);
+} else {
+  console.error("unknown source: " + source);
+  process.exit(1);
+}
+
+if (!existsSync(tarball)) {
+  console.error("tarball not found: " + tarball);
+  process.exit(1);
+}
+console.log("  tarball: " + tarball);
+
+console.log("> cleaning fixture node_modules");
+rmSync(join(fixtureDir, "node_modules"), {recursive: true, force: true});
+rmSync(join(fixtureDir, "package-lock.json"), {force: true});
+
+console.log("> npm install " + tarball + " (in " + fixtureDir + ")");
+execSync(
+  "npm install --no-save --no-audit --no-fund --silent " + JSON.stringify(tarball),
+  {cwd: fixtureDir, stdio: "inherit"},
+);
+
+console.log("> fixture ready at " + fixtureDir);

--- a/web/syntaqlite-js/tests/smoke.spec.ts
+++ b/web/syntaqlite-js/tests/smoke.spec.ts
@@ -1,0 +1,45 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import {test, expect} from "@playwright/test";
+
+test("packed tarball formats and validates SQL in a real browser", async ({page}) => {
+  const logs: string[] = [];
+  page.on("console", (msg) => logs.push(`[${msg.type()}] ${msg.text()}`));
+  page.on("pageerror", (err) => logs.push(`[pageerror] ${err.message}`));
+
+  await page.goto("/");
+  await expect(page.locator("#status")).toHaveText(/READY|ERROR/, {timeout: 30_000});
+
+  const result = await page.evaluate(
+    () => (window as unknown as {__syntaqlite_result?: unknown}).__syntaqlite_result,
+  ) as {
+    ok: boolean;
+    error?: string;
+    stack?: string;
+    fmt?: {ok: boolean; text: string};
+    diag?: {ok: boolean; diagnostics: unknown[]};
+  } | undefined;
+
+  if (!result?.ok) {
+    const pageLog = await page.locator("#log").textContent();
+    throw new Error(
+      "smoke failed: " + (result?.error ?? "no result") + "\n" +
+      "stack:\n" + (result?.stack ?? "") + "\n" +
+      "page log:\n" + pageLog + "\n" +
+      "console:\n" + logs.join("\n"),
+    );
+  }
+
+  // Formatting: `select a,b from t where a=1` with upper + 2-space indent
+  // should emit SELECT/FROM/WHERE in uppercase with a reformatted body.
+  expect(result.fmt!.ok).toBe(true);
+  expect(result.fmt!.text).toMatch(/SELECT/);
+  expect(result.fmt!.text).toMatch(/FROM/);
+  expect(result.fmt!.text).toMatch(/WHERE/);
+
+  // Validation: `selec 1 frm t` is syntactically invalid; the validator
+  // must report at least one diagnostic.
+  expect(result.diag!.ok).toBe(true);
+  expect(result.diag!.diagnostics.length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
Fixes #189

The npm publish workflow only ran tsc, so the published tarball was
missing the wasm/ runtime and consumers hit load errors calling
new Engine(). Close the gap at three layers: build, guard, and test.

- publish-npm.yml: install Rust+Emscripten build deps, run
  tools/build-web-playground --hermetic (which already copies
  runtime+sqlite wasm into web/syntaqlite-js/wasm/), then verify the
  tarball contents before publishing.
- scripts/verify-tarball.mjs: parse `npm pack --dry-run --json` and
  fail if dist/ or wasm/ files are missing. Wired as prepublishOnly
  so local `npm publish` is also covered.
- ci.yml playwright-tests: after the playground e2e, run
  `npm run test:package` — packs the tarball, installs it into
  tests/fixture/, launches Chromium via Playwright, loads
  fixture/index.html which imports {Engine, DialectManager} from the
  installed tarball, runs runFmt + runDiagnostics against real SQL,
  and asserts formatter output plus diagnostic count.
- test-install.yml test-npm: after release publish, pull the actual
  registry tarball with `npm pack syntaqlite@latest` and run the same
  Playwright smoke (test:package:registry) to catch any gap between
  what we built and what npmjs served.
- tests/{setup-fixture.mjs, smoke.spec.ts}, fixture/{index.html,
  smoke.js, package.json}, playwright.config.ts: test harness.


