### PR TITLE
synq: fan out formatter c-api scenarios

### DIFF
--- a/tests/c_api_tests/formatter.py
+++ b/tests/c_api_tests/formatter.py
@@ -28,6 +28,61 @@ SELECT 1 FROM t;
 """,
         )
 
+    def test_empty_input(self):
+        return CApiScenario(
+            input="""\
+create
+format
+.
+""",
+            expected="""\
+create ok
+format ok len=0
+
+.
+""",
+        )
+
+    def test_comments(self):
+        return CApiScenario(
+            input="""\
+create
+format
+-- leading comment
+select 1; -- trailing comment
+.
+""",
+            expected="""\
+create ok
+format ok len=49
+-- leading comment
+SELECT 1; -- trailing comment
+.
+""",
+        )
+
+    def test_multi_statement(self):
+        return CApiScenario(
+            input="""\
+create
+format
+select 1;select 2;select 3;
+.
+""",
+            expected="""\
+create ok
+format ok len=32
+SELECT 1;
+
+SELECT 2;
+
+SELECT 3;
+.
+""",
+        )
+
+
+class ConfigFormatter(CApiTestSuite):
     def test_keyword_lower(self):
         return CApiScenario(
             input="""\
@@ -44,6 +99,151 @@ select * from Tbl;
 """,
         )
 
+    def test_line_width_narrow(self):
+        return CApiScenario(
+            input="""\
+create line_width=20
+format
+SELECT a, b, c, d, e FROM long_table_name;
+.
+""",
+            expected="""\
+create ok
+format ok len=43
+SELECT a, b, c, d, e
+FROM long_table_name;
+.
+""",
+        )
+
+    def test_indent_width(self):
+        return CApiScenario(
+            input="""\
+create indent_width=4 line_width=30
+format
+CREATE TABLE t (a INTEGER, b TEXT NOT NULL, c REAL DEFAULT 0);
+.
+""",
+            expected="""\
+create ok
+format ok len=78
+CREATE TABLE t(
+    a INTEGER,
+    b TEXT NOT NULL,
+    c REAL DEFAULT (0)
+);
+.
+""",
+        )
+
+    def test_semicolons_off(self):
+        return CApiScenario(
+            input="""\
+create semicolons=0
+format
+select 1 from t;
+.
+""",
+            expected="""\
+create ok
+format ok len=16
+SELECT 1 FROM t
+.
+""",
+        )
+
+
+class LifecycleFormatter(CApiTestSuite):
+    def test_reuse_after_success(self):
+        return CApiScenario(
+            input="""\
+create
+format
+select 1;
+.
+format
+select 2 from t;
+.
+""",
+            expected="""\
+create ok
+format ok len=10
+SELECT 1;
+.
+format ok len=17
+SELECT 2 FROM t;
+.
+""",
+        )
+
+    def test_reuse_after_error(self):
+        return CApiScenario(
+            input="""\
+create
+format
+select from where;
+.
+format
+select 1;
+.
+""",
+            expected="""\
+create ok
+format err syntax error near 'from'
+format ok len=10
+SELECT 1;
+.
+""",
+        )
+
+    def test_reconfigure(self):
+        return CApiScenario(
+            input="""\
+create
+format
+select 1 from t;
+.
+create keyword_case=lower
+format
+select 1 from t;
+.
+""",
+            expected="""\
+create ok
+format ok len=17
+SELECT 1 FROM t;
+.
+create ok
+format ok len=17
+select 1 from t;
+.
+""",
+        )
+
+    def test_destroy_no_handle(self):
+        return CApiScenario(
+            input="""\
+destroy
+create
+format
+select 1;
+.
+destroy
+destroy
+""",
+            expected="""\
+destroy ok
+create ok
+format ok len=10
+SELECT 1;
+.
+destroy ok
+destroy ok
+""",
+        )
+
+
+class ErrorsFormatter(CApiTestSuite):
     def test_parse_error(self):
         return CApiScenario(
             input="""\
@@ -55,5 +255,35 @@ select from where;
             expected="""\
 create ok
 format err syntax error near 'from'
+""",
+        )
+
+    def test_no_handle(self):
+        return CApiScenario(
+            input="""\
+format
+select 1;
+.
+""",
+            expected="""\
+format err no_handle
+""",
+        )
+
+    def test_unknown_verb(self):
+        return CApiScenario(
+            input="""\
+nonsense
+create
+format
+select 1;
+.
+""",
+            expected="""\
+error unknown_verb nonsense
+create ok
+format ok len=10
+SELECT 1;
+.
 """,
         )


### PR DESCRIPTION
Expand the c-api suite's formatter coverage from three smoke scenarios
to fifteen, exercising the full SyntaqliteFormatConfig surface plus
error, reuse, and lifecycle paths.

Config matrix:
- line_width_narrow: narrow wrap triggers line break.
- indent_width: 4-space indent visible on nested CREATE TABLE columns.
- semicolons_off: semicolons=0 drops trailing `;`.
- keyword_lower already covers SYNTAQLITE_KEYWORD_LOWER (pre-existing).

Multi-statement and reuse:
- multi_statement: three statements in one format call.
- reuse_after_success: two successful format() calls on the same handle.
- reuse_after_error: parse error followed by a successful format() on
  the same handle (validates post-error state recovery).
- reconfigure: create → format → create with new config → format,
  proving destroy+recreate works.

Error / edge paths:
- empty_input: zero-length source, format ok len=0.
- comments: leading + trailing SQL comments round-trip through the
  formatter.
- no_handle: format before create reports driver-side `no_handle`.
- destroy_no_handle: leading destroy on NULL and trailing double
  destroy exercise the NULL-safe destroy contract.
- unknown_verb: driver surfaces unknown-verb errors.

