### PR TITLE
synq: relocate pass-result types from lsp/ into semantic::analysis

### DIFF
--- a/syntaqlite/src/lsp/analysis_data.rs
+++ b/syntaqlite/src/lsp/analysis_data.rs
@@ -1,48 +1,30 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-//! LSP-local storage captured during a semantic-analyzer pass.
+//! LSP-side glue for capturing semantic-analyzer events.
 //!
-//! The semantic layer emits events via [`AnalysisObserver`]; this module
-//! defines the concrete storage (tokens, comments, resolutions, definition
-//! offsets) plus an observer implementation that fills it. Nothing here is
-//! visible to the semantic layer.
+//! The analysis output types themselves live in [`crate::semantic::analysis`].
+//! This module holds:
+//!
+//! - [`LspObserver`] — an [`AnalysisObserver`] impl that fills a
+//!   [`DocumentAnalysisData`] during a pass.
+//! - [`ExternalDefinitions`] — a cross-file definition-site registry consulted
+//!   by the observer to correlate resolutions with schema files.
+//! - [`CompletionInfo`] / [`CompletionContext`] — the completion-probe output
+//!   consumed by the LSP completion service.
 
 use std::collections::HashMap;
 
 use syntaqlite_syntax::ParserTokenFlags;
-use syntaqlite_syntax::any::{AnyTokenType, TokenCategory};
+use syntaqlite_syntax::any::AnyTokenType;
 use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange};
 
-use crate::dialect::AnyDialect;
+use crate::semantic::analysis::{
+    DefinitionLocation, DocumentAnalysisData, Resolution, ResolvedSymbol, StoredComment,
+    StoredToken,
+};
 use crate::semantic::catalog::{AritySpec, FunctionCategory};
 use crate::semantic::observer::AnalysisObserver;
-
-// ── Token positions ──────────────────────────────────────────────────────────
-
-/// A parser token observed during analysis.
-#[derive(Debug, Clone)]
-pub(crate) struct StoredToken {
-    pub(crate) offset: DocOffset,
-    pub(crate) length: DocLen,
-    pub(crate) token_type: AnyTokenType,
-    pub(crate) flags: ParserTokenFlags,
-}
-
-/// A comment observed during analysis.
-#[derive(Debug, Clone)]
-pub(crate) struct StoredComment {
-    pub(crate) offset: DocOffset,
-    pub(crate) length: DocLen,
-}
-
-/// A token classified for editor syntax highlighting.
-#[derive(Debug, Clone)]
-pub(crate) struct SemanticToken {
-    pub(crate) offset: DocOffset,
-    pub(crate) length: DocLen,
-    pub(crate) category: TokenCategory,
-}
 
 // ── Completion ───────────────────────────────────────────────────────────────
 
@@ -71,96 +53,6 @@ pub(crate) struct CompletionInfo {
     pub(crate) tokens: Vec<AnyTokenType>,
     pub(crate) context: CompletionContext,
     pub(crate) qualifier: Option<String>,
-}
-
-// ── Resolved symbols ─────────────────────────────────────────────────────────
-
-/// A definition site that a reference points to.
-#[derive(Debug, Clone)]
-pub(crate) struct DefinitionLocation {
-    pub(crate) range: DocRange,
-    /// `Some` when the definition lives in another file (external schema).
-    pub(crate) file_uri: Option<String>,
-}
-
-/// Result of a go-to-definition lookup.
-#[derive(Debug, Clone)]
-pub(crate) struct DefinitionResult {
-    pub(crate) origin: DocRange,
-    pub(crate) target: DefinitionLocation,
-}
-
-/// A symbol resolution recorded during the validation pass.
-#[derive(Debug, Clone)]
-pub(crate) enum ResolvedSymbol {
-    Table {
-        name: String,
-        columns: Option<Vec<String>>,
-        definition: Option<DefinitionLocation>,
-    },
-    Column {
-        column: String,
-        table: String,
-        all_columns: Vec<String>,
-        definition: Option<DefinitionLocation>,
-    },
-    Function {
-        category: String,
-        arities: Vec<String>,
-    },
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct Resolution {
-    pub(crate) range: DocRange,
-    pub(crate) symbol: ResolvedSymbol,
-}
-
-/// Identity of a symbol for matching across resolutions.
-#[derive(Debug)]
-pub(crate) enum SymbolIdentity {
-    Table(String),
-    Column { table: String, column: String },
-}
-
-impl SymbolIdentity {
-    pub(crate) fn from_resolved(sym: &ResolvedSymbol) -> Option<Self> {
-        match sym {
-            ResolvedSymbol::Table { name, .. } => {
-                Some(SymbolIdentity::Table(name.to_ascii_lowercase()))
-            }
-            ResolvedSymbol::Column { column, table, .. } => Some(SymbolIdentity::Column {
-                table: table.to_ascii_lowercase(),
-                column: column.to_ascii_lowercase(),
-            }),
-            ResolvedSymbol::Function { .. } => None,
-        }
-    }
-
-    fn matches(&self, sym: &ResolvedSymbol) -> bool {
-        match (self, sym) {
-            (SymbolIdentity::Table(name), ResolvedSymbol::Table { name: n, .. }) => {
-                n.eq_ignore_ascii_case(name)
-            }
-            (
-                SymbolIdentity::Column { table, column },
-                ResolvedSymbol::Column {
-                    table: t,
-                    column: c,
-                    ..
-                },
-            ) => t.eq_ignore_ascii_case(table) && c.eq_ignore_ascii_case(column),
-            _ => false,
-        }
-    }
-
-    /// Key into `definition_offsets` for this symbol.
-    pub(crate) fn definition_key(&self) -> String {
-        match self {
-            SymbolIdentity::Table(name) => name.clone(),
-            SymbolIdentity::Column { table, column } => format!("{table}.{column}"),
-        }
-    }
 }
 
 // ── External definition registry ─────────────────────────────────────────────
@@ -229,75 +121,6 @@ impl ExternalDefinitions {
             column.to_ascii_lowercase()
         );
         self.sites.get(&key)
-    }
-}
-
-// ── DocumentAnalysisData ─────────────────────────────────────────────────────
-
-/// All the data an editor needs that was captured during a single analysis
-/// pass. Populated by [`LspObserver`].
-#[derive(Debug, Default)]
-pub(crate) struct DocumentAnalysisData {
-    pub(crate) tokens: Vec<StoredToken>,
-    pub(crate) comments: Vec<StoredComment>,
-    pub(crate) resolutions: Vec<Resolution>,
-    /// Maps `lowercase(name)` → `DocRange` for same-file definition sites.
-    /// Keys for columns look like `"table.column"` (lowercased).
-    pub(crate) definition_offsets: HashMap<String, DocRange>,
-}
-
-impl DocumentAnalysisData {
-    pub(crate) fn semantic_tokens(&self, dialect: &AnyDialect) -> Vec<SemanticToken> {
-        let mut out = Vec::new();
-        for t in &self.tokens {
-            let cat = dialect.classify_token(t.token_type, t.flags);
-            if cat != TokenCategory::Other {
-                out.push(SemanticToken {
-                    offset: t.offset,
-                    length: t.length,
-                    category: cat,
-                });
-            }
-        }
-        for c in &self.comments {
-            out.push(SemanticToken {
-                offset: c.offset,
-                length: c.length,
-                category: TokenCategory::Comment,
-            });
-        }
-        out.sort_by_key(|t| t.offset);
-        out
-    }
-
-    /// The resolution whose span contains `offset`, if any.
-    pub(crate) fn resolution_at(&self, offset: DocOffset) -> Option<&Resolution> {
-        self.resolutions
-            .iter()
-            .find(|r| offset >= r.range.start && offset < r.range.end)
-    }
-
-    /// Find all resolutions in this document that match the given identity.
-    pub(crate) fn references_matching(&self, kind: &SymbolIdentity) -> Vec<DocRange> {
-        self.resolutions
-            .iter()
-            .filter(|r| kind.matches(&r.symbol))
-            .map(|r| r.range)
-            .collect()
-    }
-
-    /// Go-to-definition target for the resolution at `offset`, if any.
-    pub(crate) fn definition_at(&self, offset: DocOffset) -> Option<DefinitionResult> {
-        self.resolution_at(offset).and_then(|r| match &r.symbol {
-            ResolvedSymbol::Table { definition, .. }
-            | ResolvedSymbol::Column { definition, .. } => {
-                definition.as_ref().map(|d| DefinitionResult {
-                    origin: r.range,
-                    target: d.clone(),
-                })
-            }
-            ResolvedSymbol::Function { .. } => None,
-        })
     }
 }
 

--- a/syntaqlite/src/lsp/completion.rs
+++ b/syntaqlite/src/lsp/completion.rs
@@ -4,9 +4,11 @@
 //! LSP-specific analysis helpers: semantic tokens, completion boundaries,
 //! qualifier detection, and expected-token computation.
 //!
-//! These operate on [`DocumentAnalysisData`] captured by
-//! [`LspObserver`](super::analysis_data::LspObserver) plus the dialect and
-//! are not part of semantic validation — they answer editor queries.
+//! These operate on
+//! [`DocumentAnalysisData`](crate::semantic::analysis::DocumentAnalysisData)
+//! captured by [`LspObserver`](super::analysis_data::LspObserver) plus the
+//! dialect and are not part of semantic validation — they answer editor
+//! queries.
 
 use std::collections::HashSet;
 
@@ -16,7 +18,9 @@ use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange, DocText};
 
 use crate::dialect::AnyDialect;
 
-use super::analysis_data::{CompletionContext, CompletionInfo, DocumentAnalysisData, StoredToken};
+use crate::semantic::analysis::{DocumentAnalysisData, StoredToken};
+
+use super::analysis_data::{CompletionContext, CompletionInfo};
 
 /// Expected tokens and semantic context at `offset` (for completion).
 pub(crate) fn completion_info(

--- a/syntaqlite/src/lsp/completion_service.rs
+++ b/syntaqlite/src/lsp/completion_service.rs
@@ -1,0 +1,88 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+//! Completion item assembly.
+//!
+//! Converts pre-computed [`CompletionInfo`] plus the active dialect and catalog
+//! into a list of [`CompletionEntry`] values. Keywords, columns, tables, and
+//! functions are filtered by the expected-token set and context; qualified
+//! references (`t.`) return only columns of the qualifier.
+
+use std::collections::HashSet;
+
+use syntaqlite_syntax::util::is_suggestable_keyword;
+
+use crate::dialect::AnyDialect;
+use crate::semantic::Catalog;
+
+use super::analysis_data::CompletionContext;
+use super::{CompletionEntry, CompletionInfo, CompletionKind};
+
+/// Assemble completion items from the given completion info, dialect, and
+/// catalog. The result is sorted by [`CompletionKind::sort_priority`].
+pub(crate) fn build_completion_items(
+    info: CompletionInfo,
+    dialect: &AnyDialect,
+    catalog: &Catalog,
+) -> Vec<CompletionEntry> {
+    let expected_set: HashSet<u32> = info.tokens.iter().map(|&t| u32::from(t)).collect();
+
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut items: Vec<CompletionEntry> = Vec::new();
+
+    for entry in dialect.keywords() {
+        let code = u32::from(entry.token_type());
+        if !expected_set.contains(&code) || !is_suggestable_keyword(entry.keyword()) {
+            continue;
+        }
+        if seen.insert(entry.keyword().to_string()) {
+            items.push(CompletionEntry::new(
+                entry.keyword().to_string(),
+                CompletionKind::Keyword,
+            ));
+        }
+    }
+
+    // When the cursor follows `qualifier.`, only suggest columns from that
+    // table — no keywords, functions, or other tables.
+    if let Some(ref qualifier) = info.qualifier {
+        items.clear();
+        seen.clear();
+        for name in catalog.all_column_names(Some(qualifier)) {
+            if seen.insert(name.clone()) {
+                items.push(CompletionEntry::new(name, CompletionKind::Column));
+            }
+        }
+        return items;
+    }
+
+    match info.context {
+        CompletionContext::TableRef => {
+            for name in catalog.all_relation_names() {
+                if seen.insert(name.clone()) {
+                    items.push(CompletionEntry::new(name, CompletionKind::Table));
+                }
+            }
+        }
+        CompletionContext::Expression | CompletionContext::Unknown => {
+            for name in catalog.all_function_names() {
+                if seen.insert(name.clone()) {
+                    items.push(CompletionEntry::new(name, CompletionKind::Function));
+                }
+            }
+            for name in catalog.all_column_names(None) {
+                if seen.insert(name.clone()) {
+                    items.push(CompletionEntry::new(name, CompletionKind::Column));
+                }
+            }
+            for name in catalog.all_relation_names() {
+                if seen.insert(name.clone()) {
+                    items.push(CompletionEntry::new(name, CompletionKind::Table));
+                }
+            }
+        }
+    }
+
+    items.sort_by_key(|a| a.kind().sort_priority());
+    items
+}

--- a/syntaqlite/src/lsp/completion_service.rs
+++ b/syntaqlite/src/lsp/completion_service.rs
@@ -21,7 +21,7 @@ use super::{CompletionEntry, CompletionInfo, CompletionKind};
 /// Assemble completion items from the given completion info, dialect, and
 /// catalog. The result is sorted by [`CompletionKind::sort_priority`].
 pub(crate) fn build_completion_items(
-    info: CompletionInfo,
+    info: &CompletionInfo,
     dialect: &AnyDialect,
     catalog: &Catalog,
 ) -> Vec<CompletionEntry> {
@@ -45,7 +45,7 @@ pub(crate) fn build_completion_items(
 
     // When the cursor follows `qualifier.`, only suggest columns from that
     // table — no keywords, functions, or other tables.
-    if let Some(ref qualifier) = info.qualifier {
+    if let Some(qualifier) = info.qualifier.as_ref() {
         items.clear();
         seen.clear();
         for name in catalog.all_column_names(Some(qualifier)) {

--- a/syntaqlite/src/lsp/document_store.rs
+++ b/syntaqlite/src/lsp/document_store.rs
@@ -1,0 +1,110 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+//! Per-document state and storage for the LSP host.
+//!
+//! Owns the URI → [`Document`] map and is responsible for inserting, updating,
+//! removing, and looking up documents. Analysis caches live on the individual
+//! [`Document`] values; the store exposes the map to analysis dispatchers via
+//! [`DocumentStore::get`] and [`DocumentStore::get_mut`].
+
+use std::collections::HashMap;
+
+use super::analysis_data::DocumentAnalysisData;
+use super::analysis_data::SemanticToken;
+use crate::semantic::diagnostics::Diagnostic;
+
+/// A single open document with lazily populated analysis caches.
+pub(crate) struct Document {
+    pub(crate) version: i32,
+    pub(crate) source: String,
+    /// Cached parse-error diagnostics. `None` when dirty.
+    pub(crate) cached_parse_diags: Option<Vec<Diagnostic>>,
+    /// All diagnostics produced by the last analysis pass (parse + semantic).
+    pub(crate) cached_all_diags: Option<Vec<Diagnostic>>,
+    /// Analysis events captured by `LspObserver`. `None` when dirty.
+    pub(crate) analysis: Option<DocumentAnalysisData>,
+    /// Semantic tokens derived from `analysis`. Populated on first request.
+    pub(crate) cached_sem_tokens: Option<Vec<SemanticToken>>,
+}
+
+impl Document {
+    pub(crate) fn invalidate(&mut self) {
+        self.cached_parse_diags = None;
+        self.cached_all_diags = None;
+        self.analysis = None;
+        self.cached_sem_tokens = None;
+    }
+}
+
+/// Storage for all open documents keyed by URI.
+pub(crate) struct DocumentStore {
+    documents: HashMap<String, Document>,
+}
+
+impl DocumentStore {
+    pub(crate) fn new() -> Self {
+        DocumentStore {
+            documents: HashMap::new(),
+        }
+    }
+
+    /// Register a newly opened document.
+    pub(crate) fn open(&mut self, uri: &str, version: i32, text: String) {
+        self.documents.insert(
+            uri.to_string(),
+            Document {
+                version,
+                source: text,
+                cached_parse_diags: None,
+                cached_all_diags: None,
+                analysis: None,
+                cached_sem_tokens: None,
+            },
+        );
+    }
+
+    /// Update a document's content, invalidating cached analysis.
+    /// Opens the document if it is not yet present.
+    pub(crate) fn update(&mut self, uri: &str, version: i32, text: String) {
+        if let Some(doc) = self.documents.get_mut(uri) {
+            doc.version = version;
+            doc.source = text;
+            doc.invalidate();
+        } else {
+            self.open(uri, version, text);
+        }
+    }
+
+    /// Remove a document from the store.
+    pub(crate) fn close(&mut self, uri: &str) {
+        self.documents.remove(uri);
+    }
+
+    /// Source text for a document.
+    pub(crate) fn source(&self, uri: &str) -> Option<&str> {
+        self.documents.get(uri).map(|doc| doc.source.as_str())
+    }
+
+    /// Immutable access to a document.
+    pub(crate) fn get(&self, uri: &str) -> Option<&Document> {
+        self.documents.get(uri)
+    }
+
+    /// Mutable access to a document.
+    pub(crate) fn get_mut(&mut self, uri: &str) -> Option<&mut Document> {
+        self.documents.get_mut(uri)
+    }
+
+    /// Invalidate cached analysis on every open document.
+    pub(crate) fn invalidate_all(&mut self) {
+        for doc in self.documents.values_mut() {
+            doc.invalidate();
+        }
+    }
+
+    /// All URIs currently tracked by the store.
+    pub(crate) fn uris(&self) -> Vec<String> {
+        self.documents.keys().cloned().collect()
+    }
+}

--- a/syntaqlite/src/lsp/document_store.rs
+++ b/syntaqlite/src/lsp/document_store.rs
@@ -10,8 +10,7 @@
 
 use std::collections::HashMap;
 
-use super::analysis_data::DocumentAnalysisData;
-use super::analysis_data::SemanticToken;
+use crate::semantic::analysis::{DocumentAnalysisData, SemanticToken};
 use crate::semantic::diagnostics::Diagnostic;
 
 /// A single open document with lazily populated analysis caches.

--- a/syntaqlite/src/lsp/host.rs
+++ b/syntaqlite/src/lsp/host.rs
@@ -6,7 +6,6 @@ use std::path::{Path, PathBuf};
 
 use syntaqlite_syntax::any::TokenCategory;
 use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange, DocText};
-use syntaqlite_syntax::util::is_suggestable_keyword;
 
 use crate::dialect::AnyDialect;
 use crate::fmt::FormatConfig;
@@ -17,10 +16,10 @@ use crate::semantic::analyzer::SemanticAnalyzer;
 use crate::semantic::diagnostics::Diagnostic;
 
 use super::analysis_data::{
-    DefinitionResult, DocumentAnalysisData, ExternalDefinitions, LspObserver, ResolvedSymbol,
-    SemanticToken, StoredToken, SymbolIdentity,
+    DefinitionResult, ExternalDefinitions, LspObserver, SemanticToken, StoredToken, SymbolIdentity,
 };
-use super::{CompletionEntry, CompletionInfo, CompletionKind};
+use super::document_store::{Document, DocumentStore};
+use super::{CompletionEntry, CompletionInfo};
 
 // ── SchemaMap ─────────────────────────────────────────────────────────────────
 
@@ -79,29 +78,7 @@ impl SchemaMap {
     }
 }
 
-// ── Document store ────────────────────────────────────────────────────────────
-
-struct Document {
-    version: i32,
-    source: String,
-    /// Cached parse-error diagnostics. `None` when dirty.
-    cached_parse_diags: Option<Vec<Diagnostic>>,
-    /// All diagnostics produced by the last analysis pass (parse + semantic).
-    cached_all_diags: Option<Vec<Diagnostic>>,
-    /// Analysis events captured by [`LspObserver`]. `None` when dirty.
-    analysis: Option<DocumentAnalysisData>,
-    /// Semantic tokens derived from `analysis`. Populated on first request.
-    cached_sem_tokens: Option<Vec<SemanticToken>>,
-}
-
-impl Document {
-    fn invalidate(&mut self) {
-        self.cached_parse_diags = None;
-        self.cached_all_diags = None;
-        self.analysis = None;
-        self.cached_sem_tokens = None;
-    }
-}
+// ── Analysis dispatch ────────────────────────────────────────────────────────
 
 /// Run analysis for `doc` if nothing is cached yet.
 fn ensure_analysis(
@@ -132,7 +109,7 @@ fn ensure_analysis(
 /// [`ensure_analysis`]. Returns `false` if the document is not found.
 fn ensure_analysis_for(
     uri: &str,
-    documents: &mut HashMap<String, Document>,
+    documents: &mut DocumentStore,
     analyzer: &mut SemanticAnalyzer,
     schema_map: Option<&SchemaMap>,
     user_catalog: &Catalog,
@@ -206,7 +183,7 @@ pub struct LspHost {
     /// go-to-definition targets.
     external_defs: ExternalDefinitions,
     analyzer: SemanticAnalyzer,
-    documents: HashMap<String, Document>,
+    documents: DocumentStore,
     /// Format config from project config file. `None` means use defaults.
     format_config: Option<FormatConfig>,
     /// Validation config (`strict_schema` is set when a schema is provided).
@@ -232,7 +209,7 @@ impl LspHost {
             external_defs: ExternalDefinitions::new(),
             analyzer: SemanticAnalyzer::new(),
             dialect,
-            documents: HashMap::new(),
+            documents: DocumentStore::new(),
             format_config: None,
             validation_config: ValidationConfig::default(),
             schema_map: None,
@@ -247,7 +224,7 @@ impl LspHost {
             external_defs: ExternalDefinitions::new(),
             analyzer: SemanticAnalyzer::with_dialect(dialect.clone()),
             dialect,
-            documents: HashMap::new(),
+            documents: DocumentStore::new(),
             format_config: None,
             validation_config: ValidationConfig::default(),
             schema_map: None,
@@ -269,9 +246,7 @@ impl LspHost {
     /// Set the validation config.
     pub fn set_validation_config(&mut self, config: ValidationConfig) {
         self.validation_config = config;
-        for doc in self.documents.values_mut() {
-            doc.invalidate();
-        }
+        self.documents.invalidate_all();
     }
 
     /// Set the per-file schema map from `[schemas]` config globs.
@@ -279,56 +254,36 @@ impl LspHost {
     /// matching catalog and `strict_schema` is set automatically.
     pub fn set_schema_map(&mut self, map: SchemaMap) {
         self.schema_map = Some(map);
-        for doc in self.documents.values_mut() {
-            doc.invalidate();
-        }
+        self.documents.invalidate_all();
     }
 
     /// Set the session context (user-provided schema and functions).
     /// Invalidates all cached analysis.
     pub fn set_session_context(&mut self, ctx: Catalog) {
         self.user_catalog = ctx;
-        for doc in self.documents.values_mut() {
-            doc.invalidate();
-        }
+        self.documents.invalidate_all();
     }
 
     // ── Document lifecycle ─────────────────────────────────────────────────────
 
     /// Register a newly opened document.
     pub(crate) fn open_document(&mut self, uri: &str, version: i32, text: String) {
-        self.documents.insert(
-            uri.to_string(),
-            Document {
-                version,
-                source: text,
-                cached_parse_diags: None,
-                cached_all_diags: None,
-                analysis: None,
-                cached_sem_tokens: None,
-            },
-        );
+        self.documents.open(uri, version, text);
     }
 
     /// Update a document's content, invalidating cached analysis.
     pub fn update_document(&mut self, uri: &str, version: i32, text: String) {
-        if let Some(doc) = self.documents.get_mut(uri) {
-            doc.version = version;
-            doc.source = text;
-            doc.invalidate();
-        } else {
-            self.open_document(uri, version, text);
-        }
+        self.documents.update(uri, version, text);
     }
 
     /// Remove a document from the host.
     pub(crate) fn close_document(&mut self, uri: &str) {
-        self.documents.remove(uri);
+        self.documents.close(uri);
     }
 
     /// Source text for a document.
     pub(crate) fn document_source(&self, uri: &str) -> Option<&str> {
-        self.documents.get(uri).map(|doc| doc.source.as_str())
+        self.documents.source(uri)
     }
 
     // ── Analysis queries ───────────────────────────────────────────────────────
@@ -427,71 +382,12 @@ impl LspHost {
 
     /// Completion items (keywords + functions) at a byte offset.
     pub fn completion_items(&mut self, uri: &str, offset: DocOffset) -> Vec<CompletionEntry> {
-        use std::collections::HashSet;
-
         let info = self.completion_info_at_offset(uri, offset);
-        let expected_set: HashSet<u32> = info.tokens.iter().map(|&t| u32::from(t)).collect();
-
-        let mut seen: HashSet<String> = HashSet::new();
-        let mut items: Vec<CompletionEntry> = Vec::new();
-
-        for entry in self.dialect.keywords() {
-            let code = u32::from(entry.token_type());
-            if !expected_set.contains(&code) || !is_suggestable_keyword(entry.keyword()) {
-                continue;
-            }
-            if seen.insert(entry.keyword().to_string()) {
-                items.push(CompletionEntry::new(
-                    entry.keyword().to_string(),
-                    CompletionKind::Keyword,
-                ));
-            }
-        }
-
-        let catalog = self.analyzer.catalog();
-
-        // When the cursor follows `qualifier.`, only suggest columns from that
-        // table — no keywords, functions, or other tables.
-        if let Some(ref qualifier) = info.qualifier {
-            items.clear();
-            seen.clear();
-            for name in catalog.all_column_names(Some(qualifier)) {
-                if seen.insert(name.clone()) {
-                    items.push(CompletionEntry::new(name, CompletionKind::Column));
-                }
-            }
-            return items;
-        }
-
-        match info.context {
-            super::CompletionContext::TableRef => {
-                for name in catalog.all_relation_names() {
-                    if seen.insert(name.clone()) {
-                        items.push(CompletionEntry::new(name, CompletionKind::Table));
-                    }
-                }
-            }
-            super::CompletionContext::Expression | super::CompletionContext::Unknown => {
-                for name in catalog.all_function_names() {
-                    if seen.insert(name.clone()) {
-                        items.push(CompletionEntry::new(name, CompletionKind::Function));
-                    }
-                }
-                for name in catalog.all_column_names(None) {
-                    if seen.insert(name.clone()) {
-                        items.push(CompletionEntry::new(name, CompletionKind::Column));
-                    }
-                }
-                for name in catalog.all_relation_names() {
-                    if seen.insert(name.clone()) {
-                        items.push(CompletionEntry::new(name, CompletionKind::Table));
-                    }
-                }
-            }
-        }
-
-        items.sort_by_key(|a| a.kind().sort_priority());
-        items
+        super::completion_service::build_completion_items(
+            info,
+            &self.dialect,
+            self.analyzer.catalog(),
+        )
     }
 
     // ── Semantic validation ────────────────────────────────────────────────────
@@ -589,10 +485,7 @@ impl LspHost {
             .analysis
             .as_ref()
             .expect("ensure_analysis sets analysis");
-
-        let resolution = data.resolution_at(offset)?;
-        let hover = format_resolved_hover(&resolution.symbol);
-        Some((hover, resolution.range))
+        super::hover_service::hover_info(data, offset)
     }
 
     // ── Go-to-definition ───────────────────────────────────────────────────
@@ -617,7 +510,7 @@ impl LspHost {
             .analysis
             .as_ref()
             .expect("ensure_analysis sets analysis");
-        data.definition_at(offset)
+        super::hover_service::definition_info(data, offset)
     }
 
     // ── Find references ──────────────────────────────────────────────────────
@@ -641,7 +534,7 @@ impl LspHost {
         let mut results = Vec::new();
 
         // Collect matching resolutions from all open documents.
-        let uris: Vec<String> = self.documents.keys().cloned().collect();
+        let uris: Vec<String> = self.documents.uris();
         for doc_uri in &uris {
             ensure_analysis_for(
                 doc_uri,
@@ -710,13 +603,7 @@ impl LspHost {
             .analysis
             .as_ref()
             .expect("ensure_analysis sets analysis");
-        let res = data.resolution_at(offset)?;
-        let name = match &res.symbol {
-            ResolvedSymbol::Table { name, .. } => name.clone(),
-            ResolvedSymbol::Column { column, .. } => column.clone(),
-            ResolvedSymbol::Function { .. } => return None,
-        };
-        Some((res.range, name))
+        super::hover_service::prepare_rename(data, offset)
     }
 
     /// Rename the symbol at `offset` to `new_name` across all open documents.
@@ -758,26 +645,7 @@ impl LspHost {
             .analysis
             .as_ref()
             .expect("ensure_analysis sets analysis");
-
-        // First check resolutions (references in DML/queries).
-        if let Some(res) = data.resolution_at(offset) {
-            return SymbolIdentity::from_resolved(&res.symbol);
-        }
-
-        // Fall back to definition_offsets (cursor on a CREATE TABLE name, etc).
-        for (key, &range) in &data.definition_offsets {
-            if offset >= range.start && offset < range.end {
-                return if let Some((table, col)) = key.split_once('.') {
-                    Some(SymbolIdentity::Column {
-                        table: table.to_string(),
-                        column: col.to_string(),
-                    })
-                } else {
-                    Some(SymbolIdentity::Table(key.clone()))
-                };
-            }
-        }
-        None
+        super::hover_service::symbol_identity_at(data, offset)
     }
 
     /// Look up an external (schema-file) definition site for a symbol from the
@@ -1021,38 +889,6 @@ pub(crate) struct SignatureHelpInfo {
     pub name: String,
     pub arities: Vec<AritySpec>,
     pub active_parameter: u32,
-}
-
-fn format_resolved_hover(symbol: &ResolvedSymbol) -> String {
-    match symbol {
-        ResolvedSymbol::Table { name, columns, .. } => match columns {
-            Some(cols) => format!("**table** `{name}`\n\n```\n{}\n```", cols.join(", ")),
-            None => format!("**table** `{name}`"),
-        },
-        ResolvedSymbol::Column {
-            column,
-            table,
-            all_columns,
-            ..
-        } => {
-            let col_list: Vec<String> = all_columns
-                .iter()
-                .map(|c| {
-                    if c.eq_ignore_ascii_case(column) {
-                        format!("**{c}**")
-                    } else {
-                        c.clone()
-                    }
-                })
-                .collect();
-            format!("**column** in `{table}`\n\n{}", col_list.join(", "))
-        }
-        ResolvedSymbol::Function {
-            category, arities, ..
-        } => {
-            format!("**{category}**\n\n```\n{}\n```", arities.join("\n"))
-        }
-    }
 }
 
 /// Walk backwards from cursor to find enclosing `func_name(` and count commas

--- a/syntaqlite/src/lsp/host.rs
+++ b/syntaqlite/src/lsp/host.rs
@@ -15,9 +15,9 @@ use crate::semantic::ValidationConfig;
 use crate::semantic::analyzer::SemanticAnalyzer;
 use crate::semantic::diagnostics::Diagnostic;
 
-use super::analysis_data::{
-    DefinitionResult, ExternalDefinitions, LspObserver, SemanticToken, StoredToken, SymbolIdentity,
-};
+use crate::semantic::analysis::{DefinitionResult, SemanticToken, StoredToken, SymbolIdentity};
+
+use super::analysis_data::{ExternalDefinitions, LspObserver};
 use super::document_store::{Document, DocumentStore};
 use super::{CompletionEntry, CompletionInfo};
 
@@ -384,7 +384,7 @@ impl LspHost {
     pub fn completion_items(&mut self, uri: &str, offset: DocOffset) -> Vec<CompletionEntry> {
         let info = self.completion_info_at_offset(uri, offset);
         super::completion_service::build_completion_items(
-            info,
+            &info,
             &self.dialect,
             self.analyzer.catalog(),
         )

--- a/syntaqlite/src/lsp/hover_service.rs
+++ b/syntaqlite/src/lsp/hover_service.rs
@@ -1,0 +1,110 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+//! Hover + go-to-definition data shaping.
+//!
+//! Pure functions that consume an already-computed [`DocumentAnalysisData`] and
+//! produce the host's hover/definition/rename responses. No analysis dispatch,
+//! no document store access — the [`LspHost`](super::host::LspHost) facade
+//! handles those before delegating.
+
+use syntaqlite_syntax::source::{DocOffset, DocRange};
+
+use super::analysis_data::{
+    DefinitionResult, DocumentAnalysisData, ResolvedSymbol, SymbolIdentity,
+};
+
+/// Hover information at `offset`: returns `(hover_text, token_range)` or `None`
+/// if the cursor is not on a resolved symbol.
+pub(crate) fn hover_info(
+    data: &DocumentAnalysisData,
+    offset: DocOffset,
+) -> Option<(String, DocRange)> {
+    let resolution = data.resolution_at(offset)?;
+    let hover = format_resolved_hover(&resolution.symbol);
+    Some((hover, resolution.range))
+}
+
+/// Go-to-definition target at `offset`, or `None` if the cursor is not on a
+/// known reference.
+pub(crate) fn definition_info(
+    data: &DocumentAnalysisData,
+    offset: DocOffset,
+) -> Option<DefinitionResult> {
+    data.definition_at(offset)
+}
+
+/// If `offset` lies on a renameable resolved symbol, return its range and
+/// current name. Functions are not renameable.
+pub(crate) fn prepare_rename(
+    data: &DocumentAnalysisData,
+    offset: DocOffset,
+) -> Option<(DocRange, String)> {
+    let res = data.resolution_at(offset)?;
+    let name = match &res.symbol {
+        ResolvedSymbol::Table { name, .. } => name.clone(),
+        ResolvedSymbol::Column { column, .. } => column.clone(),
+        ResolvedSymbol::Function { .. } => return None,
+    };
+    Some((res.range, name))
+}
+
+/// Determine the symbol identity at `offset` — either from a resolution or
+/// from a definition site (CREATE TABLE / column-def).
+pub(crate) fn symbol_identity_at(
+    data: &DocumentAnalysisData,
+    offset: DocOffset,
+) -> Option<SymbolIdentity> {
+    // First check resolutions (references in DML/queries).
+    if let Some(res) = data.resolution_at(offset) {
+        return SymbolIdentity::from_resolved(&res.symbol);
+    }
+
+    // Fall back to definition_offsets (cursor on a CREATE TABLE name, etc).
+    for (key, &range) in &data.definition_offsets {
+        if offset >= range.start && offset < range.end {
+            return if let Some((table, col)) = key.split_once('.') {
+                Some(SymbolIdentity::Column {
+                    table: table.to_string(),
+                    column: col.to_string(),
+                })
+            } else {
+                Some(SymbolIdentity::Table(key.clone()))
+            };
+        }
+    }
+    None
+}
+
+/// Render the markdown hover string for a resolved symbol.
+pub(crate) fn format_resolved_hover(symbol: &ResolvedSymbol) -> String {
+    match symbol {
+        ResolvedSymbol::Table { name, columns, .. } => match columns {
+            Some(cols) => format!("**table** `{name}`\n\n```\n{}\n```", cols.join(", ")),
+            None => format!("**table** `{name}`"),
+        },
+        ResolvedSymbol::Column {
+            column,
+            table,
+            all_columns,
+            ..
+        } => {
+            let col_list: Vec<String> = all_columns
+                .iter()
+                .map(|c| {
+                    if c.eq_ignore_ascii_case(column) {
+                        format!("**{c}**")
+                    } else {
+                        c.clone()
+                    }
+                })
+                .collect();
+            format!("**column** in `{table}`\n\n{}", col_list.join(", "))
+        }
+        ResolvedSymbol::Function {
+            category, arities, ..
+        } => {
+            format!("**{category}**\n\n```\n{}\n```", arities.join("\n"))
+        }
+    }
+}

--- a/syntaqlite/src/lsp/hover_service.rs
+++ b/syntaqlite/src/lsp/hover_service.rs
@@ -10,7 +10,7 @@
 
 use syntaqlite_syntax::source::{DocOffset, DocRange};
 
-use super::analysis_data::{
+use crate::semantic::analysis::{
     DefinitionResult, DocumentAnalysisData, ResolvedSymbol, SymbolIdentity,
 };
 

--- a/syntaqlite/src/lsp/mod.rs
+++ b/syntaqlite/src/lsp/mod.rs
@@ -117,7 +117,10 @@ impl CompletionKind {
 
 mod analysis_data;
 mod completion;
+mod completion_service;
+mod document_store;
 mod host;
+mod hover_service;
 mod server;
 mod source_map;
 

--- a/syntaqlite/src/semantic/analysis.rs
+++ b/syntaqlite/src/semantic/analysis.rs
@@ -1,0 +1,203 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+//! Outputs captured during a semantic-analyzer pass.
+//!
+//! The analyzer fires events through [`AnalysisObserver`](super::observer::AnalysisObserver);
+//! consumers — today the LSP host, tomorrow each composable analysis pass —
+//! collect those events into the data types defined here. Nothing in this
+//! module depends on LSP protocol machinery.
+
+use std::collections::HashMap;
+
+use syntaqlite_syntax::ParserTokenFlags;
+use syntaqlite_syntax::any::{AnyTokenType, TokenCategory};
+use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange};
+
+use crate::dialect::AnyDialect;
+
+// ── Token positions ──────────────────────────────────────────────────────────
+
+/// A parser token observed during analysis.
+#[derive(Debug, Clone)]
+pub(crate) struct StoredToken {
+    pub(crate) offset: DocOffset,
+    pub(crate) length: DocLen,
+    pub(crate) token_type: AnyTokenType,
+    pub(crate) flags: ParserTokenFlags,
+}
+
+/// A comment observed during analysis.
+#[derive(Debug, Clone)]
+pub(crate) struct StoredComment {
+    pub(crate) offset: DocOffset,
+    pub(crate) length: DocLen,
+}
+
+/// A token classified for editor syntax highlighting.
+#[derive(Debug, Clone)]
+pub(crate) struct SemanticToken {
+    pub(crate) offset: DocOffset,
+    pub(crate) length: DocLen,
+    pub(crate) category: TokenCategory,
+}
+
+// ── Resolved symbols ─────────────────────────────────────────────────────────
+
+/// A definition site that a reference points to.
+#[derive(Debug, Clone)]
+pub(crate) struct DefinitionLocation {
+    pub(crate) range: DocRange,
+    /// `Some` when the definition lives in another file (external schema).
+    pub(crate) file_uri: Option<String>,
+}
+
+/// Result of a go-to-definition lookup.
+#[derive(Debug, Clone)]
+pub(crate) struct DefinitionResult {
+    pub(crate) origin: DocRange,
+    pub(crate) target: DefinitionLocation,
+}
+
+/// A symbol resolution recorded during the validation pass.
+#[derive(Debug, Clone)]
+pub(crate) enum ResolvedSymbol {
+    Table {
+        name: String,
+        columns: Option<Vec<String>>,
+        definition: Option<DefinitionLocation>,
+    },
+    Column {
+        column: String,
+        table: String,
+        all_columns: Vec<String>,
+        definition: Option<DefinitionLocation>,
+    },
+    Function {
+        category: String,
+        arities: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Resolution {
+    pub(crate) range: DocRange,
+    pub(crate) symbol: ResolvedSymbol,
+}
+
+/// Identity of a symbol for matching across resolutions.
+#[derive(Debug)]
+pub(crate) enum SymbolIdentity {
+    Table(String),
+    Column { table: String, column: String },
+}
+
+impl SymbolIdentity {
+    pub(crate) fn from_resolved(sym: &ResolvedSymbol) -> Option<Self> {
+        match sym {
+            ResolvedSymbol::Table { name, .. } => {
+                Some(SymbolIdentity::Table(name.to_ascii_lowercase()))
+            }
+            ResolvedSymbol::Column { column, table, .. } => Some(SymbolIdentity::Column {
+                table: table.to_ascii_lowercase(),
+                column: column.to_ascii_lowercase(),
+            }),
+            ResolvedSymbol::Function { .. } => None,
+        }
+    }
+
+    fn matches(&self, sym: &ResolvedSymbol) -> bool {
+        match (self, sym) {
+            (SymbolIdentity::Table(name), ResolvedSymbol::Table { name: n, .. }) => {
+                n.eq_ignore_ascii_case(name)
+            }
+            (
+                SymbolIdentity::Column { table, column },
+                ResolvedSymbol::Column {
+                    table: t,
+                    column: c,
+                    ..
+                },
+            ) => t.eq_ignore_ascii_case(table) && c.eq_ignore_ascii_case(column),
+            _ => false,
+        }
+    }
+
+    /// Key into `definition_offsets` for this symbol.
+    pub(crate) fn definition_key(&self) -> String {
+        match self {
+            SymbolIdentity::Table(name) => name.clone(),
+            SymbolIdentity::Column { table, column } => format!("{table}.{column}"),
+        }
+    }
+}
+
+// ── DocumentAnalysisData ─────────────────────────────────────────────────────
+
+/// All the data captured during a single analysis pass that downstream
+/// consumers (editors, LSP services) query after the fact. Populated by an
+/// [`AnalysisObserver`](super::observer::AnalysisObserver) impl.
+#[derive(Debug, Default)]
+pub(crate) struct DocumentAnalysisData {
+    pub(crate) tokens: Vec<StoredToken>,
+    pub(crate) comments: Vec<StoredComment>,
+    pub(crate) resolutions: Vec<Resolution>,
+    /// Maps `lowercase(name)` → `DocRange` for same-file definition sites.
+    /// Keys for columns look like `"table.column"` (lowercased).
+    pub(crate) definition_offsets: HashMap<String, DocRange>,
+}
+
+impl DocumentAnalysisData {
+    pub(crate) fn semantic_tokens(&self, dialect: &AnyDialect) -> Vec<SemanticToken> {
+        let mut out = Vec::new();
+        for t in &self.tokens {
+            let cat = dialect.classify_token(t.token_type, t.flags);
+            if cat != TokenCategory::Other {
+                out.push(SemanticToken {
+                    offset: t.offset,
+                    length: t.length,
+                    category: cat,
+                });
+            }
+        }
+        for c in &self.comments {
+            out.push(SemanticToken {
+                offset: c.offset,
+                length: c.length,
+                category: TokenCategory::Comment,
+            });
+        }
+        out.sort_by_key(|t| t.offset);
+        out
+    }
+
+    /// The resolution whose span contains `offset`, if any.
+    pub(crate) fn resolution_at(&self, offset: DocOffset) -> Option<&Resolution> {
+        self.resolutions
+            .iter()
+            .find(|r| offset >= r.range.start && offset < r.range.end)
+    }
+
+    /// Find all resolutions in this document that match the given identity.
+    pub(crate) fn references_matching(&self, kind: &SymbolIdentity) -> Vec<DocRange> {
+        self.resolutions
+            .iter()
+            .filter(|r| kind.matches(&r.symbol))
+            .map(|r| r.range)
+            .collect()
+    }
+
+    /// Go-to-definition target for the resolution at `offset`, if any.
+    pub(crate) fn definition_at(&self, offset: DocOffset) -> Option<DefinitionResult> {
+        self.resolution_at(offset).and_then(|r| match &r.symbol {
+            ResolvedSymbol::Table { definition, .. }
+            | ResolvedSymbol::Column { definition, .. } => {
+                definition.as_ref().map(|d| DefinitionResult {
+                    origin: r.range,
+                    target: d.clone(),
+                })
+            }
+            ResolvedSymbol::Function { .. } => None,
+        })
+    }
+}

--- a/syntaqlite/src/semantic/mod.rs
+++ b/syntaqlite/src/semantic/mod.rs
@@ -42,6 +42,8 @@
 //! assert!(model.has_diagnostics());
 //! ```
 
+#[cfg(feature = "lsp")]
+pub(crate) mod analysis;
 #[cfg(feature = "validation")]
 pub(crate) mod analyzer;
 #[cfg(feature = "validation")]

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -1369,6 +1369,8 @@ pub fn syntaqlite_syntax::nodes::DeleteStmt<'a>::orderby(&self) -> core::option:
 pub fn syntaqlite_syntax::nodes::DeleteStmt<'a>::returning(&self) -> core::option::Option<syntaqlite_syntax::nodes::ResultColumnList<'a>>
 pub fn syntaqlite_syntax::nodes::DeleteStmt<'a>::table(&self) -> core::option::Option<syntaqlite_syntax::nodes::TableRef<'a>>
 pub fn syntaqlite_syntax::nodes::DeleteStmt<'a>::where_clause(&self) -> core::option::Option<syntaqlite_syntax::nodes::Expr<'a>>
+pub fn syntaqlite_syntax::nodes::DeleteStmt<'a>::with_ctes(&self) -> core::option::Option<syntaqlite_syntax::nodes::CteList<'a>>
+pub fn syntaqlite_syntax::nodes::DeleteStmt<'a>::with_recursive(&self) -> bool
 pub fn syntaqlite_syntax::nodes::DeleteStmtId::from(n: syntaqlite_syntax::nodes::DeleteStmt<'a>) -> Self
 pub fn syntaqlite_syntax::nodes::DeleteStmtId::into_inner(self) -> syntaqlite_syntax::any::AnyNodeId
 pub fn syntaqlite_syntax::nodes::DetachStmt<'_>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1492,6 +1494,8 @@ pub fn syntaqlite_syntax::nodes::InsertStmt<'a>::returning(&self) -> core::optio
 pub fn syntaqlite_syntax::nodes::InsertStmt<'a>::source(&self) -> core::option::Option<syntaqlite_syntax::nodes::Select<'a>>
 pub fn syntaqlite_syntax::nodes::InsertStmt<'a>::table(&self) -> core::option::Option<syntaqlite_syntax::nodes::TableRef<'a>>
 pub fn syntaqlite_syntax::nodes::InsertStmt<'a>::upsert(&self) -> core::option::Option<syntaqlite_syntax::nodes::UpsertClauseList<'a>>
+pub fn syntaqlite_syntax::nodes::InsertStmt<'a>::with_ctes(&self) -> core::option::Option<syntaqlite_syntax::nodes::CteList<'a>>
+pub fn syntaqlite_syntax::nodes::InsertStmt<'a>::with_recursive(&self) -> bool
 pub fn syntaqlite_syntax::nodes::InsertStmtId::from(n: syntaqlite_syntax::nodes::InsertStmt<'a>) -> Self
 pub fn syntaqlite_syntax::nodes::InsertStmtId::into_inner(self) -> syntaqlite_syntax::any::AnyNodeId
 pub fn syntaqlite_syntax::nodes::IsExpr<'_>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
@@ -1752,6 +1756,8 @@ pub fn syntaqlite_syntax::nodes::UpdateStmt<'a>::returning(&self) -> core::optio
 pub fn syntaqlite_syntax::nodes::UpdateStmt<'a>::setlist(&self) -> core::option::Option<syntaqlite_syntax::nodes::SetClauseList<'a>>
 pub fn syntaqlite_syntax::nodes::UpdateStmt<'a>::table(&self) -> core::option::Option<syntaqlite_syntax::nodes::TableRef<'a>>
 pub fn syntaqlite_syntax::nodes::UpdateStmt<'a>::where_clause(&self) -> core::option::Option<syntaqlite_syntax::nodes::Expr<'a>>
+pub fn syntaqlite_syntax::nodes::UpdateStmt<'a>::with_ctes(&self) -> core::option::Option<syntaqlite_syntax::nodes::CteList<'a>>
+pub fn syntaqlite_syntax::nodes::UpdateStmt<'a>::with_recursive(&self) -> bool
 pub fn syntaqlite_syntax::nodes::UpdateStmtId::from(n: syntaqlite_syntax::nodes::UpdateStmt<'a>) -> Self
 pub fn syntaqlite_syntax::nodes::UpdateStmtId::into_inner(self) -> syntaqlite_syntax::any::AnyNodeId
 pub fn syntaqlite_syntax::nodes::UpsertAction::as_str(&self) -> &'static str


### PR DESCRIPTION
First step of moving SQL query analysis into a composable pass
pipeline. Types that semantic analysis produces — tokens, references,
definitions — move out of `lsp/analysis_data.rs` into a new
`semantic::analysis` module. The LSP host retains only the
observer glue and completion probe types that are genuinely
LSP-shaped.

Includes the prerequisite commit that split `lsp/host.rs` into
`document_store` + `hover_service` + `completion_service`.

No behavior change. Module is feature-gated on `lsp` for now; gate
widens in step 2 when non-LSP passes start consuming it.

## Test plan
- [x] cargo check, default + lsp features
- [x] cargo test -p syntaqlite --features lsp
- [x] tools/pre-push --fix