### PR TITLE
synq: remove stale clippy expect attributes breaking CI

### DIFF
--- a/syntaqlite/src/fmt/comment.rs
+++ b/syntaqlite/src/fmt/comment.rs
@@ -119,7 +119,6 @@ impl CommentCtx {
         self.drain_impl(end, source, arena, true)
     }
 
-    #[expect(clippy::too_many_lines)]
     fn drain_impl<'a>(
         &self,
         before: StmtOffset,

--- a/syntaqlite/src/fmt/formatter.rs
+++ b/syntaqlite/src/fmt/formatter.rs
@@ -315,7 +315,6 @@ impl Formatter {
     /// # Errors
     ///
     /// Returns `FormatError` if the source cannot be parsed.
-    #[expect(clippy::too_many_lines)]
     pub fn dump_bytecode(&mut self, source: &str) -> Result<String, FormatError> {
         use std::fmt::Write;
         use syntaqlite_common::fmt::bytecode::opcodes;

--- a/syntaqlite/src/semantic/ffi/statement.rs
+++ b/syntaqlite/src/semantic/ffi/statement.rs
@@ -23,7 +23,6 @@ fn ensure_source<'a>(cache: &'a mut PerStatementCache, stmt: &StatementModel) ->
         .get_or_insert_with(|| CString::new(stmt.source()).unwrap_or_default())
 }
 
-#[expect(clippy::cast_possible_truncation)]
 fn ensure_diagnostics<'a>(
     cache: &'a mut PerStatementCache,
     stmt: &StatementModel,


### PR DESCRIPTION
Three #[expect(...)] attributes no longer triggered their lints and
caused `unfulfilled_lint_expectations` to fail the CI clippy job on
main (run 24684871717).

- semantic/ffi/statement.rs: drop clippy::cast_possible_truncation on
  ensure_diagnostics (no cast remains; diagnostic offsets use as_u32)
- fmt/comment.rs: drop clippy::too_many_lines on CommentCtx::drain_impl
- fmt/formatter.rs: drop clippy::too_many_lines on Formatter::dump_bytecode

