### PR TITLE
synq: move completion + sig-help into semantic::completion

### DIFF
--- a/syntaqlite/src/lsp/analysis_data.rs
+++ b/syntaqlite/src/lsp/analysis_data.rs
@@ -1,28 +1,26 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-//! LSP-side capture pass and per-file glue.
+//! LSP-shaped analysis data and the capture pass that populates it.
 //!
-//! The core analysis output types live in [`crate::semantic::analysis`]. This
-//! module owns:
+//! The types in this module describe analysis results in the shape LSP
+//! services want: resolved symbols with markdown-friendly fields, cross-file
+//! definition locations, per-document bundles. Generic token/comment data
+//! lives in [`crate::semantic::analysis`].
 //!
 //! - [`LspCapturePass`] — a [`WalkPass`] impl that fills a
-//!   [`DocumentAnalysisData`] directly during analysis. Replaces the old
-//!   observer-based capture.
+//!   [`DocumentAnalysisData`] directly during analysis.
 //! - [`ExternalDefinitions`] — a cross-file definition-site registry consulted
 //!   by the capture pass to correlate resolutions with schema files.
-//! - [`CompletionInfo`] / [`CompletionContext`] — the completion-probe output
-//!   consumed by the LSP completion service.
 
 use std::collections::HashMap;
 
-use syntaqlite_syntax::any::{AnyParseError, AnyParsedStatement, AnyTokenType};
-use syntaqlite_syntax::source::DocRange;
+use syntaqlite_syntax::any::TokenCategory;
+use syntaqlite_syntax::any::{AnyParseError, AnyParsedStatement};
+use syntaqlite_syntax::source::{DocOffset, DocRange};
 
-use crate::semantic::analysis::{
-    DefinitionLocation, DocumentAnalysisData, Resolution, ResolvedSymbol, StoredComment,
-    StoredToken,
-};
+use crate::dialect::AnyDialect;
+use crate::semantic::analysis::{SemanticToken, StoredComment, StoredToken};
 use crate::semantic::analyzer::walker::{
     CallEvent, ColumnRefEvent, SourceRefEvent, WalkCtx, WalkPass,
 };
@@ -30,36 +28,167 @@ use crate::semantic::catalog::{
     AritySpec, ColumnResolution, FunctionCategory, FunctionCheckResult,
 };
 
-// ── Completion ───────────────────────────────────────────────────────────────
+// ── Resolved symbols ──────────────────────────────────────────────────────────
 
-/// Semantic completion context derived from parser stack state.
-#[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum CompletionContext {
-    Unknown = 0,
-    Expression = 1,
-    TableRef = 2,
+/// A definition site that a reference points to.
+#[derive(Debug, Clone)]
+pub(crate) struct DefinitionLocation {
+    pub(crate) range: DocRange,
+    /// `Some` when the definition lives in another file (external schema).
+    pub(crate) file_uri: Option<String>,
 }
 
-impl CompletionContext {
-    pub(crate) fn from_parser(v: syntaqlite_syntax::CompletionContext) -> Self {
-        match v {
-            syntaqlite_syntax::CompletionContext::Expression => Self::Expression,
-            syntaqlite_syntax::CompletionContext::TableRef => Self::TableRef,
-            syntaqlite_syntax::CompletionContext::Unknown => Self::Unknown,
+/// Result of a go-to-definition lookup.
+#[derive(Debug, Clone)]
+pub(crate) struct DefinitionResult {
+    pub(crate) origin: DocRange,
+    pub(crate) target: DefinitionLocation,
+}
+
+/// A symbol resolution recorded during the validation pass.
+#[derive(Debug, Clone)]
+pub(crate) enum ResolvedSymbol {
+    Table {
+        name: String,
+        columns: Option<Vec<String>>,
+        definition: Option<DefinitionLocation>,
+    },
+    Column {
+        column: String,
+        table: String,
+        all_columns: Vec<String>,
+        definition: Option<DefinitionLocation>,
+    },
+    Function {
+        category: String,
+        arities: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Resolution {
+    pub(crate) range: DocRange,
+    pub(crate) symbol: ResolvedSymbol,
+}
+
+/// Identity of a symbol for matching across resolutions.
+#[derive(Debug)]
+pub(crate) enum SymbolIdentity {
+    Table(String),
+    Column { table: String, column: String },
+}
+
+impl SymbolIdentity {
+    pub(crate) fn from_resolved(sym: &ResolvedSymbol) -> Option<Self> {
+        match sym {
+            ResolvedSymbol::Table { name, .. } => {
+                Some(SymbolIdentity::Table(name.to_ascii_lowercase()))
+            }
+            ResolvedSymbol::Column { column, table, .. } => Some(SymbolIdentity::Column {
+                table: table.to_ascii_lowercase(),
+                column: column.to_ascii_lowercase(),
+            }),
+            ResolvedSymbol::Function { .. } => None,
+        }
+    }
+
+    fn matches(&self, sym: &ResolvedSymbol) -> bool {
+        match (self, sym) {
+            (SymbolIdentity::Table(name), ResolvedSymbol::Table { name: n, .. }) => {
+                n.eq_ignore_ascii_case(name)
+            }
+            (
+                SymbolIdentity::Column { table, column },
+                ResolvedSymbol::Column {
+                    table: t,
+                    column: c,
+                    ..
+                },
+            ) => t.eq_ignore_ascii_case(table) && c.eq_ignore_ascii_case(column),
+            _ => false,
+        }
+    }
+
+    /// Key into `definition_offsets` for this symbol.
+    pub(crate) fn definition_key(&self) -> String {
+        match self {
+            SymbolIdentity::Table(name) => name.clone(),
+            SymbolIdentity::Column { table, column } => format!("{table}.{column}"),
         }
     }
 }
 
-/// Expected tokens and semantic context at a cursor position.
-#[derive(Debug)]
-pub(crate) struct CompletionInfo {
-    pub(crate) tokens: Vec<AnyTokenType>,
-    pub(crate) context: CompletionContext,
-    pub(crate) qualifier: Option<String>,
+// ── DocumentAnalysisData ──────────────────────────────────────────────────────
+
+/// Per-document bundle of everything LSP services query after analysis:
+/// tokens, comments, resolved references, definition sites. Populated by
+/// [`LspCapturePass`] during a semantic-analyzer pass.
+#[derive(Debug, Default)]
+pub(crate) struct DocumentAnalysisData {
+    pub(crate) tokens: Vec<StoredToken>,
+    pub(crate) comments: Vec<StoredComment>,
+    pub(crate) resolutions: Vec<Resolution>,
+    /// Maps `lowercase(name)` → `DocRange` for same-file definition sites.
+    /// Keys for columns look like `"table.column"` (lowercased).
+    pub(crate) definition_offsets: HashMap<String, DocRange>,
 }
 
-// ── External definition registry ─────────────────────────────────────────────
+impl DocumentAnalysisData {
+    pub(crate) fn semantic_tokens(&self, dialect: &AnyDialect) -> Vec<SemanticToken> {
+        let mut out = Vec::new();
+        for t in &self.tokens {
+            let cat = dialect.classify_token(t.token_type, t.flags);
+            if cat != TokenCategory::Other {
+                out.push(SemanticToken {
+                    offset: t.offset,
+                    length: t.length,
+                    category: cat,
+                });
+            }
+        }
+        for c in &self.comments {
+            out.push(SemanticToken {
+                offset: c.offset,
+                length: c.length,
+                category: TokenCategory::Comment,
+            });
+        }
+        out.sort_by_key(|t| t.offset);
+        out
+    }
+
+    /// The resolution whose span contains `offset`, if any.
+    pub(crate) fn resolution_at(&self, offset: DocOffset) -> Option<&Resolution> {
+        self.resolutions
+            .iter()
+            .find(|r| offset >= r.range.start && offset < r.range.end)
+    }
+
+    /// Find all resolutions in this document that match the given identity.
+    pub(crate) fn references_matching(&self, kind: &SymbolIdentity) -> Vec<DocRange> {
+        self.resolutions
+            .iter()
+            .filter(|r| kind.matches(&r.symbol))
+            .map(|r| r.range)
+            .collect()
+    }
+
+    /// Go-to-definition target for the resolution at `offset`, if any.
+    pub(crate) fn definition_at(&self, offset: DocOffset) -> Option<DefinitionResult> {
+        self.resolution_at(offset).and_then(|r| match &r.symbol {
+            ResolvedSymbol::Table { definition, .. }
+            | ResolvedSymbol::Column { definition, .. } => {
+                definition.as_ref().map(|d| DefinitionResult {
+                    origin: r.range,
+                    target: d.clone(),
+                })
+            }
+            ResolvedSymbol::Function { .. } => None,
+        })
+    }
+}
+
+// ── External definition registry ──────────────────────────────────────────────
 
 /// A definition site in a source file other than the one being analyzed
 /// (e.g. an external schema that was loaded via `from_ddl`).
@@ -132,9 +261,6 @@ impl ExternalDefinitions {
 
 /// Walk-time pass that fills a [`DocumentAnalysisData`] with everything LSP
 /// services need: resolved references, definition sites, tokens, comments.
-///
-/// The pass holds a reference to an optional external-definition registry so it
-/// can correlate resolutions with cross-file definition sites.
 pub(crate) struct LspCapturePass<'a> {
     pub(crate) data: DocumentAnalysisData,
     external: Option<&'a ExternalDefinitions>,

--- a/syntaqlite/src/lsp/completion_service.rs
+++ b/syntaqlite/src/lsp/completion_service.rs
@@ -15,7 +15,8 @@ use syntaqlite_syntax::util::is_suggestable_keyword;
 use crate::dialect::AnyDialect;
 use crate::semantic::Catalog;
 
-use super::analysis_data::CompletionContext;
+use crate::semantic::completion::CompletionContext;
+
 use super::{CompletionEntry, CompletionInfo, CompletionKind};
 
 /// Assemble completion items from the given completion info, dialect, and

--- a/syntaqlite/src/lsp/document_store.rs
+++ b/syntaqlite/src/lsp/document_store.rs
@@ -10,7 +10,9 @@
 
 use std::collections::HashMap;
 
-use crate::semantic::analysis::{DocumentAnalysisData, SemanticToken};
+use crate::semantic::analysis::SemanticToken;
+
+use super::analysis_data::DocumentAnalysisData;
 use crate::semantic::diagnostics::Diagnostic;
 
 /// A single open document with lazily populated analysis caches.

--- a/syntaqlite/src/lsp/host.rs
+++ b/syntaqlite/src/lsp/host.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use syntaqlite_syntax::any::TokenCategory;
-use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange, DocText};
+use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange};
 
 use crate::dialect::AnyDialect;
 use crate::fmt::FormatConfig;
@@ -15,9 +15,10 @@ use crate::semantic::ValidationConfig;
 use crate::semantic::analyzer::SemanticAnalyzer;
 use crate::semantic::diagnostics::Diagnostic;
 
-use crate::semantic::analysis::{DefinitionResult, SemanticToken, StoredToken, SymbolIdentity};
+use crate::semantic::analysis::SemanticToken;
+use crate::semantic::completion::{self, SignatureHelpInfo};
 
-use super::analysis_data::{ExternalDefinitions, LspCapturePass};
+use super::analysis_data::{DefinitionResult, ExternalDefinitions, LspCapturePass, SymbolIdentity};
 use super::document_store::{Document, DocumentStore};
 use super::{CompletionEntry, CompletionInfo};
 
@@ -370,12 +371,14 @@ impl LspHost {
             .documents
             .get(uri)
             .expect("ensure_model_for guarantees document exists");
-        super::completion::completion_info(
+        let analysis = doc
+            .analysis
+            .as_ref()
+            .expect("ensure_analysis sets analysis");
+        completion::completion_info(
             &self.analyzer.dialect(),
             &doc.source,
-            doc.analysis
-                .as_ref()
-                .expect("ensure_analysis sets analysis"),
+            &analysis.tokens,
             offset,
         )
     }
@@ -691,7 +694,8 @@ impl LspHost {
         // Walk backwards from offset to find enclosing `name(` and count commas.
         let cursor_byte = std::cmp::min(offset.as_usize(), source.len());
         let before = &source[..cursor_byte];
-        let (func_name, active_param) = find_enclosing_call(before, &data.tokens, &self.dialect)?;
+        let (func_name, active_param) =
+            completion::find_enclosing_call(before, &data.tokens, &self.dialect)?;
 
         let (_category, arities) = self.user_catalog.function_signature(&func_name)?;
 
@@ -879,68 +883,6 @@ fn utf16_len(bytes: &[u8]) -> u32 {
 }
 
 use super::utf8_char_len;
-
-// ── Hover/signature helpers ────────────────────────────────────────────────────
-
-use crate::semantic::catalog::AritySpec;
-
-/// Signature help result from the host.
-pub(crate) struct SignatureHelpInfo {
-    pub name: String,
-    pub arities: Vec<AritySpec>,
-    pub active_parameter: u32,
-}
-
-/// Walk backwards from cursor to find enclosing `func_name(` and count commas
-/// to determine active parameter index.
-fn find_enclosing_call(
-    before: &str,
-    tokens: &[StoredToken],
-    dialect: &AnyDialect,
-) -> Option<(String, u32)> {
-    let before_doc = DocText::new(before);
-    let bytes = before.as_bytes();
-    let mut depth: i32 = 0;
-    let mut commas: u32 = 0;
-    let mut pos = bytes.len();
-
-    // Scan backwards to find the matching `(`.
-    while pos > 0 {
-        pos -= 1;
-        match bytes[pos] {
-            b')' => depth += 1,
-            b'(' => {
-                if depth == 0 {
-                    // Found the opening paren — look for the function name token before it.
-                    let paren_offset = DocOffset::from_raw(u32::try_from(pos).unwrap_or(u32::MAX));
-                    let func_token = tokens.iter().rev().find(|t| {
-                        t.offset + t.length <= paren_offset
-                            && dialect.classify_token(t.token_type, t.flags)
-                                == TokenCategory::Function
-                    })?;
-                    // Make sure the function token is immediately before the paren
-                    // (only whitespace between).
-                    let tok_end = func_token.offset + func_token.length;
-                    let between = &before_doc[DocRange {
-                        start: tok_end,
-                        end: paren_offset,
-                    }];
-                    if between.trim().is_empty() {
-                        let name = before_doc
-                            [DocRange::from_offset_len(func_token.offset, func_token.length)]
-                        .to_string();
-                        return Some((name, commas));
-                    }
-                    return None;
-                }
-                depth -= 1;
-            }
-            b',' if depth == 0 => commas += 1,
-            _ => {}
-        }
-    }
-    None
-}
 
 // ── FormatError ───────────────────────────────────────────────────────────────
 

--- a/syntaqlite/src/lsp/hover_service.rs
+++ b/syntaqlite/src/lsp/hover_service.rs
@@ -10,7 +10,7 @@
 
 use syntaqlite_syntax::source::{DocOffset, DocRange};
 
-use crate::semantic::analysis::{
+use super::analysis_data::{
     DefinitionResult, DocumentAnalysisData, ResolvedSymbol, SymbolIdentity,
 };
 

--- a/syntaqlite/src/lsp/mod.rs
+++ b/syntaqlite/src/lsp/mod.rs
@@ -47,7 +47,7 @@ pub use host::SchemaMap;
 #[doc(inline)]
 pub use server::{LspConfig, LspServer};
 
-pub(crate) use analysis_data::{CompletionContext, CompletionInfo};
+pub(crate) use crate::semantic::completion::{CompletionContext, CompletionInfo};
 
 // ── LSP-specific types ──────────────────────────────────────────────────
 
@@ -116,7 +116,6 @@ impl CompletionKind {
 }
 
 mod analysis_data;
-mod completion;
 mod completion_service;
 mod document_store;
 mod host;

--- a/syntaqlite/src/semantic/analysis.rs
+++ b/syntaqlite/src/semantic/analysis.rs
@@ -1,25 +1,21 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-//! Outputs captured during a semantic-analyzer pass.
+//! Neutral analysis-time data captured by passes.
 //!
-//! The analyzer fires events through [`AnalysisObserver`](super::observer::AnalysisObserver);
-//! consumers — today the LSP host, tomorrow each composable analysis pass —
-//! collect those events into the data types defined here. Nothing in this
-//! module depends on LSP protocol machinery.
-
-use std::collections::HashMap;
+//! These types are the common currency between the walker, token-capturing
+//! passes, and higher-layer consumers. They carry no LSP-protocol shape —
+//! anything LSP-specific (resolved symbols, go-to-def targets, the cached
+//! document bundle) lives in `crate::lsp`.
 
 use syntaqlite_syntax::ParserTokenFlags;
 use syntaqlite_syntax::any::{AnyTokenType, TokenCategory};
-use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange};
-
-use crate::dialect::AnyDialect;
+use syntaqlite_syntax::source::{DocLen, DocOffset};
 
 // ── Token positions ──────────────────────────────────────────────────────────
 
-/// A parser token observed during analysis.
-#[derive(Debug, Clone)]
+/// A parser token captured during analysis.
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct StoredToken {
     pub(crate) offset: DocOffset,
     pub(crate) length: DocLen,
@@ -27,177 +23,17 @@ pub(crate) struct StoredToken {
     pub(crate) flags: ParserTokenFlags,
 }
 
-/// A comment observed during analysis.
-#[derive(Debug, Clone)]
+/// A comment captured during analysis.
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct StoredComment {
     pub(crate) offset: DocOffset,
     pub(crate) length: DocLen,
 }
 
-/// A token classified for editor syntax highlighting.
-#[derive(Debug, Clone)]
+/// A token classified for editor-style syntax highlighting.
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct SemanticToken {
     pub(crate) offset: DocOffset,
     pub(crate) length: DocLen,
     pub(crate) category: TokenCategory,
-}
-
-// ── Resolved symbols ─────────────────────────────────────────────────────────
-
-/// A definition site that a reference points to.
-#[derive(Debug, Clone)]
-pub(crate) struct DefinitionLocation {
-    pub(crate) range: DocRange,
-    /// `Some` when the definition lives in another file (external schema).
-    pub(crate) file_uri: Option<String>,
-}
-
-/// Result of a go-to-definition lookup.
-#[derive(Debug, Clone)]
-pub(crate) struct DefinitionResult {
-    pub(crate) origin: DocRange,
-    pub(crate) target: DefinitionLocation,
-}
-
-/// A symbol resolution recorded during the validation pass.
-#[derive(Debug, Clone)]
-pub(crate) enum ResolvedSymbol {
-    Table {
-        name: String,
-        columns: Option<Vec<String>>,
-        definition: Option<DefinitionLocation>,
-    },
-    Column {
-        column: String,
-        table: String,
-        all_columns: Vec<String>,
-        definition: Option<DefinitionLocation>,
-    },
-    Function {
-        category: String,
-        arities: Vec<String>,
-    },
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct Resolution {
-    pub(crate) range: DocRange,
-    pub(crate) symbol: ResolvedSymbol,
-}
-
-/// Identity of a symbol for matching across resolutions.
-#[derive(Debug)]
-pub(crate) enum SymbolIdentity {
-    Table(String),
-    Column { table: String, column: String },
-}
-
-impl SymbolIdentity {
-    pub(crate) fn from_resolved(sym: &ResolvedSymbol) -> Option<Self> {
-        match sym {
-            ResolvedSymbol::Table { name, .. } => {
-                Some(SymbolIdentity::Table(name.to_ascii_lowercase()))
-            }
-            ResolvedSymbol::Column { column, table, .. } => Some(SymbolIdentity::Column {
-                table: table.to_ascii_lowercase(),
-                column: column.to_ascii_lowercase(),
-            }),
-            ResolvedSymbol::Function { .. } => None,
-        }
-    }
-
-    fn matches(&self, sym: &ResolvedSymbol) -> bool {
-        match (self, sym) {
-            (SymbolIdentity::Table(name), ResolvedSymbol::Table { name: n, .. }) => {
-                n.eq_ignore_ascii_case(name)
-            }
-            (
-                SymbolIdentity::Column { table, column },
-                ResolvedSymbol::Column {
-                    table: t,
-                    column: c,
-                    ..
-                },
-            ) => t.eq_ignore_ascii_case(table) && c.eq_ignore_ascii_case(column),
-            _ => false,
-        }
-    }
-
-    /// Key into `definition_offsets` for this symbol.
-    pub(crate) fn definition_key(&self) -> String {
-        match self {
-            SymbolIdentity::Table(name) => name.clone(),
-            SymbolIdentity::Column { table, column } => format!("{table}.{column}"),
-        }
-    }
-}
-
-// ── DocumentAnalysisData ─────────────────────────────────────────────────────
-
-/// All the data captured during a single analysis pass that downstream
-/// consumers (editors, LSP services) query after the fact. Populated by an
-/// [`AnalysisObserver`](super::observer::AnalysisObserver) impl.
-#[derive(Debug, Default)]
-pub(crate) struct DocumentAnalysisData {
-    pub(crate) tokens: Vec<StoredToken>,
-    pub(crate) comments: Vec<StoredComment>,
-    pub(crate) resolutions: Vec<Resolution>,
-    /// Maps `lowercase(name)` → `DocRange` for same-file definition sites.
-    /// Keys for columns look like `"table.column"` (lowercased).
-    pub(crate) definition_offsets: HashMap<String, DocRange>,
-}
-
-impl DocumentAnalysisData {
-    pub(crate) fn semantic_tokens(&self, dialect: &AnyDialect) -> Vec<SemanticToken> {
-        let mut out = Vec::new();
-        for t in &self.tokens {
-            let cat = dialect.classify_token(t.token_type, t.flags);
-            if cat != TokenCategory::Other {
-                out.push(SemanticToken {
-                    offset: t.offset,
-                    length: t.length,
-                    category: cat,
-                });
-            }
-        }
-        for c in &self.comments {
-            out.push(SemanticToken {
-                offset: c.offset,
-                length: c.length,
-                category: TokenCategory::Comment,
-            });
-        }
-        out.sort_by_key(|t| t.offset);
-        out
-    }
-
-    /// The resolution whose span contains `offset`, if any.
-    pub(crate) fn resolution_at(&self, offset: DocOffset) -> Option<&Resolution> {
-        self.resolutions
-            .iter()
-            .find(|r| offset >= r.range.start && offset < r.range.end)
-    }
-
-    /// Find all resolutions in this document that match the given identity.
-    pub(crate) fn references_matching(&self, kind: &SymbolIdentity) -> Vec<DocRange> {
-        self.resolutions
-            .iter()
-            .filter(|r| kind.matches(&r.symbol))
-            .map(|r| r.range)
-            .collect()
-    }
-
-    /// Go-to-definition target for the resolution at `offset`, if any.
-    pub(crate) fn definition_at(&self, offset: DocOffset) -> Option<DefinitionResult> {
-        self.resolution_at(offset).and_then(|r| match &r.symbol {
-            ResolvedSymbol::Table { definition, .. }
-            | ResolvedSymbol::Column { definition, .. } => {
-                definition.as_ref().map(|d| DefinitionResult {
-                    origin: r.range,
-                    target: d.clone(),
-                })
-            }
-            ResolvedSymbol::Function { .. } => None,
-        })
-    }
 }

--- a/syntaqlite/src/semantic/completion.rs
+++ b/syntaqlite/src/semantic/completion.rs
@@ -1,14 +1,12 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-//! LSP-specific analysis helpers: semantic tokens, completion boundaries,
-//! qualifier detection, and expected-token computation.
+//! Parse-level probes for interactive tooling: completion and signature help.
 //!
-//! These operate on
-//! [`DocumentAnalysisData`](crate::semantic::analysis::DocumentAnalysisData)
-//! captured by [`LspObserver`](super::analysis_data::LspObserver) plus the
-//! dialect and are not part of semantic validation — they answer editor
-//! queries.
+//! These are neutral queries over a captured token stream + a source string.
+//! They do not depend on any LSP protocol machinery — the LSP layer assembles
+//! [`CompletionEntry`](crate::lsp::CompletionEntry) values from
+//! [`CompletionInfo`] separately.
 
 use std::collections::HashSet;
 
@@ -17,20 +15,47 @@ use syntaqlite_syntax::any::{AnyParser, AnyTokenType, TokenCategory};
 use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange, DocText};
 
 use crate::dialect::AnyDialect;
+use crate::semantic::analysis::StoredToken;
+use crate::semantic::catalog::AritySpec;
 
-use crate::semantic::analysis::{DocumentAnalysisData, StoredToken};
+// ── Completion ───────────────────────────────────────────────────────────────
 
-use super::analysis_data::{CompletionContext, CompletionInfo};
+/// Semantic completion context derived from parser stack state.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompletionContext {
+    Unknown = 0,
+    Expression = 1,
+    TableRef = 2,
+}
 
-/// Expected tokens and semantic context at `offset` (for completion).
+impl CompletionContext {
+    pub(crate) fn from_parser(v: syntaqlite_syntax::CompletionContext) -> Self {
+        match v {
+            syntaqlite_syntax::CompletionContext::Expression => Self::Expression,
+            syntaqlite_syntax::CompletionContext::TableRef => Self::TableRef,
+            syntaqlite_syntax::CompletionContext::Unknown => Self::Unknown,
+        }
+    }
+}
+
+/// Expected tokens and semantic context at a cursor position.
+#[derive(Debug)]
+pub(crate) struct CompletionInfo {
+    pub(crate) tokens: Vec<AnyTokenType>,
+    pub(crate) context: CompletionContext,
+    pub(crate) qualifier: Option<String>,
+}
+
+/// Expected tokens and semantic context at `offset`, derived by feeding the
+/// statement's tokens through an incremental parser up to the cursor.
 pub(crate) fn completion_info(
     dialect: &AnyDialect,
     source_text: &str,
-    data: &DocumentAnalysisData,
+    tokens: &[StoredToken],
     offset: DocOffset,
 ) -> CompletionInfo {
     let source = DocText::new(source_text);
-    let tokens = &data.tokens;
     let end_of_doc = source.byte_len();
     let doc_end = DocOffset::default() + end_of_doc;
     let cursor = if offset > doc_end { doc_end } else { offset };
@@ -159,6 +184,69 @@ fn merge_expected_tokens(into: &mut Vec<AnyTokenType>, extra: Vec<AnyTokenType>)
             into.push(token);
         }
     }
+}
+
+// ── Signature help ───────────────────────────────────────────────────────────
+
+/// Signature-help probe result: the enclosing function name, its arity
+/// overloads, and the active parameter index.
+pub(crate) struct SignatureHelpInfo {
+    pub(crate) name: String,
+    pub(crate) arities: Vec<AritySpec>,
+    pub(crate) active_parameter: u32,
+}
+
+/// Walk backwards from `before.len()` to find the enclosing `func_name(` and
+/// count commas at the outermost depth to determine the active parameter
+/// index. Returns `(function_name, active_parameter)` when the cursor is
+/// inside a call whose callee was classified as a `Function` token.
+pub(crate) fn find_enclosing_call(
+    before: &str,
+    tokens: &[StoredToken],
+    dialect: &AnyDialect,
+) -> Option<(String, u32)> {
+    let before_doc = DocText::new(before);
+    let bytes = before.as_bytes();
+    let mut depth: i32 = 0;
+    let mut commas: u32 = 0;
+    let mut pos = bytes.len();
+
+    // Scan backwards to find the matching `(`.
+    while pos > 0 {
+        pos -= 1;
+        match bytes[pos] {
+            b')' => depth += 1,
+            b'(' => {
+                if depth == 0 {
+                    // Found the opening paren — look for the function name token before it.
+                    let paren_offset = DocOffset::from_raw(u32::try_from(pos).unwrap_or(u32::MAX));
+                    let func_token = tokens.iter().rev().find(|t| {
+                        t.offset + t.length <= paren_offset
+                            && dialect.classify_token(t.token_type, t.flags)
+                                == TokenCategory::Function
+                    })?;
+                    // Make sure the function token is immediately before the paren
+                    // (only whitespace between).
+                    let tok_end = func_token.offset + func_token.length;
+                    let between = &before_doc[DocRange {
+                        start: tok_end,
+                        end: paren_offset,
+                    }];
+                    if between.trim().is_empty() {
+                        let name = before_doc
+                            [DocRange::from_offset_len(func_token.offset, func_token.length)]
+                        .to_string();
+                        return Some((name, commas));
+                    }
+                    return None;
+                }
+                depth -= 1;
+            }
+            b',' if depth == 0 => commas += 1,
+            _ => {}
+        }
+    }
+    None
 }
 
 #[cfg(test)]

--- a/syntaqlite/src/semantic/mod.rs
+++ b/syntaqlite/src/semantic/mod.rs
@@ -42,12 +42,14 @@
 //! assert!(model.has_diagnostics());
 //! ```
 
-#[cfg(feature = "lsp")]
+#[cfg(feature = "validation")]
 pub(crate) mod analysis;
 #[cfg(feature = "validation")]
 pub(crate) mod analyzer;
 #[cfg(feature = "validation")]
 pub(crate) mod catalog;
+#[cfg(feature = "validation")]
+pub(crate) mod completion;
 #[cfg(feature = "validation")]
 pub(crate) mod ddl;
 pub(crate) mod diagnostics;


### PR DESCRIPTION
Fifth step of the pass-based refactor. The completion-boundary and
signature-help logic isn't LSP-specific — it's a parse-level probe
over a captured token stream. Moving it into semantic puts it where
other interactive frontends (CLI REPL, embedded editor) can reuse it,
and makes LSP genuinely thin over semantic.

Also fixes a layering violation the previous step left behind:
semantic::analysis was feature-gated on "lsp" because it held
LSP-shaped types (Resolution, DocumentAnalysisData, SymbolIdentity).
Those types are moved back to lsp/analysis_data.rs where they
belong; semantic::analysis now holds only neutral token types
(StoredToken, StoredComment, SemanticToken) and is gated on
"validation" like the rest of semantic.

- new semantic::completion module holds CompletionContext,
  CompletionInfo, completion_info() + helpers, SignatureHelpInfo,
  find_enclosing_call
- completion_info now takes `tokens: &[StoredToken]` directly
  instead of threading through DocumentAnalysisData, decoupling it
  from the LSP bundle shape
- semantic::analysis slimmed to StoredToken + StoredComment +
  SemanticToken only; un-gated from "lsp" to "validation"
- DefinitionLocation / DefinitionResult / ResolvedSymbol /
  Resolution / SymbolIdentity / DocumentAnalysisData relocated
  back to lsp/analysis_data.rs (that's the layer that cares about
  their shape)
- lsp/completion.rs deleted
- LSP SignatureHelpInfo + find_enclosing_call removed from host.rs;
  host now calls semantic::completion::* directly

No behavior change. 244 unit + 34 doctests + 25 integration tests
pass on --features lsp.

