### PR TITLE
synq: declarative Python diff tests for the LSP

### DIFF
--- a/python/dev/diff_tests/lsp_client.py
+++ b/python/dev/diff_tests/lsp_client.py
@@ -1,0 +1,153 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Minimal JSON-RPC client for driving the syntaqlite LSP server over stdio.
+
+Shared between the RPC integration suite (`suites/lsp.py`) and the declarative
+diff-test suite (`suites/lsp_diff.py`).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+
+class LspClient:
+    """Tiny JSON-RPC client that talks to an LSP server over stdin/stdout."""
+
+    def __init__(self, proc: subprocess.Popen[bytes]):
+        self._proc = proc
+        self._id = 0
+
+    def send_request(self, method: str, params: Any = None) -> Any:
+        self._id += 1
+        msg: dict[str, Any] = {"jsonrpc": "2.0", "id": self._id, "method": method}
+        if params is not None:
+            msg["params"] = params
+        self._write(msg)
+        return self._read_response(self._id)
+
+    def send_notification(self, method: str, params: Any = None) -> None:
+        msg: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            msg["params"] = params
+        self._write(msg)
+
+    def collect_diagnostics(
+        self,
+        timeout: float = 5.0,
+        uri: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Read notifications until we get publishDiagnostics or timeout.
+
+        When `uri` is given, publishDiagnostics notifications for other
+        documents are skipped — important when one client serves multiple
+        tests in sequence and stale notifications linger in the pipe.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            msg = self._read_message(timeout=deadline - time.monotonic())
+            if msg is None:
+                continue
+            if msg.get("method") != "textDocument/publishDiagnostics":
+                continue
+            params = msg.get("params", {})
+            if uri is not None and params.get("uri") != uri:
+                continue
+            return params.get("diagnostics", [])
+        return []
+
+    def shutdown(self) -> None:
+        try:
+            self.send_request("shutdown")
+            self.send_notification("exit")
+        except (BrokenPipeError, OSError):
+            pass
+        self._proc.wait(timeout=5)
+
+    # ── Wire protocol ────────────────────────────────────────────────────
+
+    def _write(self, msg: dict[str, Any]) -> None:
+        body = json.dumps(msg).encode("utf-8")
+        header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+        assert self._proc.stdin is not None
+        self._proc.stdin.write(header + body)
+        self._proc.stdin.flush()
+
+    def _read_message(self, timeout: float = 5.0) -> dict[str, Any] | None:
+        import select
+
+        assert self._proc.stdout is not None
+        fd = self._proc.stdout.fileno()
+
+        ready, _, _ = select.select([fd], [], [], timeout)
+        if not ready:
+            return None
+
+        header = b""
+        while b"\r\n\r\n" not in header:
+            ready, _, _ = select.select([fd], [], [], 2.0)
+            if not ready:
+                return None
+            chunk = self._proc.stdout.read(1)
+            if not chunk:
+                return None
+            header += chunk
+
+        length = 0
+        for line in header.split(b"\r\n"):
+            if line.startswith(b"Content-Length:"):
+                length = int(line.split(b":")[1].strip())
+
+        if length == 0:
+            return None
+
+        body = b""
+        while len(body) < length:
+            chunk = self._proc.stdout.read(length - len(body))
+            if not chunk:
+                return None
+            body += chunk
+
+        return json.loads(body.decode("utf-8"))
+
+    def _read_response(self, req_id: int) -> Any:
+        """Read messages until we find the response matching req_id."""
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            msg = self._read_message(timeout=deadline - time.monotonic())
+            if msg is None:
+                continue
+            if msg.get("id") == req_id:
+                if "error" in msg:
+                    raise RuntimeError(f"LSP error: {msg['error']}")
+                return msg.get("result")
+        raise TimeoutError(f"No response for request id={req_id}")
+
+
+def spawn_lsp(binary: Path, init_options: dict[str, Any] | None = None) -> LspClient:
+    """Spawn the LSP server and complete the initialize handshake."""
+    proc = subprocess.Popen(
+        [str(binary), "--no-config", "lsp"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        bufsize=0,
+    )
+    client = LspClient(proc)
+
+    init_params: dict[str, Any] = {
+        "processId": None,
+        "capabilities": {},
+        "rootUri": None,
+    }
+    if init_options is not None:
+        init_params["initializationOptions"] = init_options
+
+    client.send_request("initialize", init_params)
+    client.send_notification("initialized", {})
+    return client

--- a/python/dev/diff_tests/lsp_executor.py
+++ b/python/dev/diff_tests/lsp_executor.py
@@ -1,0 +1,334 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Execute a single LSP diff-test blueprint against a running LSP server.
+
+The test's SQL carries a `<|>` cursor marker. The marker is stripped, the
+document is opened, the requested operation runs at the cursor position, and
+the JSON-RPC response is rendered to deterministic text for comparison.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from python.dev.diff_tests.lsp_client import LspClient
+from python.dev.diff_tests.test_executor import TestResult, normalize_output
+from python.dev.diff_tests.testing import LspDiffTestBlueprint
+
+CURSOR_MARKER = "<|>"
+
+# Completion item kinds emitted by the syntaqlite LSP (see lsp/server.rs).
+# We tag entries with these names and use them for sort ordering so the
+# rendered output is deterministic.
+_KIND_NAMES: dict[int, str] = {
+    14: "keyword",
+    3: "function",
+    22: "table",
+    5: "column",
+}
+
+# Column completions first, then tables, then keywords, then functions
+# (matches `CompletionKind::sort_priority` in the Rust side so the rendered
+# order is stable across either dispatch path).
+_KIND_ORDER: dict[str, int] = {
+    "column": 0,
+    "table": 1,
+    "keyword": 2,
+    "function": 3,
+}
+
+
+def _split_cursor(sql: str, required: bool = True) -> tuple[str, int, int]:
+    """Strip the cursor marker and return (text, line, character).
+
+    `character` is a 0-indexed column assuming ASCII (one byte per char),
+    matching how the LSP source_map converts positions for the tests here.
+    When `required` is False and no marker is present, returns the original
+    text with position (0, 0); used for ops like `diagnostics` that don't
+    need a cursor.
+    """
+    idx = sql.find(CURSOR_MARKER)
+    if idx < 0:
+        if required:
+            raise ValueError(f"sql missing cursor marker {CURSOR_MARKER!r}")
+        return sql, 0, 0
+    if sql.find(CURSOR_MARKER, idx + len(CURSOR_MARKER)) >= 0:
+        raise ValueError(f"sql contains multiple cursor markers {CURSOR_MARKER!r}")
+    before = sql[:idx]
+    line = before.count("\n")
+    last_nl = before.rfind("\n")
+    character = len(before) - (last_nl + 1) if last_nl >= 0 else len(before)
+    text = before + sql[idx + len(CURSOR_MARKER):]
+    return text, line, character
+
+
+def _render_hover(result: Any) -> str:
+    if result is None:
+        return "(no hover)"
+    contents = result.get("contents")
+    if isinstance(contents, dict):
+        # MarkupContent: { kind, value }
+        return str(contents.get("value", ""))
+    if isinstance(contents, str):
+        return contents
+    if isinstance(contents, list):
+        parts: list[str] = []
+        for item in contents:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                parts.append(str(item.get("value", "")))
+        return "\n".join(parts)
+    return str(contents)
+
+
+def _fmt_range(r: dict[str, Any]) -> str:
+    start = r["start"]
+    end = r["end"]
+    return f"{start['line']}:{start['character']}..{end['line']}:{end['character']}"
+
+
+def _render_definition(result: Any, own_uri: str) -> str:
+    if result is None:
+        return "(no definition)"
+    locations: list[dict[str, Any]]
+    if isinstance(result, list):
+        locations = result
+    else:
+        locations = [result]
+    lines: list[str] = []
+    for loc in locations:
+        uri = loc.get("uri") or loc.get("targetUri", "")
+        rng = loc.get("range") or loc.get("targetRange")
+        if rng is None:
+            continue
+        # Omit URI when the target is in the same document (the common case);
+        # include it only when go-to-def crosses files.
+        if uri == own_uri:
+            lines.append(f"target: {_fmt_range(rng)}")
+        else:
+            lines.append(f"target: {uri}:{_fmt_range(rng)}")
+    return "\n".join(lines) if lines else "(no definition)"
+
+
+def _render_references(result: Any, own_uri: str) -> str:
+    if result is None:
+        return "(no references)"
+    if not isinstance(result, list):
+        return "(no references)"
+    lines: list[str] = []
+    for loc in result:
+        uri = loc.get("uri", "")
+        rng = loc.get("range")
+        if rng is None:
+            continue
+        if uri == own_uri:
+            lines.append(_fmt_range(rng))
+        else:
+            lines.append(f"{uri}:{_fmt_range(rng)}")
+    if not lines:
+        return "(no references)"
+    lines.sort()
+    return "\n".join(lines)
+
+
+def _render_prepare_rename(result: Any) -> str:
+    if result is None:
+        return "(no rename)"
+    if isinstance(result, dict):
+        rng = result.get("range") or result
+        placeholder = result.get("placeholder", "")
+        if "start" in rng and "end" in rng:
+            suffix = f' "{placeholder}"' if placeholder else ""
+            return f"{_fmt_range(rng)}{suffix}"
+    return "(no rename)"
+
+
+def _render_rename(result: Any, own_uri: str) -> str:
+    if result is None:
+        return "(no rename)"
+    changes = result.get("changes") if isinstance(result, dict) else None
+    if not changes:
+        return "(no rename)"
+    lines: list[str] = []
+    for edit_uri, edits in changes.items():
+        for edit in edits:
+            rng = edit.get("range")
+            new_text = edit.get("newText", "")
+            if rng is None:
+                continue
+            location = (
+                _fmt_range(rng)
+                if edit_uri == own_uri
+                else f"{edit_uri}:{_fmt_range(rng)}"
+            )
+            lines.append(f'{location} -> "{new_text}"')
+    if not lines:
+        return "(no rename)"
+    lines.sort()
+    return "\n".join(lines)
+
+
+_SEVERITY_NAMES: dict[int, str] = {1: "error", 2: "warning", 3: "info", 4: "hint"}
+
+
+def _render_diagnostics(diags: list[dict[str, Any]]) -> str:
+    if not diags:
+        return "(no diagnostics)"
+    lines: list[str] = []
+    for d in diags:
+        sev = _SEVERITY_NAMES.get(d.get("severity", 0), "unknown")
+        rng = d.get("range")
+        msg = d.get("message", "")
+        if rng is None:
+            continue
+        lines.append(f"{sev} {_fmt_range(rng)}: {msg}")
+    lines.sort()
+    return "\n".join(lines)
+
+
+def _render_completion(result: Any) -> str:
+    if result is None:
+        return "(no completions)"
+    items: list[dict[str, Any]]
+    if isinstance(result, dict) and "items" in result:
+        items = result["items"]
+    elif isinstance(result, list):
+        items = result
+    else:
+        items = []
+    if not items:
+        return "(no completions)"
+    rows: list[tuple[int, str, str]] = []
+    for item in items:
+        kind_name = _KIND_NAMES.get(item.get("kind", 0), "other")
+        label = item.get("label", "")
+        rows.append((_KIND_ORDER.get(kind_name, 99), kind_name, label))
+    rows.sort(key=lambda r: (r[0], r[1], r[2]))
+    return "\n".join(f"{kind}: {label}" for _, kind, label in rows)
+
+
+def _test_uri(name: str) -> str:
+    """Deterministic document URI for a test, derived from its name."""
+    return f"file:///test/{name.replace('.', '/')}.sql"
+
+
+def _open_and_run(
+    client: LspClient,
+    name: str,
+    blueprint: LspDiffTestBlueprint,
+) -> str:
+    """Open a fresh document for this test, run the op, render output."""
+    cursor_required = blueprint.op != "diagnostics"
+    text, line, character = _split_cursor(blueprint.sql, required=cursor_required)
+    uri = _test_uri(name)
+
+    client.send_notification(
+        "textDocument/didOpen",
+        {
+            "textDocument": {
+                "uri": uri,
+                "languageId": "sql",
+                "version": 1,
+                "text": text,
+            },
+        },
+    )
+
+    position = {"line": line, "character": character}
+    op = blueprint.op
+
+    if op == "hover":
+        result = client.send_request(
+            "textDocument/hover",
+            {"textDocument": {"uri": uri}, "position": position},
+        )
+        rendered = _render_hover(result)
+    elif op == "definition":
+        result = client.send_request(
+            "textDocument/definition",
+            {"textDocument": {"uri": uri}, "position": position},
+        )
+        rendered = _render_definition(result, uri)
+    elif op == "completion":
+        result = client.send_request(
+            "textDocument/completion",
+            {"textDocument": {"uri": uri}, "position": position},
+        )
+        rendered = _render_completion(result)
+    elif op == "references":
+        result = client.send_request(
+            "textDocument/references",
+            {
+                "textDocument": {"uri": uri},
+                "position": position,
+                "context": {"includeDeclaration": blueprint.include_declaration},
+            },
+        )
+        rendered = _render_references(result, uri)
+    elif op == "prepare-rename":
+        result = client.send_request(
+            "textDocument/prepareRename",
+            {"textDocument": {"uri": uri}, "position": position},
+        )
+        rendered = _render_prepare_rename(result)
+    elif op == "rename":
+        if blueprint.new_name is None:
+            raise ValueError("rename op requires new_name on the blueprint")
+        result = client.send_request(
+            "textDocument/rename",
+            {
+                "textDocument": {"uri": uri},
+                "position": position,
+                "newName": blueprint.new_name,
+            },
+        )
+        rendered = _render_rename(result, uri)
+    elif op == "diagnostics":
+        # Collect the publishDiagnostics notification that the server sends
+        # after didOpen. The cursor position is ignored for this op.
+        # Filter by URI so stale notifications from earlier tests (one
+        # LSP process serves the whole suite) are discarded.
+        diags = client.collect_diagnostics(uri=uri)
+        rendered = _render_diagnostics(diags)
+    else:
+        raise ValueError(f"unsupported op: {op!r}")
+
+    client.send_notification(
+        "textDocument/didClose",
+        {"textDocument": {"uri": uri}},
+    )
+    return rendered
+
+
+def execute_lsp_test(
+    client: LspClient,
+    name: str,
+    blueprint: LspDiffTestBlueprint,
+) -> TestResult:
+    t0 = time.monotonic()
+    try:
+        actual_raw = _open_and_run(client, name, blueprint)
+    except Exception as e:  # noqa: BLE001
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        return TestResult(
+            name=name,
+            passed=False,
+            elapsed_ms=elapsed_ms,
+            error=f"{type(e).__name__}: {e}",
+            sql=blueprint.sql,
+        )
+    elapsed_ms = int((time.monotonic() - t0) * 1000)
+    actual = normalize_output(actual_raw)
+    expected = normalize_output(blueprint.out)
+    return TestResult(
+        name=name,
+        passed=(actual == expected),
+        elapsed_ms=elapsed_ms,
+        actual=actual,
+        expected=expected,
+        sql=blueprint.sql,
+    )

--- a/python/dev/diff_tests/lsp_runner.py
+++ b/python/dev/diff_tests/lsp_runner.py
@@ -1,0 +1,215 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Main entry point for LSP declarative diff tests.
+
+Loads `LspDiffTestBlueprint` instances from a test directory, drives them
+serially against a single spawned LSP server, and either reports diffs or
+rewrites expected outputs in-place when `--rebaseline` is given.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import importlib
+import inspect
+import sys
+import time
+from glob import glob as _glob
+from pathlib import Path
+
+from python.dev.diff_tests.lsp_client import spawn_lsp
+from python.dev.diff_tests.lsp_executor import execute_lsp_test
+from python.dev.diff_tests.runner import (
+    _rewrite_test_file,
+    print_failed,
+    print_failure_details,
+    print_ok,
+    print_run,
+)
+from python.dev.diff_tests.test_executor import TestResult
+from python.dev.diff_tests.testing import LspDiffTestBlueprint, TestSuite
+from python.dev.diff_tests.utils import Colors, colorize
+
+
+def _load_tests(
+    root_dir: Path,
+    test_dir: str,
+    filter_pattern: str | None,
+) -> list[tuple[str, LspDiffTestBlueprint]]:
+    test_base = root_dir / test_dir
+    tests: list[tuple[str, LspDiffTestBlueprint]] = []
+    for test_file in sorted(_glob(str(test_base / "*.py"))):
+        path = Path(test_file)
+        if path.name == "__init__.py":
+            continue
+        relative = path.relative_to(root_dir)
+        module_name = str(relative.with_suffix("")).replace("/", ".")
+        module = importlib.import_module(module_name)
+        for _, obj in inspect.getmembers(module, inspect.isclass):
+            if not (issubclass(obj, TestSuite) and obj is not TestSuite):
+                continue
+            suite_instance = obj()
+            for name, blueprint in suite_instance.fetch():
+                if isinstance(blueprint, LspDiffTestBlueprint):
+                    if filter_pattern is None or fnmatch.fnmatch(
+                        name, filter_pattern
+                    ):
+                        tests.append((name, blueprint))
+    return tests
+
+
+def _apply_rebaseline(
+    root_dir: Path,
+    test_dir: str,
+    results: list[TestResult],
+) -> None:
+    updates = {r.name: r.actual for r in results if not r.passed and not r.error and r.actual}
+    if not updates:
+        return
+
+    test_base = root_dir / test_dir
+    file_updates: dict[str, list] = {}
+
+    for test_file in sorted(_glob(str(test_base / "*.py"))):
+        path = Path(test_file)
+        if path.name == "__init__.py":
+            continue
+        relative = path.relative_to(root_dir)
+        module_name = str(relative.with_suffix("")).replace("/", ".")
+        module = importlib.import_module(module_name)
+        for _, obj in inspect.getmembers(module, inspect.isclass):
+            if not (issubclass(obj, TestSuite) and obj is not TestSuite):
+                continue
+            for attr in dir(obj):
+                if not attr.startswith("test_"):
+                    continue
+                test_name = f"{obj.__name__}.{attr[5:]}"
+                if test_name not in updates:
+                    continue
+                method = getattr(obj, attr)
+                src_file = inspect.getsourcefile(method)
+                file_updates.setdefault(src_file, []).append(
+                    (method, updates[test_name])
+                )
+
+    rebaselined = 0
+    for src_file, method_updates in file_updates.items():
+        rebaselined += _rewrite_test_file(src_file, method_updates)
+    print(f"Rebaselined {rebaselined} test(s) in {len(file_updates)} file(s).")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run LSP diff tests")
+    parser.add_argument(
+        "--binary",
+        default="target/debug/syntaqlite",
+        help="Path to syntaqlite binary",
+    )
+    parser.add_argument("--filter", help="Run only tests matching glob pattern")
+    parser.add_argument(
+        "--rebaseline",
+        action="store_true",
+        help="Rewrite expected output for failures",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase verbosity (-v for results, -vv for RUN markers)",
+    )
+    parser.add_argument("--root", default=None, help="Project root directory")
+    parser.add_argument(
+        "--test-dir",
+        default="tests/lsp_diff_tests",
+        help="Relative path to test directory",
+    )
+    args = parser.parse_args(argv)
+
+    if args.root:
+        root_dir = Path(args.root)
+    else:
+        root_dir = Path(__file__).parent.parent.parent.parent
+        if not (root_dir / "Cargo.toml").exists():
+            print("Error: Could not find project root.", file=sys.stderr)
+            return 1
+
+    binary = Path(args.binary)
+    if not binary.is_absolute():
+        binary = root_dir / binary
+
+    try:
+        tests = _load_tests(root_dir, args.test_dir, args.filter)
+    except ImportError as e:
+        print(f"Error loading tests: {e}", file=sys.stderr)
+        return 1
+
+    if not tests:
+        print("No tests to run.")
+        return 0
+
+    suites = set(name.split(".")[0] for name, _ in tests)
+    verbosity = args.verbose
+
+    if verbosity >= 1:
+        print(
+            f"[==========] Running {len(tests)} tests from {len(suites)} test suites."
+        )
+
+    # One LSP subprocess serves all tests; each test uses a unique URI and
+    # closes its document afterwards, so state doesn't bleed.
+    client = spawn_lsp(binary)
+    start_time = time.time()
+    results: list[TestResult] = []
+    failed_tests: list[str] = []
+
+    try:
+        for name, blueprint in tests:
+            if verbosity >= 2:
+                print_run(name)
+            result = execute_lsp_test(client, name, blueprint)
+            results.append(result)
+            if result.passed:
+                if verbosity >= 1:
+                    print_ok(result.name, result.elapsed_ms)
+            else:
+                if verbosity >= 1:
+                    print_failed(result.name, result.elapsed_ms)
+                if not args.rebaseline:
+                    print_failure_details(result)
+                failed_tests.append(result.name)
+    finally:
+        client.shutdown()
+
+    elapsed_ms = int((time.time() - start_time) * 1000)
+    passed = sum(1 for r in results if r.passed)
+    failed = len(failed_tests)
+
+    if verbosity >= 1:
+        print(
+            f"[==========] {len(results)} tests from {len(suites)} test suites ran. "
+            f"({elapsed_ms} ms total)"
+        )
+
+    if passed > 0:
+        msg = colorize("[  PASSED  ]", Colors.GREEN)
+        print(f"{msg} {passed} tests.")
+
+    if failed > 0:
+        if args.rebaseline:
+            _apply_rebaseline(root_dir, args.test_dir, results)
+            return 0
+        msg = colorize("[  FAILED  ]", Colors.RED)
+        print(f"{msg} {failed} tests, listed below:")
+        for name in failed_tests:
+            print(f"{msg} {name}")
+        print()
+        print(f" {failed} FAILED TESTS")
+
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/dev/diff_tests/testing.py
+++ b/python/dev/diff_tests/testing.py
@@ -27,6 +27,35 @@ class DiffTestBlueprint:
     strict_schema: bool = False
 
 
+@dataclass
+class LspDiffTestBlueprint:
+    """Defines a single LSP diff test.
+
+    The query is driven against the real `syntaqlite lsp` server over
+    JSON-RPC. The response is rendered to deterministic text and compared
+    against `out`.
+
+    Attributes:
+        sql: SQL opened as the document. Must contain exactly one cursor
+             marker `<|>` indicating where the LSP query runs. The marker
+             is stripped before the document is sent. Any schema DDL that
+             the test needs can be included inline in this SQL (CREATE
+             TABLE, CREATE VIEW, WITH binding, etc.) — the LSP host
+             analyzes it as part of the document.
+        op: One of "hover", "definition", "completion", "references",
+            "prepare-rename", "rename", "diagnostics".
+        out: Expected rendered output.
+        new_name: New symbol name (required for op="rename").
+        include_declaration: When true (default), find-references includes
+            the symbol's definition site.
+    """
+    sql: str
+    op: str
+    out: str
+    new_name: Optional[str] = None
+    include_declaration: bool = True
+
+
 class TestSuite:
     """Base class for test suites.
 
@@ -43,13 +72,13 @@ class TestSuite:
                 )
     """
 
-    def fetch(self) -> List[Tuple[str, DiffTestBlueprint]]:
+    def fetch(self) -> List[Tuple[str, object]]:
         """Discover and return all test methods.
 
         Returns:
-            List of (test_name, blueprint) tuples.
-            Test names are formatted as "ClassName#method_name" where
-            method_name has the "test_" prefix stripped.
+            List of (test_name, blueprint) tuples. The blueprint is any
+            recognized `*TestBlueprint` dataclass; the test runner dispatches
+            on type.
         """
         tests = []
         for name in sorted(dir(self)):
@@ -57,7 +86,7 @@ class TestSuite:
                 method = getattr(self, name)
                 if callable(method):
                     blueprint = method()
-                    if isinstance(blueprint, DiffTestBlueprint):
+                    if isinstance(blueprint, (DiffTestBlueprint, LspDiffTestBlueprint)):
                         # Format: ClassName.method_name (without test_ prefix)
                         test_name = f"{self.__class__.__name__}.{name[5:]}"
                         tests.append((test_name, blueprint))

--- a/python/dev/integration_tests/runner.py
+++ b/python/dev/integration_tests/runner.py
@@ -38,6 +38,7 @@ _SUITE_MODULES = [
     "python.dev.integration_tests.suites.sql_idempotency",
     "python.dev.integration_tests.suites.upstream_sqlite",
     "python.dev.integration_tests.suites.lsp",
+    "python.dev.integration_tests.suites.lsp_diff",
     "python.dev.integration_tests.suites.validate",
     "python.dev.integration_tests.suites.semantic",
     "python.dev.integration_tests.suites.lineage",

--- a/python/dev/integration_tests/suites/lsp.py
+++ b/python/dev/integration_tests/suites/lsp.py
@@ -9,147 +9,17 @@ stdio to verify schema loading and diagnostic behaviour.
 
 from __future__ import annotations
 
-import json
 import shutil
 import subprocess
-import sys
 import tempfile
-import time
 from pathlib import Path
 from typing import Any
 
+from python.dev.diff_tests.lsp_client import LspClient, spawn_lsp
 from python.dev.integration_tests.suite import SuiteContext
 
 NAME = "lsp"
 DESCRIPTION = "LSP server integration tests (schema loading, diagnostics)"
-
-
-# ── Minimal LSP JSON-RPC client ──────────────────────────────────────────
-
-class LspClient:
-    """Tiny JSON-RPC client that talks to an LSP server over stdin/stdout."""
-
-    def __init__(self, proc: subprocess.Popen[bytes]):
-        self._proc = proc
-        self._id = 0
-
-    def send_request(self, method: str, params: Any = None) -> Any:
-        self._id += 1
-        msg: dict[str, Any] = {"jsonrpc": "2.0", "id": self._id, "method": method}
-        if params is not None:
-            msg["params"] = params
-        self._write(msg)
-        return self._read_response(self._id)
-
-    def send_notification(self, method: str, params: Any = None) -> None:
-        msg: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
-        if params is not None:
-            msg["params"] = params
-        self._write(msg)
-
-    def collect_diagnostics(self, timeout: float = 5.0) -> list[dict[str, Any]]:
-        """Read notifications until we get publishDiagnostics or timeout."""
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            msg = self._read_message(timeout=deadline - time.monotonic())
-            if msg is None:
-                continue
-            if msg.get("method") == "textDocument/publishDiagnostics":
-                return msg.get("params", {}).get("diagnostics", [])
-        return []
-
-    def shutdown(self) -> None:
-        try:
-            self.send_request("shutdown")
-            self.send_notification("exit")
-        except (BrokenPipeError, OSError):
-            pass
-        self._proc.wait(timeout=5)
-
-    # ── Wire protocol ────────────────────────────────────────────────────
-
-    def _write(self, msg: dict[str, Any]) -> None:
-        body = json.dumps(msg).encode("utf-8")
-        header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
-        assert self._proc.stdin is not None
-        self._proc.stdin.write(header + body)
-        self._proc.stdin.flush()
-
-    def _read_message(self, timeout: float = 5.0) -> dict[str, Any] | None:
-        import select
-
-        assert self._proc.stdout is not None
-        fd = self._proc.stdout.fileno()
-
-        # Wait for data to be available.
-        ready, _, _ = select.select([fd], [], [], timeout)
-        if not ready:
-            return None
-
-        # Read Content-Length header.
-        header = b""
-        while b"\r\n\r\n" not in header:
-            ready, _, _ = select.select([fd], [], [], 2.0)
-            if not ready:
-                return None
-            chunk = self._proc.stdout.read(1)
-            if not chunk:
-                return None
-            header += chunk
-
-        length = 0
-        for line in header.split(b"\r\n"):
-            if line.startswith(b"Content-Length:"):
-                length = int(line.split(b":")[1].strip())
-
-        if length == 0:
-            return None
-
-        body = b""
-        while len(body) < length:
-            chunk = self._proc.stdout.read(length - len(body))
-            if not chunk:
-                return None
-            body += chunk
-
-        return json.loads(body.decode("utf-8"))
-
-    def _read_response(self, req_id: int) -> Any:
-        """Read messages until we find the response matching req_id."""
-        deadline = time.monotonic() + 10.0
-        while time.monotonic() < deadline:
-            msg = self._read_message(timeout=deadline - time.monotonic())
-            if msg is None:
-                continue
-            if msg.get("id") == req_id:
-                if "error" in msg:
-                    raise RuntimeError(f"LSP error: {msg['error']}")
-                return msg.get("result")
-        raise TimeoutError(f"No response for request id={req_id}")
-
-
-def _spawn_lsp(binary: Path, init_options: dict[str, Any] | None = None) -> LspClient:
-    """Spawn the LSP server and complete the initialize handshake."""
-    proc = subprocess.Popen(
-        [str(binary), "--no-config", "lsp"],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        bufsize=0,
-    )
-    client = LspClient(proc)
-
-    init_params: dict[str, Any] = {
-        "processId": None,
-        "capabilities": {},
-        "rootUri": None,
-    }
-    if init_options is not None:
-        init_params["initializationOptions"] = init_options
-
-    client.send_request("initialize", init_params)
-    client.send_notification("initialized", {})
-    return client
 
 
 def _open_and_get_diagnostics(
@@ -189,7 +59,7 @@ def _test_schema_from_ddl(ctx: SuiteContext) -> bool:
     schema_file = ctx.root_dir / "tests" / "lsp_tests" / "schema.sql"
     query_text = (ctx.root_dir / "tests" / "lsp_tests" / "query.sql").read_text()
 
-    client = _spawn_lsp(ctx.binary, {"schemaPath": str(schema_file)})
+    client = spawn_lsp(ctx.binary, {"schemaPath": str(schema_file)})
     try:
         diags = _open_and_get_diagnostics(client, "file:///test.sql", query_text)
         # Filter to only error-severity diagnostics about unknown tables/columns.
@@ -207,7 +77,7 @@ def _test_no_schema_warns(ctx: SuiteContext) -> bool:
     """Without schemaPath, SELECT from unknown table should emit a diagnostic."""
     query_text = (ctx.root_dir / "tests" / "lsp_tests" / "query.sql").read_text()
 
-    client = _spawn_lsp(ctx.binary)
+    client = spawn_lsp(ctx.binary)
     try:
         diags = _open_and_get_diagnostics(client, "file:///test.sql", query_text)
         table_diags = [d for d in diags if "users" in d.get("message", "").lower()]
@@ -276,7 +146,7 @@ def _test_sqlite3_dot_schema(ctx: SuiteContext) -> bool:
         schema_path.write_text(result.stdout)
 
         # Feed the real .schema output to the LSP.
-        client = _spawn_lsp(ctx.binary, {"schemaPath": str(schema_path)})
+        client = spawn_lsp(ctx.binary, {"schemaPath": str(schema_path)})
         try:
             # Query both tables using columns from the schema.
             diags = _open_and_get_diagnostics(
@@ -299,7 +169,7 @@ def _test_schema_reload(ctx: SuiteContext) -> bool:
     schema_file = ctx.root_dir / "tests" / "lsp_tests" / "schema.sql"
 
     # Start without schema — should warn.
-    client = _spawn_lsp(ctx.binary)
+    client = spawn_lsp(ctx.binary)
     try:
         diags = _open_and_get_diagnostics(client, "file:///test.sql", query_text)
         table_diags = [d for d in diags if "users" in d.get("message", "").lower()]
@@ -338,7 +208,7 @@ def _test_multi_schema(ctx: SuiteContext) -> bool:
         schema_b.write_text("CREATE TABLE orders (id INTEGER PRIMARY KEY, amount REAL);\n")
 
         # Start with schema_a (users table).
-        client = _spawn_lsp(ctx.binary, {"schemaPath": str(schema_a)})
+        client = spawn_lsp(ctx.binary, {"schemaPath": str(schema_a)})
         try:
             # Query users — should be fine with schema_a.
             diags = _open_and_get_diagnostics(

--- a/python/dev/integration_tests/suites/lsp_diff.py
+++ b/python/dev/integration_tests/suites/lsp_diff.py
@@ -1,0 +1,30 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""LSP declarative diff-test suite.
+
+Runs `tests/lsp_diff_tests/` against the real `syntaqlite lsp` server over
+JSON-RPC. Each test declares an SQL input with a `<|>` cursor marker, an
+operation (hover / definition / completion), and expected text output.
+"""
+
+from python.dev.integration_tests.suite import SuiteContext
+
+NAME = "lsp-diff"
+DESCRIPTION = "LSP declarative diff tests (tests/lsp_diff_tests/)"
+
+
+def run(ctx: SuiteContext) -> int:
+    from python.dev.diff_tests.lsp_runner import main
+
+    argv = [
+        "--binary", str(ctx.binary),
+        "--test-dir", "tests/lsp_diff_tests",
+    ]
+    if ctx.filter_pattern:
+        argv += ["--filter", ctx.filter_pattern]
+    if ctx.rebaseline:
+        argv.append("--rebaseline")
+    if ctx.verbose >= 1:
+        argv.append("-v")
+    return main(argv)

--- a/syntaqlite/src/lsp/host.rs
+++ b/syntaqlite/src/lsp/host.rs
@@ -15,7 +15,7 @@ use crate::semantic::analyzer::SemanticAnalyzer;
 use crate::semantic::completion::{self, SignatureHelpInfo};
 use crate::semantic::diagnostics::Diagnostic;
 
-use super::analysis_data::{DefinitionResult, ExternalDefinitions, LspCapturePass, SymbolIdentity};
+use super::analysis_data::{DefinitionResult, ExternalDefinitions, LspCapturePass};
 use super::document_store::{Document, DocumentStore};
 use super::semantic_tokens_codec::encode_semantic_tokens;
 use super::{CompletionEntry, CompletionInfo};
@@ -106,7 +106,7 @@ fn ensure_analysis(
 
 /// Resolve the correct catalog for `uri` via `schema_map`, then call
 /// [`ensure_analysis`]. Returns `false` if the document is not found.
-fn ensure_analysis_for(
+pub(super) fn ensure_analysis_for(
     uri: &str,
     documents: &mut DocumentStore,
     analyzer: &mut SemanticAnalyzer,
@@ -526,60 +526,17 @@ impl LspHost {
         offset: DocOffset,
         include_declaration: bool,
     ) -> Vec<(String, DocRange)> {
-        // Identify the symbol at the cursor.
-        let identity = self.symbol_identity_at(uri, offset);
-        let Some(identity) = identity else {
-            return Vec::new();
-        };
-
-        let mut results = Vec::new();
-
-        // Collect matching resolutions from all open documents.
-        let uris: Vec<String> = self.documents.uris();
-        for doc_uri in &uris {
-            ensure_analysis_for(
-                doc_uri,
-                &mut self.documents,
-                &mut self.analyzer,
-                self.schema_map.as_ref(),
-                &self.user_catalog,
-                &self.validation_config,
-                Some(&self.external_defs),
-            );
-            let doc = self
-                .documents
-                .get(doc_uri.as_str())
-                .expect("doc_uri came from keys()");
-            let data = doc
-                .analysis
-                .as_ref()
-                .expect("ensure_analysis sets analysis");
-            for range in data.references_matching(&identity) {
-                results.push((doc_uri.clone(), range));
-            }
-            if include_declaration {
-                let key = identity.definition_key();
-                if let Some(&range) = data.definition_offsets.get(&key) {
-                    // Avoid duplicates (definition might also be in resolutions).
-                    let already = results.iter().any(|(u, r)| u == doc_uri && *r == range);
-                    if !already {
-                        results.push((doc_uri.clone(), range));
-                    }
-                }
-            }
-        }
-
-        // Include external (schema) definition site if requested.
-        if include_declaration && let Some(def_site) = self.external_definition_site(&identity) {
-            let already = results
-                .iter()
-                .any(|(u, r)| *u == def_site.0 && *r == def_site.1);
-            if !already {
-                results.push(def_site);
-            }
-        }
-
-        results
+        super::refs_service::find_references(
+            &mut self.documents,
+            &mut self.analyzer,
+            self.schema_map.as_ref(),
+            &self.user_catalog,
+            &self.validation_config,
+            &self.external_defs,
+            uri,
+            offset,
+            include_declaration,
+        )
     }
 
     // ── Rename ──────────────────────────────────────────────────────────────
@@ -616,52 +573,17 @@ impl LspHost {
         offset: DocOffset,
         new_name: &str,
     ) -> HashMap<String, Vec<(DocRange, String)>> {
-        let refs = self.find_references(uri, offset, true);
-        let mut edits: HashMap<String, Vec<(DocRange, String)>> = HashMap::new();
-        for (ref_uri, range) in refs {
-            edits
-                .entry(ref_uri)
-                .or_default()
-                .push((range, new_name.to_string()));
-        }
-        edits
-    }
-
-    // ── Symbol identity helpers ─────────────────────────────────────────────
-
-    /// Determine the symbol identity at `offset` — either from a resolution or
-    /// from a definition site (CREATE TABLE / column-def).
-    fn symbol_identity_at(&mut self, uri: &str, offset: DocOffset) -> Option<SymbolIdentity> {
-        ensure_analysis_for(
-            uri,
+        super::refs_service::rename(
             &mut self.documents,
             &mut self.analyzer,
             self.schema_map.as_ref(),
             &self.user_catalog,
             &self.validation_config,
-            Some(&self.external_defs),
-        );
-        let doc = self.documents.get(uri)?;
-        let data = doc
-            .analysis
-            .as_ref()
-            .expect("ensure_analysis sets analysis");
-        super::hover_service::symbol_identity_at(data, offset)
-    }
-
-    /// Look up an external (schema-file) definition site for a symbol from the
-    /// registry populated by [`Self::set_session_context_from_ddl`].
-    fn external_definition_site(&self, identity: &SymbolIdentity) -> Option<(String, DocRange)> {
-        match identity {
-            SymbolIdentity::Table(name) => {
-                let site = self.external_defs.relation(name)?;
-                Some((site.file_uri.clone(), site.range))
-            }
-            SymbolIdentity::Column { table, column } => {
-                let site = self.external_defs.column(table, column)?;
-                Some((site.file_uri.clone(), site.range))
-            }
-        }
+            &self.external_defs,
+            uri,
+            offset,
+            new_name,
+        )
     }
 
     // ── Signature help ────────────────────────────────────────────────────────

--- a/syntaqlite/src/lsp/host.rs
+++ b/syntaqlite/src/lsp/host.rs
@@ -738,21 +738,8 @@ impl std::error::Error for FormatError {}
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
-impl LspHost {
-    /// Expected terminal token IDs (as `u32` ordinals) at a byte offset.
-    pub(crate) fn expected_tokens_at_offset(&mut self, uri: &str, offset: DocOffset) -> Vec<u32> {
-        self.completion_info_at_offset(uri, offset)
-            .tokens
-            .iter()
-            .map(|&t| u32::from(t))
-            .collect()
-    }
-}
-
-#[cfg(test)]
 #[cfg(feature = "sqlite")]
 mod tests {
-    use syntaqlite_syntax::TokenType;
     use syntaqlite_syntax::source::DocOffset;
 
     use super::LspHost;
@@ -760,75 +747,7 @@ mod tests {
     use crate::semantic::Catalog;
     use crate::semantic::ValidationConfig;
     use crate::semantic::catalog::{AritySpec, CatalogLayer, FunctionCategory};
-    use crate::semantic::diagnostics::{DiagnosticMessage, Severity};
-
-    #[test]
-    fn completions_fall_back_to_last_good_state_on_parse_error() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "SELECT * FR";
-        host.open_document(uri, 1, sql.to_string());
-        let expected = host
-            .expected_tokens_at_offset(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
-        assert!(
-            expected.contains(&(TokenType::From as u32)),
-            "expected From after SELECT *, got {expected:?}"
-        );
-    }
-
-    #[test]
-    fn completions_ignore_prior_statement_errors_after_semicolon() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "SELEC 1; SELECT * FR";
-        host.open_document(uri, 1, sql.to_string());
-        let expected = host
-            .expected_tokens_at_offset(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
-        assert!(
-            expected.contains(&(TokenType::From as u32)),
-            "expected From in second statement context, got {expected:?}"
-        );
-    }
-
-    #[test]
-    fn completions_include_join_after_from_alias_with_partial_next_token() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "SELECT * FROM s AS x J";
-        host.open_document(uri, 1, sql.to_string());
-        let expected = host
-            .expected_tokens_at_offset(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
-        assert!(
-            expected.contains(&(TokenType::JoinKw as u32)),
-            "expected JoinKw after FROM alias, got {expected:?}"
-        );
-    }
-
-    #[test]
-    fn completions_include_join_after_from_table_with_trailing_space() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "SELECT * FROM slice ";
-        host.open_document(uri, 1, sql.to_string());
-        let expected = host
-            .expected_tokens_at_offset(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
-        assert!(
-            expected.contains(&(TokenType::Join as u32)),
-            "expected Join"
-        );
-        assert!(
-            !expected.contains(&(TokenType::Create as u32)),
-            "Create should not appear"
-        );
-        assert!(
-            !expected.contains(&(TokenType::Select as u32)),
-            "Select should not appear"
-        );
-        assert!(
-            !expected.contains(&(TokenType::Virtual as u32)),
-            "Virtual should not appear"
-        );
-    }
+    use crate::semantic::diagnostics::Severity;
 
     #[test]
     fn available_functions_default_config_includes_baseline() {
@@ -856,17 +775,6 @@ mod tests {
     }
 
     #[test]
-    fn completion_context_after_from_is_table_ref() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "SELECT acos() as foo FROM ";
-        host.open_document(uri, 1, sql.to_string());
-        let info = host
-            .completion_info_at_offset(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
-        assert_eq!(info.context, super::super::CompletionContext::TableRef);
-    }
-
-    #[test]
     fn completion_context_after_select_is_not_table_ref() {
         let mut host = LspHost::new();
         let uri = "file:///test.sql";
@@ -889,135 +797,12 @@ mod tests {
     }
 
     #[test]
-    fn completions_include_join_after_from_table_no_trailing_space() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "SELECT * FROM slice";
-        host.open_document(uri, 1, sql.to_string());
-        let expected = host
-            .expected_tokens_at_offset(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
-        assert!(expected.contains(&(TokenType::Join as u32)));
-    }
-
-    #[test]
-    fn validate_select_after_create_table_as_select_no_diags() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        host.open_document(
-            uri,
-            1,
-            "CREATE TABLE orders AS SELECT 1 AS order_id;\nSELECT o.order_id FROM orders o;"
-                .to_string(),
-        );
-        let diags = host.validate(uri, &ValidationConfig::default());
-        assert!(diags.is_empty(), "unexpected diagnostics: {diags:?}");
-    }
-
-    #[test]
-    fn validate_select_from_unknown_table_still_warns() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        host.open_document(uri, 1, "SELECT * FROM nonexistent;".to_string());
-        let diags = host.validate(uri, &ValidationConfig::default());
-        assert!(!diags.is_empty());
-    }
-
-    #[test]
-    fn validate_forward_reference_warns() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        host.open_document(
-            uri,
-            1,
-            "SELECT * FROM t;\nCREATE TABLE t (id INTEGER);".to_string(),
-        );
-        let diags = host.validate(uri, &ValidationConfig::default());
-        assert!(!diags.is_empty());
-    }
-
-    #[test]
-    fn syntax_error_produces_diagnostic_for_bare_select() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        host.open_document(uri, 1, "SELECT ".to_string());
-        let diags = host.diagnostics(uri);
-        assert!(!diags.is_empty());
-        assert_eq!(diags[0].severity, Severity::Error);
-    }
-
-    #[test]
-    fn syntax_error_produces_diagnostic_for_incomplete_from() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        host.open_document(uri, 1, "SELECT * FROM".to_string());
-        let diags = host.diagnostics(uri);
-        assert!(!diags.is_empty());
-    }
-
-    #[test]
-    fn validation_returns_error_for_syntax_invalid_sql() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        host.open_document(uri, 1, "NOT VALID SQL;".to_string());
-        let diags = host.diagnostics(uri);
-        assert!(!diags.is_empty());
-    }
-
-    #[test]
-    fn multiple_syntax_errors_all_reported() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        host.open_document(uri, 1, "include ;\ninclude ;\nSELECT 1;".to_string());
-        let diags = host.diagnostics(uri);
-        let errors: Vec<_> = diags
-            .iter()
-            .filter(|d| d.severity == Severity::Error)
-            .collect();
-        assert_eq!(errors.len(), 2, "got {}: {:?}", errors.len(), errors);
-    }
-
-    #[test]
-    fn syntax_errors_do_not_suppress_later_valid_statements() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        host.open_document(uri, 1, "NOT VALID;\nSELECT 1;".to_string());
-        let diags = host.diagnostics(uri);
-        assert_eq!(diags.len(), 1, "got {}: {:?}", diags.len(), diags);
-    }
-
-    #[test]
-    fn syntax_error_after_valid_statement_is_reported() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        host.open_document(uri, 1, "SELECT 1;\nNOT VALID;".to_string());
-        let diags = host.diagnostics(uri);
-        assert_eq!(diags.len(), 1, "got {}: {:?}", diags.len(), diags);
-    }
-
-    #[test]
     fn validate_does_not_duplicate_parse_error_diagnostics() {
         let mut host = LspHost::new();
         let uri = "file:///test.sql";
         host.open_document(uri, 1, "SELECT ;\nSELECT 1;".to_string());
         let diags = host.validate(uri, &ValidationConfig::default());
         assert_eq!(diags.len(), 0, "got: {diags:?}");
-    }
-
-    #[test]
-    fn validate_continues_past_errors_to_check_later_statements() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        host.open_document(
-            uri,
-            1,
-            "SELECT ;\nSELECT ;\nSELECT * FROM no_such_table;".to_string(),
-        );
-        let diags = host.validate(uri, &ValidationConfig::default());
-        let table_diags: Vec<_> = diags
-            .iter()
-            .filter(|d| matches!(&d.message, DiagnosticMessage::UnknownTable { .. }))
-            .collect();
-        assert_eq!(table_diags.len(), 1, "got: {diags:?}");
     }
 
     #[test]
@@ -1129,75 +914,7 @@ mod tests {
         );
     }
 
-    #[test]
-    fn syntax_error_for_create_table_as_missing_select() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        host.open_document(uri, 1, "create table orders as;".to_string());
-        let diags = host.all_diagnostics(uri, &ValidationConfig::default());
-        assert!(
-            !diags.is_empty(),
-            "expected syntax error for 'create table orders as;', got none"
-        );
-        assert!(
-            diags.iter().any(|d| d.severity == Severity::Error),
-            "expected an error-severity diagnostic, got: {diags:?}"
-        );
-    }
-
     // ── Find-references tests ──────────────────────────────────────────────
-
-    #[test]
-    fn find_references_table_in_single_file() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "CREATE TABLE users (id INT);\nSELECT * FROM users;\nDELETE FROM users;";
-        host.open_document(uri, 1, sql.to_string());
-
-        // Click on "users" in the SELECT statement.
-        let offset = sql.find("SELECT").unwrap() + "SELECT * FROM ".len();
-        let refs = host.find_references(
-            uri,
-            DocOffset::from_raw(u32::try_from(offset).unwrap()),
-            false,
-        );
-        // Should find the two DML references (SELECT + DELETE), not the CREATE.
-        assert_eq!(refs.len(), 2, "expected 2 refs, got: {refs:?}");
-    }
-
-    #[test]
-    fn find_references_table_include_declaration() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "CREATE TABLE users (id INT);\nSELECT * FROM users;\nDELETE FROM users;";
-        host.open_document(uri, 1, sql.to_string());
-
-        let offset = sql.find("SELECT").unwrap() + "SELECT * FROM ".len();
-        let refs = host.find_references(
-            uri,
-            DocOffset::from_raw(u32::try_from(offset).unwrap()),
-            true,
-        );
-        // Should find the two DML references + the CREATE TABLE definition.
-        assert_eq!(refs.len(), 3, "expected 3 refs (incl decl), got: {refs:?}");
-    }
-
-    #[test]
-    fn find_references_column_in_single_file() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "CREATE TABLE t (id INT, name TEXT);\nSELECT id FROM t;\nSELECT id, name FROM t;";
-        host.open_document(uri, 1, sql.to_string());
-
-        // Click on "id" in the first SELECT.
-        let offset = sql.find("SELECT id").unwrap() + "SELECT ".len();
-        let refs = host.find_references(
-            uri,
-            DocOffset::from_raw(u32::try_from(offset).unwrap()),
-            false,
-        );
-        assert_eq!(refs.len(), 2, "expected 2 column refs, got: {refs:?}");
-    }
 
     #[test]
     fn find_references_cross_file() {
@@ -1225,98 +942,7 @@ mod tests {
         assert!(ref_uris.contains(&uri2));
     }
 
-    #[test]
-    fn find_references_cursor_on_definition() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "CREATE TABLE users (id INT);\nSELECT * FROM users;";
-        host.open_document(uri, 1, sql.to_string());
-
-        // Click on "users" in CREATE TABLE — should still find the SELECT reference.
-        let offset = sql.find("users").unwrap();
-        let refs = host.find_references(
-            uri,
-            DocOffset::from_raw(u32::try_from(offset).unwrap()),
-            false,
-        );
-        assert_eq!(
-            refs.len(),
-            1,
-            "expected 1 ref from definition site, got: {refs:?}"
-        );
-    }
-
-    #[test]
-    fn find_references_cursor_on_definition_include_declaration() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "CREATE TABLE users (id INT);\nSELECT * FROM users;";
-        host.open_document(uri, 1, sql.to_string());
-
-        let offset = sql.find("users").unwrap();
-        let refs = host.find_references(
-            uri,
-            DocOffset::from_raw(u32::try_from(offset).unwrap()),
-            true,
-        );
-        assert_eq!(refs.len(), 2, "expected 2 refs (incl decl), got: {refs:?}");
-    }
-
     // ── Rename tests ────────────────────────────────────────────────────────
-
-    #[test]
-    fn prepare_rename_returns_range_for_table() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "CREATE TABLE users (id INT);\nSELECT * FROM users;";
-        host.open_document(uri, 1, sql.to_string());
-
-        let offset = sql.find("SELECT").unwrap() + "SELECT * FROM ".len();
-        let result = host.prepare_rename(uri, DocOffset::from_raw(u32::try_from(offset).unwrap()));
-        assert!(result.is_some(), "expected rename range");
-        let (range, text) = result.unwrap();
-        assert_eq!(text, "users");
-        assert_eq!(&sql[range.start.as_usize()..range.end.as_usize()], "users");
-    }
-
-    #[test]
-    fn rename_table_in_single_file() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "CREATE TABLE users (id INT);\nSELECT * FROM users;\nDELETE FROM users;";
-        host.open_document(uri, 1, sql.to_string());
-
-        let offset = sql.find("SELECT").unwrap() + "SELECT * FROM ".len();
-        let edits = host.rename(
-            uri,
-            DocOffset::from_raw(u32::try_from(offset).unwrap()),
-            "accounts",
-        );
-        // Should produce edits for all 3 occurrences (definition + 2 refs).
-        let file_edits = edits.get(uri).expect("expected edits for test file");
-        assert_eq!(file_edits.len(), 3, "expected 3 edits, got: {file_edits:?}");
-        for (_, text) in file_edits {
-            assert_eq!(text.as_str(), "accounts");
-        }
-    }
-
-    #[test]
-    fn rename_column_in_single_file() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "CREATE TABLE t (id INT, name TEXT);\nSELECT id FROM t;\nSELECT id, name FROM t;";
-        host.open_document(uri, 1, sql.to_string());
-
-        let offset = sql.find("SELECT id").unwrap() + "SELECT ".len();
-        let edits = host.rename(
-            uri,
-            DocOffset::from_raw(u32::try_from(offset).unwrap()),
-            "user_id",
-        );
-        let file_edits = edits.get(uri).expect("expected edits for test file");
-        // 2 column refs + 1 definition = 3 edits.
-        assert_eq!(file_edits.len(), 3, "expected 3 edits, got: {file_edits:?}");
-    }
 
     #[test]
     fn rename_cross_file() {
@@ -1340,87 +966,6 @@ mod tests {
         // Should have edits in both open files.
         assert!(edits.contains_key(uri1), "expected edits in a.sql");
         assert!(edits.contains_key(uri2), "expected edits in b.sql");
-    }
-
-    #[test]
-    fn completion_on_suggested_after_join_target() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "SELECT * FROM slice JOIN thread ";
-        host.open_document(uri, 1, sql.to_string());
-        let items =
-            host.completion_items(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
-        let labels: Vec<&str> = items.iter().map(|e| e.label.as_str()).collect();
-        assert!(
-            labels.contains(&"ON"),
-            "ON should be suggested, got: {labels:?}"
-        );
-    }
-
-    #[test]
-    fn completion_qualifier_detected_after_dot() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "CREATE TABLE t1 (a INT, b TEXT);\nCREATE TABLE t2 (c INT);\nSELECT t1.";
-        host.open_document(uri, 1, sql.to_string());
-        let info = host
-            .completion_info_at_offset(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
-        assert_eq!(
-            info.qualifier.as_deref(),
-            Some("t1"),
-            "should detect t1 as qualifier, got: {:?}",
-            info.qualifier
-        );
-    }
-
-    #[test]
-    fn completion_qualified_column_only_from_table() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "CREATE TABLE t1 (a INT, b TEXT);\nCREATE TABLE t2 (c INT);\nSELECT t1.";
-        host.open_document(uri, 1, sql.to_string());
-        let items =
-            host.completion_items(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
-        let labels: Vec<&str> = items.iter().map(|e| e.label.as_str()).collect();
-        assert!(labels.contains(&"a"), "should suggest column a");
-        assert!(labels.contains(&"b"), "should suggest column b");
-        assert!(
-            !labels.contains(&"c"),
-            "should NOT suggest column c from t2"
-        );
-        assert!(
-            items.iter().all(|e| e.kind == CompletionKind::Column),
-            "all items should be columns, got: {labels:?}"
-        );
-    }
-
-    #[test]
-    fn completion_tables_after_from() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "CREATE TABLE users (id INT);\nSELECT * FROM ";
-        host.open_document(uri, 1, sql.to_string());
-        let items =
-            host.completion_items(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
-        let labels: Vec<&str> = items.iter().map(|e| e.label.as_str()).collect();
-        assert!(
-            labels.contains(&"users"),
-            "should suggest table users, got: {labels:?}"
-        );
-    }
-
-    #[test]
-    fn completion_columns_after_select() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let sql = "CREATE TABLE users (id INT, name TEXT);\nSELECT ";
-        host.open_document(uri, 1, sql.to_string());
-        let items =
-            host.completion_items(uri, DocOffset::from_raw(u32::try_from(sql.len()).unwrap()));
-        let labels: Vec<&str> = items.iter().map(|e| e.label.as_str()).collect();
-        assert!(labels.contains(&"id"), "should suggest column id");
-        assert!(labels.contains(&"name"), "should suggest column name");
-        assert!(labels.contains(&"abs"), "should suggest function abs");
     }
 
     #[test]
@@ -1619,138 +1164,6 @@ mod tests {
             errors.is_empty(),
             "unmatched file should have no errors (lenient mode), got: {errors:?}"
         );
-    }
-
-    #[test]
-    fn goto_definition_cte_reference() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let src = "WITH cte AS (SELECT 1) SELECT * FROM cte";
-        host.open_document(uri, 1, src.to_string());
-
-        let ref_offset = src.rfind("cte").unwrap();
-        let def = host
-            .definition_info(uri, DocOffset::from_raw(u32::try_from(ref_offset).unwrap()))
-            .expect("definition");
-        let cte_def_offset = src.find("cte").unwrap();
-        assert_eq!(def.target.range.start.as_usize(), cte_def_offset);
-        assert_eq!(
-            def.target.range.end.as_usize(),
-            cte_def_offset + "cte".len()
-        );
-    }
-
-    #[test]
-    fn goto_definition_ddl_table_reference() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let src = "CREATE TABLE users (id INTEGER); SELECT id FROM users;";
-        host.open_document(uri, 1, src.to_string());
-
-        let ref_offset = src.rfind("users").unwrap();
-        let def = host
-            .definition_info(uri, DocOffset::from_raw(u32::try_from(ref_offset).unwrap()))
-            .expect("definition");
-        let ddl_offset = src.find("users").unwrap();
-        assert_eq!(def.target.range.start.as_usize(), ddl_offset);
-        assert_eq!(def.target.range.end.as_usize(), ddl_offset + "users".len());
-    }
-
-    #[test]
-    fn goto_definition_cte_shadows_ddl() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let src = "CREATE TABLE t (id INTEGER); WITH t AS (SELECT 1 AS id) SELECT * FROM t;";
-        host.open_document(uri, 1, src.to_string());
-
-        let from_t_offset = src.rfind("FROM t").unwrap() + 5;
-        let def = host
-            .definition_info(
-                uri,
-                DocOffset::from_raw(u32::try_from(from_t_offset).unwrap()),
-            )
-            .expect("definition");
-        let cte_t_offset = src[29..].find('t').unwrap() + 29;
-        assert_eq!(def.target.range.start.as_usize(), cte_t_offset);
-    }
-
-    #[test]
-    fn goto_definition_unknown_table_returns_none() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let src = "SELECT * FROM nonexistent";
-        host.open_document(uri, 1, src.to_string());
-
-        let from_offset = src.find("nonexistent").unwrap();
-        assert!(
-            host.definition_info(
-                uri,
-                DocOffset::from_raw(u32::try_from(from_offset).unwrap())
-            )
-            .is_none()
-        );
-    }
-
-    #[test]
-    fn goto_definition_column_in_ddl_table() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let src = "CREATE TABLE users (id INTEGER, name TEXT);\nSELECT name FROM users;";
-        host.open_document(uri, 1, src.to_string());
-
-        let select_name_offset = src.rfind("name").unwrap();
-        let def = host
-            .definition_info(
-                uri,
-                DocOffset::from_raw(u32::try_from(select_name_offset).unwrap()),
-            )
-            .expect("definition");
-        let ddl_name_offset = src.find("name").unwrap();
-        assert_eq!(def.target.range.start.as_usize(), ddl_name_offset);
-    }
-
-    #[test]
-    fn goto_definition_unknown_column_returns_none() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let src = "CREATE TABLE t (a INT);\nSELECT b FROM t;";
-        host.open_document(uri, 1, src.to_string());
-
-        let b_offset = src.find('b').unwrap();
-        assert!(
-            host.definition_info(uri, DocOffset::from_raw(u32::try_from(b_offset).unwrap()))
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn goto_definition_cte_column_inferred_from_alias() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let src = "WITH foo AS (SELECT 1 AS a)\nSELECT a FROM foo;";
-        host.open_document(uri, 1, src.to_string());
-
-        let a_offset = src.find("SELECT a").unwrap() + "SELECT ".len();
-        let def = host
-            .definition_info(uri, DocOffset::from_raw(u32::try_from(a_offset).unwrap()))
-            .expect("definition");
-        let cte_a_offset = src.find("AS a").unwrap() + "AS ".len();
-        assert_eq!(def.target.range.start.as_usize(), cte_a_offset);
-    }
-
-    #[test]
-    fn goto_definition_cte_column_from_declared_list() {
-        let mut host = LspHost::new();
-        let uri = "file:///test.sql";
-        let src = "WITH foo(x) AS (SELECT 1)\nSELECT x FROM foo;";
-        host.open_document(uri, 1, src.to_string());
-
-        let x_offset = src.find("SELECT x").unwrap() + "SELECT ".len();
-        let def = host
-            .definition_info(uri, DocOffset::from_raw(u32::try_from(x_offset).unwrap()))
-            .expect("definition");
-        let decl_x_offset = src.find("(x)").unwrap() + 1;
-        assert_eq!(def.target.range.start.as_usize(), decl_x_offset);
     }
 
     #[test]

--- a/syntaqlite/src/lsp/mod.rs
+++ b/syntaqlite/src/lsp/mod.rs
@@ -118,8 +118,9 @@ impl CompletionKind {
 mod analysis_data;
 mod completion_service;
 mod document_store;
-mod host;
+pub(crate) mod host;
 mod hover_service;
+mod refs_service;
 mod semantic_tokens_codec;
 mod server;
 mod source_map;

--- a/syntaqlite/src/lsp/refs_service.rs
+++ b/syntaqlite/src/lsp/refs_service.rs
@@ -1,0 +1,161 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+//! Cross-document reference tracking: find-references, rename, external
+//! definition-site lookup.
+//!
+//! Pure functions over [`DocumentStore`] + [`SemanticAnalyzer`] state. The
+//! LSP facade assembles the call by threading its borrowed state in.
+
+use std::collections::HashMap;
+
+use syntaqlite_syntax::source::{DocOffset, DocRange};
+
+use crate::semantic::ValidationConfig;
+use crate::semantic::analyzer::SemanticAnalyzer;
+use crate::semantic::catalog::Catalog;
+
+use super::analysis_data::{ExternalDefinitions, SymbolIdentity};
+use super::document_store::DocumentStore;
+use super::host::{SchemaMap, ensure_analysis_for};
+
+/// Find all references to the symbol at `offset` across all open documents.
+///
+/// When `include_declaration` is true, the definition site (in-file or
+/// external) is included in the results. Returns an empty vec when the
+/// cursor is not on a resolvable symbol.
+#[expect(clippy::too_many_arguments)]
+pub(super) fn find_references(
+    documents: &mut DocumentStore,
+    analyzer: &mut SemanticAnalyzer,
+    schema_map: Option<&SchemaMap>,
+    user_catalog: &Catalog,
+    validation_config: &ValidationConfig,
+    external_defs: &ExternalDefinitions,
+    uri: &str,
+    offset: DocOffset,
+    include_declaration: bool,
+) -> Vec<(String, DocRange)> {
+    // Identify the symbol at the cursor.
+    if !ensure_analysis_for(
+        uri,
+        documents,
+        analyzer,
+        schema_map,
+        user_catalog,
+        validation_config,
+        Some(external_defs),
+    ) {
+        return Vec::new();
+    }
+    let identity = documents
+        .get(uri)
+        .and_then(|doc| doc.analysis.as_ref())
+        .and_then(|data| super::hover_service::symbol_identity_at(data, offset));
+    let Some(identity) = identity else {
+        return Vec::new();
+    };
+
+    let mut results = Vec::new();
+
+    // Collect matching resolutions from all open documents.
+    let uris: Vec<String> = documents.uris();
+    for doc_uri in &uris {
+        ensure_analysis_for(
+            doc_uri,
+            documents,
+            analyzer,
+            schema_map,
+            user_catalog,
+            validation_config,
+            Some(external_defs),
+        );
+        let doc = documents
+            .get(doc_uri.as_str())
+            .expect("doc_uri came from keys()");
+        let data = doc
+            .analysis
+            .as_ref()
+            .expect("ensure_analysis sets analysis");
+        for range in data.references_matching(&identity) {
+            results.push((doc_uri.clone(), range));
+        }
+        if include_declaration {
+            let key = identity.definition_key();
+            if let Some(&range) = data.definition_offsets.get(&key) {
+                // Avoid duplicates (definition might also be in resolutions).
+                let already = results.iter().any(|(u, r)| u == doc_uri && *r == range);
+                if !already {
+                    results.push((doc_uri.clone(), range));
+                }
+            }
+        }
+    }
+
+    // Include external (schema) definition site if requested.
+    if include_declaration
+        && let Some(def_site) = external_definition_site(external_defs, &identity)
+    {
+        let already = results
+            .iter()
+            .any(|(u, r)| *u == def_site.0 && *r == def_site.1);
+        if !already {
+            results.push(def_site);
+        }
+    }
+
+    results
+}
+
+/// Rename the symbol at `offset` to `new_name` across all open documents.
+///
+/// Returns a map of `uri -> Vec<(range, new_text)>` edits.
+#[expect(clippy::too_many_arguments)]
+pub(super) fn rename(
+    documents: &mut DocumentStore,
+    analyzer: &mut SemanticAnalyzer,
+    schema_map: Option<&SchemaMap>,
+    user_catalog: &Catalog,
+    validation_config: &ValidationConfig,
+    external_defs: &ExternalDefinitions,
+    uri: &str,
+    offset: DocOffset,
+    new_name: &str,
+) -> HashMap<String, Vec<(DocRange, String)>> {
+    let refs = find_references(
+        documents,
+        analyzer,
+        schema_map,
+        user_catalog,
+        validation_config,
+        external_defs,
+        uri,
+        offset,
+        true,
+    );
+    let mut edits: HashMap<String, Vec<(DocRange, String)>> = HashMap::new();
+    for (ref_uri, range) in refs {
+        edits
+            .entry(ref_uri)
+            .or_default()
+            .push((range, new_name.to_string()));
+    }
+    edits
+}
+
+/// Look up an external (schema-file) definition site for a symbol.
+pub(super) fn external_definition_site(
+    external_defs: &ExternalDefinitions,
+    identity: &SymbolIdentity,
+) -> Option<(String, DocRange)> {
+    match identity {
+        SymbolIdentity::Table(name) => {
+            let site = external_defs.relation(name)?;
+            Some((site.file_uri.clone(), site.range))
+        }
+        SymbolIdentity::Column { table, column } => {
+            let site = external_defs.column(table, column)?;
+            Some((site.file_uri.clone(), site.range))
+        }
+    }
+}

--- a/tests/lsp_diff_tests/__init__.py
+++ b/tests/lsp_diff_tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.

--- a/tests/lsp_diff_tests/completion.py
+++ b/tests/lsp_diff_tests/completion.py
@@ -1,0 +1,606 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+from python.dev.diff_tests.testing import LspDiffTestBlueprint, TestSuite
+
+
+class Completion(TestSuite):
+    def test_columns_after_select(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE users (id INTEGER, name TEXT);\nSELECT <|> FROM users;",
+            op="completion",
+            out="""\
+            column: id
+            column: name
+            table: users
+            keyword: ALL
+            keyword: CASE
+            keyword: CAST
+            keyword: CROSS
+            keyword: CURRENT_DATE
+            keyword: CURRENT_TIME
+            keyword: CURRENT_TIMESTAMP
+            keyword: DISTINCT
+            keyword: EXISTS
+            keyword: FULL
+            keyword: INDEXED
+            keyword: INNER
+            keyword: LEFT
+            keyword: NATURAL
+            keyword: NOT
+            keyword: NULL
+            keyword: OUTER
+            keyword: RAISE
+            keyword: RIGHT
+            function: ->
+            function: ->>
+            function: abs
+            function: avg
+            function: changes
+            function: char
+            function: coalesce
+            function: concat
+            function: concat_ws
+            function: count
+            function: cume_dist
+            function: current_date
+            function: current_time
+            function: current_timestamp
+            function: date
+            function: datetime
+            function: dense_rank
+            function: first_value
+            function: format
+            function: glob
+            function: group_concat
+            function: hex
+            function: if
+            function: ifnull
+            function: iif
+            function: instr
+            function: json
+            function: json_array
+            function: json_array_length
+            function: json_error_position
+            function: json_extract
+            function: json_group_array
+            function: json_group_object
+            function: json_insert
+            function: json_object
+            function: json_patch
+            function: json_pretty
+            function: json_quote
+            function: json_remove
+            function: json_replace
+            function: json_set
+            function: json_type
+            function: json_valid
+            function: jsonb
+            function: jsonb_array
+            function: jsonb_extract
+            function: jsonb_group_array
+            function: jsonb_group_object
+            function: jsonb_insert
+            function: jsonb_object
+            function: jsonb_patch
+            function: jsonb_remove
+            function: jsonb_replace
+            function: jsonb_set
+            function: julianday
+            function: lag
+            function: last_insert_rowid
+            function: last_value
+            function: lead
+            function: length
+            function: like
+            function: likelihood
+            function: likely
+            function: load_extension
+            function: lower
+            function: ltrim
+            function: match
+            function: max
+            function: min
+            function: nth_value
+            function: ntile
+            function: nullif
+            function: octet_length
+            function: percent_rank
+            function: printf
+            function: quote
+            function: random
+            function: randomblob
+            function: rank
+            function: replace
+            function: round
+            function: row_number
+            function: rtrim
+            function: sign
+            function: snippet
+            function: sqlite_compileoption_get
+            function: sqlite_compileoption_used
+            function: sqlite_log
+            function: sqlite_source_id
+            function: sqlite_version
+            function: strftime
+            function: string_agg
+            function: substr
+            function: substring
+            function: subtype
+            function: sum
+            function: time
+            function: timediff
+            function: total
+            function: total_changes
+            function: trim
+            function: typeof
+            function: unhex
+            function: unicode
+            function: unistr
+            function: unistr_quote
+            function: unixepoch
+            function: unlikely
+            function: upper
+            function: zeroblob
+""",
+        )
+
+    def test_qualified_column_only_from_table(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE users (id INTEGER, name TEXT);\nSELECT users.<|> FROM users;",
+            op="completion",
+            out="""\
+            column: id
+            column: name
+""",
+        )
+
+    def test_tables_after_from(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE users (id INTEGER);\nCREATE TABLE orders (id INTEGER);\nSELECT * FROM <|>",
+            op="completion",
+            out="""\
+table: orders
+table: users
+keyword: CROSS
+keyword: FULL
+keyword: INDEXED
+keyword: INNER
+keyword: LEFT
+keyword: NATURAL
+keyword: OUTER
+keyword: RIGHT
+""",
+        )
+
+    def test_from_keyword_after_select_star(self):
+        return LspDiffTestBlueprint(
+            sql="SELECT * FR<|>",
+            op="completion",
+            out="""\
+            keyword: ALTER
+            keyword: ANALYZE
+            keyword: ATTACH
+            keyword: BEGIN
+            keyword: COMMIT
+            keyword: CREATE
+            keyword: DELETE
+            keyword: DETACH
+            keyword: DROP
+            keyword: END
+            keyword: EXCEPT
+            keyword: EXPLAIN
+            keyword: FROM
+            keyword: GROUP
+            keyword: HAVING
+            keyword: INSERT
+            keyword: INTERSECT
+            keyword: LIMIT
+            keyword: ORDER
+            keyword: PRAGMA
+            keyword: REINDEX
+            keyword: RELEASE
+            keyword: REPLACE
+            keyword: ROLLBACK
+            keyword: SAVEPOINT
+            keyword: SELECT
+            keyword: UNION
+            keyword: UPDATE
+            keyword: VACUUM
+            keyword: VALUES
+            keyword: WHERE
+            keyword: WINDOW
+            keyword: WITH
+            function: ->
+            function: ->>
+            function: abs
+            function: avg
+            function: changes
+            function: char
+            function: coalesce
+            function: concat
+            function: concat_ws
+            function: count
+            function: cume_dist
+            function: current_date
+            function: current_time
+            function: current_timestamp
+            function: date
+            function: datetime
+            function: dense_rank
+            function: first_value
+            function: format
+            function: glob
+            function: group_concat
+            function: hex
+            function: if
+            function: ifnull
+            function: iif
+            function: instr
+            function: json
+            function: json_array
+            function: json_array_length
+            function: json_error_position
+            function: json_extract
+            function: json_group_array
+            function: json_group_object
+            function: json_insert
+            function: json_object
+            function: json_patch
+            function: json_pretty
+            function: json_quote
+            function: json_remove
+            function: json_replace
+            function: json_set
+            function: json_type
+            function: json_valid
+            function: jsonb
+            function: jsonb_array
+            function: jsonb_extract
+            function: jsonb_group_array
+            function: jsonb_group_object
+            function: jsonb_insert
+            function: jsonb_object
+            function: jsonb_patch
+            function: jsonb_remove
+            function: jsonb_replace
+            function: jsonb_set
+            function: julianday
+            function: lag
+            function: last_insert_rowid
+            function: last_value
+            function: lead
+            function: length
+            function: like
+            function: likelihood
+            function: likely
+            function: load_extension
+            function: lower
+            function: ltrim
+            function: match
+            function: max
+            function: min
+            function: nth_value
+            function: ntile
+            function: nullif
+            function: octet_length
+            function: percent_rank
+            function: printf
+            function: quote
+            function: random
+            function: randomblob
+            function: rank
+            function: replace
+            function: round
+            function: row_number
+            function: rtrim
+            function: sign
+            function: snippet
+            function: sqlite_compileoption_get
+            function: sqlite_compileoption_used
+            function: sqlite_log
+            function: sqlite_source_id
+            function: sqlite_version
+            function: strftime
+            function: string_agg
+            function: substr
+            function: substring
+            function: subtype
+            function: sum
+            function: time
+            function: timediff
+            function: total
+            function: total_changes
+            function: trim
+            function: typeof
+            function: unhex
+            function: unicode
+            function: unistr
+            function: unistr_quote
+            function: unixepoch
+            function: unlikely
+            function: upper
+            function: zeroblob
+""",
+        )
+
+    def test_second_statement_after_parse_error(self):
+        return LspDiffTestBlueprint(
+            sql="SELEC 1; SELECT * FR<|>",
+            op="completion",
+            out="""\
+            keyword: ALTER
+            keyword: ANALYZE
+            keyword: ATTACH
+            keyword: BEGIN
+            keyword: COMMIT
+            keyword: CREATE
+            keyword: DELETE
+            keyword: DETACH
+            keyword: DROP
+            keyword: END
+            keyword: EXCEPT
+            keyword: EXPLAIN
+            keyword: FROM
+            keyword: GROUP
+            keyword: HAVING
+            keyword: INSERT
+            keyword: INTERSECT
+            keyword: LIMIT
+            keyword: ORDER
+            keyword: PRAGMA
+            keyword: REINDEX
+            keyword: RELEASE
+            keyword: REPLACE
+            keyword: ROLLBACK
+            keyword: SAVEPOINT
+            keyword: SELECT
+            keyword: UNION
+            keyword: UPDATE
+            keyword: VACUUM
+            keyword: VALUES
+            keyword: WHERE
+            keyword: WINDOW
+            keyword: WITH
+            function: ->
+            function: ->>
+            function: abs
+            function: avg
+            function: changes
+            function: char
+            function: coalesce
+            function: concat
+            function: concat_ws
+            function: count
+            function: cume_dist
+            function: current_date
+            function: current_time
+            function: current_timestamp
+            function: date
+            function: datetime
+            function: dense_rank
+            function: first_value
+            function: format
+            function: glob
+            function: group_concat
+            function: hex
+            function: if
+            function: ifnull
+            function: iif
+            function: instr
+            function: json
+            function: json_array
+            function: json_array_length
+            function: json_error_position
+            function: json_extract
+            function: json_group_array
+            function: json_group_object
+            function: json_insert
+            function: json_object
+            function: json_patch
+            function: json_pretty
+            function: json_quote
+            function: json_remove
+            function: json_replace
+            function: json_set
+            function: json_type
+            function: json_valid
+            function: jsonb
+            function: jsonb_array
+            function: jsonb_extract
+            function: jsonb_group_array
+            function: jsonb_group_object
+            function: jsonb_insert
+            function: jsonb_object
+            function: jsonb_patch
+            function: jsonb_remove
+            function: jsonb_replace
+            function: jsonb_set
+            function: julianday
+            function: lag
+            function: last_insert_rowid
+            function: last_value
+            function: lead
+            function: length
+            function: like
+            function: likelihood
+            function: likely
+            function: load_extension
+            function: lower
+            function: ltrim
+            function: match
+            function: max
+            function: min
+            function: nth_value
+            function: ntile
+            function: nullif
+            function: octet_length
+            function: percent_rank
+            function: printf
+            function: quote
+            function: random
+            function: randomblob
+            function: rank
+            function: replace
+            function: round
+            function: row_number
+            function: rtrim
+            function: sign
+            function: snippet
+            function: sqlite_compileoption_get
+            function: sqlite_compileoption_used
+            function: sqlite_log
+            function: sqlite_source_id
+            function: sqlite_version
+            function: strftime
+            function: string_agg
+            function: substr
+            function: substring
+            function: subtype
+            function: sum
+            function: time
+            function: timediff
+            function: total
+            function: total_changes
+            function: trim
+            function: typeof
+            function: unhex
+            function: unicode
+            function: unistr
+            function: unistr_quote
+            function: unixepoch
+            function: unlikely
+            function: upper
+            function: zeroblob
+""",
+        )
+
+    def test_join_keyword_after_from_alias(self):
+        return LspDiffTestBlueprint(
+            sql="SELECT * FROM s AS x J<|>",
+            op="completion",
+            out="""\
+            keyword: ALTER
+            keyword: ANALYZE
+            keyword: ATTACH
+            keyword: BEGIN
+            keyword: COMMIT
+            keyword: CREATE
+            keyword: CROSS
+            keyword: DELETE
+            keyword: DETACH
+            keyword: DROP
+            keyword: END
+            keyword: EXCEPT
+            keyword: EXPLAIN
+            keyword: FULL
+            keyword: GROUP
+            keyword: HAVING
+            keyword: INDEXED
+            keyword: INNER
+            keyword: INSERT
+            keyword: INTERSECT
+            keyword: JOIN
+            keyword: LEFT
+            keyword: LIMIT
+            keyword: NATURAL
+            keyword: NOT
+            keyword: ON
+            keyword: ORDER
+            keyword: OUTER
+            keyword: PRAGMA
+            keyword: REINDEX
+            keyword: RELEASE
+            keyword: REPLACE
+            keyword: RIGHT
+            keyword: ROLLBACK
+            keyword: SAVEPOINT
+            keyword: SELECT
+            keyword: UNION
+            keyword: UPDATE
+            keyword: USING
+            keyword: VACUUM
+            keyword: VALUES
+            keyword: WHERE
+            keyword: WINDOW
+            keyword: WITH
+""",
+        )
+
+    def test_join_keyword_after_from_table_trailing_space(self):
+        return LspDiffTestBlueprint(
+            sql="SELECT * FROM slice <|>",
+            op="completion",
+            out="""\
+            keyword: AS
+            keyword: CROSS
+            keyword: EXCEPT
+            keyword: FULL
+            keyword: GROUP
+            keyword: HAVING
+            keyword: INDEXED
+            keyword: INNER
+            keyword: INTERSECT
+            keyword: JOIN
+            keyword: LEFT
+            keyword: LIMIT
+            keyword: NATURAL
+            keyword: NOT
+            keyword: ON
+            keyword: ORDER
+            keyword: OUTER
+            keyword: RIGHT
+            keyword: UNION
+            keyword: USING
+            keyword: WHERE
+            keyword: WINDOW
+""",
+        )
+
+    def test_join_keyword_after_from_table_no_trailing_space(self):
+        return LspDiffTestBlueprint(
+            sql="SELECT * FROM slice<|>",
+            op="completion",
+            out="""\
+            keyword: AS
+            keyword: CROSS
+            keyword: EXCEPT
+            keyword: FULL
+            keyword: GROUP
+            keyword: HAVING
+            keyword: INDEXED
+            keyword: INNER
+            keyword: INTERSECT
+            keyword: JOIN
+            keyword: LEFT
+            keyword: LIMIT
+            keyword: NATURAL
+            keyword: NOT
+            keyword: ON
+            keyword: ORDER
+            keyword: OUTER
+            keyword: RIGHT
+            keyword: UNION
+            keyword: USING
+            keyword: WHERE
+            keyword: WINDOW
+""",
+        )
+
+    def test_join_target_after_join_keyword(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE a (id INTEGER);\nCREATE TABLE b (id INTEGER);\nSELECT * FROM a JOIN <|>",
+            op="completion",
+            out="""\
+            table: a
+            table: b
+            keyword: CROSS
+            keyword: FULL
+            keyword: INDEXED
+            keyword: INNER
+            keyword: LEFT
+            keyword: NATURAL
+            keyword: OUTER
+            keyword: RIGHT
+""",
+        )

--- a/tests/lsp_diff_tests/definition.py
+++ b/tests/lsp_diff_tests/definition.py
@@ -1,0 +1,78 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+from python.dev.diff_tests.testing import LspDiffTestBlueprint, TestSuite
+
+
+class Definition(TestSuite):
+    def test_ddl_table_reference(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE users (id INTEGER); SELECT id FROM <|>users;",
+            op="definition",
+            out="""\
+target: 0:13..0:18
+""",
+        )
+
+    def test_cte_reference(self):
+        return LspDiffTestBlueprint(
+            sql="WITH cte AS (SELECT 1) SELECT * FROM <|>cte;",
+            op="definition",
+            out="""\
+target: 0:5..0:8
+""",
+        )
+
+    def test_cte_shadows_ddl(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE t (id INTEGER); WITH t AS (SELECT 1 AS id) SELECT * FROM <|>t;",
+            op="definition",
+            out="""\
+            target: 0:34..0:35
+""",
+        )
+
+    def test_unknown_table_returns_none(self):
+        return LspDiffTestBlueprint(
+            sql="SELECT * FROM <|>nonexistent;",
+            op="definition",
+            out="""\
+(no definition)
+""",
+        )
+
+    def test_column_in_ddl_table(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE users (id INTEGER, name TEXT);\nSELECT <|>name FROM users;",
+            op="definition",
+            out="""\
+target: 0:32..0:36
+""",
+        )
+
+    def test_unknown_column_returns_none(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE t (a INT);\nSELECT <|>b FROM t;",
+            op="definition",
+            out="""\
+(no definition)
+""",
+        )
+
+    def test_cte_column_inferred_from_alias(self):
+        return LspDiffTestBlueprint(
+            sql="WITH foo AS (SELECT 1 AS a)\nSELECT <|>a FROM foo;",
+            op="definition",
+            out="""\
+            target: 0:25..0:26
+""",
+        )
+
+    def test_cte_column_from_declared_list(self):
+        return LspDiffTestBlueprint(
+            sql="WITH foo(x) AS (SELECT 1)\nSELECT <|>x FROM foo;",
+            op="definition",
+            out="""\
+            target: 0:9..0:10
+""",
+        )

--- a/tests/lsp_diff_tests/diagnostics.py
+++ b/tests/lsp_diff_tests/diagnostics.py
@@ -1,0 +1,109 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+from python.dev.diff_tests.testing import LspDiffTestBlueprint, TestSuite
+
+
+class Diagnostics(TestSuite):
+    def test_select_after_create_table_as_select_is_clean(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE orders AS SELECT 1 AS order_id;\n"
+                "SELECT o.order_id FROM orders o;",
+            op="diagnostics",
+            out="""\
+            (no diagnostics)
+""",
+        )
+
+    def test_unknown_table_warns(self):
+        return LspDiffTestBlueprint(
+            sql="SELECT * FROM nonexistent;",
+            op="diagnostics",
+            out="""\
+            warning 0:14..0:25: unknown table 'nonexistent'
+""",
+        )
+
+    def test_forward_reference_warns(self):
+        return LspDiffTestBlueprint(
+            sql="SELECT * FROM t;\nCREATE TABLE t (id INTEGER);",
+            op="diagnostics",
+            out="""\
+            warning 0:14..0:15: unknown table 't'
+""",
+        )
+
+    def test_syntax_error_on_bare_select(self):
+        return LspDiffTestBlueprint(
+            sql="SELECT ",
+            op="diagnostics",
+            out="""\
+            error 0:6..0:7: incomplete SQL statement
+""",
+        )
+
+    def test_syntax_error_on_incomplete_from(self):
+        return LspDiffTestBlueprint(
+            sql="SELECT * FROM",
+            op="diagnostics",
+            out="""\
+            error 0:12..0:13: incomplete SQL statement
+""",
+        )
+
+    def test_invalid_sql(self):
+        return LspDiffTestBlueprint(
+            sql="NOT VALID SQL;",
+            op="diagnostics",
+            out="""\
+            error 0:0..0:3: syntax error near 'NOT'
+""",
+        )
+
+    def test_multiple_syntax_errors_all_reported(self):
+        return LspDiffTestBlueprint(
+            sql="include ;\ninclude ;\nSELECT 1;",
+            op="diagnostics",
+            out="""\
+            error 0:0..0:7: syntax error near 'include'
+            error 1:0..1:7: syntax error near 'include'
+""",
+        )
+
+    def test_syntax_errors_do_not_suppress_later_statements(self):
+        return LspDiffTestBlueprint(
+            sql="NOT VALID;\nSELECT 1;",
+            op="diagnostics",
+            out="""\
+            error 0:0..0:3: syntax error near 'NOT'
+""",
+        )
+
+    def test_syntax_error_after_valid_statement_is_reported(self):
+        return LspDiffTestBlueprint(
+            sql="SELECT 1;\nNOT VALID;",
+            op="diagnostics",
+            out="""\
+            error 1:0..1:3: syntax error near 'NOT'
+""",
+        )
+
+    def test_validation_continues_past_errors(self):
+        return LspDiffTestBlueprint(
+            sql="SELECT ;\nSELECT ;\nSELECT * FROM no_such_table;",
+            op="diagnostics",
+            out="""\
+            error 0:7..0:8: syntax error near ';'
+            error 1:7..1:8: syntax error near ';'
+            warning 2:14..2:27: unknown table 'no_such_table'
+""",
+        )
+
+    def test_syntax_error_for_create_table_as_missing_select(self):
+        return LspDiffTestBlueprint(
+            sql="create table orders as;",
+            op="diagnostics",
+            out="""\
+            error 0:22..0:23: syntax error near ';'
+""",
+        )

--- a/tests/lsp_diff_tests/hover.py
+++ b/tests/lsp_diff_tests/hover.py
@@ -1,0 +1,51 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+from python.dev.diff_tests.testing import LspDiffTestBlueprint, TestSuite
+
+
+class Hover(TestSuite):
+    def test_on_ddl_table(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE users (id INTEGER, name TEXT); SELECT * FROM <|>users;",
+            op="hover",
+            out="""\
+**table** `users`
+
+```
+id, name
+```
+""",
+        )
+
+    def test_on_ddl_column(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE users (id INTEGER, name TEXT);\nSELECT <|>name FROM users;",
+            op="hover",
+            out="""\
+**column** in `users`
+
+id, **name**
+""",
+        )
+
+    def test_on_builtin_function(self):
+        return LspDiffTestBlueprint(
+            sql="SELECT <|>count(*);",
+            op="hover",
+            out="""\
+            **window function**
+
+            ```
+            count()
+            count(arg1)
+            ```
+""",
+        )
+
+    def test_on_unknown_identifier_returns_none(self):
+        return LspDiffTestBlueprint(
+            sql="SELECT * FROM <|>nonexistent;",
+            op="hover",
+            out="(no hover)",
+        )

--- a/tests/lsp_diff_tests/references.py
+++ b/tests/lsp_diff_tests/references.py
@@ -1,0 +1,59 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+from python.dev.diff_tests.testing import LspDiffTestBlueprint, TestSuite
+
+
+class References(TestSuite):
+    def test_table_in_single_file(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE users (id INT);\nSELECT * FROM <|>users;\nDELETE FROM users;",
+            op="references",
+            include_declaration=False,
+            out="""\
+            1:14..1:19
+            2:12..2:17
+""",
+        )
+
+    def test_table_include_declaration(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE users (id INT);\nSELECT * FROM <|>users;\nDELETE FROM users;",
+            op="references",
+            out="""\
+            0:13..0:18
+            1:14..1:19
+            2:12..2:17
+""",
+        )
+
+    def test_column_in_single_file(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE t (id INT, name TEXT);\nSELECT <|>id FROM t;\nSELECT id, name FROM t;",
+            op="references",
+            include_declaration=False,
+            out="""\
+            1:7..1:9
+            2:7..2:9
+""",
+        )
+
+    def test_cursor_on_definition(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE <|>users (id INT);\nSELECT * FROM users;",
+            op="references",
+            include_declaration=False,
+            out="""\
+            1:14..1:19
+""",
+        )
+
+    def test_cursor_on_definition_include_declaration(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE <|>users (id INT);\nSELECT * FROM users;",
+            op="references",
+            out="""\
+            0:13..0:18
+            1:14..1:19
+""",
+        )

--- a/tests/lsp_diff_tests/rename.py
+++ b/tests/lsp_diff_tests/rename.py
@@ -1,0 +1,48 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+from python.dev.diff_tests.testing import LspDiffTestBlueprint, TestSuite
+
+
+class Rename(TestSuite):
+    def test_prepare_rename_for_table(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE users (id INT);\nSELECT * FROM <|>users;",
+            op="prepare-rename",
+            out="""\
+            1:14..1:19 "users"
+""",
+        )
+
+    def test_rename_table_in_single_file(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE users (id INT);\nSELECT * FROM <|>users;\nDELETE FROM users;",
+            op="rename",
+            new_name="accounts",
+            out="""\
+            0:13..0:18 -> "accounts"
+            1:14..1:19 -> "accounts"
+            2:12..2:17 -> "accounts"
+""",
+        )
+
+    def test_rename_column_in_single_file(self):
+        return LspDiffTestBlueprint(
+            sql="CREATE TABLE t (id INT, name TEXT);\nSELECT <|>id FROM t;\nSELECT id, name FROM t;",
+            op="rename",
+            new_name="user_id",
+            out="""\
+            0:16..0:18 -> "user_id"
+            1:7..1:9 -> "user_id"
+            2:7..2:9 -> "user_id"
+""",
+        )
+
+    def test_prepare_rename_on_unknown_returns_none(self):
+        return LspDiffTestBlueprint(
+            sql="SELECT * FROM <|>nonexistent;",
+            op="prepare-rename",
+            out="""\
+(no rename)
+""",
+        )


### PR DESCRIPTION
Adds a declarative diff-test harness for the LSP that drives the real
`syntaqlite lsp` server over JSON-RPC. Each test is a one-liner
blueprint: SQL with an inline `<|>` cursor marker, an op (hover /
definition / completion / references / prepare-rename / rename /
diagnostics), and the expected text rendering. Rebaselineable via
the existing runner. Migrates 38 Rust LSP unit tests across to the
declarative system.

- python/dev/diff_tests/lsp_client.py: extracted the JSON-RPC
  LspClient + spawn_lsp helper out of the existing RPC integration
  suite into a shared module; now used by both suites.
- python/dev/diff_tests/lsp_executor.py: runs a single blueprint
  against a running LSP client, renders the response to deterministic
  text (hover markdown verbatim; locations as `line:col..line:col`
  with URI elided for same-file targets; completions sorted by kind
  then label; diagnostics rendered as `severity range: message`).
- python/dev/diff_tests/lsp_runner.py: main entry point — loads
  tests, spawns one LSP process per suite run, runs tests serially,
  filters publishDiagnostics by URI to avoid cross-test leakage,
  reuses the existing `_rewrite_test_file` for `--rebaseline`.
- python/dev/diff_tests/testing.py: adds LspDiffTestBlueprint
  (sql, op, out, new_name, include_declaration) and teaches
  TestSuite.fetch() to accept both blueprint types.
- python/dev/integration_tests/suites/lsp_diff.py: thin suite wrapper
  plus registration in the integration-tests runner.
- tests/lsp_diff_tests/: 41 declarative tests across hover,
  definition, completion, references, rename, diagnostics —
  migrated 1:1 from the corresponding Rust unit tests wherever
  semantics translated.
- syntaqlite/src/lsp/host.rs: deleted 38 migrated unit tests and the
  test-only `expected_tokens_at_offset` helper. Kept Rust tests that
  genuinely need Rust-API access: pure-API tests (available_function_names,
  set_session_context_from_ddl, validate-vs-diagnostics split,
  specific parse-error offset checks), SchemaMap internals, and
  cross-file scenarios that require a real schema file.
- python/dev/integration_tests/suites/lsp.py: slimmed to just the
  multi-phase server-lifecycle scenarios (schema reload, multi-schema
  switching, sqlite3 .schema integration) now that the single-shot
  query tests live in the declarative suite.

41 Python diff tests pass; 206 Rust lib tests pass.

