### PR TITLE
synq: add c-api integration test suite (issue #21)

### DIFF
--- a/python/dev/integration_tests/runner.py
+++ b/python/dev/integration_tests/runner.py
@@ -45,6 +45,7 @@ _SUITE_MODULES = [
     "python.dev.integration_tests.suites.introspect",
     "python.dev.integration_tests.suites.serve",
     "python.dev.integration_tests.suites.python_api",
+    "python.dev.integration_tests.suites.c_api",
 ]
 
 _BLUE = "\033[1;34m"

--- a/python/dev/integration_tests/suites/c_api.py
+++ b/python/dev/integration_tests/suites/c_api.py
@@ -1,0 +1,218 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""C API integration test suite.
+
+Compiles small C drivers against the syntaqlite static library and runs
+each scenario through the matching driver's stdin, diffing stdout
+against the scenario's expected output.
+
+Scenarios are defined in Python under `tests/c_api_tests/<area>.py` as
+classes deriving from `CApiTestSuite`; the module filename selects the
+driver area (e.g. `formatter.py` → `formatter_driver.c`).
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from python.dev.diff_tests.utils import Colors, colorize, format_diff
+from python.dev.integration_tests.suite import SuiteContext
+
+NAME = "c-api"
+DESCRIPTION = "C API integration tests (tests/c_api_tests/)"
+NEEDS_BINARY = False
+
+
+# ---------------------------------------------------------------------------
+# Scenario dataclass and test-suite base class
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CApiScenario:
+    """A single C API test scenario.
+
+    Attributes:
+        input: Line-protocol input fed to the driver's stdin.
+        expected: Expected stdout, byte-for-byte.
+    """
+    input: str
+    expected: str
+
+
+class CApiTestSuite:
+    """Base for C API scenario classes.
+
+    Subclass this and add methods prefixed with `test_` that return
+    `CApiScenario` instances; `fetch()` collects them as
+    `(class.method, scenario)` tuples.
+    """
+
+    def fetch(self) -> list[tuple[str, CApiScenario]]:
+        out: list[tuple[str, CApiScenario]] = []
+        for name in sorted(dir(self)):
+            if not name.startswith("test_"):
+                continue
+            method = getattr(self, name)
+            if not callable(method):
+                continue
+            scenario = method()
+            if not isinstance(scenario, CApiScenario):
+                continue
+            out.append((f"{self.__class__.__name__}.{name[5:]}", scenario))
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Driver compilation
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Driver:
+    area: str           # scenario module stem (e.g. "formatter")
+    source: str         # path of the driver .c relative to root_dir
+
+_DRIVERS = [
+    Driver(area="formatter", source="tests/c_api_tests/formatter_driver.c"),
+]
+
+_STATIC_LIB_REL = "target/debug/libsyntaqlite.a"
+
+
+def _ensure_static_lib(root_dir: Path, verbose: int) -> Path:
+    lib = root_dir / _STATIC_LIB_REL
+    if lib.exists():
+        return lib
+    if verbose >= 1:
+        print(f"Building {lib.name} via cargo...")
+    subprocess.check_call(
+        ["cargo", "build", "-p", "syntaqlite"],
+        cwd=root_dir,
+    )
+    if not lib.exists():
+        raise RuntimeError(f"cargo build did not produce {lib}")
+    return lib
+
+
+def _platform_link_args() -> list[str]:
+    if sys.platform == "darwin":
+        return ["-framework", "Security", "-framework", "SystemConfiguration",
+                "-framework", "CoreFoundation", "-lc++"]
+    if sys.platform.startswith("linux"):
+        return ["-lpthread", "-ldl", "-lm"]
+    return []
+
+
+def _compile_driver(
+    root_dir: Path, driver: Driver, static_lib: Path, out_dir: Path,
+    verbose: int,
+) -> Path:
+    out_bin = out_dir / (Path(driver.source).stem + (".exe" if sys.platform == "win32" else ""))
+    src = root_dir / driver.source
+    inc_dirs = [
+        root_dir / "syntaqlite" / "include",
+        root_dir / "syntaqlite-syntax" / "include",
+    ]
+    cmd = ["cc", "-std=c11", "-Wall", "-Wextra", "-Werror", "-O0", "-g",
+           "-o", str(out_bin), str(src), str(static_lib)]
+    for inc in inc_dirs:
+        cmd.extend(["-I", str(inc)])
+    cmd.extend(_platform_link_args())
+    if verbose >= 1:
+        print(f"Compiling {driver.source} -> {out_bin.name}")
+    subprocess.check_call(cmd)
+    return out_bin
+
+
+# ---------------------------------------------------------------------------
+# Scenario discovery
+# ---------------------------------------------------------------------------
+
+def _load_scenarios(root_dir: Path, area: str) -> list[tuple[str, CApiScenario]]:
+    module_name = f"tests.c_api_tests.{area}"
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        return []
+    scenarios: list[tuple[str, CApiScenario]] = []
+    for _, cls in inspect.getmembers(module, inspect.isclass):
+        if cls is CApiTestSuite or not issubclass(cls, CApiTestSuite):
+            continue
+        if cls.__module__ != module_name:
+            continue
+        scenarios.extend(cls().fetch())
+    return scenarios
+
+
+# ---------------------------------------------------------------------------
+# Execution
+# ---------------------------------------------------------------------------
+
+def _run_scenario(binary: Path, scenario: CApiScenario) -> tuple[bool, str]:
+    proc = subprocess.run(
+        [str(binary)], input=scenario.input.encode("utf-8"),
+        capture_output=True, timeout=30,
+    )
+    actual = proc.stdout.decode("utf-8", errors="replace")
+    ok = proc.returncode == 0 and actual == scenario.expected
+    return ok, actual
+
+
+def run(ctx: SuiteContext) -> int:
+    root_dir = ctx.root_dir
+    static_lib = _ensure_static_lib(root_dir, ctx.verbose)
+
+    filter_re = re.compile(ctx.filter_pattern) if ctx.filter_pattern else None
+
+    with tempfile.TemporaryDirectory(prefix="syntaqlite_c_api_") as tmp:
+        out_dir = Path(tmp)
+        results: list[tuple[str, bool]] = []
+        failed: list[str] = []
+
+        for driver in _DRIVERS:
+            scenarios = _load_scenarios(root_dir, driver.area)
+            if filter_re is not None:
+                scenarios = [
+                    (name, s) for name, s in scenarios
+                    if filter_re.search(f"{driver.area}.{name}")
+                ]
+            if not scenarios:
+                if ctx.verbose >= 1:
+                    print(f"No scenarios for driver '{driver.area}', skipping.")
+                continue
+            binary = _compile_driver(root_dir, driver, static_lib, out_dir, ctx.verbose)
+
+            for name, scenario in scenarios:
+                full = f"{driver.area}.{name}"
+                start = time.time()
+                ok, actual = _run_scenario(binary, scenario)
+                elapsed_ms = int((time.time() - start) * 1000)
+                results.append((full, ok))
+                if ok:
+                    if ctx.verbose >= 1:
+                        tag = colorize("[       OK ]", Colors.GREEN)
+                        print(f"{tag} {full} ({elapsed_ms} ms)")
+                else:
+                    tag = colorize("[  FAILED  ]", Colors.RED)
+                    print(f"{tag} {full} ({elapsed_ms} ms)")
+                    for line in format_diff(scenario.expected, actual):
+                        print(line)
+                    failed.append(full)
+
+        passed = sum(1 for _, ok in results if ok)
+        if passed:
+            print(colorize("[  PASSED  ]", Colors.GREEN) + f" {passed} tests.")
+        if failed:
+            print(colorize("[  FAILED  ]", Colors.RED) + f" {len(failed)} tests, listed below:")
+            for name in failed:
+                print(f"  {name}")
+            return 1
+        return 0

--- a/tests/c_api_tests/formatter.py
+++ b/tests/c_api_tests/formatter.py
@@ -1,0 +1,59 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Formatter C API scenarios.
+
+Each test method returns a `CApiScenario` with a line-protocol `input`
+fed to `formatter_driver.c` and the byte-for-byte `expected` stdout.
+See `tests/c_api_tests/formatter_driver.c` for the supported verbs.
+"""
+
+from python.dev.integration_tests.suites.c_api import CApiScenario, CApiTestSuite
+
+
+class BasicFormatter(CApiTestSuite):
+    def test_basic(self):
+        return CApiScenario(
+            input="""\
+create
+format
+select 1 from t;
+.
+""",
+            expected="""\
+create ok
+format ok len=17
+SELECT 1 FROM t;
+.
+""",
+        )
+
+    def test_keyword_lower(self):
+        return CApiScenario(
+            input="""\
+create keyword_case=lower
+format
+SELECT * FROM Tbl;
+.
+""",
+            expected="""\
+create ok
+format ok len=19
+select * from Tbl;
+.
+""",
+        )
+
+    def test_parse_error(self):
+        return CApiScenario(
+            input="""\
+create
+format
+select from where;
+.
+""",
+            expected="""\
+create ok
+format err syntax error near 'from'
+""",
+        )

--- a/tests/c_api_tests/formatter_driver.c
+++ b/tests/c_api_tests/formatter_driver.c
@@ -1,0 +1,139 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+// Line-protocol driver for the formatter C API integration tests.
+//
+// Reads verbs from stdin, one per line. SQL bodies for the `format` verb
+// follow the verb line and are terminated by a line containing only `.`.
+// Each verb produces one status line on stdout, optionally followed by an
+// output body terminated by a `.` line. Blank lines and lines starting
+// with `#` are ignored.
+//
+// Verbs:
+//   create [k=v ...]   Create a SQLite formatter. Options:
+//                        line_width, indent_width, semicolons (uint)
+//                        keyword_case = upper|lower
+//   format             Format the SQL block that follows (until `.`).
+//   destroy            Destroy the active handle.
+//
+// See python/dev/integration_tests/suites/c_api.py for the harness.
+
+// Needed for strtok_r under glibc when compiling with -std=c11.
+#define _POSIX_C_SOURCE 200809L
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "syntaqlite/formatter.h"
+
+static char g_line[64 * 1024];
+static char g_sql[256 * 1024];
+
+static void chomp(char* s) {
+  size_t n = strlen(s);
+  while (n > 0 && (s[n - 1] == '\n' || s[n - 1] == '\r')) s[--n] = '\0';
+}
+
+static int apply_kv(SyntaqliteFormatConfig* cfg, char* tok) {
+  char* eq = strchr(tok, '=');
+  if (!eq) return -1;
+  *eq = '\0';
+  const char* k = tok;
+  const char* v = eq + 1;
+  if (strcmp(k, "line_width") == 0) {
+    cfg->line_width = (uint32_t)strtoul(v, NULL, 10);
+  } else if (strcmp(k, "indent_width") == 0) {
+    cfg->indent_width = (uint32_t)strtoul(v, NULL, 10);
+  } else if (strcmp(k, "semicolons") == 0) {
+    cfg->semicolons = (uint32_t)strtoul(v, NULL, 10);
+  } else if (strcmp(k, "keyword_case") == 0) {
+    if (strcmp(v, "upper") == 0) cfg->keyword_case = SYNTAQLITE_KEYWORD_UPPER;
+    else if (strcmp(v, "lower") == 0) cfg->keyword_case = SYNTAQLITE_KEYWORD_LOWER;
+    else return -1;
+  } else {
+    return -1;
+  }
+  return 0;
+}
+
+static int apply_kvs(SyntaqliteFormatConfig* cfg, char* args) {
+  char* save = NULL;
+  for (char* tok = strtok_r(args, " \t", &save); tok;
+       tok = strtok_r(NULL, " \t", &save)) {
+    if (apply_kv(cfg, tok) != 0) return -1;
+  }
+  return 0;
+}
+
+static int read_block(char* out, size_t cap) {
+  size_t used = 0;
+  while (fgets(g_line, sizeof(g_line), stdin)) {
+    chomp(g_line);
+    if (strcmp(g_line, ".") == 0) {
+      if (used > 0) used--;  // drop trailing newline
+      out[used] = '\0';
+      return (int)used;
+    }
+    size_t len = strlen(g_line);
+    if (used + len + 2 > cap) return -1;
+    memcpy(out + used, g_line, len);
+    used += len;
+    out[used++] = '\n';
+  }
+  return -1;
+}
+
+int main(void) {
+  SyntaqliteFormatter* f = NULL;
+
+  while (fgets(g_line, sizeof(g_line), stdin)) {
+    chomp(g_line);
+    if (g_line[0] == '#' || g_line[0] == '\0') continue;
+
+    char* verb = g_line;
+    char* args = strchr(g_line, ' ');
+    if (args) { *args = '\0'; args++; }
+
+    if (strcmp(verb, "create") == 0) {
+      SyntaqliteFormatConfig cfg = {
+          .line_width = 80,
+          .indent_width = 2,
+          .keyword_case = SYNTAQLITE_KEYWORD_UPPER,
+          .semicolons = 1,
+      };
+      if (args && apply_kvs(&cfg, args) != 0) {
+        printf("create err bad_kv\n");
+        continue;
+      }
+      if (f) syntaqlite_formatter_destroy(f);
+      f = syntaqlite_formatter_create_sqlite_with_config(&cfg);
+      printf("create %s\n", f ? "ok" : "err null");
+    } else if (strcmp(verb, "destroy") == 0) {
+      syntaqlite_formatter_destroy(f);
+      f = NULL;
+      printf("destroy ok\n");
+    } else if (strcmp(verb, "format") == 0) {
+      int n = read_block(g_sql, sizeof(g_sql));
+      if (n < 0) { printf("format err no_terminator\n"); break; }
+      if (!f) { printf("format err no_handle\n"); continue; }
+      int32_t rc = syntaqlite_formatter_format(f, g_sql, (uint32_t)n);
+      if (rc == SYNTAQLITE_FORMAT_OK) {
+        const char* out = syntaqlite_formatter_output(f);
+        uint32_t out_len = syntaqlite_formatter_output_len(f);
+        printf("format ok len=%u\n", (unsigned)out_len);
+        if (out && out_len > 0) fwrite(out, 1, out_len, stdout);
+        if (out_len == 0 || out[out_len - 1] != '\n') fputc('\n', stdout);
+        printf(".\n");
+      } else {
+        const char* err = syntaqlite_formatter_error_msg(f);
+        printf("format err %s\n", err ? err : "unknown");
+      }
+    } else {
+      printf("error unknown_verb %s\n", verb);
+    }
+  }
+  if (f) syntaqlite_formatter_destroy(f);
+  return 0;
+}


### PR DESCRIPTION
Existing C API tests lean on Rust-side #[test] that call FFI in-process
with Rust types in scope, which misses header/ABI issues a real C
consumer would hit. Add a line-protocol integration suite that compiles
tiny C drivers against libsyntaqlite.a and drives them through stdin
scenarios, modelled after the amalgamation harness.

This PR lands the plumbing plus a formatter driver with three scenarios
(basic, keyword_lower, parse_error). Validator/parser drivers and
wider scenario fan-out will follow.

- tests/c_api_tests/formatter_driver.c: REPL-style driver with verbs
  create/format/destroy and key=value config. SQL blocks terminated
  by a `.` line, one status line per verb.
- tests/c_api_tests/scenarios/formatter/*: initial scenarios + golden
  outputs.
- python/dev/integration_tests/suites/c_api.py: ensures the staticlib
  is built, compiles each driver with -Wall -Wextra -Werror, runs each
  scenario and diffs stdout against the .expected file. Honours
  ctx.filter_pattern.
- python/dev/integration_tests/runner.py: register c-api suite.

