### PR TITLE
synq: add parser c-api driver + scenarios

### DIFF
--- a/python/dev/integration_tests/suites/c_api.py
+++ b/python/dev/integration_tests/suites/c_api.py
@@ -83,6 +83,7 @@ class Driver:
 _DRIVERS = [
     Driver(area="formatter", source="tests/c_api_tests/formatter_driver.c"),
     Driver(area="validator", source="tests/c_api_tests/validator_driver.c"),
+    Driver(area="parser",    source="tests/c_api_tests/parser_driver.c"),
 ]
 
 _STATIC_LIB_REL = "target/debug/libsyntaqlite.a"

--- a/tests/c_api_tests/parser.py
+++ b/tests/c_api_tests/parser.py
@@ -1,0 +1,388 @@
+# Copyright 2025 The syntaqlite Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Parser C API scenarios.
+
+Each test method returns a `CApiScenario` with a line-protocol `input`
+fed to `parser_driver.c` and the byte-for-byte `expected` stdout.
+See `tests/c_api_tests/parser_driver.c` for the supported verbs.
+"""
+
+from python.dev.integration_tests.suites.c_api import CApiScenario, CApiTestSuite
+
+
+class BasicParser(CApiTestSuite):
+    def test_simple_select(self):
+        return CApiScenario(
+            input="""\
+create
+reset
+SELECT 1 FROM t;
+.
+parse_one
+node_count
+parser_text
+""",
+            expected="""\
+create ok
+reset ok len=16
+parse_one ok root=4 recovery=0
+node_count 5
+parser_text off=0 len=16
+SELECT 1 FROM t;
+.
+""",
+        )
+
+    def test_multi_statements(self):
+        return CApiScenario(
+            input="""\
+create
+reset
+SELECT 1; SELECT 2; SELECT 3;
+.
+parse_one
+parse_one
+parse_one
+parse_one
+""",
+            expected="""\
+create ok
+reset ok len=29
+parse_one ok root=3 recovery=0
+parse_one ok root=3 recovery=0
+parse_one ok root=3 recovery=0
+parse_one done root=0 recovery=0
+""",
+        )
+
+    def test_bare_semicolons_done(self):
+        return CApiScenario(
+            input="""\
+create
+reset
+;; ;;
+.
+parse_one
+""",
+            expected="""\
+create ok
+reset ok len=5
+parse_one done root=0 recovery=0
+""",
+        )
+
+    def test_empty_input(self):
+        return CApiScenario(
+            input="""\
+create
+reset
+.
+parse_one
+""",
+            expected="""\
+create ok
+reset ok len=0
+parse_one done root=0 recovery=0
+""",
+        )
+
+
+class ErrorParser(CApiTestSuite):
+    def test_parse_error(self):
+        return CApiScenario(
+            input="""\
+create
+reset
+SELECT from where;
+.
+parse_one
+error_info
+""",
+            expected="""\
+create ok
+reset ok len=18
+parse_one error root=0 recovery=0
+error_info msg="syntax error near 'from'" off=7 len=4 recovery=0
+""",
+        )
+
+    def test_parse_continues_after_error(self):
+        return CApiScenario(
+            input="""\
+create
+reset
+SELECT from where; SELECT 1;
+.
+parse_one
+error_info
+parse_one
+""",
+            expected="""\
+create ok
+reset ok len=28
+parse_one error root=0 recovery=0
+error_info msg="syntax error near 'from'" off=7 len=4 recovery=0
+parse_one ok root=3 recovery=0
+""",
+        )
+
+    def test_no_handle_reset(self):
+        return CApiScenario(
+            input="""\
+reset
+SELECT 1;
+.
+""",
+            expected="""\
+reset err no_handle
+""",
+        )
+
+
+class TokensParser(CApiTestSuite):
+    def test_tokens_disabled_empty(self):
+        return CApiScenario(
+            input="""\
+create
+reset
+SELECT 1 FROM t;
+.
+parse_one
+dump_tokens
+""",
+            expected="""\
+create ok
+reset ok len=16
+parse_one ok root=4 recovery=0
+tokens count=0
+.
+""",
+        )
+
+    def test_tokens_enabled(self):
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+reset
+SELECT 1 FROM t;
+.
+parse_one
+dump_tokens
+""",
+            expected="""\
+create ok
+collect_tokens ok
+reset ok len=16
+parse_one ok root=4 recovery=0
+tokens count=5
+tok[0] type=161 off=0 len=6 flags=0 layer=0
+tok[1] type=110 off=7 len=1 flags=0 layer=0
+tok[2] type=127 off=9 len=4 flags=0 layer=0
+tok[3] type=40 off=14 len=1 flags=1 layer=0
+tok[4] type=112 off=15 len=1 flags=0 layer=0
+.
+""",
+        )
+
+    def test_config_after_reset_sealed(self):
+        return CApiScenario(
+            input="""\
+create
+reset
+SELECT 1;
+.
+collect_tokens 1
+collect_extents 1
+""",
+            expected="""\
+create ok
+reset ok len=9
+collect_tokens err already_used
+collect_extents err already_used
+""",
+        )
+
+
+class CommentsParser(CApiTestSuite):
+    def test_leading_and_trailing(self):
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+reset
+-- preamble
+SELECT 1; -- after select
+.
+parse_one
+dump_comments
+token_comments 0
+token_comments 2
+""",
+            expected="""\
+create ok
+collect_tokens ok
+reset ok len=37
+parse_one ok root=3 recovery=0
+comments count=2
+com[0] side=leading kind=line off=0 len=11 token_idx=0
+com[1] side=trailing kind=line off=22 len=15 token_idx=2
+.
+token_comments idx=0 leading=1 trailing=0
+lead[0] side=leading kind=line off=0 len=11 token_idx=0
+.
+token_comments idx=2 leading=0 trailing=1
+trail[0] side=trailing kind=line off=22 len=15 token_idx=2
+.
+""",
+        )
+
+    def test_block_comment(self):
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+reset
+/* block */ SELECT 1;
+.
+parse_one
+dump_comments
+""",
+            expected="""\
+create ok
+collect_tokens ok
+reset ok len=21
+parse_one ok root=3 recovery=0
+comments count=1
+com[0] side=leading kind=block off=0 len=11 token_idx=0
+.
+""",
+        )
+
+
+class ExtentsParser(CApiTestSuite):
+    def test_extents_disabled_none(self):
+        return CApiScenario(
+            input="""\
+create
+reset
+SELECT 1 FROM t;
+.
+parse_one
+node_text 4
+""",
+            expected="""\
+create ok
+reset ok len=16
+parse_one ok root=4 recovery=0
+node_text none
+""",
+        )
+
+    def test_extents_enabled_slice(self):
+        return CApiScenario(
+            input="""\
+create
+collect_extents 1
+reset
+SELECT 1 FROM t;
+.
+parse_one
+node_text 4
+""",
+            expected="""\
+create ok
+collect_extents ok
+reset ok len=16
+parse_one ok root=4 recovery=0
+node_text id=4 off=0 len=15
+SELECT 1 FROM t
+.
+""",
+        )
+
+
+class IntrospectionParser(CApiTestSuite):
+    def test_full_text_roundtrip(self):
+        return CApiScenario(
+            input="""\
+create
+reset
+SELECT 1; SELECT 2;
+.
+parse_one
+full_text
+""",
+            expected="""\
+create ok
+reset ok len=19
+parse_one ok root=3 recovery=0
+full_text len=19
+SELECT 1; SELECT 2;
+.
+""",
+        )
+
+    def test_parser_text_per_statement(self):
+        return CApiScenario(
+            input="""\
+create
+reset
+SELECT 1; SELECT 22;
+.
+parse_one
+parser_text
+parse_one
+parser_text
+""",
+            expected="""\
+create ok
+reset ok len=20
+parse_one ok root=3 recovery=0
+parser_text off=0 len=9
+SELECT 1;
+.
+parse_one ok root=3 recovery=0
+parser_text off=10 len=10
+SELECT 22;
+.
+""",
+        )
+
+    def test_dump_root(self):
+        return CApiScenario(
+            input="""\
+create
+reset
+SELECT 1;
+.
+parse_one
+dump_root
+""",
+            expected="""\
+create ok
+reset ok len=9
+parse_one ok root=3 recovery=0
+dump_root ok
+SelectStmt
+  flags: (none)
+  columns:
+    ResultColumnList [1 items]
+      ResultColumn
+        flags: (none)
+        alias: (none)
+        expr:
+          Literal
+            literal_type: INTEGER
+            source: "1"
+  from_clause: (none)
+  where_clause: (none)
+  groupby: (none)
+  having: (none)
+  orderby: (none)
+  limit_clause: (none)
+  window_clause: (none)
+.
+""",
+        )

--- a/tests/c_api_tests/parser_driver.c
+++ b/tests/c_api_tests/parser_driver.c
@@ -1,0 +1,241 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+// Line-protocol driver for the parser C API integration tests.
+//
+// Unlike test_ast.c (which is compiled against a dialect amalgamation),
+// this driver links against libsyntaqlite.a and targets the parser
+// surface beyond single-shot AST dumps: configuration flags, explicit
+// parse_one stepping, tokens/comments/extents dumps, and error info.
+//
+// Each verb emits one status line on stdout. Dump verbs follow their
+// status line with a block terminated by a `.` line.
+//
+// Verbs:
+//   create                Create a SQLite parser with default mem.
+//   destroy               Destroy the active handle.
+//   collect_tokens 0|1    Configure (must be before first reset).
+//   collect_extents 0|1   Configure (must be before first reset).
+//   reset                 Bind multi-line source (until `.`).
+//   parse_one             Call next() once; prints status + root.
+//   node_count            Prints arena node count.
+//   parser_text           Prints statement text range + first N bytes.
+//   full_text             Prints full source length + slice.
+//   dump_root             dump_node at root with indent 0.
+//   dump_tokens           All tokens for current statement.
+//   dump_comments         All comments for current statement.
+//   token_comments <idx>  Leading + trailing comments for token idx.
+//   node_text <id>        Authored text slice for node (needs extents).
+//   error_info            error_msg/off/len/recovery_root dump.
+
+// Needed for strtok_r under glibc when compiling with -std=c11.
+#define _POSIX_C_SOURCE 200809L
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "syntaqlite/parser.h"
+#include "syntaqlite/types.h"
+
+static char g_line[64 * 1024];
+static char g_body[256 * 1024];
+
+static void chomp(char* s) {
+  size_t n = strlen(s);
+  while (n > 0 && (s[n - 1] == '\n' || s[n - 1] == '\r')) s[--n] = '\0';
+}
+
+static int read_block(char* out, size_t cap) {
+  size_t used = 0;
+  while (fgets(g_line, sizeof(g_line), stdin)) {
+    chomp(g_line);
+    if (strcmp(g_line, ".") == 0) {
+      if (used > 0) used--;  // drop trailing newline
+      out[used] = '\0';
+      return (int)used;
+    }
+    size_t len = strlen(g_line);
+    if (used + len + 2 > cap) return -1;
+    memcpy(out + used, g_line, len);
+    used += len;
+    out[used++] = '\n';
+  }
+  return -1;
+}
+
+static int tokenize(char* s, char** argv, int max) {
+  int n = 0;
+  char* save = NULL;
+  for (char* tok = strtok_r(s, " \t", &save); tok && n < max;
+       tok = strtok_r(NULL, " \t", &save)) {
+    argv[n++] = tok;
+  }
+  return n;
+}
+
+static const char* cfg_rc_str(int32_t rc) {
+  switch (rc) {
+    case SYNTAQLITE_OK:               return "ok";
+    case SYNTAQLITE_ERR_ALREADY_USED: return "err already_used";
+    default:                          return "err unknown";
+  }
+}
+
+static const char* parse_rc_str(int32_t rc) {
+  switch (rc) {
+    case SYNTAQLITE_PARSE_DONE:  return "done";
+    case SYNTAQLITE_PARSE_OK:    return "ok";
+    case SYNTAQLITE_PARSE_ERROR: return "error";
+    default:                     return "?";
+  }
+}
+
+static void print_comment(const SyntaqliteComment* c, const char* prefix, uint32_t i) {
+  const char* side = c->side == SYNQ_COMMENT_LEADING ? "leading" : "trailing";
+  const char* kind = c->kind == 0 ? "line" : "block";
+  printf("%s[%u] side=%s kind=%s off=%u len=%u token_idx=%u\n",
+         prefix, i, side, kind, c->offset, c->length, c->token_idx);
+}
+
+int main(void) {
+  SyntaqliteParser* p = NULL;
+  int32_t last_parse_rc = SYNTAQLITE_PARSE_DONE;
+
+  while (fgets(g_line, sizeof(g_line), stdin)) {
+    chomp(g_line);
+    if (g_line[0] == '#' || g_line[0] == '\0') continue;
+
+    char* argv[8];
+    int argc = tokenize(g_line, argv, 8);
+    if (argc == 0) continue;
+    const char* verb = argv[0];
+
+    if (strcmp(verb, "create") == 0) {
+      if (p) syntaqlite_parser_destroy(p);
+      p = syntaqlite_parser_create(NULL);
+      printf("create %s\n", p ? "ok" : "err null");
+    } else if (strcmp(verb, "destroy") == 0) {
+      syntaqlite_parser_destroy(p);
+      p = NULL;
+      printf("destroy ok\n");
+    } else if (strcmp(verb, "reset") == 0) {
+      int n = read_block(g_body, sizeof(g_body));
+      if (n < 0) { printf("reset err no_terminator\n"); break; }
+      if (!p) { printf("reset err no_handle\n"); continue; }
+      syntaqlite_parser_reset(p, g_body, (SyntaqliteDocLen)n);
+      printf("reset ok len=%d\n", n);
+    } else if (!p) {
+      printf("%s err no_handle\n", verb);
+    } else if (strcmp(verb, "collect_tokens") == 0) {
+      if (argc < 2) { printf("collect_tokens err bad_arg\n"); continue; }
+      int32_t rc = syntaqlite_parser_set_collect_tokens(
+          p, (uint32_t)strtoul(argv[1], NULL, 10));
+      printf("collect_tokens %s\n", cfg_rc_str(rc));
+    } else if (strcmp(verb, "collect_extents") == 0) {
+      if (argc < 2) { printf("collect_extents err bad_arg\n"); continue; }
+      int32_t rc = syntaqlite_parser_set_collect_node_extents(
+          p, (uint32_t)strtoul(argv[1], NULL, 10));
+      printf("collect_extents %s\n", cfg_rc_str(rc));
+    } else if (strcmp(verb, "parse_one") == 0) {
+      last_parse_rc = syntaqlite_parser_next(p);
+      uint32_t root = syntaqlite_result_root(p);
+      uint32_t recovery = syntaqlite_result_recovery_root(p);
+      printf("parse_one %s root=%u recovery=%u\n",
+             parse_rc_str(last_parse_rc),
+             root == SYNTAQLITE_NULL_NODE ? 0 : root,
+             recovery == SYNTAQLITE_NULL_NODE ? 0 : recovery);
+    } else if (strcmp(verb, "node_count") == 0) {
+      printf("node_count %u\n", syntaqlite_parser_node_count(p));
+    } else if (strcmp(verb, "parser_text") == 0) {
+      SyntaqliteDocOffset off = 0;
+      SyntaqliteStmtLen len = 0;
+      const char* t = syntaqlite_parser_text(p, &off, &len);
+      if (!t) {
+        printf("parser_text none\n");
+      } else {
+        printf("parser_text off=%u len=%u\n", off, len);
+        fwrite(t, 1, len, stdout);
+        if (len == 0 || t[len - 1] != '\n') fputc('\n', stdout);
+        printf(".\n");
+      }
+    } else if (strcmp(verb, "full_text") == 0) {
+      SyntaqliteDocLen len = 0;
+      const char* t = syntaqlite_parser_full_text(p, &len);
+      if (!t) {
+        printf("full_text none\n");
+      } else {
+        printf("full_text len=%u\n", len);
+        fwrite(t, 1, len, stdout);
+        if (len == 0 || t[len - 1] != '\n') fputc('\n', stdout);
+        printf(".\n");
+      }
+    } else if (strcmp(verb, "dump_root") == 0) {
+      uint32_t root = syntaqlite_result_root(p);
+      if (root == SYNTAQLITE_NULL_NODE) {
+        printf("dump_root none\n");
+      } else {
+        char* s = syntaqlite_dump_node(p, root, 0);
+        printf("dump_root ok\n");
+        if (s) { fputs(s, stdout); free(s); }
+        printf(".\n");
+      }
+    } else if (strcmp(verb, "dump_tokens") == 0) {
+      uint32_t count = 0;
+      const SyntaqliteParserToken* toks = syntaqlite_result_tokens(p, &count);
+      printf("tokens count=%u\n", count);
+      for (uint32_t i = 0; i < count; i++) {
+        printf("tok[%u] type=%u off=%u len=%u flags=%u layer=%u\n",
+               i, toks[i].type, toks[i].offset, toks[i].length,
+               toks[i].flags, toks[i]._layer_id);
+      }
+      printf(".\n");
+    } else if (strcmp(verb, "dump_comments") == 0) {
+      uint32_t count = 0;
+      const SyntaqliteComment* cs = syntaqlite_result_comments(p, &count);
+      printf("comments count=%u\n", count);
+      for (uint32_t i = 0; i < count; i++) print_comment(&cs[i], "com", i);
+      printf(".\n");
+    } else if (strcmp(verb, "token_comments") == 0) {
+      if (argc < 2) { printf("token_comments err bad_arg\n"); continue; }
+      SyntaqliteTokenIdx idx = (SyntaqliteTokenIdx)strtoul(argv[1], NULL, 10);
+      uint32_t lead = 0, trail = 0;
+      const SyntaqliteComment* lc = syntaqlite_token_leading_comments(p, idx, &lead);
+      const SyntaqliteComment* tc = syntaqlite_token_trailing_comments(p, idx, &trail);
+      printf("token_comments idx=%u leading=%u trailing=%u\n", idx, lead, trail);
+      for (uint32_t i = 0; i < lead; i++) print_comment(&lc[i], "lead", i);
+      for (uint32_t i = 0; i < trail; i++) print_comment(&tc[i], "trail", i);
+      printf(".\n");
+    } else if (strcmp(verb, "node_text") == 0) {
+      if (argc < 2) { printf("node_text err bad_arg\n"); continue; }
+      uint32_t id = (uint32_t)strtoul(argv[1], NULL, 10);
+      uint32_t len = 0, off = 0;
+      const char* t = syntaqlite_parser_node_text(p, id, &len, &off);
+      if (!t) {
+        printf("node_text none\n");
+      } else {
+        printf("node_text id=%u off=%u len=%u\n", id, off, len);
+        fwrite(t, 1, len, stdout);
+        if (len == 0 || t[len - 1] != '\n') fputc('\n', stdout);
+        printf(".\n");
+      }
+    } else if (strcmp(verb, "error_info") == 0) {
+      const char* msg = syntaqlite_result_error_msg(p);
+      SyntaqliteStmtOffset off = syntaqlite_result_error_offset(p);
+      SyntaqliteStmtLen len = syntaqlite_result_error_length(p);
+      uint32_t recovery = syntaqlite_result_recovery_root(p);
+      printf("error_info msg=\"%s\" off=%u len=%u recovery=%u\n",
+             msg ? msg : "",
+             off == 0xFFFFFFFFu ? 0xFFFFFFFFu : off,
+             len,
+             recovery == SYNTAQLITE_NULL_NODE ? 0 : recovery);
+    } else {
+      printf("error unknown_verb %s\n", verb);
+    }
+  }
+
+  if (p) syntaqlite_parser_destroy(p);
+  (void)last_parse_rc;
+  return 0;
+}


### PR DESCRIPTION
Adds the third driver to the c-api suite, targeting the parser surface
that lives beyond `test_ast.c` in the amalg harness: configuration
flags, explicit parse_one stepping, tokens/comments/extents dumps, and
error info.

- tests/c_api_tests/parser_driver.c: REPL driver linking against
  libsyntaqlite.a (not the amalgamation). Verbs cover create/destroy,
  collect_tokens / collect_extents config, reset + parse_one, error_info,
  node_count, parser_text, full_text, dump_root, dump_tokens,
  dump_comments, token_comments, node_text. `reset` consumes its body
  before the no-handle check so a bare `reset` from an empty state
  reports a single clean error line.
- tests/c_api_tests/parser.py: 17 scenarios across
    - BasicParser: simple SELECT, multi-statement DONE-terminated
      loop, bare-semicolon input, empty input.
    - ErrorParser: parse error + error_info, parser recovers and
      continues after an error, no-handle reset.
    - TokensParser: collect_tokens=0 yields empty array, enabled emits
      typed token rows, config-after-reset returns ALREADY_USED.
    - CommentsParser: line leading+trailing assignment per token,
      block comment attachment.
    - ExtentsParser: node_text returns none without extents enabled,
      returns an exact source slice when enabled.
    - IntrospectionParser: full_text roundtrip, per-statement
      parser_text slices, dump_root of a minimal SELECT.
- python/dev/integration_tests/suites/c_api.py: register the parser
  driver alongside formatter + validator.

