### PR TITLE
synq: run tools/pre-push in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
-# CI: run unit tests, integration tests, UI tests, and Playwright e2e tests on every PR and push to main.
+# CI: run pre-push checks (fmt/clippy/C checks/public API/unit tests/integration suites),
+# upstream SQLite validation, amalgamation build, Zed extension, UI tests, and Playwright e2e tests
+# on every PR and push to main.
 name: CI
 
 on:
@@ -22,8 +24,8 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  unit-tests:
-    name: Unit tests
+  pre-push:
+    name: Pre-push checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -46,11 +48,11 @@ jobs:
           key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-${{ runner.os }}-
 
-      - name: Run unit tests
-        run: tools/run-unit-tests
-
-      - name: Build CLI
-        run: tools/cargo build -p syntaqlite-cli
+      - name: Run pre-push checks
+        run: tools/pre-push --all -v
+        env:
+          CC: clang
+          CXX: clang++
 
       - name: Upload CLI binary
         uses: actions/upload-artifact@v6
@@ -59,33 +61,9 @@ jobs:
           path: target/debug/syntaqlite
           retention-days: 1
 
-  integration-tests:
-    name: Integration tests
-    needs: [unit-tests]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Download CLI binary
-        uses: actions/download-artifact@v7
-        with:
-          name: syntaqlite-cli
-          path: target/debug
-
-      - name: Make CLI binary executable
-        run: chmod +x target/debug/syntaqlite
-
-      - name: Run integration tests
-        run: tools/run-integration-tests
-        env:
-          CC: clang
-          CXX: clang++
-
   upstream-sqlite-validation:
     name: Upstream SQLite validation
-    needs: [unit-tests]
+    needs: [pre-push]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Locally we run tools/pre-push before pushing, but nothing forces that
to happen. If a contributor forgets, the missing checks (fmt, clippy,
C format, check-c-deps, check-public-api) silently slip through.

Add a single CI job that runs `tools/pre-push --all -v` and collapse
the jobs it already covers into it.

- add `pre-push` job that runs the full pre-push script and uploads
  the syntaqlite-cli artifact for downstream jobs
- drop `unit-tests` — subsumed by pre-push Phase 3
- drop `integration-tests` — subsumed by pre-push Phase 4 (all 6 suites)
- point `upstream-sqlite-validation` `needs:` at the new job
- leave `zed-extension`, `amalgamation`, `ui-tests`, `playwright-tests`,
  and `deploy-playwright-report` untouched (they cover territory
  pre-push does not)

