### PR TITLE
synq: decouple LSP from semantic validator via AnalysisObserver

### DIFF
--- a/syntaqlite-cli/src/util.rs
+++ b/syntaqlite-cli/src/util.rs
@@ -115,19 +115,13 @@ pub(crate) fn build_schema_catalog(
     }
     let paths = expand_paths(schema_files)?;
     let mut sources = Vec::new();
-    let mut uris = Vec::new();
     for path in &paths {
         let source =
             fs::read_to_string(path).map_err(|e| format!("schema {}: {e}", path.display()))?;
-        uris.push(format!("file://{}", path.display()));
         sources.push(source);
     }
-    let pairs: Vec<(&str, Option<&str>)> = sources
-        .iter()
-        .zip(uris.iter())
-        .map(|(s, u)| (s.as_str(), Some(u.as_str())))
-        .collect();
-    let (catalog, errors) = Catalog::from_ddl(dialect.clone(), &pairs);
+    let source_refs: Vec<&str> = sources.iter().map(String::as_str).collect();
+    let (catalog, errors) = Catalog::from_ddl(dialect.clone(), &source_refs);
     for err in &errors {
         eprintln!("warning: schema: {err}");
     }

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -289,10 +289,7 @@ impl CParser {
     ///
     /// # Safety
     /// The returned slice must not outlive the borrow underlying `self`.
-    pub(crate) unsafe fn node_text<'a>(
-        &self,
-        node_id: u32,
-    ) -> Option<(&'a str, StmtOffset)> {
+    pub(crate) unsafe fn node_text<'a>(&self, node_id: u32) -> Option<(&'a str, StmtOffset)> {
         let mut out_len: u32 = 0;
         let mut out_offset: u32 = 0;
         // SAFETY: self is a valid, non-null CParser pointer owned by the caller.
@@ -429,10 +426,7 @@ impl CParser {
         unsafe { std::slice::from_raw_parts(ptr, count as usize) }
     }
 
-    pub(crate) unsafe fn token_leading_comments(
-        &self,
-        token_idx: TokenIdx,
-    ) -> &[CComment] {
+    pub(crate) unsafe fn token_leading_comments(&self, token_idx: TokenIdx) -> &[CComment] {
         let mut count: u32 = 0;
         // SAFETY: self is a valid, non-null CParser pointer; result
         // accessors are valid after `next()` returns a non-DONE code.
@@ -451,10 +445,7 @@ impl CParser {
         unsafe { std::slice::from_raw_parts(ptr, count as usize) }
     }
 
-    pub(crate) unsafe fn token_trailing_comments(
-        &self,
-        token_idx: TokenIdx,
-    ) -> &[CComment] {
+    pub(crate) unsafe fn token_trailing_comments(&self, token_idx: TokenIdx) -> &[CComment] {
         let mut count: u32 = 0;
         // SAFETY: self is a valid, non-null CParser pointer; result
         // accessors are valid after `next()` returns a non-DONE code.

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -1404,7 +1404,10 @@ mod tests {
         // whose expansion range contains n's arg, then recursing.
         let n_segs: Vec<_> = rewrites[1].arg_segments().collect();
         assert_eq!(n_segs.len(), 1);
-        assert_eq!(n_segs[0].origin(), ArgOrigin::Rewrite(RewriteIdx::from_raw(0)));
+        assert_eq!(
+            n_segs[0].origin(),
+            ArgOrigin::Rewrite(RewriteIdx::from_raw(0))
+        );
         let m_expansion = rewrites[0].expansion();
         let n_arg_range = crate::source::LayerRange::from_offset_len(
             n_segs[0].origin_offset(),

--- a/syntaqlite/src/embedded/mod.rs
+++ b/syntaqlite/src/embedded/mod.rs
@@ -27,7 +27,8 @@ pub use python::extract_python;
 #[doc(inline)]
 pub use typescript::extract_typescript;
 
-use syntaqlite_syntax::any::TokenCategory;
+use syntaqlite_syntax::ParserTokenFlags;
+use syntaqlite_syntax::any::{AnyTokenType, TokenCategory};
 use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange};
 
 use crate::dialect::AnyDialect;
@@ -35,6 +36,7 @@ use crate::semantic::ValidationConfig;
 use crate::semantic::analyzer::SemanticAnalyzer;
 use crate::semantic::catalog::Catalog;
 use crate::semantic::diagnostics::Diagnostic;
+use crate::semantic::observer::AnalysisObserver;
 
 use offset_map::OffsetMap;
 
@@ -291,12 +293,26 @@ impl EmbeddedAnalyzer {
         fragment: &EmbeddedFragment,
     ) -> Vec<(DocOffset, DocLen, TokenCategory)> {
         let mut analyzer = self.make_analyzer();
-        let model = analyzer.analyze(fragment.sql_text(), &self.catalog, &self.config);
-        model
-            .semantic_tokens(&analyzer.dialect())
-            .into_iter()
-            .map(|t| (t.offset, t.length, t.category))
-            .collect()
+        let mut observer = TokenObserver::default();
+        let _ = analyzer.analyze_with_observer(
+            fragment.sql_text(),
+            &self.catalog,
+            &self.config,
+            &mut observer,
+        );
+        let dialect = analyzer.dialect();
+        let mut out: Vec<(DocOffset, DocLen, TokenCategory)> = Vec::new();
+        for (offset, length, tt, flags) in observer.tokens {
+            let cat = dialect.classify_token(tt, flags);
+            if cat != TokenCategory::Other {
+                out.push((offset, length, cat));
+            }
+        }
+        for (offset, length) in observer.comments {
+            out.push((offset, length, TokenCategory::Comment));
+        }
+        out.sort_by_key(|t| t.0);
+        out
     }
 
     /// Produce LSP-encoded semantic tokens for a host-language source containing
@@ -394,6 +410,35 @@ impl EmbeddedAnalyzer {
         let mut analyzer = self.make_analyzer();
         let model = analyzer.analyze(fragment.sql_text(), &self.catalog, &self.config);
         model.diagnostics().cloned().collect()
+    }
+}
+
+/// Observer that captures only tokens and comments, for
+/// [`EmbeddedAnalyzer::fragment_semantic_tokens`].
+#[derive(Default)]
+struct TokenObserver {
+    tokens: Vec<(DocOffset, DocLen, AnyTokenType, ParserTokenFlags)>,
+    comments: Vec<(DocOffset, DocLen)>,
+}
+
+impl AnalysisObserver for TokenObserver {
+    fn wants_tokens(&self) -> bool {
+        true
+    }
+    fn wants_comments(&self) -> bool {
+        true
+    }
+    fn on_token(
+        &mut self,
+        offset: DocOffset,
+        length: DocLen,
+        token_type: AnyTokenType,
+        flags: ParserTokenFlags,
+    ) {
+        self.tokens.push((offset, length, token_type, flags));
+    }
+    fn on_comment(&mut self, offset: DocOffset, length: DocLen) {
+        self.comments.push((offset, length));
     }
 }
 

--- a/syntaqlite/src/fmt/comment.rs
+++ b/syntaqlite/src/fmt/comment.rs
@@ -19,11 +19,11 @@ pub(crate) struct CommentEntry {
 }
 
 impl CommentEntry {
-    fn range(&self) -> StmtRange {
+    fn range(self) -> StmtRange {
         StmtRange::from_offset_len(self.offset, self.length)
     }
 
-    fn end(&self) -> StmtOffset {
+    fn end(self) -> StmtOffset {
         self.offset + self.length
     }
 }
@@ -36,11 +36,11 @@ pub(crate) struct TokenEntry {
 }
 
 impl TokenEntry {
-    fn range(&self) -> StmtRange {
+    fn range(self) -> StmtRange {
         StmtRange::from_offset_len(self.offset, self.length)
     }
 
-    fn end(&self) -> StmtOffset {
+    fn end(self) -> StmtOffset {
         self.offset + self.length
     }
 }
@@ -138,13 +138,7 @@ impl CommentCtx {
             if !skip_text_check {
                 let scan_end = before.min(source_end);
                 if t.end() < scan_end
-                    && has_non_comment_text(
-                        source,
-                        t.end(),
-                        scan_end,
-                        &self.comments,
-                        cursor + 1,
-                    )
+                    && has_non_comment_text(source, t.end(), scan_end, &self.comments, cursor + 1)
                 {
                     break;
                 }

--- a/syntaqlite/src/fmt/formatter.rs
+++ b/syntaqlite/src/fmt/formatter.rs
@@ -162,15 +162,17 @@ impl Formatter {
         // coincides with the statement-relative offset the formatter
         // compares against.  Nested rewrites measure into their parent's
         // expansion and belong to a different coordinate system.
-        self.macro_rewrites
-            .extend(erased.macro_rewrites().filter(|r| r.parent().is_none()).map(
-                |r| {
+        self.macro_rewrites.extend(
+            erased
+                .macro_rewrites()
+                .filter(|r| r.parent().is_none())
+                .map(|r| {
                     (
                         StmtOffset::from_raw(r.call_offset().as_u32()),
                         StmtLen::from(r.call_length()),
                     )
-                },
-            ));
+                }),
+        );
     }
 
     /// Format SQL source text. Handles multiple statements and preserves comments.
@@ -828,7 +830,13 @@ mod tests {
         );
         let mut arena = DocArena::new();
         let mut parts = Vec::new();
-        drain_gap_comments(&ctx, StmtOffset::from_raw(9), source, &mut arena, &mut parts);
+        drain_gap_comments(
+            &ctx,
+            StmtOffset::from_raw(9),
+            source,
+            &mut arena,
+            &mut parts,
+        );
         assert_eq!(render_parts(&mut arena, &parts), "--a\n/*b*/\n");
     }
 }

--- a/syntaqlite/src/lsp/analysis_data.rs
+++ b/syntaqlite/src/lsp/analysis_data.rs
@@ -1,0 +1,480 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+//! LSP-local storage captured during a semantic-analyzer pass.
+//!
+//! The semantic layer emits events via [`AnalysisObserver`]; this module
+//! defines the concrete storage (tokens, comments, resolutions, definition
+//! offsets) plus an observer implementation that fills it. Nothing here is
+//! visible to the semantic layer.
+
+use std::collections::HashMap;
+
+use syntaqlite_syntax::ParserTokenFlags;
+use syntaqlite_syntax::any::{AnyTokenType, TokenCategory};
+use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange};
+
+use crate::dialect::AnyDialect;
+use crate::semantic::catalog::{AritySpec, FunctionCategory};
+use crate::semantic::observer::AnalysisObserver;
+
+// ── Token positions ──────────────────────────────────────────────────────────
+
+/// A parser token observed during analysis.
+#[derive(Debug, Clone)]
+pub(crate) struct StoredToken {
+    pub(crate) offset: DocOffset,
+    pub(crate) length: DocLen,
+    pub(crate) token_type: AnyTokenType,
+    pub(crate) flags: ParserTokenFlags,
+}
+
+/// A comment observed during analysis.
+#[derive(Debug, Clone)]
+pub(crate) struct StoredComment {
+    pub(crate) offset: DocOffset,
+    pub(crate) length: DocLen,
+}
+
+/// A token classified for editor syntax highlighting.
+#[derive(Debug, Clone)]
+pub(crate) struct SemanticToken {
+    pub(crate) offset: DocOffset,
+    pub(crate) length: DocLen,
+    pub(crate) category: TokenCategory,
+}
+
+// ── Completion ───────────────────────────────────────────────────────────────
+
+/// Semantic completion context derived from parser stack state.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompletionContext {
+    Unknown = 0,
+    Expression = 1,
+    TableRef = 2,
+}
+
+impl CompletionContext {
+    pub(crate) fn from_parser(v: syntaqlite_syntax::CompletionContext) -> Self {
+        match v {
+            syntaqlite_syntax::CompletionContext::Expression => Self::Expression,
+            syntaqlite_syntax::CompletionContext::TableRef => Self::TableRef,
+            syntaqlite_syntax::CompletionContext::Unknown => Self::Unknown,
+        }
+    }
+}
+
+/// Expected tokens and semantic context at a cursor position.
+#[derive(Debug)]
+pub(crate) struct CompletionInfo {
+    pub(crate) tokens: Vec<AnyTokenType>,
+    pub(crate) context: CompletionContext,
+    pub(crate) qualifier: Option<String>,
+}
+
+// ── Resolved symbols ─────────────────────────────────────────────────────────
+
+/// A definition site that a reference points to.
+#[derive(Debug, Clone)]
+pub(crate) struct DefinitionLocation {
+    pub(crate) range: DocRange,
+    /// `Some` when the definition lives in another file (external schema).
+    pub(crate) file_uri: Option<String>,
+}
+
+/// Result of a go-to-definition lookup.
+#[derive(Debug, Clone)]
+pub(crate) struct DefinitionResult {
+    pub(crate) origin: DocRange,
+    pub(crate) target: DefinitionLocation,
+}
+
+/// A symbol resolution recorded during the validation pass.
+#[derive(Debug, Clone)]
+pub(crate) enum ResolvedSymbol {
+    Table {
+        name: String,
+        columns: Option<Vec<String>>,
+        definition: Option<DefinitionLocation>,
+    },
+    Column {
+        column: String,
+        table: String,
+        all_columns: Vec<String>,
+        definition: Option<DefinitionLocation>,
+    },
+    Function {
+        category: String,
+        arities: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Resolution {
+    pub(crate) range: DocRange,
+    pub(crate) symbol: ResolvedSymbol,
+}
+
+/// Identity of a symbol for matching across resolutions.
+#[derive(Debug)]
+pub(crate) enum SymbolIdentity {
+    Table(String),
+    Column { table: String, column: String },
+}
+
+impl SymbolIdentity {
+    pub(crate) fn from_resolved(sym: &ResolvedSymbol) -> Option<Self> {
+        match sym {
+            ResolvedSymbol::Table { name, .. } => {
+                Some(SymbolIdentity::Table(name.to_ascii_lowercase()))
+            }
+            ResolvedSymbol::Column { column, table, .. } => Some(SymbolIdentity::Column {
+                table: table.to_ascii_lowercase(),
+                column: column.to_ascii_lowercase(),
+            }),
+            ResolvedSymbol::Function { .. } => None,
+        }
+    }
+
+    fn matches(&self, sym: &ResolvedSymbol) -> bool {
+        match (self, sym) {
+            (SymbolIdentity::Table(name), ResolvedSymbol::Table { name: n, .. }) => {
+                n.eq_ignore_ascii_case(name)
+            }
+            (
+                SymbolIdentity::Column { table, column },
+                ResolvedSymbol::Column {
+                    table: t,
+                    column: c,
+                    ..
+                },
+            ) => t.eq_ignore_ascii_case(table) && c.eq_ignore_ascii_case(column),
+            _ => false,
+        }
+    }
+
+    /// Key into `definition_offsets` for this symbol.
+    pub(crate) fn definition_key(&self) -> String {
+        match self {
+            SymbolIdentity::Table(name) => name.clone(),
+            SymbolIdentity::Column { table, column } => format!("{table}.{column}"),
+        }
+    }
+}
+
+// ── External definition registry ─────────────────────────────────────────────
+
+/// A definition site in a source file other than the one being analyzed
+/// (e.g. an external schema that was loaded via `from_ddl`).
+#[derive(Debug, Clone)]
+pub(crate) struct ExternalDefinitionSite {
+    pub(crate) file_uri: String,
+    pub(crate) range: DocRange,
+}
+
+/// Definition sites collected while parsing external schema files.
+///
+/// Keyed by `lowercase(name)` for tables/views and by
+/// `lowercase(table).lowercase(column)` for columns.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct ExternalDefinitions {
+    sites: HashMap<String, ExternalDefinitionSite>,
+}
+
+impl ExternalDefinitions {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn insert_relation(&mut self, name: &str, file_uri: &str, range: DocRange) {
+        self.sites.insert(
+            name.to_ascii_lowercase(),
+            ExternalDefinitionSite {
+                file_uri: file_uri.to_string(),
+                range,
+            },
+        );
+    }
+
+    pub(crate) fn insert_column(
+        &mut self,
+        table: &str,
+        column: &str,
+        file_uri: &str,
+        range: DocRange,
+    ) {
+        let key = format!(
+            "{}.{}",
+            table.to_ascii_lowercase(),
+            column.to_ascii_lowercase()
+        );
+        self.sites.insert(
+            key,
+            ExternalDefinitionSite {
+                file_uri: file_uri.to_string(),
+                range,
+            },
+        );
+    }
+
+    pub(crate) fn relation(&self, name: &str) -> Option<&ExternalDefinitionSite> {
+        self.sites.get(&name.to_ascii_lowercase())
+    }
+
+    pub(crate) fn column(&self, table: &str, column: &str) -> Option<&ExternalDefinitionSite> {
+        let key = format!(
+            "{}.{}",
+            table.to_ascii_lowercase(),
+            column.to_ascii_lowercase()
+        );
+        self.sites.get(&key)
+    }
+}
+
+// ── DocumentAnalysisData ─────────────────────────────────────────────────────
+
+/// All the data an editor needs that was captured during a single analysis
+/// pass. Populated by [`LspObserver`].
+#[derive(Debug, Default)]
+pub(crate) struct DocumentAnalysisData {
+    pub(crate) tokens: Vec<StoredToken>,
+    pub(crate) comments: Vec<StoredComment>,
+    pub(crate) resolutions: Vec<Resolution>,
+    /// Maps `lowercase(name)` → `DocRange` for same-file definition sites.
+    /// Keys for columns look like `"table.column"` (lowercased).
+    pub(crate) definition_offsets: HashMap<String, DocRange>,
+}
+
+impl DocumentAnalysisData {
+    pub(crate) fn semantic_tokens(&self, dialect: &AnyDialect) -> Vec<SemanticToken> {
+        let mut out = Vec::new();
+        for t in &self.tokens {
+            let cat = dialect.classify_token(t.token_type, t.flags);
+            if cat != TokenCategory::Other {
+                out.push(SemanticToken {
+                    offset: t.offset,
+                    length: t.length,
+                    category: cat,
+                });
+            }
+        }
+        for c in &self.comments {
+            out.push(SemanticToken {
+                offset: c.offset,
+                length: c.length,
+                category: TokenCategory::Comment,
+            });
+        }
+        out.sort_by_key(|t| t.offset);
+        out
+    }
+
+    /// The resolution whose span contains `offset`, if any.
+    pub(crate) fn resolution_at(&self, offset: DocOffset) -> Option<&Resolution> {
+        self.resolutions
+            .iter()
+            .find(|r| offset >= r.range.start && offset < r.range.end)
+    }
+
+    /// Find all resolutions in this document that match the given identity.
+    pub(crate) fn references_matching(&self, kind: &SymbolIdentity) -> Vec<DocRange> {
+        self.resolutions
+            .iter()
+            .filter(|r| kind.matches(&r.symbol))
+            .map(|r| r.range)
+            .collect()
+    }
+
+    /// Go-to-definition target for the resolution at `offset`, if any.
+    pub(crate) fn definition_at(&self, offset: DocOffset) -> Option<DefinitionResult> {
+        self.resolution_at(offset).and_then(|r| match &r.symbol {
+            ResolvedSymbol::Table { definition, .. }
+            | ResolvedSymbol::Column { definition, .. } => {
+                definition.as_ref().map(|d| DefinitionResult {
+                    origin: r.range,
+                    target: d.clone(),
+                })
+            }
+            ResolvedSymbol::Function { .. } => None,
+        })
+    }
+}
+
+// ── LspObserver ──────────────────────────────────────────────────────────────
+
+/// Observer that fills a [`DocumentAnalysisData`] during a
+/// [`SemanticAnalyzer`](crate::semantic::SemanticAnalyzer) pass.
+///
+/// The observer holds a reference to an optional external-definition registry
+/// so it can correlate resolutions with cross-file definition sites.
+pub(crate) struct LspObserver<'a> {
+    pub(crate) data: DocumentAnalysisData,
+    external: Option<&'a ExternalDefinitions>,
+}
+
+impl<'a> LspObserver<'a> {
+    pub(crate) fn new(external: Option<&'a ExternalDefinitions>) -> Self {
+        Self {
+            data: DocumentAnalysisData::default(),
+            external,
+        }
+    }
+
+    pub(crate) fn into_data(self) -> DocumentAnalysisData {
+        self.data
+    }
+
+    fn lookup_table_definition(&self, name: &str) -> Option<DefinitionLocation> {
+        let lower = name.to_ascii_lowercase();
+        if let Some(&range) = self.data.definition_offsets.get(&lower) {
+            return Some(DefinitionLocation {
+                range,
+                file_uri: None,
+            });
+        }
+        self.external.and_then(|ext| {
+            ext.relation(name).map(|site| DefinitionLocation {
+                range: site.range,
+                file_uri: Some(site.file_uri.clone()),
+            })
+        })
+    }
+
+    fn lookup_column_definition(&self, table: &str, column: &str) -> Option<DefinitionLocation> {
+        let key = format!(
+            "{}.{}",
+            table.to_ascii_lowercase(),
+            column.to_ascii_lowercase()
+        );
+        if let Some(&range) = self.data.definition_offsets.get(&key) {
+            return Some(DefinitionLocation {
+                range,
+                file_uri: None,
+            });
+        }
+        self.external.and_then(|ext| {
+            ext.column(table, column).map(|site| DefinitionLocation {
+                range: site.range,
+                file_uri: Some(site.file_uri.clone()),
+            })
+        })
+    }
+}
+
+impl AnalysisObserver for LspObserver<'_> {
+    fn wants_tokens(&self) -> bool {
+        true
+    }
+    fn wants_comments(&self) -> bool {
+        true
+    }
+    fn wants_definitions(&self) -> bool {
+        true
+    }
+    fn wants_references(&self) -> bool {
+        true
+    }
+
+    fn on_token(
+        &mut self,
+        offset: DocOffset,
+        length: DocLen,
+        token_type: AnyTokenType,
+        flags: ParserTokenFlags,
+    ) {
+        self.data.tokens.push(StoredToken {
+            offset,
+            length,
+            token_type,
+            flags,
+        });
+    }
+
+    fn on_comment(&mut self, offset: DocOffset, length: DocLen) {
+        self.data.comments.push(StoredComment { offset, length });
+    }
+
+    fn on_relation_definition(&mut self, name: &str, range: DocRange) {
+        self.data
+            .definition_offsets
+            .insert(name.to_ascii_lowercase(), range);
+    }
+
+    fn on_column_definition(&mut self, table: &str, column: &str, range: DocRange) {
+        let key = format!(
+            "{}.{}",
+            table.to_ascii_lowercase(),
+            column.to_ascii_lowercase()
+        );
+        self.data.definition_offsets.insert(key, range);
+    }
+
+    fn on_table_reference(&mut self, range: DocRange, name: &str, columns: Option<&[String]>) {
+        let definition = self.lookup_table_definition(name);
+        self.data.resolutions.push(Resolution {
+            range,
+            symbol: ResolvedSymbol::Table {
+                name: name.to_string(),
+                columns: columns.map(<[String]>::to_vec),
+                definition,
+            },
+        });
+    }
+
+    fn on_column_reference(
+        &mut self,
+        range: DocRange,
+        table: &str,
+        column: &str,
+        all_columns: &[String],
+    ) {
+        let definition = self.lookup_column_definition(table, column);
+        self.data.resolutions.push(Resolution {
+            range,
+            symbol: ResolvedSymbol::Column {
+                column: column.to_string(),
+                table: table.to_string(),
+                all_columns: all_columns.to_vec(),
+                definition,
+            },
+        });
+    }
+
+    fn on_function_reference(
+        &mut self,
+        range: DocRange,
+        name: &str,
+        category: FunctionCategory,
+        arities: &[AritySpec],
+    ) {
+        let cat_str = match category {
+            FunctionCategory::Scalar => "scalar function",
+            FunctionCategory::Aggregate => "aggregate function",
+            FunctionCategory::Window => "window function",
+        };
+        let arity_strs: Vec<String> = arities.iter().map(|a| format_arity(name, *a)).collect();
+        self.data.resolutions.push(Resolution {
+            range,
+            symbol: ResolvedSymbol::Function {
+                category: cat_str.to_string(),
+                arities: arity_strs,
+            },
+        });
+    }
+}
+
+fn format_arity(name: &str, arity: AritySpec) -> String {
+    match arity {
+        AritySpec::Exact(n) => {
+            let params: Vec<String> = (0..n).map(|i| format!("arg{}", i + 1)).collect();
+            format!("{}({})", name, params.join(", "))
+        }
+        AritySpec::AtLeast(n) => {
+            let mut params: Vec<String> = (0..n).map(|i| format!("arg{}", i + 1)).collect();
+            params.push("...".to_string());
+            format!("{}({})", name, params.join(", "))
+        }
+        AritySpec::Any => format!("{name}(...)"),
+    }
+}

--- a/syntaqlite/src/lsp/completion.rs
+++ b/syntaqlite/src/lsp/completion.rs
@@ -4,8 +4,9 @@
 //! LSP-specific analysis helpers: semantic tokens, completion boundaries,
 //! qualifier detection, and expected-token computation.
 //!
-//! These operate on an already-analyzed [`SemanticModel`] plus the dialect
-//! and are not part of semantic validation — they answer editor queries.
+//! These operate on [`DocumentAnalysisData`] captured by
+//! [`LspObserver`](super::analysis_data::LspObserver) plus the dialect and
+//! are not part of semantic validation — they answer editor queries.
 
 use std::collections::HashSet;
 
@@ -14,16 +15,18 @@ use syntaqlite_syntax::any::{AnyParser, AnyTokenType, TokenCategory};
 use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange, DocText};
 
 use crate::dialect::AnyDialect;
-use crate::semantic::model::{CompletionContext, CompletionInfo, SemanticModel, StoredToken};
+
+use super::analysis_data::{CompletionContext, CompletionInfo, DocumentAnalysisData, StoredToken};
 
 /// Expected tokens and semantic context at `offset` (for completion).
 pub(crate) fn completion_info(
     dialect: &AnyDialect,
-    model: &SemanticModel,
+    source_text: &str,
+    data: &DocumentAnalysisData,
     offset: DocOffset,
 ) -> CompletionInfo {
-    let source = DocText::new(model.source());
-    let tokens = &model.tokens;
+    let source = DocText::new(source_text);
+    let tokens = &data.tokens;
     let end_of_doc = source.byte_len();
     let doc_end = DocOffset::default() + end_of_doc;
     let cursor = if offset > doc_end { doc_end } else { offset };

--- a/syntaqlite/src/lsp/host.rs
+++ b/syntaqlite/src/lsp/host.rs
@@ -15,10 +15,11 @@ use crate::semantic::Catalog;
 use crate::semantic::ValidationConfig;
 use crate::semantic::analyzer::SemanticAnalyzer;
 use crate::semantic::diagnostics::Diagnostic;
-use crate::semantic::model::{
-    DefinitionResult, ResolvedSymbol, SemanticModel, SemanticToken, StoredToken, SymbolIdentity,
-};
 
+use super::analysis_data::{
+    DefinitionResult, DocumentAnalysisData, ExternalDefinitions, LspObserver, ResolvedSymbol,
+    SemanticToken, StoredToken, SymbolIdentity,
+};
 use super::{CompletionEntry, CompletionInfo, CompletionKind};
 
 // ── SchemaMap ─────────────────────────────────────────────────────────────────
@@ -83,43 +84,60 @@ impl SchemaMap {
 struct Document {
     version: i32,
     source: String,
-    /// Cached analysis result. `None` when dirty (source changed or catalog changed).
-    model: Option<SemanticModel>,
-    /// Parse errors from the last analysis (derived from `model`).
+    /// Cached parse-error diagnostics. `None` when dirty.
     cached_parse_diags: Option<Vec<Diagnostic>>,
-    /// Semantic tokens from the last analysis (derived from `model`).
+    /// All diagnostics produced by the last analysis pass (parse + semantic).
+    cached_all_diags: Option<Vec<Diagnostic>>,
+    /// Analysis events captured by [`LspObserver`]. `None` when dirty.
+    analysis: Option<DocumentAnalysisData>,
+    /// Semantic tokens derived from `analysis`. Populated on first request.
     cached_sem_tokens: Option<Vec<SemanticToken>>,
 }
 
-/// Run analysis for `doc` if no model is cached yet.
-fn ensure_model(
+impl Document {
+    fn invalidate(&mut self) {
+        self.cached_parse_diags = None;
+        self.cached_all_diags = None;
+        self.analysis = None;
+        self.cached_sem_tokens = None;
+    }
+}
+
+/// Run analysis for `doc` if nothing is cached yet.
+fn ensure_analysis(
     doc: &mut Document,
     analyzer: &mut SemanticAnalyzer,
     user_catalog: &Catalog,
     validation_config: &ValidationConfig,
+    external_defs: Option<&ExternalDefinitions>,
 ) {
-    if doc.model.is_some() {
+    if doc.analysis.is_some() {
         return;
     }
-    let model = analyzer.analyze(&doc.source, user_catalog, validation_config);
-    let parse_diags = model
-        .diagnostics()
+    let mut observer = LspObserver::new(external_defs);
+    let model =
+        analyzer.analyze_with_observer(&doc.source, user_catalog, validation_config, &mut observer);
+    let all_diags: Vec<Diagnostic> = model.diagnostics().cloned().collect();
+    let parse_diags: Vec<Diagnostic> = all_diags
+        .iter()
         .filter(|d| d.message().is_parse_error())
         .cloned()
         .collect();
     doc.cached_parse_diags = Some(parse_diags);
-    doc.model = Some(model);
+    doc.cached_all_diags = Some(all_diags);
+    doc.analysis = Some(observer.into_data());
 }
 
 /// Resolve the correct catalog for `uri` via `schema_map`, then call
-/// [`ensure_model`]. Returns `false` if the document is not found.
-fn ensure_model_for(
+/// [`ensure_analysis`]. Returns `false` if the document is not found.
+fn ensure_analysis_for(
     uri: &str,
     documents: &mut HashMap<String, Document>,
     analyzer: &mut SemanticAnalyzer,
     schema_map: Option<&SchemaMap>,
     user_catalog: &Catalog,
     base_validation_config: &ValidationConfig,
+    external_defs: Option<&ExternalDefinitions>,
 ) -> bool {
     let Some(doc) = documents.get_mut(uri) else {
         return false;
@@ -133,7 +151,7 @@ fn ensure_model_for(
     } else {
         (user_catalog, *base_validation_config)
     };
-    ensure_model(doc, analyzer, catalog, &config);
+    ensure_analysis(doc, analyzer, catalog, &config, external_defs);
     true
 }
 
@@ -183,6 +201,10 @@ pub struct LspHost {
     dialect: AnyDialect,
     /// User-provided schema (tables, views, functions).
     user_catalog: Catalog,
+    /// External definition sites (populated from schema DDL that carries a
+    /// `file://` URI). Consulted by [`LspObserver`] to build cross-file
+    /// go-to-definition targets.
+    external_defs: ExternalDefinitions,
     analyzer: SemanticAnalyzer,
     documents: HashMap<String, Document>,
     /// Format config from project config file. `None` means use defaults.
@@ -207,6 +229,7 @@ impl LspHost {
         let dialect = crate::sqlite::dialect::any_dialect();
         LspHost {
             user_catalog: Catalog::new(dialect.clone()),
+            external_defs: ExternalDefinitions::new(),
             analyzer: SemanticAnalyzer::new(),
             dialect,
             documents: HashMap::new(),
@@ -221,6 +244,7 @@ impl LspHost {
         let dialect = dialect.into();
         LspHost {
             user_catalog: Catalog::new(dialect.clone()),
+            external_defs: ExternalDefinitions::new(),
             analyzer: SemanticAnalyzer::with_dialect(dialect.clone()),
             dialect,
             documents: HashMap::new(),
@@ -246,9 +270,7 @@ impl LspHost {
     pub fn set_validation_config(&mut self, config: ValidationConfig) {
         self.validation_config = config;
         for doc in self.documents.values_mut() {
-            doc.model = None;
-            doc.cached_parse_diags = None;
-            doc.cached_sem_tokens = None;
+            doc.invalidate();
         }
     }
 
@@ -258,9 +280,7 @@ impl LspHost {
     pub fn set_schema_map(&mut self, map: SchemaMap) {
         self.schema_map = Some(map);
         for doc in self.documents.values_mut() {
-            doc.model = None;
-            doc.cached_parse_diags = None;
-            doc.cached_sem_tokens = None;
+            doc.invalidate();
         }
     }
 
@@ -269,9 +289,7 @@ impl LspHost {
     pub fn set_session_context(&mut self, ctx: Catalog) {
         self.user_catalog = ctx;
         for doc in self.documents.values_mut() {
-            doc.model = None;
-            doc.cached_parse_diags = None;
-            doc.cached_sem_tokens = None;
+            doc.invalidate();
         }
     }
 
@@ -284,8 +302,9 @@ impl LspHost {
             Document {
                 version,
                 source: text,
-                model: None,
                 cached_parse_diags: None,
+                cached_all_diags: None,
+                analysis: None,
                 cached_sem_tokens: None,
             },
         );
@@ -296,9 +315,7 @@ impl LspHost {
         if let Some(doc) = self.documents.get_mut(uri) {
             doc.version = version;
             doc.source = text;
-            doc.model = None;
-            doc.cached_parse_diags = None;
-            doc.cached_sem_tokens = None;
+            doc.invalidate();
         } else {
             self.open_document(uri, version, text);
         }
@@ -318,13 +335,14 @@ impl LspHost {
 
     /// Parse-error diagnostics for a document, lazily computed.
     pub(crate) fn diagnostics(&mut self, uri: &str) -> &[Diagnostic] {
-        if !ensure_model_for(
+        if !ensure_analysis_for(
             uri,
             &mut self.documents,
             &mut self.analyzer,
             self.schema_map.as_ref(),
             &self.user_catalog,
             &self.validation_config,
+            Some(&self.external_defs),
         ) {
             return &[];
         }
@@ -342,13 +360,14 @@ impl LspHost {
     /// Panics if the internal model or token cache is in an inconsistent state
     /// (this indicates a bug in `ensure_model`).
     pub fn semantic_tokens_encoded(&mut self, uri: &str, range: Option<DocRange>) -> Vec<u32> {
-        if !ensure_model_for(
+        if !ensure_analysis_for(
             uri,
             &mut self.documents,
             &mut self.analyzer,
             self.schema_map.as_ref(),
             &self.user_catalog,
             &self.validation_config,
+            Some(&self.external_defs),
         ) {
             return Vec::new();
         }
@@ -358,9 +377,9 @@ impl LspHost {
             .expect("ensure_model_for guarantees document exists");
         if doc.cached_sem_tokens.is_none() {
             let tokens = doc
-                .model
+                .analysis
                 .as_ref()
-                .expect("ensure_model sets model")
+                .expect("ensure_analysis sets analysis")
                 .semantic_tokens(&self.analyzer.dialect());
             doc.cached_sem_tokens = Some(tokens);
         }
@@ -377,13 +396,14 @@ impl LspHost {
         uri: &str,
         offset: DocOffset,
     ) -> CompletionInfo {
-        if !ensure_model_for(
+        if !ensure_analysis_for(
             uri,
             &mut self.documents,
             &mut self.analyzer,
             self.schema_map.as_ref(),
             &self.user_catalog,
             &self.validation_config,
+            Some(&self.external_defs),
         ) {
             return CompletionInfo {
                 tokens: Vec::new(),
@@ -397,7 +417,10 @@ impl LspHost {
             .expect("ensure_model_for guarantees document exists");
         super::completion::completion_info(
             &self.analyzer.dialect(),
-            doc.model.as_ref().expect("ensure_model sets model"),
+            &doc.source,
+            doc.analysis
+                .as_ref()
+                .expect("ensure_analysis sets analysis"),
             offset,
         )
     }
@@ -481,29 +504,28 @@ impl LspHost {
         &mut self,
         uri: &str,
     ) -> Option<(i32, String, Vec<Diagnostic>)> {
-        if !ensure_model_for(
+        if !ensure_analysis_for(
             uri,
             &mut self.documents,
             &mut self.analyzer,
             self.schema_map.as_ref(),
             &self.user_catalog,
             &self.validation_config,
+            Some(&self.external_defs),
         ) {
             return None;
         }
         let doc = self
             .documents
             .get(uri)
-            .expect("ensure_model_for guarantees document exists");
+            .expect("ensure_analysis_for guarantees document exists");
         let version = doc.version;
         let source = doc.source.clone();
         let diags = doc
-            .model
+            .cached_all_diags
             .as_ref()
-            .expect("ensure_model sets model")
-            .diagnostics()
-            .cloned()
-            .collect();
+            .expect("ensure_analysis sets cached_all_diags")
+            .clone();
         Some((version, source, diags))
     }
 
@@ -553,26 +575,24 @@ impl LspHost {
         uri: &str,
         offset: DocOffset,
     ) -> Option<(String, DocRange)> {
-        ensure_model_for(
+        ensure_analysis_for(
             uri,
             &mut self.documents,
             &mut self.analyzer,
             self.schema_map.as_ref(),
             &self.user_catalog,
             &self.validation_config,
+            Some(&self.external_defs),
         );
         let doc = self.documents.get(uri)?;
-        let model = doc.model.as_ref().expect("ensure_model sets model");
+        let data = doc
+            .analysis
+            .as_ref()
+            .expect("ensure_analysis sets analysis");
 
-        let resolution = model.resolution_at(offset)?;
-        let range = model
-            .resolutions
-            .iter()
-            .find(|r| offset >= r.range.start && offset < r.range.end)
-            .map(|r| r.range)?;
-
-        let hover = format_resolved_hover(resolution);
-        Some((hover, range))
+        let resolution = data.resolution_at(offset)?;
+        let hover = format_resolved_hover(&resolution.symbol);
+        Some((hover, resolution.range))
     }
 
     // ── Go-to-definition ───────────────────────────────────────────────────
@@ -583,17 +603,21 @@ impl LspHost {
         uri: &str,
         offset: DocOffset,
     ) -> Option<DefinitionResult> {
-        ensure_model_for(
+        ensure_analysis_for(
             uri,
             &mut self.documents,
             &mut self.analyzer,
             self.schema_map.as_ref(),
             &self.user_catalog,
             &self.validation_config,
+            Some(&self.external_defs),
         );
         let doc = self.documents.get(uri)?;
-        let model = doc.model.as_ref().expect("ensure_model sets model");
-        model.definition_at(offset)
+        let data = doc
+            .analysis
+            .as_ref()
+            .expect("ensure_analysis sets analysis");
+        data.definition_at(offset)
     }
 
     // ── Find references ──────────────────────────────────────────────────────
@@ -619,25 +643,29 @@ impl LspHost {
         // Collect matching resolutions from all open documents.
         let uris: Vec<String> = self.documents.keys().cloned().collect();
         for doc_uri in &uris {
-            ensure_model_for(
+            ensure_analysis_for(
                 doc_uri,
                 &mut self.documents,
                 &mut self.analyzer,
                 self.schema_map.as_ref(),
                 &self.user_catalog,
                 &self.validation_config,
+                Some(&self.external_defs),
             );
             let doc = self
                 .documents
                 .get(doc_uri.as_str())
                 .expect("doc_uri came from keys()");
-            let model = doc.model.as_ref().expect("ensure_model sets model");
-            for range in model.references_matching(&identity) {
+            let data = doc
+                .analysis
+                .as_ref()
+                .expect("ensure_analysis sets analysis");
+            for range in data.references_matching(&identity) {
                 results.push((doc_uri.clone(), range));
             }
             if include_declaration {
                 let key = identity.definition_key();
-                if let Some(&range) = model.definition_offsets.get(&key) {
+                if let Some(&range) = data.definition_offsets.get(&key) {
                     // Avoid duplicates (definition might also be in resolutions).
                     let already = results.iter().any(|(u, r)| u == doc_uri && *r == range);
                     if !already {
@@ -668,20 +696,21 @@ impl LspHost {
         uri: &str,
         offset: DocOffset,
     ) -> Option<(DocRange, String)> {
-        ensure_model_for(
+        ensure_analysis_for(
             uri,
             &mut self.documents,
             &mut self.analyzer,
             self.schema_map.as_ref(),
             &self.user_catalog,
             &self.validation_config,
+            Some(&self.external_defs),
         );
         let doc = self.documents.get(uri)?;
-        let model = doc.model.as_ref().expect("ensure_model sets model");
-        let res = model
-            .resolutions
-            .iter()
-            .find(|r| offset >= r.range.start && offset < r.range.end)?;
+        let data = doc
+            .analysis
+            .as_ref()
+            .expect("ensure_analysis sets analysis");
+        let res = data.resolution_at(offset)?;
         let name = match &res.symbol {
             ResolvedSymbol::Table { name, .. } => name.clone(),
             ResolvedSymbol::Column { column, .. } => column.clone(),
@@ -715,24 +744,28 @@ impl LspHost {
     /// Determine the symbol identity at `offset` — either from a resolution or
     /// from a definition site (CREATE TABLE / column-def).
     fn symbol_identity_at(&mut self, uri: &str, offset: DocOffset) -> Option<SymbolIdentity> {
-        ensure_model_for(
+        ensure_analysis_for(
             uri,
             &mut self.documents,
             &mut self.analyzer,
             self.schema_map.as_ref(),
             &self.user_catalog,
             &self.validation_config,
+            Some(&self.external_defs),
         );
         let doc = self.documents.get(uri)?;
-        let model = doc.model.as_ref().expect("ensure_model sets model");
+        let data = doc
+            .analysis
+            .as_ref()
+            .expect("ensure_analysis sets analysis");
 
         // First check resolutions (references in DML/queries).
-        if let Some(sym) = model.resolution_at(offset) {
-            return SymbolIdentity::from_resolved(sym);
+        if let Some(res) = data.resolution_at(offset) {
+            return SymbolIdentity::from_resolved(&res.symbol);
         }
 
         // Fall back to definition_offsets (cursor on a CREATE TABLE name, etc).
-        for (key, &range) in &model.definition_offsets {
+        for (key, &range) in &data.definition_offsets {
             if offset >= range.start && offset < range.end {
                 return if let Some((table, col)) = key.split_once('.') {
                     Some(SymbolIdentity::Column {
@@ -747,15 +780,16 @@ impl LspHost {
         None
     }
 
-    /// Look up an external (schema-file) definition site for a symbol from the catalog.
+    /// Look up an external (schema-file) definition site for a symbol from the
+    /// registry populated by [`Self::set_session_context_from_ddl`].
     fn external_definition_site(&self, identity: &SymbolIdentity) -> Option<(String, DocRange)> {
         match identity {
             SymbolIdentity::Table(name) => {
-                let site = self.user_catalog.relation_definition_site(name)?;
+                let site = self.external_defs.relation(name)?;
                 Some((site.file_uri.clone(), site.range))
             }
             SymbolIdentity::Column { table, column } => {
-                let site = self.user_catalog.column_definition_site(table, column)?;
+                let site = self.external_defs.column(table, column)?;
                 Some((site.file_uri.clone(), site.range))
             }
         }
@@ -770,22 +804,26 @@ impl LspHost {
         uri: &str,
         offset: DocOffset,
     ) -> Option<SignatureHelpInfo> {
-        ensure_model_for(
+        ensure_analysis_for(
             uri,
             &mut self.documents,
             &mut self.analyzer,
             self.schema_map.as_ref(),
             &self.user_catalog,
             &self.validation_config,
+            Some(&self.external_defs),
         );
         let doc = self.documents.get(uri)?;
-        let model = doc.model.as_ref().expect("ensure_model sets model");
-        let source = model.source();
+        let data = doc
+            .analysis
+            .as_ref()
+            .expect("ensure_analysis sets analysis");
+        let source = doc.source.as_str();
 
         // Walk backwards from offset to find enclosing `name(` and count commas.
         let cursor_byte = std::cmp::min(offset.as_usize(), source.len());
         let before = &source[..cursor_byte];
-        let (func_name, active_param) = find_enclosing_call(before, &model.tokens, &self.dialect)?;
+        let (func_name, active_param) = find_enclosing_call(before, &data.tokens, &self.dialect)?;
 
         let (_category, arities) = self.user_catalog.function_signature(&func_name)?;
 
@@ -836,12 +874,49 @@ impl LspHost {
         ddl: &str,
         file_uri: Option<&str>,
     ) -> Result<(), Vec<String>> {
-        let (catalog, errors) = Catalog::from_ddl(self.dialect.clone(), &[(ddl, file_uri)]);
+        let (catalog, errors) = Catalog::from_ddl(self.dialect.clone(), &[ddl]);
         self.set_session_context(catalog);
+        if let Some(uri) = file_uri {
+            record_external_definitions(&mut self.external_defs, &self.dialect, ddl, uri);
+        }
         if errors.is_empty() {
             Ok(())
         } else {
             Err(errors)
+        }
+    }
+}
+
+/// Parse `ddl` and record table/view/column definition spans into `defs`,
+/// tagged with `file_uri`.
+#[cfg(feature = "sqlite")]
+fn record_external_definitions(
+    defs: &mut ExternalDefinitions,
+    dialect: &AnyDialect,
+    ddl: &str,
+    file_uri: &str,
+) {
+    use syntaqlite_syntax::ParseOutcome;
+
+    use crate::semantic::ddl::DdlReader;
+
+    let parser = syntaqlite_syntax::Parser::new();
+    let mut session = parser.parse(ddl);
+    loop {
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => break,
+            ParseOutcome::Err(_) => continue,
+        };
+        let Some(root) = stmt.root() else { continue };
+        let root_id = root.node_id().into();
+        let erased = stmt.erase();
+        let reader = DdlReader::new(&erased, dialect.roles());
+        if let Some((name, range)) = reader.name_span(root_id) {
+            defs.insert_relation(&name, file_uri, range);
+            for (col_name, col_range) in reader.column_spans(root_id) {
+                defs.insert_column(&name, &col_name, file_uri, col_range);
+            }
         }
     }
 }
@@ -1896,7 +1971,7 @@ mod tests {
         let dialect = crate::sqlite::dialect::any_dialect();
         let (users_catalog, _) = Catalog::from_ddl(
             dialect.clone(),
-            &[("CREATE TABLE users (id INTEGER, name TEXT);", None)],
+            &["CREATE TABLE users (id INTEGER, name TEXT);"],
         );
 
         // Build a SchemaMap where "matched/*.sql" gets the users catalog,
@@ -2073,14 +2148,12 @@ mod tests {
 
     #[test]
     fn goto_definition_schema_table_jumps_to_external_file() {
-        use crate::semantic::catalog::Catalog;
         let schema = "CREATE TABLE users (id INTEGER, name TEXT);";
         let file_uri = "file:///path/to/schema.sql";
-        let dialect = crate::sqlite::dialect::dialect();
-        let cat = Catalog::from_ddl(dialect, &[(schema, Some(file_uri))]).0;
 
         let mut host = LspHost::new();
-        host.set_session_context(cat);
+        host.set_session_context_from_ddl(schema, Some(file_uri))
+            .expect("schema parses");
 
         let uri = "file:///test.sql";
         let src = "SELECT * FROM users";
@@ -2101,14 +2174,12 @@ mod tests {
 
     #[test]
     fn goto_definition_same_file_ddl_shadows_schema() {
-        use crate::semantic::catalog::Catalog;
         let schema = "CREATE TABLE t (x INTEGER);";
         let file_uri = "file:///schema.sql";
-        let dialect = crate::sqlite::dialect::dialect();
-        let cat = Catalog::from_ddl(dialect, &[(schema, Some(file_uri))]).0;
 
         let mut host = LspHost::new();
-        host.set_session_context(cat);
+        host.set_session_context_from_ddl(schema, Some(file_uri))
+            .expect("schema parses");
 
         let uri = "file:///test.sql";
         let src = "CREATE TABLE t (y INTEGER); SELECT * FROM t;";

--- a/syntaqlite/src/lsp/mod.rs
+++ b/syntaqlite/src/lsp/mod.rs
@@ -47,8 +47,7 @@ pub use host::SchemaMap;
 #[doc(inline)]
 pub use server::{LspConfig, LspServer};
 
-// Re-export shared types from semantic layer.
-pub(crate) use crate::semantic::model::{CompletionContext, CompletionInfo};
+pub(crate) use analysis_data::{CompletionContext, CompletionInfo};
 
 // ── LSP-specific types ──────────────────────────────────────────────────
 
@@ -116,6 +115,7 @@ impl CompletionKind {
     }
 }
 
+mod analysis_data;
 mod completion;
 mod host;
 mod server;

--- a/syntaqlite/src/lsp/server.rs
+++ b/syntaqlite/src/lsp/server.rs
@@ -932,8 +932,10 @@ impl<'a> SourcePositionMap<'a> {
 
     /// Convert an LSP `Position` (with UTF-16 character offset) to a document-absolute byte offset.
     pub(crate) fn position_to_offset(&self, pos: Position) -> DocOffset {
-        self.inner
-            .utf16_to_byte_offset(Utf16Line::from_raw(pos.line), Utf16Col::from_raw(pos.character))
+        self.inner.utf16_to_byte_offset(
+            Utf16Line::from_raw(pos.line),
+            Utf16Col::from_raw(pos.character),
+        )
     }
 }
 

--- a/syntaqlite/src/lsp/source_map.rs
+++ b/syntaqlite/src/lsp/source_map.rs
@@ -28,7 +28,7 @@ impl<'a> SourceMap<'a> {
     /// one O(n) pass, returning results in the same order as `offsets`.
     ///
     /// Batching amortizes the source walk: `n` offsets cost
-    /// O(n + source_len), versus O(n × source_len) for single conversions.
+    /// O(n + `source_len`), versus O(n × `source_len`) for single conversions.
     pub(crate) fn byte_offsets_to_utf16(
         &self,
         offsets: &[DocOffset],

--- a/syntaqlite/src/semantic/analyzer/helpers.rs
+++ b/syntaqlite/src/semantic/analyzer/helpers.rs
@@ -5,16 +5,10 @@
 //! span lookup, macro registration extraction, rowid aliasing.
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParseError, AnyParsedStatement, FieldValue};
-#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-use syntaqlite_syntax::source::StatementBase;
 use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange, StmtLen};
 
 use crate::dialect::{FIELD_ABSENT, MacroDef, SemanticRole};
-#[cfg(feature = "lsp")]
-use crate::semantic::catalog::AritySpec;
 use crate::semantic::model::DefinedRelation;
-#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-use crate::semantic::model::{StoredComment, StoredToken};
 
 /// Extract relations defined by a DDL statement (CREATE TABLE / CREATE VIEW).
 pub(super) fn extract_defined_relations(
@@ -43,52 +37,6 @@ pub(super) fn extract_defined_relations(
         }]
     } else {
         Vec::new()
-    }
-}
-
-#[cfg(feature = "lsp")]
-pub(super) fn format_arity(name: &str, arity: AritySpec) -> String {
-    match arity {
-        AritySpec::Exact(n) => {
-            let params: Vec<String> = (0..n).map(|i| format!("arg{}", i + 1)).collect();
-            format!("{}({})", name, params.join(", "))
-        }
-        AritySpec::AtLeast(n) => {
-            let mut params: Vec<String> = (0..n).map(|i| format!("arg{}", i + 1)).collect();
-            params.push("...".to_string());
-            format!("{}({})", name, params.join(", "))
-        }
-        AritySpec::Any => format!("{name}(...)"),
-    }
-}
-
-#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-pub(super) fn collect_tokens<'a>(
-    iter: impl Iterator<Item = syntaqlite_syntax::any::AnyParserToken<'a>>,
-    stmt_base: StatementBase,
-    tokens: &mut Vec<StoredToken>,
-) {
-    for tok in iter {
-        tokens.push(StoredToken {
-            offset: tok.offset().to_doc(stmt_base),
-            length: tok.length().into(),
-            token_type: tok.token_type(),
-            flags: tok.flags(),
-        });
-    }
-}
-
-#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-pub(super) fn collect_comments<'a>(
-    iter: impl Iterator<Item = syntaqlite_syntax::Comment<'a>>,
-    stmt_base: StatementBase,
-    comments: &mut Vec<StoredComment>,
-) {
-    for c in iter {
-        comments.push(StoredComment {
-            offset: c.offset().to_doc(stmt_base),
-            length: c.length().into(),
-        });
     }
 }
 

--- a/syntaqlite/src/semantic/analyzer/mod.rs
+++ b/syntaqlite/src/semantic/analyzer/mod.rs
@@ -16,20 +16,13 @@ use crate::dialect::AnyDialect;
 use crate::dialect::SemanticRole;
 
 use super::catalog::{Catalog, CatalogLayer};
+use super::ddl::DdlReader;
 use super::diagnostics::{Diagnostic, DiagnosticMessage};
-#[cfg(feature = "lsp")]
-use super::model::Resolution;
 use super::model::{SemanticModel, StatementModel};
-#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-use super::model::{StoredComment, StoredToken};
+use super::observer::{AnalysisObserver, NoopObserver};
 use super::{AnalysisMode, ValidationConfig};
 
-#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-use helpers::{collect_comments, collect_tokens};
 use helpers::{extract_defined_relations, extract_macro_registration, parse_error_span};
-
-#[cfg(feature = "lsp")]
-use super::ddl::DdlReader;
 
 mod helpers;
 mod pass;
@@ -194,6 +187,22 @@ impl SemanticAnalyzer {
         user_catalog: &Catalog,
         config: &ValidationConfig,
     ) -> SemanticModel {
+        self.analyze_with_observer(source, user_catalog, config, &mut NoopObserver)
+    }
+
+    /// Run a complete single-pass analysis, forwarding resolution / token /
+    /// comment / definition events to `observer` as they occur.
+    ///
+    /// This is the hook that in-crate LSP and embedded-SQL consumers use to
+    /// capture the data they need (go-to-definition, find-references, semantic
+    /// tokens, completion) without the analyzer knowing anything about them.
+    pub(crate) fn analyze_with_observer(
+        &mut self,
+        source: &str,
+        user_catalog: &Catalog,
+        config: &ValidationConfig,
+        observer: &mut dyn AnalysisObserver,
+    ) -> SemanticModel {
         self.catalog.new_document();
         match self.mode {
             AnalysisMode::Document => {
@@ -204,7 +213,7 @@ impl SemanticAnalyzer {
                 self.catalog.copy_database_from(user_catalog);
             }
         }
-        let model = self.analyze_inner(source, config);
+        let model = self.analyze_inner(source, config, observer);
         if self.mode == AnalysisMode::Execute {
             self.catalog.promote_document_to_connection();
         }
@@ -212,7 +221,12 @@ impl SemanticAnalyzer {
     }
 
     #[expect(clippy::too_many_lines)]
-    fn analyze_inner(&mut self, source: &str, config: &ValidationConfig) -> SemanticModel {
+    fn analyze_inner(
+        &mut self,
+        source: &str,
+        config: &ValidationConfig,
+        observer: &mut dyn AnalysisObserver,
+    ) -> SemanticModel {
         type MacroRegistry = HashMap<String, (Vec<String>, String)>;
 
         struct SharedRegistryLookup(Rc<RefCell<MacroRegistry>>);
@@ -255,15 +269,9 @@ impl SemanticAnalyzer {
 
         let mut session = parser.parse(source);
 
-        #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-        let mut tokens: Vec<StoredToken> = Vec::new();
-        #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-        let mut comments: Vec<StoredComment> = Vec::new();
         let mut statements: Vec<StatementModel> = Vec::new();
-        #[cfg(feature = "lsp")]
-        let mut definition_offsets: HashMap<String, DocRange> = HashMap::new();
-        #[cfg(feature = "lsp")]
-        let mut resolutions: Vec<Resolution> = Vec::new();
+        let wants_tokens = observer.wants_tokens();
+        let wants_comments = observer.wants_comments();
 
         loop {
             let stmt = match session.next() {
@@ -287,21 +295,41 @@ impl SemanticAnalyzer {
                             Vec::new(),
                         ));
                     }
-                    #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-                    {
-                        let base = e.statement_base();
-                        collect_tokens(e.tokens(), base, &mut tokens);
-                        collect_comments(e.comments(), base, &mut comments);
+                    let base = e.statement_base();
+                    if wants_tokens {
+                        for tok in e.tokens() {
+                            observer.on_token(
+                                tok.offset().to_doc(base),
+                                tok.length().into(),
+                                tok.token_type(),
+                                tok.flags(),
+                            );
+                        }
+                    }
+                    if wants_comments {
+                        for c in e.comments() {
+                            observer.on_comment(c.offset().to_doc(base), c.length().into());
+                        }
                     }
                     continue;
                 }
             };
 
-            #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-            {
-                let base = stmt.statement_base();
-                collect_tokens(stmt.tokens(), base, &mut tokens);
-                collect_comments(stmt.comments(), base, &mut comments);
+            let base = stmt.statement_base();
+            if wants_tokens {
+                for tok in stmt.tokens() {
+                    observer.on_token(
+                        tok.offset().to_doc(base),
+                        tok.length().into(),
+                        tok.token_type(),
+                        tok.flags(),
+                    );
+                }
+            }
+            if wants_comments {
+                for c in stmt.comments() {
+                    observer.on_comment(c.offset().to_doc(base), c.length().into());
+                }
             }
 
             // Process the statement and extract macro registration info.
@@ -309,14 +337,7 @@ impl SemanticAnalyzer {
             // owned macro data before dropping it and calling register_macro.
             let (stmt_model, macro_reg) = {
                 let mut erased = stmt.erase();
-                let model = self.analyze_statement(
-                    &mut erased,
-                    config,
-                    #[cfg(feature = "lsp")]
-                    &mut resolutions,
-                    #[cfg(feature = "lsp")]
-                    &mut definition_offsets,
-                );
+                let model = self.analyze_statement(&mut erased, config, observer);
                 let reg = extract_macro_registration(
                     &erased,
                     erased.root_id(),
@@ -337,15 +358,7 @@ impl SemanticAnalyzer {
 
         SemanticModel {
             source: source.to_owned(),
-            #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-            tokens,
-            #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-            comments,
             statements,
-            #[cfg(feature = "lsp")]
-            resolutions,
-            #[cfg(feature = "lsp")]
-            definition_offsets,
         }
     }
 
@@ -353,8 +366,7 @@ impl SemanticAnalyzer {
         &mut self,
         erased: &mut AnyParsedStatement<'_>,
         config: &ValidationConfig,
-        #[cfg(feature = "lsp")] resolutions: &mut Vec<Resolution>,
-        #[cfg(feature = "lsp")] definition_offsets: &mut HashMap<String, DocRange>,
+        observer: &mut dyn AnalysisObserver,
     ) -> StatementModel {
         let root_id = erased.root_id();
         let mut diagnostics: Vec<Diagnostic> = Vec::new();
@@ -365,16 +377,14 @@ impl SemanticAnalyzer {
         // Handle module imports: resolve and analyze imported source.
         self.handle_import(erased, root_id, config, &mut diagnostics);
 
-        // Record DDL definition offsets for go-to-definition (same-file).
-        #[cfg(feature = "lsp")]
-        {
+        // Emit DDL definition events (tables/views and their columns).
+        if observer.wants_definitions() {
             let reader = DdlReader::new(erased, self.dialect.roles());
             if let Some((table_name, table_range)) = reader.name_span(root_id) {
+                observer.on_relation_definition(&table_name, table_range);
                 for (col_name, col_range) in reader.column_spans(root_id) {
-                    let key = format!("{table_name}.{col_name}");
-                    definition_offsets.insert(key, col_range);
+                    observer.on_column_definition(&table_name, &col_name, col_range);
                 }
-                definition_offsets.insert(table_name, table_range);
             }
         }
 
@@ -385,10 +395,7 @@ impl SemanticAnalyzer {
             &mut self.catalog,
             config,
             &mut diagnostics,
-            #[cfg(feature = "lsp")]
-            resolutions,
-            #[cfg(feature = "lsp")]
-            definition_offsets,
+            observer,
         );
 
         let lineage =
@@ -451,7 +458,7 @@ impl SemanticAnalyzer {
 
         // DDL accumulates into the Document layer (visible to subsequent
         // statements in the importing file).
-        let _ = self.analyze_inner(&source, config);
+        let _ = self.analyze_inner(&source, config, &mut NoopObserver);
     }
 }
 

--- a/syntaqlite/src/semantic/analyzer/pass/cte.rs
+++ b/syntaqlite/src/semantic/analyzer/pass/cte.rs
@@ -5,8 +5,8 @@
 //!
 //! Walking a CTE block has its own choreography — extract bindings, register
 //! the CTE in the catalog (recursive bindings register before the body),
-//! validate declared-vs-actual column counts, and record per-column LSP
-//! definition offsets — so it lives in its own file.
+//! validate declared-vs-actual column counts, and emit per-column definition
+//! events to the observer — so it lives in its own file.
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue, NodeFields};
 use syntaqlite_syntax::source::DocRange;
@@ -70,14 +70,11 @@ impl ValidationPass<'_> {
                 continue;
             }
 
-            // Record CTE definition offset for go-to-definition.
-            #[cfg(feature = "lsp")]
-            self.definition_offsets
-                .insert(binding.name.to_ascii_lowercase(), binding.name_range);
+            if self.observer.wants_definitions() {
+                self.observer
+                    .on_relation_definition(binding.name, binding.name_range);
+            }
 
-            // Determine the CTE's column list and register it in the catalog.
-            #[cfg(feature = "lsp")]
-            let cte_key = binding.name.to_ascii_lowercase();
             let cols = if let Some(ref declared) = binding.declared_cols {
                 let col_names: Vec<&str> = declared.iter().map(|(s, _)| *s).collect();
                 self.check_cte_column_count(
@@ -87,15 +84,17 @@ impl ValidationPass<'_> {
                     &col_names,
                     binding.body_id,
                 );
-                #[cfg(feature = "lsp")]
-                for &(col_name, col_range) in declared {
-                    let key = format!("{cte_key}.{}", col_name.to_ascii_lowercase());
-                    self.definition_offsets.insert(key, col_range);
+                if self.observer.wants_definitions() {
+                    for &(col_name, col_range) in declared {
+                        self.observer
+                            .on_column_definition(binding.name, col_name, col_range);
+                    }
                 }
                 Some(declared.iter().map(|(s, _)| s.to_string()).collect())
             } else {
-                #[cfg(feature = "lsp")]
-                self.record_select_column_offsets(stmt, binding.body_id, &cte_key);
+                if self.observer.wants_definitions() {
+                    self.emit_select_column_definitions(stmt, binding.body_id, binding.name);
+                }
                 binding
                     .body_id
                     .and_then(|id| DdlReader::new(stmt, self.roles).columns_from_select(id))
@@ -107,16 +106,15 @@ impl ValidationPass<'_> {
         self.catalog.pop_query_scope();
     }
 
-    /// Record definition offsets for columns inferred from a SELECT body.
+    /// Emit definition events for columns inferred from a SELECT body.
     ///
-    /// For `WITH foo AS (SELECT 1 AS a, 2 AS b)`, records offsets for the
-    /// alias names `a` and `b` so go-to-definition can jump to them.
-    #[cfg(feature = "lsp")]
-    fn record_select_column_offsets(
+    /// For `WITH foo AS (SELECT 1 AS a, 2 AS b)`, emits events for the alias
+    /// names `a` and `b` so observers can wire up go-to-definition.
+    fn emit_select_column_definitions(
         &mut self,
         stmt: &mut AnyParsedStatement<'_>,
         body_id: Option<AnyNodeId>,
-        table_key: &str,
+        table_name: &str,
     ) {
         let Some(body_id) = body_id else { return };
         let Some((tag, fields)) = stmt.extract_fields(body_id) else {
@@ -155,8 +153,8 @@ impl ValidationPass<'_> {
             let alias_node = Self::field_node_id(&child_fields, alias_idx);
             let (alias_text, alias_range) = Self::name_text(stmt, alias_node);
             if !alias_text.is_empty() {
-                let key = format!("{table_key}.{}", alias_text.to_ascii_lowercase());
-                self.definition_offsets.insert(key, alias_range);
+                self.observer
+                    .on_column_definition(table_name, alias_text, alias_range);
             }
         }
     }

--- a/syntaqlite/src/semantic/analyzer/pass/mod.rs
+++ b/syntaqlite/src/semantic/analyzer/pass/mod.rs
@@ -2,27 +2,19 @@
 // Licensed under the Apache License, Version 2.0.
 
 //! The statement-level validation pass: visits an AST once, emitting
-//! diagnostics and populating LSP resolutions as it goes.
-
-#[cfg(feature = "lsp")]
-use std::collections::HashMap;
+//! diagnostics and forwarding resolution events to the observer as it goes.
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue, NodeFields};
 use syntaqlite_syntax::source::{DocRange, LayerRange};
 
 use crate::dialect::{AnyDialect, FIELD_ABSENT, SemanticRole};
-#[cfg(feature = "lsp")]
-use crate::semantic::catalog::FunctionCategory;
 use crate::semantic::catalog::{Catalog, ColumnResolution, FunctionCheckResult};
 use crate::semantic::ddl::DdlReader;
 use crate::semantic::diagnostics::{Diagnostic, DiagnosticMessage, Help};
 use crate::semantic::fuzzy::best_suggestion;
-#[cfg(feature = "lsp")]
-use crate::semantic::model::{DefinitionLocation, Resolution, ResolvedSymbol};
+use crate::semantic::observer::AnalysisObserver;
 use crate::semantic::{CheckConfig, CheckLevel, ValidationConfig};
 
-#[cfg(feature = "lsp")]
-use super::helpers::format_arity;
 use super::query_scope::{QueryScope, RowIdPolicy};
 
 mod cte;
@@ -32,13 +24,8 @@ pub(super) struct ValidationPass<'a> {
     catalog: &'a mut Catalog,
     config: &'a ValidationConfig,
     diagnostics: &'a mut Vec<Diagnostic>,
-    #[cfg(feature = "lsp")]
-    resolutions: &'a mut Vec<Resolution>,
+    observer: &'a mut dyn AnalysisObserver,
     scope: QueryScope,
-    /// Maps `lowercase(name)` → `(start_offset, end_offset)` for definition sites.
-    /// Populated from DDL (per-document) and CTE bindings (per-WITH scope).
-    #[cfg(feature = "lsp")]
-    definition_offsets: &'a mut HashMap<String, DocRange>,
 }
 
 impl CheckConfig {
@@ -108,7 +95,6 @@ impl<'a> ValidationPass<'a> {
         }
     }
 
-    #[cfg_attr(feature = "lsp", expect(clippy::too_many_arguments))]
     pub(super) fn run<'b>(
         stmt: &mut AnyParsedStatement<'b>,
         root: AnyNodeId,
@@ -116,8 +102,7 @@ impl<'a> ValidationPass<'a> {
         catalog: &'a mut Catalog,
         config: &'a ValidationConfig,
         diagnostics: &'a mut Vec<Diagnostic>,
-        #[cfg(feature = "lsp")] resolutions: &'a mut Vec<Resolution>,
-        #[cfg(feature = "lsp")] definition_offsets: &'a mut HashMap<String, DocRange>,
+        observer: &'a mut dyn AnalysisObserver,
     ) {
         let roles = dialect.roles();
         let mut pass = ValidationPass {
@@ -125,11 +110,8 @@ impl<'a> ValidationPass<'a> {
             catalog,
             config,
             diagnostics,
-            #[cfg(feature = "lsp")]
-            resolutions,
+            observer,
             scope: QueryScope::default(),
-            #[cfg(feature = "lsp")]
-            definition_offsets,
         };
         pass.visit(stmt, root);
     }
@@ -330,31 +312,9 @@ impl<'a> ValidationPass<'a> {
         let scope_name = if alias.is_empty() { name } else { alias };
         let (columns, without_rowid) = self.catalog.table_source_info(name);
 
-        #[cfg(feature = "lsp")]
-        if is_known {
-            let definition = self
-                .definition_offsets
-                .get(&name.to_ascii_lowercase())
-                .map(|&range| DefinitionLocation {
-                    range,
-                    file_uri: None,
-                })
-                .or_else(|| {
-                    self.catalog
-                        .relation_definition_site(name)
-                        .map(|site| DefinitionLocation {
-                            range: site.range,
-                            file_uri: Some(site.file_uri.clone()),
-                        })
-                });
-            self.resolutions.push(Resolution {
-                range,
-                symbol: ResolvedSymbol::Table {
-                    name: name.to_string(),
-                    columns: columns.clone(),
-                    definition,
-                },
-            });
+        if is_known && self.observer.wants_references() {
+            self.observer
+                .on_table_reference(range, name, columns.as_deref());
         }
 
         self.scope
@@ -380,22 +340,11 @@ impl<'a> ValidationPass<'a> {
                 .map_or(0, <[_]>::len);
             match self.catalog.check_function(name, arg_count) {
                 FunctionCheckResult::Ok => {
-                    #[cfg(feature = "lsp")]
-                    if let Some((cat, arities)) = self.catalog.function_signature(name) {
-                        let cat_str = match cat {
-                            FunctionCategory::Scalar => "scalar function",
-                            FunctionCategory::Aggregate => "aggregate function",
-                            FunctionCategory::Window => "window function",
-                        };
-                        let arity_strs: Vec<String> =
-                            arities.iter().map(|a| format_arity(name, *a)).collect();
-                        self.resolutions.push(Resolution {
-                            range,
-                            symbol: ResolvedSymbol::Function {
-                                category: cat_str.to_string(),
-                                arities: arity_strs,
-                            },
-                        });
+                    if self.observer.wants_references()
+                        && let Some((cat, arities)) = self.catalog.function_signature(name)
+                    {
+                        self.observer
+                            .on_function_reference(range, name, cat, &arities);
                     }
                 }
                 FunctionCheckResult::Unknown => {
@@ -463,10 +412,10 @@ impl<'a> ValidationPass<'a> {
                 table: resolved_table,
                 all_columns,
             } => {
-                #[cfg(feature = "lsp")]
-                self.record_column_resolution(range, column, resolved_table, all_columns);
-                #[cfg(not(feature = "lsp"))]
-                let _ = (resolved_table, all_columns);
+                if self.observer.wants_references() && !resolved_table.is_empty() {
+                    self.observer
+                        .on_column_reference(range, &resolved_table, column, &all_columns);
+                }
             }
             ColumnResolution::TableNotFound => {}
             ColumnResolution::TableFoundColumnMissing => {
@@ -509,50 +458,6 @@ impl<'a> ValidationPass<'a> {
                 );
             }
         }
-    }
-
-    /// Record a successful column-reference resolution for LSP features
-    /// (go-to-definition, find-references, hover).
-    #[cfg(feature = "lsp")]
-    fn record_column_resolution(
-        &mut self,
-        range: DocRange,
-        column: &str,
-        resolved_table: String,
-        all_columns: Vec<String>,
-    ) {
-        if resolved_table.is_empty() {
-            return;
-        }
-        let def_key = format!(
-            "{}.{}",
-            resolved_table.to_ascii_lowercase(),
-            column.to_ascii_lowercase()
-        );
-        let definition = self
-            .definition_offsets
-            .get(&def_key)
-            .map(|&range| DefinitionLocation {
-                range,
-                file_uri: None,
-            })
-            .or_else(|| {
-                self.catalog
-                    .column_definition_site(&resolved_table, column)
-                    .map(|site| DefinitionLocation {
-                        range: site.range,
-                        file_uri: Some(site.file_uri.clone()),
-                    })
-            });
-        self.resolutions.push(Resolution {
-            range,
-            symbol: ResolvedSymbol::Column {
-                column: column.to_string(),
-                table: resolved_table,
-                all_columns,
-                definition,
-            },
-        });
     }
 
     fn visit_scoped_source(

--- a/syntaqlite/src/semantic/catalog.rs
+++ b/syntaqlite/src/semantic/catalog.rs
@@ -8,8 +8,6 @@
 use std::collections::{HashMap, HashSet};
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue};
-#[cfg(feature = "lsp")]
-use syntaqlite_syntax::source::DocRange;
 
 use super::ddl::DdlReader;
 use crate::dialect::AnyDialect;
@@ -99,16 +97,6 @@ impl From<DialectFunctionCategory> for FunctionCategory {
     }
 }
 
-/// Where a catalog entry was originally defined (e.g. in an external schema file).
-#[cfg(feature = "lsp")]
-#[derive(Debug, Clone)]
-pub(crate) struct DefinitionSite {
-    /// File URI (e.g. `"file:///path/to/schema.sql"`).
-    pub file_uri: String,
-    /// Document-absolute byte range of the name in the source file.
-    pub range: DocRange,
-}
-
 #[derive(Debug, Clone)]
 struct RelationEntry {
     name: String,
@@ -119,12 +107,6 @@ struct RelationEntry {
     without_rowid: bool,
     /// `true` if this relation is a view (not a physical table).
     is_view: bool,
-    /// Where this relation was defined, if known.
-    #[cfg(feature = "lsp")]
-    definition_site: Option<DefinitionSite>,
-    /// Where each column was defined, keyed by lowercase column name.
-    #[cfg(feature = "lsp")]
-    column_definition_sites: HashMap<String, DefinitionSite>,
 }
 
 #[derive(Debug, Clone)]
@@ -238,10 +220,6 @@ impl CatalogLayerContents {
                 columns,
                 without_rowid,
                 is_view: false,
-                #[cfg(feature = "lsp")]
-                definition_site: None,
-                #[cfg(feature = "lsp")]
-                column_definition_sites: HashMap::new(),
             },
         );
     }
@@ -271,10 +249,6 @@ impl CatalogLayerContents {
                 columns,
                 without_rowid: true, // views have no rowid
                 is_view: true,
-                #[cfg(feature = "lsp")]
-                definition_site: None,
-                #[cfg(feature = "lsp")]
-                column_definition_sites: HashMap::new(),
             },
         );
     }
@@ -574,24 +548,20 @@ impl Catalog {
     /// Parse DDL statements from one or more sources and populate the database
     /// layer.
     ///
-    /// Each entry in `sources` is a `(sql_text, optional_file_uri)` pair.
-    /// All sources are accumulated into a single catalog so that tables
-    /// defined in earlier sources are visible to later ones.
+    /// All sources are accumulated into a single catalog so that tables defined
+    /// in earlier sources are visible to later ones.
     ///
     /// Returns `(catalog, errors)`. `errors` contains the human-readable
     /// message for each statement that failed to parse. Partial results from
     /// successfully parsed statements are always accumulated.
     #[cfg(feature = "sqlite")]
-    pub fn from_ddl(
-        dialect: impl Into<AnyDialect>,
-        sources: &[(&str, Option<&str>)],
-    ) -> (Self, Vec<String>) {
+    pub fn from_ddl(dialect: impl Into<AnyDialect>, sources: &[&str]) -> (Self, Vec<String>) {
         use syntaqlite_syntax::ParseOutcome;
         let dialect = dialect.into();
         let mut catalog = Catalog::new(dialect.clone());
         let mut errors: Vec<String> = Vec::new();
         let parser = syntaqlite_syntax::Parser::new();
-        for &(source, file_uri) in sources {
+        for &source in sources {
             let mut session = parser.parse(source);
             loop {
                 let stmt = match session.next() {
@@ -606,10 +576,6 @@ impl Catalog {
                 let root_id: AnyNodeId = root.node_id().into();
                 let erased = stmt.erase();
                 catalog.accumulate_ddl(CatalogLayer::Database, &erased, root_id, &dialect);
-                #[cfg(feature = "lsp")]
-                catalog.record_ddl_definition_site(&erased, root_id, &dialect, file_uri);
-                #[cfg(not(feature = "lsp"))]
-                let _ = file_uri;
             }
         }
         (catalog, errors)
@@ -865,75 +831,14 @@ impl Catalog {
         (None, false)
     }
 
-    /// Record definition sites for a DDL statement (table + columns), if `file_uri` is provided.
-    #[cfg(feature = "lsp")]
-    fn record_ddl_definition_site(
-        &mut self,
-        stmt: &AnyParsedStatement<'_>,
-        root: AnyNodeId,
-        dialect: &AnyDialect,
-        file_uri: Option<&str>,
-    ) {
-        let Some(uri) = file_uri else { return };
-        let reader = DdlReader::new(stmt, dialect.roles());
-        let Some((name, range)) = reader.name_span(root) else {
-            return;
-        };
-        let Some(entry) = self.layers[CatalogLayer::Database.index()]
-            .relations
-            .get_mut(&name)
-        else {
-            return;
-        };
-        entry.definition_site = Some(DefinitionSite {
-            file_uri: uri.to_string(),
-            range,
-        });
-        for (col_name, col_range) in reader.column_spans(root) {
-            entry.column_definition_sites.insert(
-                col_name,
-                DefinitionSite {
-                    file_uri: uri.to_string(),
-                    range: col_range,
-                },
-            );
-        }
-    }
-
-    /// Return the definition site for a column in a relation, if one was recorded.
-    #[cfg(feature = "lsp")]
-    pub(crate) fn column_definition_site(
-        &self,
-        table: &str,
-        column: &str,
-    ) -> Option<&DefinitionSite> {
-        let col_key = column.to_ascii_lowercase();
-        for layer in self.all_layers_ordered() {
-            if let Some(rel) = layer.relation(table) {
-                return rel.column_definition_sites.get(&col_key);
-            }
-        }
-        None
-    }
-
-    /// Return the definition site for a relation, if one was recorded.
-    #[cfg(feature = "lsp")]
-    pub(crate) fn relation_definition_site(&self, name: &str) -> Option<&DefinitionSite> {
-        for layer in self.all_layers_ordered() {
-            if let Some(rel) = layer.relation(name) {
-                return rel.definition_site.as_ref();
-            }
-        }
-        None
-    }
-
     // ── Enumeration (for fuzzy suggestions and completions) ───────────────────
 
     pub(crate) fn all_relation_names(&self) -> Vec<String> {
         self.unique_names_across_layers(|l| l.relations.values().map(|r| r.name.as_str()))
     }
 
-    #[cfg(feature = "lsp")]
+    /// Enumerate column names across all layers, optionally filtered to a
+    /// single relation.
     pub(crate) fn all_column_names(&self, table: Option<&str>) -> Vec<String> {
         let mut names = Vec::new();
         for layer in self.all_layers_ordered() {
@@ -951,7 +856,6 @@ impl Catalog {
     }
 
     /// Look up function metadata by name: returns (category, arities) if found.
-    #[cfg(feature = "lsp")]
     pub(crate) fn function_signature(
         &self,
         name: &str,
@@ -1081,22 +985,14 @@ mod tests {
     #[test]
     fn from_ddl_populates_tables() {
         let dialect = crate::sqlite::dialect::dialect();
-        let cat = Catalog::from_ddl(
-            dialect,
-            &[("CREATE TABLE users (id INTEGER, name TEXT);", None)],
-        )
-        .0;
+        let cat = Catalog::from_ddl(dialect, &["CREATE TABLE users (id INTEGER, name TEXT);"]).0;
         assert!(cat.resolve_relation("users"));
     }
 
     #[test]
     fn from_ddl_populates_virtual_tables() {
         let dialect = crate::sqlite::dialect::dialect();
-        let cat = Catalog::from_ddl(
-            dialect,
-            &[("CREATE VIRTUAL TABLE fts USING fts5(content);", None)],
-        )
-        .0;
+        let cat = Catalog::from_ddl(dialect, &["CREATE VIRTUAL TABLE fts USING fts5(content);"]).0;
         assert!(cat.resolve_relation("fts"));
     }
 

--- a/syntaqlite/src/semantic/ddl.rs
+++ b/syntaqlite/src/semantic/ddl.rs
@@ -9,9 +9,7 @@
 //! grouped on a single [`DdlReader`] handle.
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue, NodeFields};
-#[cfg(feature = "lsp")]
-use syntaqlite_syntax::source::DocRange;
-use syntaqlite_syntax::source::{StmtLen, StmtOffset, StmtRange};
+use syntaqlite_syntax::source::{DocRange, StmtLen, StmtOffset, StmtRange};
 
 use crate::dialect::{FIELD_ABSENT, SemanticRole};
 use crate::semantic::catalog::AritySpec;
@@ -21,13 +19,13 @@ use crate::semantic::catalog::AritySpec;
 /// Cheap to construct (just two references); construct a fresh handle at each
 /// caller rather than threading one through.
 #[derive(Clone, Copy)]
-pub(super) struct DdlReader<'a, 'stmt> {
+pub(crate) struct DdlReader<'a, 'stmt> {
     stmt: &'a AnyParsedStatement<'stmt>,
     roles: &'a [SemanticRole],
 }
 
 impl<'a, 'stmt> DdlReader<'a, 'stmt> {
-    pub(super) fn new(stmt: &'a AnyParsedStatement<'stmt>, roles: &'a [SemanticRole]) -> Self {
+    pub(crate) fn new(stmt: &'a AnyParsedStatement<'stmt>, roles: &'a [SemanticRole]) -> Self {
         Self { stmt, roles }
     }
 
@@ -46,12 +44,11 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
         }
     }
 
-    // ── DDL definition spans (LSP go-to-definition) ───────────────────────
+    // ── DDL definition spans (go-to-definition) ──────────────────────────
 
     /// `(lowercase_name, range)` for `CREATE TABLE` / `CREATE VIEW`.
     /// Returns `None` for non-DDL statements.
-    #[cfg(feature = "lsp")]
-    pub(super) fn name_span(&self, root: AnyNodeId) -> Option<(String, DocRange)> {
+    pub(crate) fn name_span(&self, root: AnyNodeId) -> Option<(String, DocRange)> {
         let (tag, fields) = self.stmt.extract_fields(root)?;
         let (SemanticRole::DefineTable { name: name_idx, .. }
         | SemanticRole::DefineView { name: name_idx, .. }) = self.role_for(tag)?
@@ -69,8 +66,7 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
     }
 
     /// Per-column `(lowercase_name, range)` pairs for a `CREATE TABLE`.
-    #[cfg(feature = "lsp")]
-    pub(super) fn column_spans(&self, root: AnyNodeId) -> Vec<(String, DocRange)> {
+    pub(crate) fn column_spans(&self, root: AnyNodeId) -> Vec<(String, DocRange)> {
         let mut out = Vec::new();
         let Some((tag, fields)) = self.stmt.extract_fields(root) else {
             return out;
@@ -101,7 +97,6 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
         out
     }
 
-    #[cfg(feature = "lsp")]
     fn column_def_name_span(&self, node_id: AnyNodeId) -> Option<(&'stmt str, DocRange)> {
         let (tag, fields) = self.stmt.extract_fields(node_id)?;
         let SemanticRole::ColumnDef { name: name_idx, .. } = self.role_for(tag)? else {

--- a/syntaqlite/src/semantic/ffi/catalog_ffi.rs
+++ b/syntaqlite/src/semantic/ffi/catalog_ffi.rs
@@ -151,7 +151,7 @@ pub unsafe extern "C" fn syntaqlite_validator_load_schema_ddl(
         std::str::from_utf8_unchecked(std::slice::from_raw_parts(source.cast(), len as usize))
     };
 
-    let (catalog, errors) = Catalog::from_ddl(state.dialect.clone(), &[(src, None)]);
+    let (catalog, errors) = Catalog::from_ddl(state.dialect.clone(), &[src]);
     state.user_catalog.copy_schema_layers_from(&catalog);
     errors.len() as u32
 }

--- a/syntaqlite/src/semantic/mod.rs
+++ b/syntaqlite/src/semantic/mod.rs
@@ -59,6 +59,8 @@ mod lineage;
 #[cfg(feature = "validation")]
 pub(crate) mod model;
 #[cfg(feature = "validation")]
+pub(crate) mod observer;
+#[cfg(feature = "validation")]
 pub(crate) mod render;
 
 // ── Public re-exports ─────────────────────────────────────────────────────────

--- a/syntaqlite/src/semantic/model.rs
+++ b/syntaqlite/src/semantic/model.rs
@@ -3,151 +3,10 @@
 
 //! Result types for a single semantic analysis pass.
 
-#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-use syntaqlite_syntax::ParserTokenFlags;
-#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-use syntaqlite_syntax::any::{AnyTokenType, TokenCategory};
-#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange};
-
-#[cfg(feature = "lsp")]
-use std::collections::HashMap;
-
 use super::diagnostics::Diagnostic;
 use super::lineage::{
     ColumnLineage, LineageResult, PhysicalTableAccess, QueryLineage, RelationAccess,
 };
-
-// ── Stored per-statement positions ───────────────────────────────────────────
-
-/// A token position recorded during parsing.
-///
-/// `token_type` is dialect-agnostic (`AnyTokenType`) so that the semantic
-/// analyzer works with any dialect, not just the built-in `SQLite` dialect.
-#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-#[derive(Debug, Clone)]
-pub(crate) struct StoredToken {
-    pub(crate) offset: DocOffset,
-    pub(crate) length: DocLen,
-    pub(crate) token_type: AnyTokenType,
-    pub(crate) flags: ParserTokenFlags,
-}
-
-/// A comment position recorded during parsing.
-#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-#[derive(Debug, Clone)]
-pub(crate) struct StoredComment {
-    pub(crate) offset: DocOffset,
-    pub(crate) length: DocLen,
-}
-
-// ── Output types ──────────────────────────────────────────────────────────────
-
-/// A semantic token for syntax highlighting.
-#[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-#[derive(Debug, Clone)]
-pub(crate) struct SemanticToken {
-    /// Document-absolute byte offset in the source text.
-    pub offset: DocOffset,
-    /// Length in bytes.
-    pub length: DocLen,
-    /// Token category for highlighting.
-    pub category: TokenCategory,
-}
-
-/// Semantic completion context derived from parser stack state.
-#[cfg(feature = "lsp")]
-#[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum CompletionContext {
-    /// Could not determine context.
-    Unknown = 0,
-    /// Cursor is in an expression position (functions/values expected).
-    Expression = 1,
-    /// Cursor is in a table-reference position (table/view names expected).
-    TableRef = 2,
-}
-
-#[cfg(feature = "lsp")]
-impl CompletionContext {
-    pub(crate) fn from_parser(v: syntaqlite_syntax::CompletionContext) -> Self {
-        match v {
-            syntaqlite_syntax::CompletionContext::Expression => Self::Expression,
-            syntaqlite_syntax::CompletionContext::TableRef => Self::TableRef,
-            syntaqlite_syntax::CompletionContext::Unknown => Self::Unknown,
-        }
-    }
-}
-
-/// Expected tokens and semantic context at a cursor position.
-#[cfg(feature = "lsp")]
-#[derive(Debug)]
-pub(crate) struct CompletionInfo {
-    /// Terminal token types valid at the cursor (dialect-agnostic).
-    pub tokens: Vec<AnyTokenType>,
-    /// Semantic context (expression vs table-ref).
-    pub context: CompletionContext,
-    /// If the cursor follows `qualifier DOT`, this is the qualifier text.
-    pub qualifier: Option<String>,
-}
-
-// ── Resolved symbols ──────────────────────────────────────────────────────────
-
-/// A definition site that a reference points to.
-#[cfg(feature = "lsp")]
-#[derive(Debug, Clone)]
-pub(crate) struct DefinitionLocation {
-    pub range: DocRange,
-    /// If `Some`, the definition is in a different file (e.g. an external schema).
-    pub file_uri: Option<String>,
-}
-
-/// Result of a go-to-definition lookup: the origin span (reference token the
-/// user clicked on) plus the target definition location.
-#[cfg(feature = "lsp")]
-#[derive(Debug, Clone)]
-pub(crate) struct DefinitionResult {
-    /// Document-absolute byte range of the reference token.
-    pub origin: DocRange,
-    /// The definition site this reference resolves to.
-    pub target: DefinitionLocation,
-}
-
-/// A symbol resolution recorded during the validation pass.
-#[cfg(feature = "lsp")]
-#[derive(Debug, Clone)]
-pub(crate) enum ResolvedSymbol {
-    /// A table or view reference that resolved successfully.
-    Table {
-        name: String,
-        columns: Option<Vec<String>>,
-        /// Where this table/CTE was defined (byte offsets), if known.
-        definition: Option<DefinitionLocation>,
-    },
-    /// A column reference that resolved successfully.
-    Column {
-        column: String,
-        table: String,
-        all_columns: Vec<String>,
-        /// Where this column was defined (byte offsets), if known.
-        definition: Option<DefinitionLocation>,
-    },
-    /// A function call that resolved successfully.
-    Function {
-        category: String,
-        arities: Vec<String>,
-    },
-}
-
-/// A resolved symbol at a specific source location.
-#[cfg(feature = "lsp")]
-#[derive(Debug, Clone)]
-pub(crate) struct Resolution {
-    pub range: DocRange,
-    pub symbol: ResolvedSymbol,
-}
-
-// ── Per-statement model ──────────────────────────────────────────────────────
 
 /// A relation defined by a DDL statement (e.g. `CREATE TABLE`, `CREATE VIEW`).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -257,9 +116,14 @@ impl StatementModel {
 
 /// Result of a single analysis pass.
 ///
-/// Owns the source text, stored token/comment positions, and per-statement
-/// analysis results (diagnostics, lineage, defined relations). Produced by
+/// Owns the source text and per-statement analysis results (diagnostics,
+/// lineage, defined relations). Produced by
 /// [`SemanticAnalyzer::analyze`](super::analyzer::SemanticAnalyzer::analyze).
+///
+/// For incremental events (symbol resolutions, definition sites, tokens,
+/// comments) use
+/// [`SemanticAnalyzer::analyze_with_observer`](super::analyzer::SemanticAnalyzer::analyze_with_observer)
+/// and supply an [`AnalysisObserver`](super::observer::AnalysisObserver).
 ///
 /// # Example
 ///
@@ -289,18 +153,7 @@ impl StatementModel {
 /// ```
 pub struct SemanticModel {
     pub(crate) source: String,
-    #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-    pub(crate) tokens: Vec<StoredToken>,
-    #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-    pub(crate) comments: Vec<StoredComment>,
     pub(crate) statements: Vec<StatementModel>,
-    #[cfg(feature = "lsp")]
-    pub(crate) resolutions: Vec<Resolution>,
-    /// Same-file definition offsets keyed by lowercase name (table) or
-    /// `table.column` (column). Used by find-references and rename to
-    /// locate definition sites within the document.
-    #[cfg(feature = "lsp")]
-    pub(crate) definition_offsets: HashMap<String, DocRange>,
 }
 
 impl SemanticModel {
@@ -343,123 +196,6 @@ impl SemanticModel {
             .iter()
             .rev()
             .find_map(StatementModel::lineage)
-    }
-
-    /// Semantic tokens (for syntax highlighting) derived from the analyzed
-    /// tokens plus comments, classified by `dialect`.
-    #[cfg(any(feature = "lsp", feature = "experimental-embedded"))]
-    pub(crate) fn semantic_tokens(
-        &self,
-        dialect: &crate::dialect::AnyDialect,
-    ) -> Vec<SemanticToken> {
-        use syntaqlite_syntax::any::TokenCategory;
-        let mut out = Vec::new();
-        for t in &self.tokens {
-            let cat = dialect.classify_token(t.token_type, t.flags);
-            if cat != TokenCategory::Other {
-                out.push(SemanticToken {
-                    offset: t.offset,
-                    length: t.length,
-                    category: cat,
-                });
-            }
-        }
-        for c in &self.comments {
-            out.push(SemanticToken {
-                offset: c.offset,
-                length: c.length,
-                category: TokenCategory::Comment,
-            });
-        }
-        out.sort_by_key(|t| t.offset);
-        out
-    }
-}
-
-#[cfg(feature = "lsp")]
-impl SemanticModel {
-    /// Find the resolved symbol at a byte offset, if any.
-    pub(crate) fn resolution_at(&self, offset: DocOffset) -> Option<&ResolvedSymbol> {
-        self.resolutions
-            .iter()
-            .find(|r| offset >= r.range.start && offset < r.range.end)
-            .map(|r| &r.symbol)
-    }
-
-    /// Find the definition location for the symbol at a byte offset, if any.
-    pub(crate) fn definition_at(&self, offset: DocOffset) -> Option<DefinitionResult> {
-        self.resolutions
-            .iter()
-            .find(|r| offset >= r.range.start && offset < r.range.end)
-            .and_then(|r| match &r.symbol {
-                ResolvedSymbol::Table { definition, .. }
-                | ResolvedSymbol::Column { definition, .. } => {
-                    definition.as_ref().map(|d| DefinitionResult {
-                        origin: r.range,
-                        target: d.clone(),
-                    })
-                }
-                ResolvedSymbol::Function { .. } => None,
-            })
-    }
-
-    /// Find all resolutions in this model that match the given symbol identity.
-    pub(crate) fn references_matching(&self, kind: &SymbolIdentity) -> Vec<DocRange> {
-        self.resolutions
-            .iter()
-            .filter(|r| kind.matches(&r.symbol))
-            .map(|r| r.range)
-            .collect()
-    }
-}
-
-/// Identity of a symbol for matching across resolutions (find-references / rename).
-#[cfg(feature = "lsp")]
-#[derive(Debug)]
-pub(crate) enum SymbolIdentity {
-    Table(String),
-    Column { table: String, column: String },
-}
-
-#[cfg(feature = "lsp")]
-impl SymbolIdentity {
-    /// Derive the identity from a `ResolvedSymbol`.
-    pub(crate) fn from_resolved(sym: &ResolvedSymbol) -> Option<Self> {
-        match sym {
-            ResolvedSymbol::Table { name, .. } => {
-                Some(SymbolIdentity::Table(name.to_ascii_lowercase()))
-            }
-            ResolvedSymbol::Column { column, table, .. } => Some(SymbolIdentity::Column {
-                table: table.to_ascii_lowercase(),
-                column: column.to_ascii_lowercase(),
-            }),
-            ResolvedSymbol::Function { .. } => None,
-        }
-    }
-
-    fn matches(&self, sym: &ResolvedSymbol) -> bool {
-        match (self, sym) {
-            (SymbolIdentity::Table(name), ResolvedSymbol::Table { name: n, .. }) => {
-                n.eq_ignore_ascii_case(name)
-            }
-            (
-                SymbolIdentity::Column { table, column },
-                ResolvedSymbol::Column {
-                    table: t,
-                    column: c,
-                    ..
-                },
-            ) => t.eq_ignore_ascii_case(table) && c.eq_ignore_ascii_case(column),
-            _ => false,
-        }
-    }
-
-    /// Key into `definition_offsets` for this symbol.
-    pub(crate) fn definition_key(&self) -> String {
-        match self {
-            SymbolIdentity::Table(name) => name.clone(),
-            SymbolIdentity::Column { table, column } => format!("{table}.{column}"),
-        }
     }
 }
 

--- a/syntaqlite/src/semantic/observer.rs
+++ b/syntaqlite/src/semantic/observer.rs
@@ -1,0 +1,114 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+//! Analysis observer — a callback interface for consumers that need to
+//! capture incremental events from a [`SemanticAnalyzer`] pass (symbol
+//! resolutions, definition sites, tokens, comments).
+//!
+//! The analyzer calls observer methods as it walks the AST. The default
+//! [`NoopObserver`] discards every event, so observer-free callers pay
+//! nothing. Editor/LSP-style tools implement their own observer to build
+//! hover/go-to-definition/completion data without the analyzer knowing
+//! anything about them.
+//!
+//! The trait is `pub(crate)` — today only the in-crate `lsp` module needs
+//! it. Promote to `pub` if and when an out-of-crate consumer appears.
+
+use syntaqlite_syntax::ParserTokenFlags;
+use syntaqlite_syntax::any::AnyTokenType;
+use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange};
+
+use super::catalog::{AritySpec, FunctionCategory};
+
+/// Receives incremental events during a [`SemanticAnalyzer`] pass.
+///
+/// Every method has a default empty body, so implementors only override the
+/// events they care about. Events are emitted in the order the analyzer
+/// encounters them; ordering across categories is not guaranteed.
+///
+/// # Capability hints
+///
+/// The `wants_*` methods let the analyzer skip work when an event category
+/// is definitely ignored. Override them to return `true` when you plan to
+/// override the matching event method — otherwise the analyzer avoids the
+/// per-token or per-definition traversal cost.
+///
+/// [`SemanticAnalyzer`]: super::analyzer::SemanticAnalyzer
+pub(crate) trait AnalysisObserver {
+    /// Return `true` to receive [`on_token`](Self::on_token) events.
+    fn wants_tokens(&self) -> bool {
+        false
+    }
+
+    /// Return `true` to receive [`on_comment`](Self::on_comment) events.
+    fn wants_comments(&self) -> bool {
+        false
+    }
+
+    /// Return `true` to receive
+    /// [`on_relation_definition`](Self::on_relation_definition) and
+    /// [`on_column_definition`](Self::on_column_definition) events.
+    fn wants_definitions(&self) -> bool {
+        false
+    }
+
+    /// Return `true` to receive any of the `on_*_reference` events
+    /// ([table](Self::on_table_reference), [column](Self::on_column_reference),
+    /// [function](Self::on_function_reference)).
+    fn wants_references(&self) -> bool {
+        false
+    }
+
+    /// A table or view reference that resolved to a known relation.
+    fn on_table_reference(&mut self, _range: DocRange, _name: &str, _columns: Option<&[String]>) {}
+
+    /// A column reference that resolved to a known column (or a table with
+    /// unknown columns — in which case `all_columns` is empty).
+    fn on_column_reference(
+        &mut self,
+        _range: DocRange,
+        _table: &str,
+        _column: &str,
+        _all_columns: &[String],
+    ) {
+    }
+
+    /// A function call that resolved to a known overload.
+    fn on_function_reference(
+        &mut self,
+        _range: DocRange,
+        _name: &str,
+        _category: FunctionCategory,
+        _arities: &[AritySpec],
+    ) {
+    }
+
+    /// A relation (table/view/CTE) defined in the analyzed document, together
+    /// with the source range of its name.
+    fn on_relation_definition(&mut self, _name: &str, _range: DocRange) {}
+
+    /// A column defined in the analyzed document, together with the source
+    /// range of its name.
+    fn on_column_definition(&mut self, _table: &str, _column: &str, _range: DocRange) {}
+
+    /// A lexer token observed during parsing.
+    fn on_token(
+        &mut self,
+        _offset: DocOffset,
+        _length: DocLen,
+        _token_type: AnyTokenType,
+        _flags: ParserTokenFlags,
+    ) {
+    }
+
+    /// A comment observed during parsing.
+    fn on_comment(&mut self, _offset: DocOffset, _length: DocLen) {}
+}
+
+/// The default observer: ignores every event.
+///
+/// Used by [`SemanticAnalyzer::analyze`](super::analyzer::SemanticAnalyzer::analyze)
+/// when no observer is supplied, so observer-free callers pay no overhead.
+pub(crate) struct NoopObserver;
+
+impl AnalysisObserver for NoopObserver {}

--- a/tests/public-api/syntaqlite.txt
+++ b/tests/public-api/syntaqlite.txt
@@ -69,7 +69,7 @@ pub enum syntaqlite::semantic::Help
 pub enum syntaqlite::semantic::LineageResult<T>
 pub enum syntaqlite::semantic::RelationKind
 pub enum syntaqlite::semantic::Severity
-pub fn syntaqlite::Catalog::from_ddl(dialect: impl core::convert::Into<syntaqlite::any::AnyDialect>, sources: &[(&str, core::option::Option<&str>)]) -> (Self, alloc::vec::Vec<alloc::string::String>)
+pub fn syntaqlite::Catalog::from_ddl(dialect: impl core::convert::Into<syntaqlite::any::AnyDialect>, sources: &[&str]) -> (Self, alloc::vec::Vec<alloc::string::String>)
 pub fn syntaqlite::Catalog::layer(&self, which: syntaqlite::semantic::CatalogLayer) -> &syntaqlite::semantic::CatalogLayerContents
 pub fn syntaqlite::Catalog::layer_mut(&mut self, which: syntaqlite::semantic::CatalogLayer) -> &mut syntaqlite::semantic::CatalogLayerContents
 pub fn syntaqlite::Catalog::new(dialect: impl core::convert::Into<syntaqlite::any::AnyDialect>) -> Self


### PR DESCRIPTION
LSP-specific concerns (symbol resolutions, definition sites, token/comment
collection, completion context) had leaked into the semantic crate behind
~70 `#[cfg(feature = "lsp")]` gates spread across model.rs, the analyzer,
the validation pass, catalog.rs, and ddl.rs. This refactor hoists them all
out so the validator builds with zero LSP-feature knowledge.

- Add `semantic::observer::AnalysisObserver` (pub(crate) trait with a
  default `NoopObserver`) plus `wants_tokens`/`wants_references`/etc.
  capability hooks so the analyzer can skip per-token traversals when
  no observer cares.
- New `SemanticAnalyzer::analyze_with_observer` threads the observer
  through; `analyze` keeps its old signature and uses `NoopObserver`.
- Move `Resolution`, `ResolvedSymbol`, `DefinitionLocation`,
  `DefinitionResult`, `SymbolIdentity`, `CompletionContext`,
  `CompletionInfo`, `StoredToken`, `SemanticToken` into a new
  `lsp::analysis_data` module alongside an `LspObserver` impl.
- Move per-file and cross-file go-to-definition storage out of
  `Catalog`: strip `DefinitionSite` + related fields/methods; the LSP
  host now owns an `ExternalDefinitions` registry populated directly
  from schema DDL. `Catalog::from_ddl` simplifies to `&[&str]`.
- `DdlReader::new`/`name_span`/`column_spans` promoted to `pub(crate)`
  so the LSP host can walk schema DDL for the external registry.
- `embedded` module uses its own small `TokenObserver` to keep its
  semantic-token path working without the removed model fields.
- Rewire `LspHost` to cache `DocumentAnalysisData` per document
  instead of `SemanticModel` fields; every LSP query (hover,
  go-to-def, find-references, rename, signature help) reads from the
  observer-owned data.
- Net: −390 lines and 0 `feature = "lsp"` gates inside the validator.

