### PR TITLE
synq: split ValidationPass into two passes + composition

### DIFF
--- a/syntaqlite/src/semantic/analyzer/pass/mod.rs
+++ b/syntaqlite/src/semantic/analyzer/pass/mod.rs
@@ -1,12 +1,18 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-//! Statement-level validation pass.
+//! Statement-level semantic validation, assembled from two single-purpose
+//! [`WalkPass`] implementors plus a hand-written composition.
 //!
-//! [`ValidationPass`] is a [`WalkPass`] implementor: the generic walker in
-//! [`super::walker`] handles role dispatch, scope maintenance, and event
-//! construction; `ValidationPass` decides what to do with each event
-//! (emit a diagnostic, forward to the observer, etc.).
+//! - [`DiagnosticsPass`] consumes walker events and emits a `Vec<Diagnostic>`.
+//! - [`ObserverForwarderPass`] consumes the same events and forwards them to
+//!   an [`AnalysisObserver`] callback interface.
+//! - [`ValidationPass`] holds both and implements `WalkPass` by delegating
+//!   to each at every hook — the composition is explicit, not generated.
+//!
+//! Splitting the two lets us stack them independently (e.g. running just the
+//! observer forwarder from a non-validating tool) and keeps each pass's code
+//! path narrow.
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement};
 use syntaqlite_syntax::source::{DocRange, LayerRange};
@@ -22,12 +28,6 @@ use super::query_scope::QueryScope;
 use super::walker::{
     self, CallEvent, ColumnRefEvent, CteColumnCountMismatchEvent, SourceRefEvent, WalkCtx, WalkPass,
 };
-
-pub(super) struct ValidationPass<'a> {
-    config: &'a ValidationConfig,
-    diagnostics: &'a mut Vec<Diagnostic>,
-    observer: &'a mut dyn AnalysisObserver,
-}
 
 impl CheckConfig {
     /// Get the check level for a diagnostic message's category.
@@ -45,30 +45,25 @@ impl CheckConfig {
     }
 }
 
-impl<'a> ValidationPass<'a> {
-    pub(super) fn run<'b>(
-        stmt: &mut AnyParsedStatement<'b>,
-        root: AnyNodeId,
-        dialect: &AnyDialect,
-        catalog: &'a mut Catalog,
-        config: &'a ValidationConfig,
-        diagnostics: &'a mut Vec<Diagnostic>,
-        observer: &'a mut dyn AnalysisObserver,
-    ) {
-        let mut pass = ValidationPass {
+// ── DiagnosticsPass ───────────────────────────────────────────────────────────
+
+/// Emits semantic diagnostics (`unknown-table`, `unknown-column`, etc.) into a
+/// `Vec<Diagnostic>`. Does not touch any observer.
+pub(super) struct DiagnosticsPass<'a> {
+    config: &'a ValidationConfig,
+    diagnostics: &'a mut Vec<Diagnostic>,
+}
+
+impl<'a> DiagnosticsPass<'a> {
+    pub(super) fn new(config: &'a ValidationConfig, diagnostics: &'a mut Vec<Diagnostic>) -> Self {
+        Self {
             config,
             diagnostics,
-            observer,
-        };
-        let mut cx = WalkCtx {
-            roles: dialect.roles(),
-            catalog,
-            scope: QueryScope::default(),
-        };
-        walker::walk(stmt, &mut cx, &mut pass, root);
+        }
     }
 
-    /// Push a diagnostic anchored to a span field of a node.
+    /// Push a diagnostic anchored to a span field of a node, including a
+    /// macro-expansion traceback if the span crossed an expansion boundary.
     fn emit(
         &mut self,
         stmt: &mut AnyParsedStatement<'_>,
@@ -114,12 +109,10 @@ impl<'a> ValidationPass<'a> {
     }
 }
 
-impl WalkPass for ValidationPass<'_> {
+impl WalkPass for DiagnosticsPass<'_> {
     const WANTS_SOURCE_REF: bool = true;
     const WANTS_COLUMN_REF: bool = true;
     const WANTS_CALL: bool = true;
-    const WANTS_RELATION_DEFINITION: bool = true;
-    const WANTS_COLUMN_DEFINITION: bool = true;
     const WANTS_CTE_COLUMN_COUNT: bool = true;
 
     fn on_source_ref(
@@ -129,10 +122,6 @@ impl WalkPass for ValidationPass<'_> {
         ev: SourceRefEvent<'_>,
     ) {
         if ev.resolved {
-            if self.observer.wants_references() {
-                self.observer
-                    .on_table_reference(ev.range, ev.name, ev.columns.as_deref());
-            }
             return;
         }
         let mut candidates = cx.catalog.all_relation_names();
@@ -157,20 +146,7 @@ impl WalkPass for ValidationPass<'_> {
         ev: ColumnRefEvent<'_>,
     ) {
         match ev.resolution {
-            ColumnResolution::Found {
-                table: resolved_table,
-                all_columns,
-            } => {
-                if self.observer.wants_references() && !resolved_table.is_empty() {
-                    self.observer.on_column_reference(
-                        ev.range,
-                        &resolved_table,
-                        ev.column,
-                        &all_columns,
-                    );
-                }
-            }
-            ColumnResolution::TableNotFound => {}
+            ColumnResolution::Found { .. } | ColumnResolution::TableNotFound => {}
             ColumnResolution::TableFoundColumnMissing => {
                 let tbl = ev
                     .table
@@ -221,14 +197,7 @@ impl WalkPass for ValidationPass<'_> {
         ev: CallEvent<'_>,
     ) {
         match ev.result {
-            FunctionCheckResult::Ok => {
-                if self.observer.wants_references()
-                    && let Some((cat, arities)) = ev.signature
-                {
-                    self.observer
-                        .on_function_reference(ev.range, ev.name, cat, &arities);
-                }
-            }
+            FunctionCheckResult::Ok => {}
             FunctionCheckResult::Unknown => {
                 let candidates = cx.catalog.all_function_names();
                 let suggestion =
@@ -252,24 +221,12 @@ impl WalkPass for ValidationPass<'_> {
                     ev.range,
                     DiagnosticMessage::FunctionArity {
                         name: ev.name.to_string(),
-                        expected,
+                        expected: expected.clone(),
                         got: ev.arg_count,
                     },
                     None,
                 );
             }
-        }
-    }
-
-    fn on_relation_definition(&mut self, name: &str, range: DocRange) {
-        if self.observer.wants_definitions() {
-            self.observer.on_relation_definition(name, range);
-        }
-    }
-
-    fn on_column_definition(&mut self, table: &str, column: &str, range: DocRange) {
-        if self.observer.wants_definitions() {
-            self.observer.on_column_definition(table, column, range);
         }
     }
 
@@ -287,5 +244,185 @@ impl WalkPass for ValidationPass<'_> {
             },
             None,
         );
+    }
+}
+
+// ── ObserverForwarderPass ─────────────────────────────────────────────────────
+
+/// Forwards resolved references and definition sites to an
+/// [`AnalysisObserver`]. Emits nothing of its own.
+pub(super) struct ObserverForwarderPass<'a> {
+    observer: &'a mut dyn AnalysisObserver,
+}
+
+impl<'a> ObserverForwarderPass<'a> {
+    pub(super) fn new(observer: &'a mut dyn AnalysisObserver) -> Self {
+        Self { observer }
+    }
+}
+
+impl WalkPass for ObserverForwarderPass<'_> {
+    const WANTS_SOURCE_REF: bool = true;
+    const WANTS_COLUMN_REF: bool = true;
+    const WANTS_CALL: bool = true;
+    const WANTS_RELATION_DEFINITION: bool = true;
+    const WANTS_COLUMN_DEFINITION: bool = true;
+
+    fn on_source_ref(
+        &mut self,
+        _stmt: &mut AnyParsedStatement<'_>,
+        _cx: &mut WalkCtx<'_>,
+        ev: SourceRefEvent<'_>,
+    ) {
+        if !ev.resolved {
+            return;
+        }
+        if self.observer.wants_references() {
+            self.observer
+                .on_table_reference(ev.range, ev.name, ev.columns);
+        }
+    }
+
+    fn on_column_ref(
+        &mut self,
+        _stmt: &mut AnyParsedStatement<'_>,
+        _cx: &mut WalkCtx<'_>,
+        ev: ColumnRefEvent<'_>,
+    ) {
+        if let ColumnResolution::Found {
+            table: resolved_table,
+            all_columns,
+        } = ev.resolution
+            && self.observer.wants_references()
+            && !resolved_table.is_empty()
+        {
+            self.observer
+                .on_column_reference(ev.range, resolved_table, ev.column, all_columns);
+        }
+    }
+
+    fn on_call(
+        &mut self,
+        _stmt: &mut AnyParsedStatement<'_>,
+        _cx: &mut WalkCtx<'_>,
+        ev: CallEvent<'_>,
+    ) {
+        if !matches!(ev.result, FunctionCheckResult::Ok) {
+            return;
+        }
+        if self.observer.wants_references()
+            && let Some((cat, arities)) = ev.signature
+        {
+            self.observer
+                .on_function_reference(ev.range, ev.name, *cat, arities);
+        }
+    }
+
+    fn on_relation_definition(&mut self, name: &str, range: DocRange) {
+        if self.observer.wants_definitions() {
+            self.observer.on_relation_definition(name, range);
+        }
+    }
+
+    fn on_column_definition(&mut self, table: &str, column: &str, range: DocRange) {
+        if self.observer.wants_definitions() {
+            self.observer.on_column_definition(table, column, range);
+        }
+    }
+}
+
+// ── ValidationPass: explicit composition ──────────────────────────────────────
+
+/// Runs both [`DiagnosticsPass`] and [`ObserverForwarderPass`] together over a
+/// single walk. No framework: each hook on [`WalkPass`] is written out by
+/// hand, calling the two inner passes in sequence.
+pub(super) struct ValidationPass<'a> {
+    diagnostics: DiagnosticsPass<'a>,
+    observer: ObserverForwarderPass<'a>,
+}
+
+impl<'a> ValidationPass<'a> {
+    pub(super) fn run<'b>(
+        stmt: &mut AnyParsedStatement<'b>,
+        root: AnyNodeId,
+        dialect: &AnyDialect,
+        catalog: &'a mut Catalog,
+        config: &'a ValidationConfig,
+        diagnostics: &'a mut Vec<Diagnostic>,
+        observer: &'a mut dyn AnalysisObserver,
+    ) {
+        let mut pass = ValidationPass {
+            diagnostics: DiagnosticsPass::new(config, diagnostics),
+            observer: ObserverForwarderPass::new(observer),
+        };
+        let mut cx = WalkCtx {
+            roles: dialect.roles(),
+            catalog,
+            scope: QueryScope::default(),
+        };
+        walker::walk(stmt, &mut cx, &mut pass, root);
+    }
+}
+
+impl WalkPass for ValidationPass<'_> {
+    const WANTS_SOURCE_REF: bool =
+        DiagnosticsPass::WANTS_SOURCE_REF || ObserverForwarderPass::WANTS_SOURCE_REF;
+    const WANTS_COLUMN_REF: bool =
+        DiagnosticsPass::WANTS_COLUMN_REF || ObserverForwarderPass::WANTS_COLUMN_REF;
+    const WANTS_CALL: bool = DiagnosticsPass::WANTS_CALL || ObserverForwarderPass::WANTS_CALL;
+    const WANTS_RELATION_DEFINITION: bool = DiagnosticsPass::WANTS_RELATION_DEFINITION
+        || ObserverForwarderPass::WANTS_RELATION_DEFINITION;
+    const WANTS_COLUMN_DEFINITION: bool =
+        DiagnosticsPass::WANTS_COLUMN_DEFINITION || ObserverForwarderPass::WANTS_COLUMN_DEFINITION;
+    const WANTS_CTE_COLUMN_COUNT: bool =
+        DiagnosticsPass::WANTS_CTE_COLUMN_COUNT || ObserverForwarderPass::WANTS_CTE_COLUMN_COUNT;
+
+    fn on_source_ref(
+        &mut self,
+        stmt: &mut AnyParsedStatement<'_>,
+        cx: &mut WalkCtx<'_>,
+        ev: SourceRefEvent<'_>,
+    ) {
+        self.diagnostics.on_source_ref(stmt, cx, ev);
+        self.observer.on_source_ref(stmt, cx, ev);
+    }
+
+    fn on_column_ref(
+        &mut self,
+        stmt: &mut AnyParsedStatement<'_>,
+        cx: &mut WalkCtx<'_>,
+        ev: ColumnRefEvent<'_>,
+    ) {
+        self.diagnostics.on_column_ref(stmt, cx, ev);
+        self.observer.on_column_ref(stmt, cx, ev);
+    }
+
+    fn on_call(
+        &mut self,
+        stmt: &mut AnyParsedStatement<'_>,
+        cx: &mut WalkCtx<'_>,
+        ev: CallEvent<'_>,
+    ) {
+        self.diagnostics.on_call(stmt, cx, ev);
+        self.observer.on_call(stmt, cx, ev);
+    }
+
+    fn on_relation_definition(&mut self, name: &str, range: DocRange) {
+        self.diagnostics.on_relation_definition(name, range);
+        self.observer.on_relation_definition(name, range);
+    }
+
+    fn on_column_definition(&mut self, table: &str, column: &str, range: DocRange) {
+        self.diagnostics.on_column_definition(table, column, range);
+        self.observer.on_column_definition(table, column, range);
+    }
+
+    fn on_cte_column_count_mismatch(
+        &mut self,
+        stmt: &mut AnyParsedStatement<'_>,
+        ev: CteColumnCountMismatchEvent<'_>,
+    ) {
+        self.diagnostics.on_cte_column_count_mismatch(stmt, ev);
+        self.observer.on_cte_column_count_mismatch(stmt, ev);
     }
 }

--- a/syntaqlite/src/semantic/analyzer/walker.rs
+++ b/syntaqlite/src/semantic/analyzer/walker.rs
@@ -36,8 +36,13 @@ pub(crate) struct WalkCtx<'a> {
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
+//
+// Events hold borrowed data so they're `Copy` and can be forwarded to multiple
+// passes in a hand-written composition without cloning. The owning storage
+// lives on the walker's stack for the duration of each hook call.
 
 /// A table/view/table-function reference in a FROM / JOIN / DML target.
+#[derive(Copy, Clone)]
 pub(crate) struct SourceRefEvent<'a> {
     pub(crate) node_id: AnyNodeId,
     pub(crate) name_idx: u8,
@@ -45,32 +50,35 @@ pub(crate) struct SourceRefEvent<'a> {
     pub(crate) name: &'a str,
     pub(crate) resolved: bool,
     /// Columns of the relation if known to the catalog, else `None`.
-    pub(crate) columns: Option<Vec<String>>,
+    pub(crate) columns: Option<&'a [String]>,
 }
 
 /// A column reference (qualified or bare) inside an expression.
+#[derive(Copy, Clone)]
 pub(crate) struct ColumnRefEvent<'a> {
     pub(crate) node_id: AnyNodeId,
     pub(crate) column_idx: u8,
     pub(crate) range: DocRange,
     pub(crate) column: &'a str,
     pub(crate) table: Option<&'a str>,
-    pub(crate) resolution: ColumnResolution,
+    pub(crate) resolution: &'a ColumnResolution,
 }
 
 /// A function / table-function / aggregate call.
+#[derive(Copy, Clone)]
 pub(crate) struct CallEvent<'a> {
     pub(crate) node_id: AnyNodeId,
     pub(crate) name_idx: u8,
     pub(crate) range: DocRange,
     pub(crate) name: &'a str,
     pub(crate) arg_count: usize,
-    pub(crate) result: FunctionCheckResult,
+    pub(crate) result: &'a FunctionCheckResult,
     /// Populated only for `FunctionCheckResult::Ok`.
-    pub(crate) signature: Option<(FunctionCategory, Vec<AritySpec>)>,
+    pub(crate) signature: Option<&'a (FunctionCategory, Vec<AritySpec>)>,
 }
 
 /// A CTE body's actual result-column count differs from its declared count.
+#[derive(Copy, Clone)]
 pub(crate) struct CteColumnCountMismatchEvent<'a> {
     pub(crate) name: &'a str,
     pub(crate) name_range: DocRange,
@@ -156,13 +164,13 @@ fn walk_node<P: WalkPass>(
         return;
     }
     if let Some(children) = stmt.list_children(node_id) {
-        let ids: Vec<AnyNodeId> = children
-            .iter()
-            .copied()
-            .filter(|id| !id.is_null())
-            .collect();
-        for child in ids {
-            walk_node(stmt, cx, pass, child);
+        // `children` has lifetime 'a (tied to the statement buffer, not the
+        // &stmt borrow), so we can iterate it while re-borrowing stmt for
+        // the recursive walk.
+        for &child in children {
+            if !child.is_null() {
+                walk_node(stmt, cx, pass, child);
+            }
         }
         return;
     }
@@ -329,7 +337,7 @@ fn walk_source_ref<P: WalkPass>(
             range,
             name,
             resolved: is_known,
-            columns: columns.clone(),
+            columns: columns.as_deref(),
         };
         pass.on_source_ref(stmt, cx, ev);
     }
@@ -359,7 +367,7 @@ fn walk_call<P: WalkPass>(
             .and_then(|id| stmt.list_children(id))
             .map_or(0, <[_]>::len);
         let result = cx.catalog.check_function(name, arg_count);
-        let signature = match result {
+        let signature = match &result {
             FunctionCheckResult::Ok => cx.catalog.function_signature(name),
             _ => None,
         };
@@ -371,8 +379,8 @@ fn walk_call<P: WalkPass>(
                 range,
                 name,
                 arg_count,
-                result,
-                signature,
+                result: &result,
+                signature: signature.as_ref(),
             };
             pass.on_call(stmt, cx, ev);
         }
@@ -416,7 +424,7 @@ fn walk_column_ref<P: WalkPass>(
             range,
             column,
             table,
-            resolution,
+            resolution: &resolution,
         };
         pass.on_column_ref(stmt, cx, ev);
     }
@@ -491,8 +499,7 @@ fn collect_select_aliases(
     let Some(children) = stmt.list_children(list_id) else {
         return aliases;
     };
-    let child_ids: Vec<AnyNodeId> = children.to_vec();
-    for child_id in child_ids {
+    for &child_id in children {
         if child_id.is_null() {
             continue;
         }
@@ -580,23 +587,25 @@ fn walk_dml_children_except_ctes<P: WalkPass>(
     bindings_idx: u8,
 ) {
     let skip = bindings_idx as usize;
-    let mut child_ids: Vec<AnyNodeId> = Vec::new();
     for idx in 0..fields.len() {
         if idx == skip {
             continue;
         }
-        if let FieldValue::NodeId(child_id) = fields[idx]
-            && !child_id.is_null()
-        {
-            if let Some(children) = stmt.list_children(child_id) {
-                child_ids.extend(children.iter().copied().filter(|id| !id.is_null()));
-            } else {
-                child_ids.push(child_id);
-            }
+        let FieldValue::NodeId(child_id) = fields[idx] else {
+            continue;
+        };
+        if child_id.is_null() {
+            continue;
         }
-    }
-    for child in child_ids {
-        walk_node(stmt, cx, pass, child);
+        if let Some(children) = stmt.list_children(child_id) {
+            for &grandchild in children {
+                if !grandchild.is_null() {
+                    walk_node(stmt, cx, pass, grandchild);
+                }
+            }
+        } else {
+            walk_node(stmt, cx, pass, child_id);
+        }
     }
 }
 
@@ -620,12 +629,11 @@ fn register_cte_bindings<P: WalkPass>(
     }
     let is_recursive = recursive_idx != FIELD_ABSENT
         && matches!(fields[recursive_idx as usize], FieldValue::Bool(true));
-    let cte_ids: Vec<AnyNodeId> = field_node_id(fields, bindings_idx)
+    let cte_ids: &[AnyNodeId] = field_node_id(fields, bindings_idx)
         .and_then(|id| stmt.list_children(id))
-        .map(<[AnyNodeId]>::to_vec)
-        .unwrap_or_default();
+        .unwrap_or(&[]);
 
-    for cte_id in cte_ids {
+    for &cte_id in cte_ids {
         let Some(binding) = extract_cte_binding(stmt, cx.roles, cte_id) else {
             continue;
         };
@@ -636,7 +644,7 @@ fn register_cte_bindings<P: WalkPass>(
             let cols = binding
                 .declared_cols
                 .as_ref()
-                .map(|v| v.iter().map(|(s, _)| s.to_string()).collect());
+                .map(|v| v.iter().map(|(s, _)| (*s).to_string()).collect());
             cx.catalog.add_query_table(binding.name, cols);
         }
 
@@ -653,15 +661,14 @@ fn register_cte_bindings<P: WalkPass>(
         }
 
         let cols = if let Some(declared) = binding.declared_cols.as_ref() {
-            let col_names: Vec<&str> = declared.iter().map(|(s, _)| *s).collect();
             if P::WANTS_CTE_COLUMN_COUNT
                 && let Some(actual) = count_result_columns(stmt, cx.roles, binding.body_id)
-                && actual != col_names.len()
+                && actual != declared.len()
             {
                 let ev = CteColumnCountMismatchEvent {
                     name: binding.name,
                     name_range: binding.name_range,
-                    declared: col_names.len(),
+                    declared: declared.len(),
                     actual,
                 };
                 pass.on_cte_column_count_mismatch(stmt, ev);
@@ -671,7 +678,7 @@ fn register_cte_bindings<P: WalkPass>(
                     pass.on_column_definition(binding.name, col_name, col_range);
                 }
             }
-            Some(declared.iter().map(|(s, _)| s.to_string()).collect())
+            Some(declared.iter().map(|(s, _)| (*s).to_string()).collect())
         } else {
             if P::WANTS_COLUMN_DEFINITION {
                 emit_select_column_definitions(stmt, cx.roles, pass, binding.body_id, binding.name);
@@ -731,16 +738,16 @@ fn extract_declared_cols<'b>(
     }
     let list_id = field_node_id(fields, cols_idx)?;
     let children = stmt.list_children(list_id)?;
-    let ids: Vec<AnyNodeId> = children
-        .iter()
-        .copied()
-        .filter(|id| !id.is_null())
-        .collect();
-    let names: Vec<(&'b str, DocRange)> = ids
-        .into_iter()
-        .map(|id| name_text(stmt, Some(id)))
-        .filter(|(s, _)| !s.is_empty())
-        .collect();
+    let mut names: Vec<(&'b str, DocRange)> = Vec::with_capacity(children.len());
+    for &id in children {
+        if id.is_null() {
+            continue;
+        }
+        let (text, range) = name_text(stmt, Some(id));
+        if !text.is_empty() {
+            names.push((text, range));
+        }
+    }
     if names.is_empty() { None } else { Some(names) }
 }
 
@@ -763,10 +770,9 @@ fn count_result_columns(
 
     let list_id = field_node_id(&body_fields, cols_idx)?;
     let children = stmt.list_children(list_id)?;
-    let child_ids: Vec<AnyNodeId> = children.to_vec();
 
     let mut count = 0usize;
-    for child_id in child_ids {
+    for &child_id in children {
         if child_id.is_null() {
             continue;
         }
@@ -816,9 +822,7 @@ fn emit_select_column_definitions<P: WalkPass>(
     let Some(children) = stmt.list_children(list_id) else {
         return;
     };
-    let child_ids: Vec<AnyNodeId> = children.to_vec();
-
-    for child_id in child_ids {
+    for &child_id in children {
         if child_id.is_null() {
             continue;
         }


### PR DESCRIPTION
Third step of the pass-based refactor. ValidationPass was a
single monolithic WalkPass implementor doing two unrelated things:
emitting diagnostics and forwarding events to an AnalysisObserver.
Split them into two single-purpose passes plus a composition struct
that holds both and delegates at each hook — the composition is
explicit, not framework-generated.

- DiagnosticsPass: consumes walker events and emits Vec<Diagnostic>
  (unknown table/column/function, arity mismatch, CTE column count).
  Doesn't know about observers.
- ObserverForwarderPass: consumes the same events and forwards to
  AnalysisObserver. Transitional; retired in a later step when
  direct-capture passes replace the observer trait entirely.
- ValidationPass: hand-written composition that holds both and
  implements WalkPass by calling each in sequence at every hook.
  Same public signature as before — analyze_statement callers
  don't change.

Event types now hold borrowed data (Option<&[String]>, &ColumnResolution,
&FunctionCheckResult, etc.) and derive Copy, so composition can forward
events to each sub-pass by value without cloning.

Drive-by perf cleanup of walker.rs: removed defensive Vec collects
at list-children iteration sites. stmt.list_children() returns
&'a [AnyNodeId] tied to the statement buffer's lifetime (not the
&stmt borrow), so the borrowed slice can be iterated directly while
re-borrowing stmt mutably for the recursive walk. Cleaned up
walk_node, collect_select_aliases, walk_dml_children_except_ctes,
register_cte_bindings, extract_declared_cols, count_result_columns,
emit_select_column_definitions.

No behavior change. 244 unit + 34 doctests + 25 integration tests
pass on --features lsp.

