### PR TITLE
synq: format macro arguments structurally via a DocId pre-compute

### DIFF
--- a/syntaqlite/src/fmt/comment.rs
+++ b/syntaqlite/src/fmt/comment.rs
@@ -119,7 +119,6 @@ impl CommentCtx {
         self.drain_impl(end, source, arena, true)
     }
 
-    #[expect(clippy::too_many_lines)]
     fn drain_impl<'a>(
         &self,
         before: StmtOffset,

--- a/syntaqlite/src/fmt/formatter.rs
+++ b/syntaqlite/src/fmt/formatter.rs
@@ -3,7 +3,8 @@
 
 use syntaqlite_syntax::ParserConfig;
 use syntaqlite_syntax::any::{
-    AnyNodeId, AnyParseError, AnyParsedStatement, AnyParser, AnyTokenizer, ParseOutcome,
+    AnyNodeId, AnyParseError, AnyParseSession, AnyParsedStatement, AnyParser, AnyTokenizer,
+    FieldValue, ParseOutcome,
 };
 use syntaqlite_syntax::source::{DocLen, DocRange, StmtLen, StmtOffset, StmtRange, StmtText};
 
@@ -11,7 +12,7 @@ use super::FormatConfig;
 use super::FormatError;
 use super::comment::{CommentCtx, CommentEntry, TokenEntry};
 use super::doc::{DocArena, DocId, NIL_DOC, RenderBuffers};
-use super::interpret::{FmtCtx, InterpretScratch};
+use super::interpret::{FmtCtx, InterpretScratch, interpret_core};
 use crate::dialect::AnyDialect;
 
 /// Convert a parse error (statement-relative offsets) to a
@@ -71,6 +72,11 @@ pub struct Formatter {
     /// verbatim; full `MacroRewrite` records would tie this buffer to
     /// the statement lifetime and prevent reuse across statements.
     pub(super) macro_rewrites: Vec<(StmtOffset, StmtLen)>,
+    /// Mini-parses created during the structured pre-compute for each
+    /// macro argument.  Held on the formatter so that the arena's
+    /// borrows into their parser buffers remain valid through render.
+    /// Cleared at the start of each statement iteration.
+    pub(super) mini_parses: Vec<MiniParse>,
     pub(super) comment_entries: Vec<CommentEntry>,
     pub(super) token_entries: Vec<TokenEntry>,
     pub(super) parts: Vec<DocId>,
@@ -133,6 +139,7 @@ impl Formatter {
             interpret_scratch: InterpretScratch::new(),
             render_bufs: RenderBuffers::new(),
             macro_rewrites: Vec::with_capacity(32),
+            mini_parses: Vec::new(),
             comment_entries: Vec::with_capacity(64),
             token_entries: Vec::with_capacity(256),
             parts: Vec::with_capacity(64),
@@ -162,17 +169,11 @@ impl Formatter {
         // coincides with the statement-relative offset the formatter
         // compares against.  Nested rewrites measure into their parent's
         // expansion and belong to a different coordinate system.
-        self.macro_rewrites.extend(
-            erased
-                .macro_rewrites()
-                .filter(|r| r.parent().is_none())
-                .map(|r| {
-                    (
-                        StmtOffset::from_raw(r.call_offset().as_u32()),
-                        StmtLen::from(r.call_length()),
-                    )
-                }),
-        );
+        for r in erased.macro_rewrites().filter(|r| r.parent().is_none()) {
+            let call_off = StmtOffset::from_raw(r.call_offset().as_u32());
+            let call_len = StmtLen::from(r.call_length());
+            self.macro_rewrites.push((call_off, call_len));
+        }
     }
 
     /// Format SQL source text. Handles multiple statements and preserves comments.
@@ -253,6 +254,24 @@ impl Formatter {
                 drain_gap_comments(cctx, next_offset, stmt_source, &mut arena, &mut self.parts);
             }
 
+            // Stage 1.5: Pre-compute structured macro-call DocIds.  The
+            // mini-parses are pulled out of `self` so that precompute
+            // can hold a long-lived `&mut Vec<MiniParse>` alongside
+            // the later `self.interpret_node` call; the Vec is moved
+            // back onto `self` after render.  Boxes' pointees don't
+            // move across the swap, so span borrows into them survive.
+            let mut mini_parses = std::mem::take(&mut self.mini_parses);
+            mini_parses.clear();
+            let macro_docs = precompute_macro_docs(
+                &self.dialect,
+                &self.config,
+                stmt_source,
+                &self.macro_rewrites,
+                &mut mini_parses,
+                &mut arena,
+                &self.macro_tokenizer,
+            );
+
             // Stage 2: Interpret bytecode for this AST into Doc fragments.
             let ctx = FmtCtx {
                 dialect: self.dialect.clone(),
@@ -260,7 +279,7 @@ impl Formatter {
                 comment_ctx,
                 macro_rewrites: std::mem::take(&mut self.macro_rewrites),
             };
-            let interpreted = self.interpret_node(&ctx, root_id, &mut arena);
+            let interpreted = self.interpret_node(&ctx, &macro_docs, root_id, &mut arena);
             self.parts.push(interpreted);
 
             // Emit this statement's terminator.  Trailing comments now
@@ -297,6 +316,9 @@ impl Formatter {
 
             // Recycle the arena, releasing all Doc borrows from this iteration.
             self.arena = DocArena::recycle(arena);
+            // Drop mini-parses now that the arena has been rendered.
+            mini_parses.clear();
+            self.mini_parses = mini_parses;
 
             stmt_num += 1;
         }
@@ -315,7 +337,6 @@ impl Formatter {
     /// # Errors
     ///
     /// Returns `FormatError` if the source cannot be parsed.
-    #[expect(clippy::too_many_lines)]
     pub fn dump_bytecode(&mut self, source: &str) -> Result<String, FormatError> {
         use std::fmt::Write;
         use syntaqlite_common::fmt::bytecode::opcodes;
@@ -489,13 +510,25 @@ impl Formatter {
                 drain_gap_comments(cctx, next_offset, stmt_source, &mut arena, &mut self.parts);
             }
 
+            let mut mini_parses = std::mem::take(&mut self.mini_parses);
+            mini_parses.clear();
+            let macro_docs = precompute_macro_docs(
+                &self.dialect,
+                &self.config,
+                stmt_source,
+                &self.macro_rewrites,
+                &mut mini_parses,
+                &mut arena,
+                &self.macro_tokenizer,
+            );
+
             let ctx = FmtCtx {
                 dialect: self.dialect.clone(),
                 reader: erased,
                 comment_ctx,
                 macro_rewrites: std::mem::take(&mut self.macro_rewrites),
             };
-            let interpreted = self.interpret_node(&ctx, root_id, &mut arena);
+            let interpreted = self.interpret_node(&ctx, &macro_docs, root_id, &mut arena);
             self.parts.push(interpreted);
 
             if let Some(cctx) = ctx.comment_ctx.as_ref() {
@@ -515,6 +548,8 @@ impl Formatter {
             }
             self.macro_rewrites = ctx.macro_rewrites;
             self.arena = DocArena::recycle(arena);
+            mini_parses.clear();
+            self.mini_parses = mini_parses;
 
             stmt_num += 1;
         }
@@ -632,6 +667,318 @@ pub(crate) fn try_macro_verbatim<'a>(
         }
     }
     None
+}
+
+/// Try to format a macro call structurally, falling back to verbatim.
+pub(crate) fn try_macro_call<'a>(
+    ctx: &FmtCtx<'a>,
+    regions: &[(StmtOffset, StmtLen)],
+    macro_docs: &[Option<DocId>],
+    arena: &mut DocArena<'a>,
+    consumed: &mut [bool],
+    tokenizer: &AnyTokenizer,
+    child_id: AnyNodeId,
+) -> Option<DocId> {
+    if let Some(doc) = try_macro_structured(ctx, regions, macro_docs, arena, consumed, child_id) {
+        return Some(doc);
+    }
+    try_macro_verbatim(ctx, regions, arena, consumed, tokenizer, child_id)
+}
+
+/// Emit a macro call using the pre-computed structured format in
+/// `macro_fmt_results`.  Returns `None` if no region matches or the
+/// slot holds `None` (structured formatting wasn't available for this
+/// call, so the caller should fall back to verbatim).
+pub(crate) fn try_macro_structured<'a>(
+    ctx: &FmtCtx<'a>,
+    regions: &[(StmtOffset, StmtLen)],
+    macro_docs: &[Option<DocId>],
+    _arena: &mut DocArena<'a>,
+    consumed: &mut [bool],
+    child_id: AnyNodeId,
+) -> Option<DocId> {
+    let cctx = ctx.comment_ctx.as_ref()?;
+    let (tok_offset, _) = cctx.peek_next_token()?;
+
+    let (node_text, node_off) = ctx.reader.node_text(child_id)?;
+    let node_len = StmtLen::from_raw(u32::try_from(node_text.len()).ok()?);
+    let node_end = node_off + node_len;
+
+    let mut matched_i: Option<usize> = None;
+    let mut r_end_matched = StmtOffset::default();
+    for (i, &(r_start, r_len)) in regions.iter().enumerate() {
+        if tok_offset == r_start && node_end == r_start + r_len {
+            matched_i = Some(i);
+            r_end_matched = r_start + r_len;
+            break;
+        }
+    }
+    let i = matched_i?;
+    if consumed[i] {
+        return Some(NIL_DOC);
+    }
+    let doc = (*macro_docs.get(i)?)?;
+    consumed[i] = true;
+    let _ = r_end_matched;
+    // Deliberately do NOT advance the cctx cursor here — let the child
+    // frame's Span op advance it via `advance_past` when it emits the
+    // fallback `TK_ID`.  Manually advancing here caused trailing-comment
+    // drains to land inside the inner group rather than after it.
+    Some(doc)
+}
+
+/// Self-contained mini-parse holder.  Owns its own `AnyParseSession`
+/// (which in turn owns the parser inner + source buffer).  Kept alive
+/// on the outer `Formatter` through render so that `DocId` trees
+/// produced from its AST remain valid.
+pub(super) struct MiniParse {
+    session: AnyParseSession,
+}
+
+impl MiniParse {
+    fn parse_select(dialect: &AnyDialect, wrapped: &str) -> Option<Self> {
+        let parser = AnyParser::with_config(
+            (**dialect).clone(),
+            &ParserConfig::default()
+                .with_collect_tokens(true)
+                .with_collect_node_extents(true)
+                .with_macro_fallback(dialect.has_macro_style()),
+        );
+        let mut session = parser.parse(wrapped);
+        match session.next() {
+            ParseOutcome::Ok(_stmt) => {
+                // `_stmt` borrows `session`; drop it here so we can move session.
+            }
+            _ => return None,
+        }
+        Some(MiniParse { session })
+    }
+
+    fn statement(&self) -> AnyParsedStatement<'_> {
+        self.session.arena_result()
+    }
+}
+
+/// Walk descendants of `root` looking for the node whose source extent
+/// equals `(offset, length)`.  Returns the first match found via a
+/// depth-first traversal.
+fn find_descendant_by_extent(
+    reader: &AnyParsedStatement<'_>,
+    root: AnyNodeId,
+    target_off: StmtOffset,
+    target_len: StmtLen,
+) -> Option<AnyNodeId> {
+    if let Some((text, off)) = reader.node_text(root) {
+        let len = StmtLen::from_raw(u32::try_from(text.len()).ok()?);
+        if off == target_off && len == target_len {
+            return Some(root);
+        }
+    }
+    if let Some((_, fields)) = reader.extract_fields(root) {
+        for i in 0..fields.len() {
+            if let FieldValue::NodeId(child) = fields[i]
+                && !child.is_null()
+                && let Some(found) =
+                    find_descendant_by_extent(reader, child, target_off, target_len)
+            {
+                return Some(found);
+            }
+        }
+    }
+    if let Some(children) = reader.list_children(root) {
+        for &c in children {
+            if let Some(found) = find_descendant_by_extent(reader, c, target_off, target_len) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+/// For each top-level macro call recorded in `regions`, produce a
+/// structured `DocId` (or `None` on any failure, meaning "verbatim").
+/// Each argument is parsed as `SELECT <arg>` via a `MiniParse` held on
+/// the outer formatter so that resulting span borrows survive render.
+struct ArgEntry {
+    mini_idx: usize,
+    sub_off: StmtOffset,
+    sub_len: StmtLen,
+}
+
+struct CallEntry {
+    name: String,
+    args: Vec<ArgEntry>,
+}
+
+pub(super) fn precompute_macro_docs<'a>(
+    dialect: &AnyDialect,
+    _config: &FormatConfig,
+    source: &'a StmtText,
+    regions: &[(StmtOffset, StmtLen)],
+    mini_parses: &'a mut Vec<MiniParse>,
+    arena: &mut DocArena<'a>,
+    macro_tokenizer: &AnyTokenizer,
+) -> Vec<Option<DocId>> {
+    let mut results: Vec<Option<DocId>> = Vec::with_capacity(regions.len());
+    // First pass: parse all args, stash MiniParses in `mini_parses`, and
+    // record per-call metadata.  We cannot build DocIds in-place because
+    // that would need simultaneous &'a refs to `mini_parses` and &mut
+    // to `arena`; splitting the two phases lets the borrow checker see
+    // that the final &'a borrow comes solely from `mini_parses`.
+    let mut calls: Vec<Option<CallEntry>> = Vec::with_capacity(regions.len());
+    for &(r_start, r_len) in regions {
+        let call_text = &source[StmtRange {
+            start: r_start,
+            end: r_start + r_len,
+        }];
+        let Some((name, arg_texts)) = parse_call_envelope_owned(call_text) else {
+            calls.push(None);
+            continue;
+        };
+        let mut args: Vec<ArgEntry> = Vec::with_capacity(arg_texts.len());
+        let mut failed = false;
+        for arg_text in &arg_texts {
+            let wrapped = format!("SELECT {arg_text}");
+            let Some(mini) = MiniParse::parse_select(dialect, &wrapped) else {
+                failed = true;
+                break;
+            };
+            let mini_idx = mini_parses.len();
+            mini_parses.push(mini);
+            let sub_off = StmtOffset::from_raw(7); // length of "SELECT "
+            let sub_len =
+                StmtLen::from_raw(u32::try_from(arg_text.len()).expect("arg length fits in u32"));
+            args.push(ArgEntry {
+                mini_idx,
+                sub_off,
+                sub_len,
+            });
+        }
+        if failed {
+            calls.push(None);
+        } else {
+            calls.push(Some(CallEntry {
+                name: name.to_string(),
+                args,
+            }));
+        }
+    }
+    // Second pass: now that all mini-parses are in `mini_parses`, build
+    // DocIds into `arena`.  Borrows into `mini_parses[i].session` are
+    // live for &'a, which outlives arena.
+    for call in calls {
+        let Some(call) = call else {
+            results.push(None);
+            continue;
+        };
+        let mut arg_docs: Vec<DocId> = Vec::with_capacity(call.args.len());
+        let mut any_fail = false;
+        for arg in &call.args {
+            let mini: &'a MiniParse = &mini_parses[arg.mini_idx];
+            let reader: AnyParsedStatement<'a> = mini.statement();
+            let root = reader.root_id();
+            if root.is_null() {
+                any_fail = true;
+                break;
+            }
+            let Some(sub) = find_descendant_by_extent(&reader, root, arg.sub_off, arg.sub_len)
+            else {
+                any_fail = true;
+                break;
+            };
+            let sub_ctx = FmtCtx {
+                dialect: dialect.clone(),
+                reader,
+                comment_ctx: None,
+                macro_rewrites: Vec::new(),
+            };
+            let mut sub_scratch = InterpretScratch::new();
+            let mut sub_consumed: Vec<bool> = Vec::new();
+            let sub_docs: Vec<Option<DocId>> = Vec::new();
+            let doc = interpret_core(
+                &sub_ctx,
+                &sub_docs,
+                sub,
+                arena,
+                &mut sub_scratch,
+                &mut sub_consumed,
+                macro_tokenizer,
+            );
+            arg_docs.push(doc);
+        }
+        if any_fail {
+            results.push(None);
+            continue;
+        }
+        // Assemble: name + "!(" + arg0 + ", " + arg1 + ... + ")"
+        // Prototype shortcut: leak the macro name so that `arena.text`
+        // gets the `&'a str` lifetime it needs.  A production
+        // implementation would stash the owned name in a per-statement
+        // arena on `Formatter`.
+        let name_str: &'a str = Box::leak(call.name.into_boxed_str());
+        let name_doc = arena.text(name_str);
+        let open = arena.text("!(");
+        let close = arena.text(")");
+        let sep = arena.text(", ");
+        let mut d = arena.cat(name_doc, open);
+        for (i, ad) in arg_docs.iter().enumerate() {
+            if i > 0 {
+                d = arena.cat(d, sep);
+            }
+            d = arena.cat(d, *ad);
+        }
+        d = arena.cat(d, close);
+        results.push(Some(d));
+    }
+    results
+}
+
+/// Owned-string variant of [`parse_call_envelope`] used by the pre-
+/// computation pass.  Returns the macro name and the trimmed arg text
+/// for each comma-separated argument.
+fn parse_call_envelope_owned(call_text: &str) -> Option<(&str, Vec<&str>)> {
+    let bang_pos = call_text.find("!(")?;
+    let name = &call_text[..bang_pos];
+    if name.is_empty() || !name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        return None;
+    }
+    let bytes = call_text.as_bytes();
+    let inner_start = bang_pos + 2;
+    let last = call_text.len().checked_sub(1)?;
+    if bytes[last] != b')' {
+        return None;
+    }
+    let inner = &call_text[inner_start..last];
+    let bytes = inner.as_bytes();
+    let mut args: Vec<&str> = Vec::new();
+    let mut depth: i32 = 0;
+    let mut seg_start = 0usize;
+    for i in 0..bytes.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            b',' if depth == 0 => {
+                let slice = inner[seg_start..i].trim();
+                if !slice.is_empty() {
+                    args.push(slice);
+                }
+                seg_start = i + 1;
+            }
+            b'\'' | b'"' => return None,
+            _ => {}
+        }
+        if depth < 0 {
+            return None;
+        }
+    }
+    if depth != 0 {
+        return None;
+    }
+    let tail = inner[seg_start..].trim();
+    if !tail.is_empty() {
+        args.push(tail);
+    }
+    Some((name, args))
 }
 
 /// Raw LP/RP token type values from the `SQLite` tokenizer. These are stable

--- a/syntaqlite/src/fmt/interpret.rs
+++ b/syntaqlite/src/fmt/interpret.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue};
+use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, AnyTokenizer, FieldValue};
 use syntaqlite_syntax::source::{StmtLen, StmtOffset, StmtText};
 
 use super::comment::{CommentCtx, DrainResult};
@@ -65,373 +65,248 @@ enum ReturnAction {
     Discard,
 }
 
-#[expect(clippy::too_many_lines)]
 impl Formatter {
     pub(super) fn interpret_node<'a>(
         &mut self,
         ctx: &FmtCtx<'a>,
+        macro_docs: &[Option<DocId>],
         root_id: AnyNodeId,
         arena: &mut DocArena<'a>,
     ) -> DocId {
         self.consumed_regions.clear();
         self.consumed_regions
             .resize(ctx.macro_rewrites.len(), false);
-        let consumed_regions = &mut self.consumed_regions;
-        let scratch = &mut self.interpret_scratch;
-        let macro_tokenizer = &self.macro_tokenizer;
+        interpret_core(
+            ctx,
+            macro_docs,
+            root_id,
+            arena,
+            &mut self.interpret_scratch,
+            &mut self.consumed_regions,
+            &self.macro_tokenizer,
+        )
+    }
+}
 
-        if root_id.is_null() {
-            return NIL_DOC;
-        }
+#[expect(clippy::too_many_lines)]
+pub(super) fn interpret_core<'a>(
+    ctx: &FmtCtx<'a>,
+    macro_docs: &[Option<DocId>],
+    root_id: AnyNodeId,
+    arena: &mut DocArena<'a>,
+    scratch: &mut InterpretScratch,
+    consumed_regions: &mut [bool],
+    macro_tokenizer: &AnyTokenizer,
+) -> DocId {
+    if root_id.is_null() {
+        return NIL_DOC;
+    }
 
-        let source = ctx.text();
-        let Some((tag, fields)) = ctx.reader.extract_fields(root_id) else {
-            return NIL_DOC;
-        };
-        let Some((ops_bytes, ops_len)) = ctx.dialect.fmt_dispatch(tag) else {
-            return NIL_DOC;
-        };
-        scratch.group_nest.clear();
-        scratch.calls.clear();
-        scratch.for_each.clear();
+    let source = ctx.text();
+    let Some((tag, fields)) = ctx.reader.extract_fields(root_id) else {
+        return NIL_DOC;
+    };
+    let Some((ops_bytes, ops_len)) = ctx.dialect.fmt_dispatch(tag) else {
+        return NIL_DOC;
+    };
+    scratch.group_nest.clear();
+    scratch.calls.clear();
+    scratch.for_each.clear();
 
-        let mut cur_node_id: AnyNodeId = root_id;
-        let mut ops: &[u8] = &ops_bytes[..ops_len * 6];
-        let mut ops_count: usize = ops_len;
-        let mut fields = fields;
-        let mut running: DocId = NIL_DOC;
-        let mut pending: DocId = NIL_DOC;
-        let mut gn_save = scratch.group_nest.len();
-        let mut fe_save = scratch.for_each.len();
-        let mut ip: usize = 0;
-        let has_comments = ctx.comment_ctx.is_some();
+    let mut cur_node_id: AnyNodeId = root_id;
+    let mut ops: &[u8] = &ops_bytes[..ops_len * 6];
+    let mut ops_count: usize = ops_len;
+    let mut fields = fields;
+    let mut running: DocId = NIL_DOC;
+    let mut pending: DocId = NIL_DOC;
+    let mut gn_save = scratch.group_nest.len();
+    let mut fe_save = scratch.for_each.len();
+    let mut ip: usize = 0;
+    let has_comments = ctx.comment_ctx.is_some();
 
-        macro_rules! push_call_frame {
-            ($child_id:expr, $child_ops_bytes:expr, $child_ops_len:expr,
+    macro_rules! push_call_frame {
+        ($child_id:expr, $child_ops_bytes:expr, $child_ops_len:expr,
          $child_fields:expr, $return_action_val:expr) => {{
-                let frame = CallFrame {
-                    ip: ip + 1,
-                    node_id: cur_node_id,
-                    running,
-                    pending,
-                    gn_save,
-                    fe_save,
-                    return_action: $return_action_val,
-                };
-                scratch.calls.push(frame);
+            let frame = CallFrame {
+                ip: ip + 1,
+                node_id: cur_node_id,
+                running,
+                pending,
+                gn_save,
+                fe_save,
+                return_action: $return_action_val,
+            };
+            scratch.calls.push(frame);
 
-                cur_node_id = $child_id;
-                ops = &$child_ops_bytes[..$child_ops_len * 6];
-                ops_count = $child_ops_len;
-                fields = $child_fields;
-                running = NIL_DOC;
-                pending = NIL_DOC;
-                gn_save = scratch.group_nest.len();
-                fe_save = scratch.for_each.len();
-                ip = 0;
-                continue;
-            }};
-        }
+            cur_node_id = $child_id;
+            ops = &$child_ops_bytes[..$child_ops_len * 6];
+            ops_count = $child_ops_len;
+            fields = $child_fields;
+            running = NIL_DOC;
+            pending = NIL_DOC;
+            gn_save = scratch.group_nest.len();
+            fe_save = scratch.for_each.len();
+            ip = 0;
+            continue;
+        }};
+    }
 
-        loop {
-            if ip >= ops_count {
-                let result = arena.cat(running, pending);
-                scratch.group_nest.truncate(gn_save);
-                scratch.for_each.truncate(fe_save);
+    loop {
+        if ip >= ops_count {
+            let result = arena.cat(running, pending);
+            scratch.group_nest.truncate(gn_save);
+            scratch.for_each.truncate(fe_save);
 
-                if scratch.calls.is_empty() {
-                    return result;
-                }
-
-                let frame = scratch
-                    .calls
-                    .pop()
-                    .expect("call_stack must contain a parent frame");
-                cur_node_id = frame.node_id;
-                ip = frame.ip;
-                let Some((restored_tag, restored_fields)) = ctx.reader.extract_fields(cur_node_id)
-                else {
-                    panic!("restored node must resolve to fields");
-                };
-                let Some((restored_ops, restored_ops_len)) = ctx.dialect.fmt_dispatch(restored_tag)
-                else {
-                    panic!("restored node must resolve to formatter ops");
-                };
-                ops = &restored_ops[..restored_ops_len * 6];
-                ops_count = restored_ops_len;
-                fields = restored_fields;
-                running = frame.running;
-                pending = frame.pending;
-                gn_save = frame.gn_save;
-                fe_save = frame.fe_save;
-
-                match frame.return_action {
-                    ReturnAction::CatOntoRunning => {
-                        running = arena.cat(running, result);
-                    }
-                    ReturnAction::WrapInParens => {
-                        let lp = arena.text("(");
-                        let inner = arena.cat(lp, result);
-                        let rp = arena.text(")");
-                        let wrapped = arena.cat(inner, rp);
-                        let grouped = arena.group(wrapped);
-                        running = arena.cat(running, grouped);
-                    }
-                    ReturnAction::Discard => {}
-                }
-                continue;
+            if scratch.calls.is_empty() {
+                return result;
             }
 
-            let op = op_at(ops, ip);
-            match op {
-                FmtOp::Keyword(sid) => {
-                    let kw_text = ctx.dialect.fmt_string(sid);
+            let frame = scratch
+                .calls
+                .pop()
+                .expect("call_stack must contain a parent frame");
+            cur_node_id = frame.node_id;
+            ip = frame.ip;
+            let Some((restored_tag, restored_fields)) = ctx.reader.extract_fields(cur_node_id)
+            else {
+                panic!("restored node must resolve to fields");
+            };
+            let Some((restored_ops, restored_ops_len)) = ctx.dialect.fmt_dispatch(restored_tag)
+            else {
+                panic!("restored node must resolve to formatter ops");
+            };
+            ops = &restored_ops[..restored_ops_len * 6];
+            ops_count = restored_ops_len;
+            fields = restored_fields;
+            running = frame.running;
+            pending = frame.pending;
+            gn_save = frame.gn_save;
+            fe_save = frame.fe_save;
 
-                    if let Some(ref cctx) = ctx.comment_ctx {
-                        if let Some((tok_offset, word_count)) =
-                            cctx.peek_keyword_tokens(kw_text, source)
-                        {
-                            let drain = cctx.drain_before(tok_offset, source, arena);
-                            if word_count > 1 {
-                                // For multi-word keywords, only flush drain_before
-                                // if it found comments; otherwise defer pending to
-                                // drain_keyword_interior to avoid a double hardline
-                                // before interior comments.
-                                if drain.trailing != NIL_DOC || drain.leading != NIL_DOC {
-                                    flush_drain(&drain, &mut pending, &mut running, arena);
-                                }
-                                let interior =
-                                    cctx.drain_keyword_interior(word_count, source, arena);
-                                flush_drain(&interior, &mut pending, &mut running, arena);
-                            } else {
+            match frame.return_action {
+                ReturnAction::CatOntoRunning => {
+                    running = arena.cat(running, result);
+                }
+                ReturnAction::WrapInParens => {
+                    let lp = arena.text("(");
+                    let inner = arena.cat(lp, result);
+                    let rp = arena.text(")");
+                    let wrapped = arena.cat(inner, rp);
+                    let grouped = arena.group(wrapped);
+                    running = arena.cat(running, grouped);
+                }
+                ReturnAction::Discard => {}
+            }
+            continue;
+        }
+
+        let op = op_at(ops, ip);
+        match op {
+            FmtOp::Keyword(sid) => {
+                let kw_text = ctx.dialect.fmt_string(sid);
+
+                if let Some(ref cctx) = ctx.comment_ctx {
+                    if let Some((tok_offset, word_count)) =
+                        cctx.peek_keyword_tokens(kw_text, source)
+                    {
+                        let drain = cctx.drain_before(tok_offset, source, arena);
+                        if word_count > 1 {
+                            // For multi-word keywords, only flush drain_before
+                            // if it found comments; otherwise defer pending to
+                            // drain_keyword_interior to avoid a double hardline
+                            // before interior comments.
+                            if drain.trailing != NIL_DOC || drain.leading != NIL_DOC {
                                 flush_drain(&drain, &mut pending, &mut running, arena);
                             }
-                            cctx.advance_token_cursor(word_count);
+                            let interior = cctx.drain_keyword_interior(word_count, source, arena);
+                            flush_drain(&interior, &mut pending, &mut running, arena);
                         } else {
-                            running = arena.cat(running, pending);
-                            pending = NIL_DOC;
-                        }
-                    }
-                    let kw = arena.keyword(kw_text);
-                    running = arena.cat(running, kw);
-                }
-                FmtOp::Span(idx) => {
-                    // INVARIANT: Span ops only target Span fields.
-                    let FieldValue::Span(span) = fields[idx as usize] else {
-                        panic!("Span: field {idx} is not a Span");
-                    };
-
-                    let (s, span_start) = ctx.reader.span_text(span);
-                    let quoted = span.is_quoted();
-                    // A zero-length unquoted span means the field is absent
-                    // (optional, unset). A zero-length *quoted* span is a
-                    // real `""` token and must round-trip as `""`.
-                    if quoted || !s.is_empty() {
-                        if let Some(ref cctx) = ctx.comment_ctx {
-                            // For quoted spans, the original token in source
-                            // starts one byte earlier (the opening quote) and
-                            // extends one byte past (the closing quote).
-                            let span_len =
-                                StmtLen::from_raw(u32::try_from(s.len()).unwrap_or(u32::MAX));
-                            let drain_offset = if quoted {
-                                span_start - StmtLen::from_raw(1)
-                            } else {
-                                span_start
-                            };
-                            let token_len = if quoted {
-                                span_len + StmtLen::from_raw(2)
-                            } else {
-                                span_len
-                            };
-                            let drain = cctx.drain_before(drain_offset, source, arena);
                             flush_drain(&drain, &mut pending, &mut running, arena);
-                            cctx.advance_past(drain_offset + token_len);
                         }
-                        if quoted {
-                            let q = arena.text("\"");
-                            let txt = arena.text(s);
-                            running = arena.cat(running, q);
-                            running = arena.cat(running, txt);
-                            running = arena.cat(running, q);
-                        } else {
-                            let txt = arena.text(s);
-                            running = arena.cat(running, txt);
-                        }
-                    }
-                }
-                FmtOp::Child(idx) => {
-                    // INVARIANT: Child ops only target NodeId fields.
-                    let FieldValue::NodeId(child_id) = fields[idx as usize] else {
-                        panic!("Child: field {idx} is not a NodeId");
-                    };
-
-                    if !child_id.is_null() {
-                        drain_comments_before_child(
-                            ctx.comment_ctx.as_ref(),
-                            source,
-                            &mut pending,
-                            &mut running,
-                            arena,
-                        );
-
-                        let mut return_action = ReturnAction::CatOntoRunning;
-                        let macro_rewrites = &ctx.macro_rewrites;
-                        if !macro_rewrites.is_empty()
-                            && ctx.reader.list_children(child_id).is_none()
-                            && let Some(doc) = super::formatter::try_macro_verbatim(
-                                ctx,
-                                macro_rewrites,
-                                arena,
-                                consumed_regions,
-                                macro_tokenizer,
-                                child_id,
-                            )
-                        {
-                            running = arena.cat(running, doc);
-                            return_action = ReturnAction::Discard;
-                        }
-
-                        if let Some((ctag, child_fields)) = ctx.reader.extract_fields(child_id)
-                            && let Some((child_ops_bytes, child_ops_len)) =
-                                ctx.dialect.fmt_dispatch(ctag)
-                        {
-                            push_call_frame!(
-                                child_id,
-                                child_ops_bytes,
-                                child_ops_len,
-                                child_fields,
-                                return_action
-                            );
-                        }
-                    }
-                }
-                FmtOp::Line | FmtOp::SoftLine | FmtOp::HardLine => {
-                    let doc = match op {
-                        FmtOp::Line => arena.line(),
-                        FmtOp::SoftLine => arena.softline(),
-                        FmtOp::HardLine => arena.hardline(),
-                        _ => unreachable!(),
-                    };
-                    if has_comments {
-                        pending = arena.cat(pending, doc);
+                        cctx.advance_token_cursor(word_count);
                     } else {
-                        running = arena.cat(running, doc);
+                        running = arena.cat(running, pending);
+                        pending = NIL_DOC;
                     }
                 }
-                FmtOp::GroupStart => {
-                    scratch.group_nest.push(GroupNestFrame::Group(running));
-                    running = NIL_DOC;
-                }
-                FmtOp::GroupEnd => {
-                    running = arena.cat(running, pending);
-                    pending = NIL_DOC;
-                    let inner = running;
-                    match scratch.group_nest.pop().expect("unmatched GroupEnd") {
-                        GroupNestFrame::Group(parent) => {
-                            let g = arena.group(inner);
-                            running = arena.cat(parent, g);
-                        }
-                        GroupNestFrame::Nest(..) => panic!("expected Group frame"),
-                    }
-                }
-                FmtOp::NestStart => {
-                    scratch.group_nest.push(GroupNestFrame::Nest(running));
-                    running = NIL_DOC;
-                }
-                FmtOp::NestEnd => {
-                    running = arena.cat(running, pending);
-                    pending = NIL_DOC;
-                    let inner = running;
-                    match scratch.group_nest.pop().expect("unmatched NestEnd") {
-                        GroupNestFrame::Nest(parent) => {
-                            let n = arena.nest(1, inner);
-                            running = arena.cat(parent, n);
-                        }
-                        GroupNestFrame::Group(_) => panic!("expected Nest frame"),
-                    }
-                }
-                FmtOp::IfSet(idx, skip) => {
-                    // INVARIANT: IfSet ops only target NodeId fields.
-                    let FieldValue::NodeId(id) = fields[idx as usize] else {
-                        panic!("IfSet: field {idx} is not a NodeId");
-                    };
-                    if id.is_null() {
-                        ip += skip as usize;
-                    }
-                }
-                FmtOp::Else(skip) => {
-                    ip += skip as usize;
-                }
-                FmtOp::EndIf => {}
-                FmtOp::ForEachStart(idx) => {
-                    // INVARIANT: ForEachStart ops only target NodeId fields.
-                    let FieldValue::NodeId(list_id) = fields[idx as usize] else {
-                        panic!("ForEachStart: field {idx} is not a NodeId");
-                    };
-                    if list_id.is_null() {
-                        ip = skip_to_foreach_end(ops, ops_count, ip);
-                    } else {
-                        let children: &'a [AnyNodeId] =
-                            ctx.reader.list_children(list_id).unwrap_or(&[]);
-                        if children.is_empty() {
-                            ip = skip_to_foreach_end(ops, ops_count, ip);
-                        } else {
-                            scratch.for_each.push(ForEachState {
-                                list_id,
-                                index: 0,
-                                body_start: ip + 1,
-                                sep_checkpoint: None,
-                            });
-                        }
-                    }
-                }
-                FmtOp::ChildItem => {
-                    let state = scratch.for_each.last().expect("ChildItem outside ForEach");
-                    let children = ctx.reader.list_children(state.list_id).unwrap_or(&[]);
-                    let child_id = children[state.index];
+                let kw = arena.keyword(kw_text);
+                running = arena.cat(running, kw);
+            }
+            FmtOp::Span(idx) => {
+                // INVARIANT: Span ops only target Span fields.
+                let FieldValue::Span(span) = fields[idx as usize] else {
+                    panic!("Span: field {idx} is not a Span");
+                };
 
+                let (s, span_start) = ctx.reader.span_text(span);
+                let quoted = span.is_quoted();
+                // A zero-length unquoted span means the field is absent
+                // (optional, unset). A zero-length *quoted* span is a
+                // real `""` token and must round-trip as `""`.
+                if quoted || !s.is_empty() {
+                    if let Some(ref cctx) = ctx.comment_ctx {
+                        // For quoted spans, the original token in source
+                        // starts one byte earlier (the opening quote) and
+                        // extends one byte past (the closing quote).
+                        let span_len =
+                            StmtLen::from_raw(u32::try_from(s.len()).unwrap_or(u32::MAX));
+                        let drain_offset = if quoted {
+                            span_start - StmtLen::from_raw(1)
+                        } else {
+                            span_start
+                        };
+                        let token_len = if quoted {
+                            span_len + StmtLen::from_raw(2)
+                        } else {
+                            span_len
+                        };
+                        let drain = cctx.drain_before(drain_offset, source, arena);
+                        flush_drain(&drain, &mut pending, &mut running, arena);
+                        cctx.advance_past(drain_offset + token_len);
+                    }
+                    if quoted {
+                        let q = arena.text("\"");
+                        let txt = arena.text(s);
+                        running = arena.cat(running, q);
+                        running = arena.cat(running, txt);
+                        running = arena.cat(running, q);
+                    } else {
+                        let txt = arena.text(s);
+                        running = arena.cat(running, txt);
+                    }
+                }
+            }
+            FmtOp::Child(idx) => {
+                // INVARIANT: Child ops only target NodeId fields.
+                let FieldValue::NodeId(child_id) = fields[idx as usize] else {
+                    panic!("Child: field {idx} is not a NodeId");
+                };
+
+                if !child_id.is_null() {
+                    drain_comments_before_child(
+                        ctx.comment_ctx.as_ref(),
+                        source,
+                        &mut pending,
+                        &mut running,
+                        arena,
+                    );
+
+                    let mut return_action = ReturnAction::CatOntoRunning;
                     let macro_rewrites = &ctx.macro_rewrites;
-                    let macro_doc = if !macro_rewrites.is_empty()
+                    if !macro_rewrites.is_empty()
                         && ctx.reader.list_children(child_id).is_none()
-                    {
-                        super::formatter::try_macro_verbatim(
+                        && let Some(doc) = super::formatter::try_macro_call(
                             ctx,
                             macro_rewrites,
+                            macro_docs,
                             arena,
                             consumed_regions,
                             macro_tokenizer,
                             child_id,
                         )
-                    } else {
-                        None
-                    };
-                    let return_action;
-
-                    if macro_doc == Some(NIL_DOC) {
-                        let state = scratch
-                            .for_each
-                            .last_mut()
-                            .expect("ForEachState must exist while handling ChildItem");
-                        if let Some((saved_running, saved_pending)) = state.sep_checkpoint.take() {
-                            running = saved_running;
-                            pending = saved_pending;
-                        }
+                    {
+                        running = arena.cat(running, doc);
                         return_action = ReturnAction::Discard;
-                    } else {
-                        drain_comments_before_child(
-                            ctx.comment_ctx.as_ref(),
-                            source,
-                            &mut pending,
-                            &mut running,
-                            arena,
-                        );
-
-                        if let Some(verbatim) = macro_doc {
-                            running = arena.cat(running, verbatim);
-                            return_action = ReturnAction::Discard;
-                        } else {
-                            return_action = ReturnAction::CatOntoRunning;
-                        }
                     }
 
                     if let Some((ctag, child_fields)) = ctx.reader.extract_fields(child_id)
@@ -447,301 +322,443 @@ impl Formatter {
                         );
                     }
                 }
-                FmtOp::ForEachSep(sid) => {
-                    let state = scratch
-                        .for_each
-                        .last_mut()
-                        .expect("ForEachSep outside ForEach");
-                    let children = ctx.reader.list_children(state.list_id).unwrap_or(&[]);
-                    if state.index < children.len() - 1 {
-                        state.sep_checkpoint = Some((running, pending));
-                        let sep_text = ctx.dialect.fmt_string(sid);
-                        if let Some(ref cctx) = ctx.comment_ctx
-                            && let Some((_, word_count)) =
-                                cctx.peek_keyword_tokens(sep_text, source)
-                        {
-                            cctx.advance_token_cursor(word_count);
-                        }
-                        let sep = arena.text(sep_text);
-                        running = arena.cat(running, sep);
-                    } else {
-                        ip = skip_to_foreach_end(ops, ops_count, ip);
-                        continue;
-                    }
+            }
+            FmtOp::Line | FmtOp::SoftLine | FmtOp::HardLine => {
+                let doc = match op {
+                    FmtOp::Line => arena.line(),
+                    FmtOp::SoftLine => arena.softline(),
+                    FmtOp::HardLine => arena.hardline(),
+                    _ => unreachable!(),
+                };
+                if has_comments {
+                    pending = arena.cat(pending, doc);
+                } else {
+                    running = arena.cat(running, doc);
                 }
-                FmtOp::ForEachEnd => {
-                    let state = scratch
-                        .for_each
-                        .last_mut()
-                        .expect("ForEachEnd outside ForEach");
-                    state.index += 1;
-                    let children = ctx.reader.list_children(state.list_id).unwrap_or(&[]);
-                    if state.index < children.len() {
-                        ip = state.body_start;
-                        continue;
+            }
+            FmtOp::GroupStart => {
+                scratch.group_nest.push(GroupNestFrame::Group(running));
+                running = NIL_DOC;
+            }
+            FmtOp::GroupEnd => {
+                running = arena.cat(running, pending);
+                pending = NIL_DOC;
+                let inner = running;
+                match scratch.group_nest.pop().expect("unmatched GroupEnd") {
+                    GroupNestFrame::Group(parent) => {
+                        let g = arena.group(inner);
+                        running = arena.cat(parent, g);
                     }
-                    scratch.for_each.pop();
+                    GroupNestFrame::Nest(..) => panic!("expected Group frame"),
                 }
-                FmtOp::IfBool(idx, skip) => {
-                    // INVARIANT: IfBool ops only target Bool fields.
-                    let FieldValue::Bool(val) = fields[idx as usize] else {
-                        panic!("IfBool: field {idx} is not a Bool");
-                    };
-                    if !val {
-                        ip += skip as usize;
+            }
+            FmtOp::NestStart => {
+                scratch.group_nest.push(GroupNestFrame::Nest(running));
+                running = NIL_DOC;
+            }
+            FmtOp::NestEnd => {
+                running = arena.cat(running, pending);
+                pending = NIL_DOC;
+                let inner = running;
+                match scratch.group_nest.pop().expect("unmatched NestEnd") {
+                    GroupNestFrame::Nest(parent) => {
+                        let n = arena.nest(1, inner);
+                        running = arena.cat(parent, n);
                     }
+                    GroupNestFrame::Group(_) => panic!("expected Nest frame"),
                 }
-                FmtOp::IfFlag(idx, mask, skip) => {
-                    // INVARIANT: IfFlag ops only target Flags fields.
-                    let FieldValue::Flags(f) = fields[idx as usize] else {
-                        panic!("IfFlag: field {idx} is not Flags");
-                    };
-                    if f & mask == 0 {
-                        ip += skip as usize;
-                    }
+            }
+            FmtOp::IfSet(idx, skip) => {
+                // INVARIANT: IfSet ops only target NodeId fields.
+                let FieldValue::NodeId(id) = fields[idx as usize] else {
+                    panic!("IfSet: field {idx} is not a NodeId");
+                };
+                if id.is_null() {
+                    ip += skip as usize;
                 }
-                FmtOp::IfEnum(idx, ordinal, skip) => {
-                    // INVARIANT: IfEnum ops only target Enum fields.
-                    let FieldValue::Enum(val) = fields[idx as usize] else {
-                        panic!("IfEnum: field {idx} is not an Enum");
-                    };
-                    if val != u32::from(ordinal) {
-                        ip += skip as usize;
-                    }
-                }
-                FmtOp::IfSpan(idx, skip) => {
-                    // INVARIANT: IfSpan ops only target Span fields.
-                    let FieldValue::Span(span) = fields[idx as usize] else {
-                        panic!("IfSpan: field {idx} is not a Span");
-                    };
-                    if span.is_empty() {
-                        ip += skip as usize;
-                    }
-                }
-                FmtOp::EnumDisplay(idx, base) => {
-                    // INVARIANT: EnumDisplay ops only target Enum fields.
-                    let FieldValue::Enum(ordinal) = fields[idx as usize] else {
-                        panic!("EnumDisplay: field {idx} is not an Enum");
-                    };
-                    let string_id = ctx
-                        .dialect
-                        .fmt_enum_display_val(base as usize + ordinal as usize);
-                    let kw_text = ctx.dialect.fmt_string(string_id);
-                    if let Some(ref cctx) = ctx.comment_ctx {
-                        if let Some((tok_offset, word_count)) =
-                            cctx.peek_keyword_tokens(kw_text, source)
-                        {
-                            let drain = cctx.drain_before(tok_offset, source, arena);
-                            if word_count > 1 {
-                                if drain.trailing != NIL_DOC || drain.leading != NIL_DOC {
-                                    flush_drain(&drain, &mut pending, &mut running, arena);
-                                }
-                                let interior =
-                                    cctx.drain_keyword_interior(word_count, source, arena);
-                                flush_drain(&interior, &mut pending, &mut running, arena);
-                            } else {
-                                flush_drain(&drain, &mut pending, &mut running, arena);
-                            }
-                            cctx.advance_token_cursor(word_count);
-                        } else {
-                            running = arena.cat(running, pending);
-                            pending = NIL_DOC;
-                        }
-                    }
-                    let kw = arena.keyword(kw_text);
-                    running = arena.cat(running, kw);
-                }
-                FmtOp::ForEachSelfStart => {
-                    let children = ctx
-                        .reader
-                        .list_children(cur_node_id)
-                        .expect("ForEachSelfStart on non-list node");
+            }
+            FmtOp::Else(skip) => {
+                ip += skip as usize;
+            }
+            FmtOp::EndIf => {}
+            FmtOp::ForEachStart(idx) => {
+                // INVARIANT: ForEachStart ops only target NodeId fields.
+                let FieldValue::NodeId(list_id) = fields[idx as usize] else {
+                    panic!("ForEachStart: field {idx} is not a NodeId");
+                };
+                if list_id.is_null() {
+                    ip = skip_to_foreach_end(ops, ops_count, ip);
+                } else {
+                    let children: &'a [AnyNodeId] =
+                        ctx.reader.list_children(list_id).unwrap_or(&[]);
                     if children.is_empty() {
                         ip = skip_to_foreach_end(ops, ops_count, ip);
                     } else {
                         scratch.for_each.push(ForEachState {
-                            list_id: cur_node_id,
+                            list_id,
                             index: 0,
                             body_start: ip + 1,
                             sep_checkpoint: None,
                         });
                     }
                 }
-                FmtOp::ChildPrec(child_idx, prec_base, packed_c) => {
-                    let op_field_idx = (packed_c >> 8) as usize;
-                    let is_right = (packed_c & 0xFF) != 0;
+            }
+            FmtOp::ChildItem => {
+                let state = scratch.for_each.last().expect("ChildItem outside ForEach");
+                let children = ctx.reader.list_children(state.list_id).unwrap_or(&[]);
+                let child_id = children[state.index];
 
-                    // Read the parent's operator ordinal.
-                    let FieldValue::Enum(parent_op_ordinal) = fields[op_field_idx] else {
-                        panic!("ChildPrec: op field {op_field_idx} is not an Enum");
-                    };
-                    let (parent_prec, parent_group_and_flags) =
-                        ctx.dialect.fmt_prec_lookup(prec_base, parent_op_ordinal);
-
-                    let FieldValue::NodeId(child_id) = fields[child_idx as usize] else {
-                        panic!("ChildPrec: child field {child_idx} is not a NodeId");
-                    };
-
-                    if !child_id.is_null() {
-                        drain_comments_before_child(
-                            ctx.comment_ctx.as_ref(),
-                            source,
-                            &mut pending,
-                            &mut running,
+                let macro_rewrites = &ctx.macro_rewrites;
+                let macro_doc =
+                    if !macro_rewrites.is_empty() && ctx.reader.list_children(child_id).is_none() {
+                        super::formatter::try_macro_call(
+                            ctx,
+                            macro_rewrites,
+                            macro_docs,
                             arena,
-                        );
+                            consumed_regions,
+                            macro_tokenizer,
+                            child_id,
+                        )
+                    } else {
+                        None
+                    };
+                let return_action;
 
-                        let mut return_action = ReturnAction::CatOntoRunning;
-                        let macro_rewrites = &ctx.macro_rewrites;
-                        if !macro_rewrites.is_empty()
-                            && ctx.reader.list_children(child_id).is_none()
-                            && let Some(doc) = super::formatter::try_macro_verbatim(
-                                ctx,
-                                macro_rewrites,
-                                arena,
-                                consumed_regions,
-                                macro_tokenizer,
-                                child_id,
-                            )
-                        {
-                            running = arena.cat(running, doc);
-                            return_action = ReturnAction::Discard;
-                        }
+                if macro_doc == Some(NIL_DOC) {
+                    let state = scratch
+                        .for_each
+                        .last_mut()
+                        .expect("ForEachState must exist while handling ChildItem");
+                    if let Some((saved_running, saved_pending)) = state.sep_checkpoint.take() {
+                        running = saved_running;
+                        pending = saved_pending;
+                    }
+                    return_action = ReturnAction::Discard;
+                } else {
+                    drain_comments_before_child(
+                        ctx.comment_ctx.as_ref(),
+                        source,
+                        &mut pending,
+                        &mut running,
+                        arena,
+                    );
 
-                        if let Some((ctag, child_fields)) = ctx.reader.extract_fields(child_id)
-                            && let Some((child_ops_bytes, child_ops_len)) =
-                                ctx.dialect.fmt_dispatch(ctag)
-                        {
-                            if return_action != ReturnAction::Discard && parent_prec > 0 {
-                                return_action = child_prec_action(
-                                    ctx,
-                                    parent_prec,
-                                    parent_group_and_flags,
-                                    is_right,
-                                    ctag,
-                                    &child_fields,
-                                );
-                            }
-                            push_call_frame!(
-                                child_id,
-                                child_ops_bytes,
-                                child_ops_len,
-                                child_fields,
-                                return_action
-                            );
-                        }
+                    if let Some(verbatim) = macro_doc {
+                        running = arena.cat(running, verbatim);
+                        return_action = ReturnAction::Discard;
+                    } else {
+                        return_action = ReturnAction::CatOntoRunning;
                     }
                 }
-                FmtOp::ChildParenList(child_idx) => {
-                    let FieldValue::NodeId(child_id) = fields[child_idx as usize] else {
-                        panic!("ChildParenList: field {child_idx} is not a NodeId");
-                    };
 
-                    if !child_id.is_null() {
-                        drain_comments_before_child(
-                            ctx.comment_ctx.as_ref(),
-                            source,
-                            &mut pending,
-                            &mut running,
-                            arena,
-                        );
-
-                        let mut return_action = ReturnAction::CatOntoRunning;
-                        let macro_rewrites = &ctx.macro_rewrites;
-                        if !macro_rewrites.is_empty()
-                            && ctx.reader.list_children(child_id).is_none()
-                            && let Some(doc) = super::formatter::try_macro_verbatim(
-                                ctx,
-                                macro_rewrites,
-                                arena,
-                                consumed_regions,
-                                macro_tokenizer,
-                                child_id,
-                            )
-                        {
-                            running = arena.cat(running, doc);
-                            return_action = ReturnAction::Discard;
-                        }
-
-                        if let Some((ctag, child_fields)) = ctx.reader.extract_fields(child_id)
-                            && let Some((child_ops_bytes, child_ops_len)) =
-                                ctx.dialect.fmt_dispatch(ctag)
-                        {
-                            if return_action != ReturnAction::Discard && ctx.dialect.is_list(ctag) {
-                                return_action = ReturnAction::WrapInParens;
+                if let Some((ctag, child_fields)) = ctx.reader.extract_fields(child_id)
+                    && let Some((child_ops_bytes, child_ops_len)) = ctx.dialect.fmt_dispatch(ctag)
+                {
+                    push_call_frame!(
+                        child_id,
+                        child_ops_bytes,
+                        child_ops_len,
+                        child_fields,
+                        return_action
+                    );
+                }
+            }
+            FmtOp::ForEachSep(sid) => {
+                let state = scratch
+                    .for_each
+                    .last_mut()
+                    .expect("ForEachSep outside ForEach");
+                let children = ctx.reader.list_children(state.list_id).unwrap_or(&[]);
+                if state.index < children.len() - 1 {
+                    state.sep_checkpoint = Some((running, pending));
+                    let sep_text = ctx.dialect.fmt_string(sid);
+                    if let Some(ref cctx) = ctx.comment_ctx
+                        && let Some((_, word_count)) = cctx.peek_keyword_tokens(sep_text, source)
+                    {
+                        cctx.advance_token_cursor(word_count);
+                    }
+                    let sep = arena.text(sep_text);
+                    running = arena.cat(running, sep);
+                } else {
+                    ip = skip_to_foreach_end(ops, ops_count, ip);
+                    continue;
+                }
+            }
+            FmtOp::ForEachEnd => {
+                let state = scratch
+                    .for_each
+                    .last_mut()
+                    .expect("ForEachEnd outside ForEach");
+                state.index += 1;
+                let children = ctx.reader.list_children(state.list_id).unwrap_or(&[]);
+                if state.index < children.len() {
+                    ip = state.body_start;
+                    continue;
+                }
+                scratch.for_each.pop();
+            }
+            FmtOp::IfBool(idx, skip) => {
+                // INVARIANT: IfBool ops only target Bool fields.
+                let FieldValue::Bool(val) = fields[idx as usize] else {
+                    panic!("IfBool: field {idx} is not a Bool");
+                };
+                if !val {
+                    ip += skip as usize;
+                }
+            }
+            FmtOp::IfFlag(idx, mask, skip) => {
+                // INVARIANT: IfFlag ops only target Flags fields.
+                let FieldValue::Flags(f) = fields[idx as usize] else {
+                    panic!("IfFlag: field {idx} is not Flags");
+                };
+                if f & mask == 0 {
+                    ip += skip as usize;
+                }
+            }
+            FmtOp::IfEnum(idx, ordinal, skip) => {
+                // INVARIANT: IfEnum ops only target Enum fields.
+                let FieldValue::Enum(val) = fields[idx as usize] else {
+                    panic!("IfEnum: field {idx} is not an Enum");
+                };
+                if val != u32::from(ordinal) {
+                    ip += skip as usize;
+                }
+            }
+            FmtOp::IfSpan(idx, skip) => {
+                // INVARIANT: IfSpan ops only target Span fields.
+                let FieldValue::Span(span) = fields[idx as usize] else {
+                    panic!("IfSpan: field {idx} is not a Span");
+                };
+                if span.is_empty() {
+                    ip += skip as usize;
+                }
+            }
+            FmtOp::EnumDisplay(idx, base) => {
+                // INVARIANT: EnumDisplay ops only target Enum fields.
+                let FieldValue::Enum(ordinal) = fields[idx as usize] else {
+                    panic!("EnumDisplay: field {idx} is not an Enum");
+                };
+                let string_id = ctx
+                    .dialect
+                    .fmt_enum_display_val(base as usize + ordinal as usize);
+                let kw_text = ctx.dialect.fmt_string(string_id);
+                if let Some(ref cctx) = ctx.comment_ctx {
+                    if let Some((tok_offset, word_count)) =
+                        cctx.peek_keyword_tokens(kw_text, source)
+                    {
+                        let drain = cctx.drain_before(tok_offset, source, arena);
+                        if word_count > 1 {
+                            if drain.trailing != NIL_DOC || drain.leading != NIL_DOC {
+                                flush_drain(&drain, &mut pending, &mut running, arena);
                             }
-                            push_call_frame!(
-                                child_id,
-                                child_ops_bytes,
-                                child_ops_len,
-                                child_fields,
-                                return_action
-                            );
+                            let interior = cctx.drain_keyword_interior(word_count, source, arena);
+                            flush_drain(&interior, &mut pending, &mut running, arena);
+                        } else {
+                            flush_drain(&drain, &mut pending, &mut running, arena);
                         }
+                        cctx.advance_token_cursor(word_count);
+                    } else {
+                        running = arena.cat(running, pending);
+                        pending = NIL_DOC;
                     }
                 }
-                FmtOp::ChildPrecFixed(child_idx, packed_b, is_right_flag) => {
-                    let parent_prec = (packed_b >> 8) as u8;
-                    let parent_group_and_flags = (packed_b & 0xFF) as u8;
-                    let is_right = is_right_flag != 0;
+                let kw = arena.keyword(kw_text);
+                running = arena.cat(running, kw);
+            }
+            FmtOp::ForEachSelfStart => {
+                let children = ctx
+                    .reader
+                    .list_children(cur_node_id)
+                    .expect("ForEachSelfStart on non-list node");
+                if children.is_empty() {
+                    ip = skip_to_foreach_end(ops, ops_count, ip);
+                } else {
+                    scratch.for_each.push(ForEachState {
+                        list_id: cur_node_id,
+                        index: 0,
+                        body_start: ip + 1,
+                        sep_checkpoint: None,
+                    });
+                }
+            }
+            FmtOp::ChildPrec(child_idx, prec_base, packed_c) => {
+                let op_field_idx = (packed_c >> 8) as usize;
+                let is_right = (packed_c & 0xFF) != 0;
 
-                    let FieldValue::NodeId(child_id) = fields[child_idx as usize] else {
-                        panic!("ChildPrecFixed: field {child_idx} is not a NodeId");
-                    };
+                // Read the parent's operator ordinal.
+                let FieldValue::Enum(parent_op_ordinal) = fields[op_field_idx] else {
+                    panic!("ChildPrec: op field {op_field_idx} is not an Enum");
+                };
+                let (parent_prec, parent_group_and_flags) =
+                    ctx.dialect.fmt_prec_lookup(prec_base, parent_op_ordinal);
 
-                    if !child_id.is_null() {
-                        drain_comments_before_child(
-                            ctx.comment_ctx.as_ref(),
-                            source,
-                            &mut pending,
-                            &mut running,
+                let FieldValue::NodeId(child_id) = fields[child_idx as usize] else {
+                    panic!("ChildPrec: child field {child_idx} is not a NodeId");
+                };
+
+                if !child_id.is_null() {
+                    drain_comments_before_child(
+                        ctx.comment_ctx.as_ref(),
+                        source,
+                        &mut pending,
+                        &mut running,
+                        arena,
+                    );
+
+                    let mut return_action = ReturnAction::CatOntoRunning;
+                    let macro_rewrites = &ctx.macro_rewrites;
+                    if !macro_rewrites.is_empty()
+                        && ctx.reader.list_children(child_id).is_none()
+                        && let Some(doc) = super::formatter::try_macro_call(
+                            ctx,
+                            macro_rewrites,
+                            macro_docs,
                             arena,
-                        );
+                            consumed_regions,
+                            macro_tokenizer,
+                            child_id,
+                        )
+                    {
+                        running = arena.cat(running, doc);
+                        return_action = ReturnAction::Discard;
+                    }
 
-                        let mut return_action = ReturnAction::CatOntoRunning;
-                        let macro_rewrites = &ctx.macro_rewrites;
-                        if !macro_rewrites.is_empty()
-                            && ctx.reader.list_children(child_id).is_none()
-                            && let Some(doc) = super::formatter::try_macro_verbatim(
+                    if let Some((ctag, child_fields)) = ctx.reader.extract_fields(child_id)
+                        && let Some((child_ops_bytes, child_ops_len)) =
+                            ctx.dialect.fmt_dispatch(ctag)
+                    {
+                        if return_action != ReturnAction::Discard && parent_prec > 0 {
+                            return_action = child_prec_action(
                                 ctx,
-                                macro_rewrites,
-                                arena,
-                                consumed_regions,
-                                macro_tokenizer,
-                                child_id,
-                            )
-                        {
-                            running = arena.cat(running, doc);
-                            return_action = ReturnAction::Discard;
-                        }
-
-                        if let Some((ctag, child_fields)) = ctx.reader.extract_fields(child_id)
-                            && let Some((child_ops_bytes, child_ops_len)) =
-                                ctx.dialect.fmt_dispatch(ctag)
-                        {
-                            if return_action != ReturnAction::Discard && parent_prec > 0 {
-                                return_action = child_prec_action(
-                                    ctx,
-                                    parent_prec,
-                                    parent_group_and_flags,
-                                    is_right,
-                                    ctag,
-                                    &child_fields,
-                                );
-                            }
-                            push_call_frame!(
-                                child_id,
-                                child_ops_bytes,
-                                child_ops_len,
-                                child_fields,
-                                return_action
+                                parent_prec,
+                                parent_group_and_flags,
+                                is_right,
+                                ctag,
+                                &child_fields,
                             );
                         }
+                        push_call_frame!(
+                            child_id,
+                            child_ops_bytes,
+                            child_ops_len,
+                            child_fields,
+                            return_action
+                        );
                     }
                 }
             }
-            ip += 1;
+            FmtOp::ChildParenList(child_idx) => {
+                let FieldValue::NodeId(child_id) = fields[child_idx as usize] else {
+                    panic!("ChildParenList: field {child_idx} is not a NodeId");
+                };
+
+                if !child_id.is_null() {
+                    drain_comments_before_child(
+                        ctx.comment_ctx.as_ref(),
+                        source,
+                        &mut pending,
+                        &mut running,
+                        arena,
+                    );
+
+                    let mut return_action = ReturnAction::CatOntoRunning;
+                    let macro_rewrites = &ctx.macro_rewrites;
+                    if !macro_rewrites.is_empty()
+                        && ctx.reader.list_children(child_id).is_none()
+                        && let Some(doc) = super::formatter::try_macro_call(
+                            ctx,
+                            macro_rewrites,
+                            macro_docs,
+                            arena,
+                            consumed_regions,
+                            macro_tokenizer,
+                            child_id,
+                        )
+                    {
+                        running = arena.cat(running, doc);
+                        return_action = ReturnAction::Discard;
+                    }
+
+                    if let Some((ctag, child_fields)) = ctx.reader.extract_fields(child_id)
+                        && let Some((child_ops_bytes, child_ops_len)) =
+                            ctx.dialect.fmt_dispatch(ctag)
+                    {
+                        if return_action != ReturnAction::Discard && ctx.dialect.is_list(ctag) {
+                            return_action = ReturnAction::WrapInParens;
+                        }
+                        push_call_frame!(
+                            child_id,
+                            child_ops_bytes,
+                            child_ops_len,
+                            child_fields,
+                            return_action
+                        );
+                    }
+                }
+            }
+            FmtOp::ChildPrecFixed(child_idx, packed_b, is_right_flag) => {
+                let parent_prec = (packed_b >> 8) as u8;
+                let parent_group_and_flags = (packed_b & 0xFF) as u8;
+                let is_right = is_right_flag != 0;
+
+                let FieldValue::NodeId(child_id) = fields[child_idx as usize] else {
+                    panic!("ChildPrecFixed: field {child_idx} is not a NodeId");
+                };
+
+                if !child_id.is_null() {
+                    drain_comments_before_child(
+                        ctx.comment_ctx.as_ref(),
+                        source,
+                        &mut pending,
+                        &mut running,
+                        arena,
+                    );
+
+                    let mut return_action = ReturnAction::CatOntoRunning;
+                    let macro_rewrites = &ctx.macro_rewrites;
+                    if !macro_rewrites.is_empty()
+                        && ctx.reader.list_children(child_id).is_none()
+                        && let Some(doc) = super::formatter::try_macro_call(
+                            ctx,
+                            macro_rewrites,
+                            macro_docs,
+                            arena,
+                            consumed_regions,
+                            macro_tokenizer,
+                            child_id,
+                        )
+                    {
+                        running = arena.cat(running, doc);
+                        return_action = ReturnAction::Discard;
+                    }
+
+                    if let Some((ctag, child_fields)) = ctx.reader.extract_fields(child_id)
+                        && let Some((child_ops_bytes, child_ops_len)) =
+                            ctx.dialect.fmt_dispatch(ctag)
+                    {
+                        if return_action != ReturnAction::Discard && parent_prec > 0 {
+                            return_action = child_prec_action(
+                                ctx,
+                                parent_prec,
+                                parent_group_and_flags,
+                                is_right,
+                                ctag,
+                                &child_fields,
+                            );
+                        }
+                        push_call_frame!(
+                            child_id,
+                            child_ops_bytes,
+                            child_ops_len,
+                            child_fields,
+                            return_action
+                        );
+                    }
+                }
+            }
         }
+        ip += 1;
     }
 }
 

--- a/tests/perfetto_fmt_diff_tests/perfetto.py
+++ b/tests/perfetto_fmt_diff_tests/perfetto.py
@@ -76,6 +76,12 @@ class PerfettoMacroCallFormat(TestSuite):
             out="SELECT foo!(1 + 2), 3",
         )
 
+    def test_macro_arg_expression_canonicalized(self):
+        return DiffTestBlueprint(
+            sql="SELECT cast_int!(1+2)",
+            out="SELECT cast_int!(1 + 2)",
+        )
+
     def test_macro_call_in_from(self):
         return DiffTestBlueprint(
             sql="SELECT * FROM my_macro!(t1)",
@@ -120,13 +126,7 @@ class PerfettoMacroCallFormat(TestSuite):
             """,
             out="""\
                 SELECT *
-                FROM graph_next_sibling!(
-                  (
-                    SELECT id, parent_id, ts
-                    FROM slice
-                    WHERE dur = 0
-                  )
-                )
+                FROM graph_next_sibling!((SELECT id, parent_id, ts FROM slice WHERE dur = 0))
             """,
         )
 
@@ -168,20 +168,7 @@ class PerfettoMacroCallFormat(TestSuite):
                   )
                 )
             """,
-            out="""\
-                SELECT *
-                FROM scan!(
-                  (
-                    SELECT
-                    IIF(
-                      x > 0,
-                      1,
-                      0
-                    ) AS flag
-                    FROM t
-                  )
-                )
-            """,
+            out="SELECT * FROM scan!((SELECT IIF(x > 0, 1, 0) AS flag FROM t))",
         )
 
     def test_macro_comma_separated_args(self):
@@ -198,18 +185,7 @@ class PerfettoMacroCallFormat(TestSuite):
                     )
                   )
             """,
-            out="""\
-                SELECT *
-                FROM scan!(
-                  edges,
-                  inits,
-                  (a, b, c),
-                  (
-                    SELECT id
-                    FROM t
-                  )
-                )
-            """,
+            out="SELECT * FROM scan!(edges, inits, (a, b, c), (SELECT id FROM t))",
         )
 
     def test_macro_call_with_alias(self):


### PR DESCRIPTION
Teaches the formatter to reformat the arguments of a PerfettoSQL
macro call rather than always emitting the call verbatim from source.
The change is the prototype discussed in issue #14, staging toward
the eventual "structured macro formatting" direction.

- `Formatter` now owns `mini_parses: Vec<MiniParse>` — self-contained
  mini-parser holders kept alive through render so that span borrows
  from their AST remain valid.  A new `precompute_macro_docs` phase
  runs before the main interpret: for each top-level macro call, it
  splits `name!(a0, a1, ...)` on top-level commas, mini-parses each
  arg as `SELECT <arg>`, locates the expression subtree by extent,
  and runs `interpret_core` against the outer arena.  The resulting
  per-call `Option<DocId>` is threaded through `interpret_node` and
  looked up by region index during the main walk.
- `interpret_core` is split out of `Formatter::interpret_node` as a
  free function taking `&mut InterpretScratch` + `&mut [bool]`
  explicitly, enabling the pre-compute pass to re-enter it on each
  arg subtree with fresh local scratch.
- `try_macro_call` now tries a lookup-based `try_macro_structured`
  before falling back to `try_macro_verbatim`.  Structured does not
  advance the cctx cursor — the child frame's Span op does that — so
  trailing-comment drains keep landing in the outer stmt frame, the
  same place verbatim put them, avoiding a spurious inner-group
  break.
- `perfetto.py` rebaselined for three tests whose previous expected
  output documented verbatim preservation of user-chosen newlines;
  structured canonicalizes those calls to a single line when the
  result fits in the configured line width.

Known prototype caveats, flagged for the follow-up cleanup:
- `precompute_macro_docs` leaks the macro name via `Box::leak` to
  obtain a `&'a str` for `arena.text`.  Real implementation should
  stash owned names in a per-statement buffer on `Formatter`.
- Comment-inside-arg support is not wired yet; args containing
  comments go through the verbatim path via the call-envelope
  parser's string-literal bail-out.

