### PR TITLE
synq: structured formatting of fallback macro-call arguments

### DIFF
--- a/syntaqlite/src/fmt/doc.rs
+++ b/syntaqlite/src/fmt/doc.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+use std::borrow::Cow;
+
 use super::{FormatConfig, KeywordCase};
 
 /// A handle into the `DocArena`. `NIL_DOC` represents an empty/absent document.
@@ -10,13 +12,16 @@ pub(super) type DocId = u32;
 /// as identity elements (e.g. `cat(NIL_DOC, x) == x`).
 pub(super) const NIL_DOC: DocId = u32::MAX;
 
-/// A node in the Wadler-style document algebra. Lifetime `'a` covers borrowed text slices.
+/// A node in the Wadler-style document algebra. Lifetime `'a` covers borrowed text
+/// slices; text/keyword nodes may also own their strings via `Cow::Owned` — used
+/// when the source text lives in a transient buffer (e.g. a mini-parse built for
+/// structured macro-arg formatting) that does not outlive render.
 #[derive(Debug, Clone)]
 enum Doc<'a> {
     /// Source text (identifiers, literals). Never case-transformed.
-    Text(&'a str),
+    Text(Cow<'a, str>),
     /// SQL keyword. Subject to `KeywordCase` at render time.
-    Keyword(&'a str),
+    Keyword(Cow<'a, str>),
     /// Flat mode: space. Break mode: newline + indent.
     Line,
     /// Flat mode: empty. Break mode: newline + indent.
@@ -83,11 +88,62 @@ impl<'a> DocArena<'a> {
     // -- Builder methods --
 
     pub(crate) fn text(&mut self, s: &'a str) -> DocId {
-        self.push(Doc::Text(s))
+        self.push(Doc::Text(Cow::Borrowed(s)))
     }
 
     pub(crate) fn keyword(&mut self, s: &'a str) -> DocId {
-        self.push(Doc::Keyword(s))
+        self.push(Doc::Keyword(Cow::Borrowed(s)))
+    }
+
+    /// Push a `Text` node whose string is owned by the arena.  Accepts
+    /// any `&str` regardless of lifetime — the contents are copied.
+    /// Use when emitting text sourced from a buffer shorter-lived than
+    /// the arena's `'a` (e.g. the AST of a transient mini-parse built
+    /// for structured macro-arg formatting).
+    pub(crate) fn own_text(&mut self, s: &str) -> DocId {
+        self.push(Doc::Text(Cow::Owned(s.to_owned())))
+    }
+
+    /// Like [`own_text`], but emits a `Keyword` node.
+    pub(crate) fn own_keyword(&mut self, s: &str) -> DocId {
+        self.push(Doc::Keyword(Cow::Owned(s.to_owned())))
+    }
+
+    /// Copy a doc tree from another arena into this one, owning all
+    /// text/keyword strings.  Used when the source arena holds borrows
+    /// into a buffer (e.g. a mini-parse's AST text) that will be
+    /// dropped before this arena is rendered.
+    ///
+    /// Non-text node shapes are reproduced verbatim.
+    pub(crate) fn copy_owned_from(&mut self, src: &DocArena<'_>, src_id: DocId) -> DocId {
+        if src_id == NIL_DOC {
+            return NIL_DOC;
+        }
+        match src.get(src_id) {
+            Doc::Text(s) => self.own_text(s),
+            Doc::Keyword(s) => self.own_keyword(s),
+            Doc::Line => self.line(),
+            Doc::SoftLine => self.softline(),
+            Doc::HardLine => self.hardline(),
+            Doc::BreakParent => self.break_parent(),
+            Doc::Cat { left, right } => {
+                let l = self.copy_owned_from(src, *left);
+                let r = self.copy_owned_from(src, *right);
+                self.cat(l, r)
+            }
+            Doc::Nest { indent, child } => {
+                let c = self.copy_owned_from(src, *child);
+                self.nest(*indent, c)
+            }
+            Doc::Group { child } => {
+                let c = self.copy_owned_from(src, *child);
+                self.group(c)
+            }
+            Doc::LineSuffix { child } => {
+                let c = self.copy_owned_from(src, *child);
+                self.line_suffix(c)
+            }
+        }
     }
 
     pub(crate) fn line(&mut self) -> DocId {
@@ -534,7 +590,7 @@ mod tests {
         let id = arena.text("hello");
         assert_eq!(id, 0);
         match arena.get(id) {
-            Doc::Text(s) => assert_eq!(*s, "hello"),
+            Doc::Text(s) => assert_eq!(s.as_ref(), "hello"),
             _ => panic!("expected Text"),
         }
     }

--- a/syntaqlite/src/fmt/formatter.rs
+++ b/syntaqlite/src/fmt/formatter.rs
@@ -62,6 +62,12 @@ fn parse_error_to_format_error(e: &AnyParseError<'_>) -> FormatError {
 pub struct Formatter {
     pub(super) dialect: AnyDialect,
     pub(super) parser: AnyParser,
+    /// Dedicated parser for structured macro-arg mini-parses.  Kept
+    /// separate from `parser` because each parser instance holds a
+    /// single `ParserInner`: while the outer render is walking a
+    /// statement, `parser`'s inner is still owned by the outer
+    /// session and cannot serve a second `parse()` call.
+    pub(super) mini_parser: AnyParser,
     pub(super) config: FormatConfig,
     // Statement-scoped state cached on the formatter to avoid per-statement allocations.
     pub(super) arena: DocArena<'static>,
@@ -119,16 +125,28 @@ impl Formatter {
         let syntax = (*dialect).clone();
         let has_macros = syntax.has_macro_style();
         let parser = AnyParser::with_config(
-            syntax,
+            syntax.clone(),
             &ParserConfig::default()
                 .with_collect_tokens(true)
                 .with_macro_fallback(has_macros)
                 .with_collect_node_extents(has_macros),
         );
+        // The mini-parser always needs node extents (used by
+        // `find_descendant_by_extent` to locate each arg's expression
+        // subtree) and macro fallback (so nested `foo!(...)` inside
+        // an arg parses as a TK_ID rather than a syntax error).
+        let mini_parser = AnyParser::with_config(
+            syntax,
+            &ParserConfig::default()
+                .with_collect_tokens(true)
+                .with_collect_node_extents(true)
+                .with_macro_fallback(has_macros),
+        );
         let macro_tokenizer = AnyTokenizer::new((*dialect).clone());
         Formatter {
             dialect,
             parser,
+            mini_parser,
             config: format_config.clone(),
             arena: DocArena::with_capacity(256),
             interpret_scratch: InterpretScratch::new(),
@@ -264,6 +282,7 @@ impl Formatter {
             // newlines, or unparseable args get `None` and fall
             // through to the existing verbatim path in `try_macro`.
             let macro_docs = macro_structured::compute_macro_docs(
+                &self.mini_parser,
                 &self.dialect,
                 &erased,
                 stmt_source,
@@ -509,6 +528,7 @@ impl Formatter {
             }
 
             let macro_docs = macro_structured::compute_macro_docs(
+                &self.mini_parser,
                 &self.dialect,
                 &erased,
                 stmt_source,

--- a/syntaqlite/src/fmt/formatter.rs
+++ b/syntaqlite/src/fmt/formatter.rs
@@ -12,6 +12,7 @@ use super::FormatError;
 use super::comment::{CommentCtx, CommentEntry, TokenEntry};
 use super::doc::{DocArena, DocId, NIL_DOC, RenderBuffers};
 use super::interpret::{FmtCtx, InterpretScratch};
+use super::macro_structured;
 use crate::dialect::AnyDialect;
 
 /// Convert a parse error (statement-relative offsets) to a
@@ -158,14 +159,18 @@ impl Formatter {
                 offset: range.start,
                 length: range.len(),
             }));
-        // Only top-level rewrites are meaningful here: their `LayerOffset`
-        // coincides with the statement-relative offset the formatter
-        // compares against.  Nested rewrites measure into their parent's
-        // expansion and belong to a different coordinate system.
+        // Only top-level fallback rewrites are meaningful here:
+        // - `parent().is_none()` keeps offsets in the statement
+        //   coordinate system the formatter compares against.
+        // - `is_fallback()` keeps only calls kept verbatim as a
+        //   `TK_ID` — those are the ones the formatter sees as a
+        //   single token range and may restructure or emit verbatim.
+        //   Expanded macros don't appear at the call site's byte
+        //   range; their tokens come from the expansion buffer.
         self.macro_rewrites.extend(
             erased
                 .macro_rewrites()
-                .filter(|r| r.parent().is_none())
+                .filter(|r| r.parent().is_none() && r.is_fallback())
                 .map(|r| {
                     (
                         StmtOffset::from_raw(r.call_offset().as_u32()),
@@ -253,12 +258,27 @@ impl Formatter {
                 drain_gap_comments(cctx, next_offset, stmt_source, &mut arena, &mut self.parts);
             }
 
+            // Stage 1.5: Pre-compute a structured `DocId` per top-level
+            // fallback macro call whose args can be parsed as
+            // expressions.  Calls with interior comments, internal
+            // newlines, or unparseable args get `None` and fall
+            // through to the existing verbatim path in `try_macro`.
+            let macro_docs = macro_structured::compute_macro_docs(
+                &self.dialect,
+                &erased,
+                stmt_source,
+                &self.macro_tokenizer,
+                &self.comment_entries,
+                &mut arena,
+            );
+
             // Stage 2: Interpret bytecode for this AST into Doc fragments.
             let ctx = FmtCtx {
                 dialect: self.dialect.clone(),
                 reader: erased,
                 comment_ctx,
                 macro_rewrites: std::mem::take(&mut self.macro_rewrites),
+                macro_docs,
             };
             let interpreted = self.interpret_node(&ctx, root_id, &mut arena);
             self.parts.push(interpreted);
@@ -488,11 +508,21 @@ impl Formatter {
                 drain_gap_comments(cctx, next_offset, stmt_source, &mut arena, &mut self.parts);
             }
 
+            let macro_docs = macro_structured::compute_macro_docs(
+                &self.dialect,
+                &erased,
+                stmt_source,
+                &self.macro_tokenizer,
+                &self.comment_entries,
+                &mut arena,
+            );
+
             let ctx = FmtCtx {
                 dialect: self.dialect.clone(),
                 reader: erased,
                 comment_ctx,
                 macro_rewrites: std::mem::take(&mut self.macro_rewrites),
+                macro_docs,
             };
             let interpreted = self.interpret_node(&ctx, root_id, &mut arena);
             self.parts.push(interpreted);
@@ -573,32 +603,33 @@ fn drain_gap_comments<'a>(
     }
 }
 
-// ── Single-node formatting ──────────────────────────────────────────────
+// ── Macro-call emission ─────────────────────────────────────────────────
 
-/// Check if the next token falls within a macro region.
+/// Emit a macro call at `child_id`, preferring pre-computed structured
+/// formatting when available and falling back to verbatim reindent.
 ///
-/// Requires `comment_ctx` to be populated on `ctx`. `format_parsed` satisfies
-/// this precondition by building a `CommentCtx` from the statement's collected
-/// tokens (which requires `collect_tokens: true` at parse time).
+/// Requires `ctx.comment_ctx` populated (`format_parsed` satisfies
+/// this).  Emits only at a node whose bytecode-emitted content is
+/// exactly the macro call: any additional content the node would emit
+/// (keywords, aliases, siblings) would be silently dropped by
+/// `ReturnAction::Discard` in the caller.
 ///
-/// Emits verbatim only at a node whose bytecode-emitted content is exactly
-/// the macro: any additional content the node would emit (keywords,
-/// aliases, siblings) would be silently dropped by `ReturnAction::Discard`
-/// in the caller.
+/// The position check boils down to:
+/// - `tok_offset == r_start`: the next unconsumed token *is* the
+///   macro's first token.  Guards against *leading* content the node's
+///   bytecode would emit (such a token would sit before `r_start`).
+/// - `node_end == r_end`: the node's extent ends exactly where the
+///   macro ends.  Guards against *trailing* content (e.g. a
+///   `ResultColumn` alias).
+/// - Node extent start is deliberately *not* checked: extents include
+///   preceding keyword glue consumed by the parent (`FROM` before a
+///   `TableRef`, `AS` before an alias `IdentName`).
 ///
-/// The decision boils down to three position checks:
-/// - `tok_offset == r_start`: the next unconsumed token *is* the macro's
-///   first token.  Guards against *leading* content the node's bytecode
-///   would emit — such a token would sit before `r_start`.
-/// - `node_end == r_end`: the node's extent ends exactly where the macro
-///   ends.  Guards against *trailing* content (e.g. a `ResultColumn`
-///   alias).
-/// - Node extent start is intentionally *not* checked: extents include
-///   preceding keyword glue already consumed by the parent (e.g. `FROM`
-///   before a `TableRef`, `AS` before an alias `IdentName`).
-pub(crate) fn try_macro_verbatim<'a>(
+/// Deliberately does NOT advance the cctx cursor — the child frame's
+/// `Span` op advances it when the fallback `TK_ID` emits, so trailing
+/// comments drain against the outer frame rather than the inner group.
+pub(crate) fn try_macro<'a>(
     ctx: &FmtCtx<'a>,
-    regions: &[(StmtOffset, StmtLen)],
     arena: &mut DocArena<'a>,
     consumed: &mut [bool],
     tokenizer: &AnyTokenizer,
@@ -615,20 +646,23 @@ pub(crate) fn try_macro_verbatim<'a>(
     );
     let node_end = node_off + node_len;
 
-    for (i, &(r_start, r_len)) in regions.iter().enumerate() {
+    for (i, &(r_start, r_len)) in ctx.macro_rewrites.iter().enumerate() {
         let r_end = r_start + r_len;
-
-        if tok_offset == r_start && node_end == r_end {
-            if consumed[i] {
-                return Some(NIL_DOC);
-            }
-            consumed[i] = true;
-            let macro_text = &source[StmtRange {
-                start: r_start,
-                end: r_end,
-            }];
-            return Some(reindent_macro(macro_text, tokenizer, arena));
+        if tok_offset != r_start || node_end != r_end {
+            continue;
         }
+        if consumed[i] {
+            return Some(NIL_DOC);
+        }
+        consumed[i] = true;
+        if let Some(Some(doc)) = ctx.macro_docs.get(i) {
+            return Some(*doc);
+        }
+        let macro_text = &source[StmtRange {
+            start: r_start,
+            end: r_end,
+        }];
+        return Some(reindent_macro(macro_text, tokenizer, arena));
     }
     None
 }

--- a/syntaqlite/src/fmt/interpret.rs
+++ b/syntaqlite/src/fmt/interpret.rs
@@ -20,6 +20,10 @@ pub(crate) struct FmtCtx<'a> {
     /// Full `MacroRewrite` records are not needed here since the
     /// formatter only uses positions to decide verbatim emission.
     pub macro_rewrites: Vec<(StmtOffset, StmtLen)>,
+    /// Pre-computed structured `DocId` per entry in `macro_rewrites`,
+    /// or `None` to fall through to verbatim emission.  Index-aligned
+    /// with `macro_rewrites`.
+    pub macro_docs: Vec<Option<DocId>>,
 }
 
 impl<'a> FmtCtx<'a> {
@@ -296,12 +300,10 @@ pub(super) fn interpret_core<'a>(
                         );
 
                         let mut return_action = ReturnAction::CatOntoRunning;
-                        let macro_rewrites = &ctx.macro_rewrites;
-                        if !macro_rewrites.is_empty()
+                        if !ctx.macro_rewrites.is_empty()
                             && ctx.reader.list_children(child_id).is_none()
-                            && let Some(doc) = super::formatter::try_macro_verbatim(
+                            && let Some(doc) = super::formatter::try_macro(
                                 ctx,
-                                macro_rewrites,
                                 arena,
                                 consumed_regions,
                                 macro_tokenizer,
@@ -411,13 +413,11 @@ pub(super) fn interpret_core<'a>(
                     let children = ctx.reader.list_children(state.list_id).unwrap_or(&[]);
                     let child_id = children[state.index];
 
-                    let macro_rewrites = &ctx.macro_rewrites;
-                    let macro_doc = if !macro_rewrites.is_empty()
+                    let macro_doc = if !ctx.macro_rewrites.is_empty()
                         && ctx.reader.list_children(child_id).is_none()
                     {
-                        super::formatter::try_macro_verbatim(
+                        super::formatter::try_macro(
                             ctx,
-                            macro_rewrites,
                             arena,
                             consumed_regions,
                             macro_tokenizer,
@@ -613,12 +613,10 @@ pub(super) fn interpret_core<'a>(
                         );
 
                         let mut return_action = ReturnAction::CatOntoRunning;
-                        let macro_rewrites = &ctx.macro_rewrites;
-                        if !macro_rewrites.is_empty()
+                        if !ctx.macro_rewrites.is_empty()
                             && ctx.reader.list_children(child_id).is_none()
-                            && let Some(doc) = super::formatter::try_macro_verbatim(
+                            && let Some(doc) = super::formatter::try_macro(
                                 ctx,
-                                macro_rewrites,
                                 arena,
                                 consumed_regions,
                                 macro_tokenizer,
@@ -668,12 +666,10 @@ pub(super) fn interpret_core<'a>(
                         );
 
                         let mut return_action = ReturnAction::CatOntoRunning;
-                        let macro_rewrites = &ctx.macro_rewrites;
-                        if !macro_rewrites.is_empty()
+                        if !ctx.macro_rewrites.is_empty()
                             && ctx.reader.list_children(child_id).is_none()
-                            && let Some(doc) = super::formatter::try_macro_verbatim(
+                            && let Some(doc) = super::formatter::try_macro(
                                 ctx,
-                                macro_rewrites,
                                 arena,
                                 consumed_regions,
                                 macro_tokenizer,
@@ -720,12 +716,10 @@ pub(super) fn interpret_core<'a>(
                         );
 
                         let mut return_action = ReturnAction::CatOntoRunning;
-                        let macro_rewrites = &ctx.macro_rewrites;
-                        if !macro_rewrites.is_empty()
+                        if !ctx.macro_rewrites.is_empty()
                             && ctx.reader.list_children(child_id).is_none()
-                            && let Some(doc) = super::formatter::try_macro_verbatim(
+                            && let Some(doc) = super::formatter::try_macro(
                                 ctx,
-                                macro_rewrites,
                                 arena,
                                 consumed_regions,
                                 macro_tokenizer,

--- a/syntaqlite/src/fmt/macro_structured.rs
+++ b/syntaqlite/src/fmt/macro_structured.rs
@@ -15,7 +15,6 @@
 //! copy-own the result into the caller's arena, then drop the
 //! mini-parse.  No per-statement mini-parse state leaks out.
 
-use syntaqlite_syntax::ParserConfig;
 use syntaqlite_syntax::any::{
     AnyNodeId, AnyParsedStatement, AnyParser, AnyTokenizer, FieldValue, MacroRewrite, ParseOutcome,
 };
@@ -30,7 +29,13 @@ use crate::dialect::AnyDialect;
 /// in `erased`.  The returned vector is index-aligned with the same
 /// `parent().is_none() && is_fallback()` filter applied by
 /// `Formatter::collect_side_channels`.
+///
+/// `mini_parser` is the caller's cached parser used for per-arg
+/// `SELECT arg;` mini-parses.  It must be distinct from the parser
+/// driving the outer render (each parser instance holds a single
+/// `ParserInner`, and the outer session still owns it at this point).
 pub(super) fn compute_macro_docs<'a>(
+    mini_parser: &AnyParser,
     dialect: &AnyDialect,
     erased: &AnyParsedStatement<'a>,
     source: &'a StmtText,
@@ -41,11 +46,12 @@ pub(super) fn compute_macro_docs<'a>(
     erased
         .macro_rewrites()
         .filter(|r| r.parent().is_none() && r.is_fallback())
-        .map(|r| compute_one(dialect, &r, source, tokenizer, comments, arena))
+        .map(|r| compute_one(mini_parser, dialect, &r, source, tokenizer, comments, arena))
         .collect()
 }
 
 fn compute_one<'a>(
+    mini_parser: &AnyParser,
     dialect: &AnyDialect,
     r: &MacroRewrite<'_>,
     source: &'a StmtText,
@@ -82,7 +88,13 @@ fn compute_one<'a>(
 
     let mut arg_docs: Vec<DocId> = Vec::with_capacity(arg_texts.len());
     for arg_text in &arg_texts {
-        arg_docs.push(format_arg(dialect, arg_text, tokenizer, arena)?);
+        arg_docs.push(format_arg(
+            mini_parser,
+            dialect,
+            arg_text,
+            tokenizer,
+            arena,
+        )?);
     }
 
     // Assemble `name!(arg0, arg1, ...)` in the outer arena.  `name`
@@ -113,23 +125,18 @@ const _: () = assert!(b"SELECT ".len() == SELECT_PREFIX_LEN as usize);
 /// Returns `None` if the mini-parse fails or the expression subtree
 /// cannot be located.
 ///
-/// On return, the mini-parse and its scratch arena have been dropped;
-/// the returned `DocId` is self-contained in `arena`.
+/// On return, the mini-parse's session has been dropped (returning
+/// its `ParserInner` to `mini_parser`), so the next call can reuse
+/// the same parser without re-allocating its C-side state.
 fn format_arg(
+    mini_parser: &AnyParser,
     dialect: &AnyDialect,
     arg_text: &str,
     tokenizer: &AnyTokenizer,
     arena: &mut DocArena<'_>,
 ) -> Option<DocId> {
     let mini_source = format!("SELECT {arg_text};");
-    let parser = AnyParser::with_config(
-        (**dialect).clone(),
-        &ParserConfig::default()
-            .with_collect_tokens(true)
-            .with_collect_node_extents(true)
-            .with_macro_fallback(dialect.has_macro_style()),
-    );
-    let mut session = parser.parse(&mini_source);
+    let mut session = mini_parser.parse(&mini_source);
     match session.next() {
         ParseOutcome::Ok(_) => {}
         _ => return None,

--- a/syntaqlite/src/fmt/macro_structured.rs
+++ b/syntaqlite/src/fmt/macro_structured.rs
@@ -115,10 +115,6 @@ fn compute_one<'a>(
     Some(arena.cat(d, close))
 }
 
-/// Byte offset of the first arg inside a synthetic `SELECT ` envelope.
-const SELECT_PREFIX_LEN: u32 = 7;
-const _: () = assert!(b"SELECT ".len() == SELECT_PREFIX_LEN as usize);
-
 /// Parse `arg_text` as an expression via a synthetic `SELECT arg;`
 /// mini-parse, format the expression subtree into a throwaway arena
 /// borrowing the mini-parse, then copy-own the result into `arena`.
@@ -142,13 +138,7 @@ fn format_arg(
         _ => return None,
     }
     let stmt = session.arena_result();
-
-    // Expression subtree has extent `(SELECT_PREFIX_LEN, arg_text.len())`
-    // inside the synthetic source; the first AST node with that
-    // extent is the outermost expression node we want to format.
-    let target_off = StmtOffset::from_raw(SELECT_PREFIX_LEN);
-    let target_len = StmtLen::from_raw(u32::try_from(arg_text.len()).ok()?);
-    let expr_id = find_descendant_by_extent(&stmt, stmt.root_id(), target_off, target_len)?;
+    let expr_id = select_wrapper_arg_node(&stmt)?;
 
     let mut sub_arena: DocArena<'_> = DocArena::new();
     let sub_ctx = FmtCtx {
@@ -171,38 +161,32 @@ fn format_arg(
     Some(arena.copy_owned_from(&sub_arena, sub_doc))
 }
 
-/// Depth-first search for the first descendant of `root` whose source
-/// extent matches `(target_off, target_len)`.  First-match order
-/// yields the outermost matching node, which is what we want for
-/// formatting (an expression wrapper, not its inner leaf).
-fn find_descendant_by_extent(
-    reader: &AnyParsedStatement<'_>,
-    root: AnyNodeId,
-    target_off: StmtOffset,
-    target_len: StmtLen,
-) -> Option<AnyNodeId> {
-    if let Some((text, off)) = reader.node_text(root) {
-        let len = StmtLen::from_raw(u32::try_from(text.len()).ok()?);
-        if off == target_off && len == target_len {
-            return Some(root);
-        }
-    }
-    if let Some((_, fields)) = reader.extract_fields(root) {
-        for i in 0..fields.len() {
-            if let FieldValue::NodeId(child) = fields[i]
-                && !child.is_null()
-                && let Some(found) =
-                    find_descendant_by_extent(reader, child, target_off, target_len)
-            {
-                return Some(found);
-            }
-        }
-    }
-    if let Some(children) = reader.list_children(root) {
-        for &c in children {
-            if let Some(found) = find_descendant_by_extent(reader, c, target_off, target_len) {
-                return Some(found);
-            }
+/// Navigate a `SELECT <arg>;` mini-parse to the `ResultColumn`
+/// wrapping `<arg>`.  We format at the `ResultColumn` level (not
+/// its `expr` child) so that row-value args like `(a, b)` get the
+/// paren-wrap emitted by `child_paren_list(expr)` in the
+/// `ResultColumn` bytecode.
+///
+/// Relies on the grammar shape defined in
+/// `syntaqlite-buildtools/parser-nodes/select.synq`: `SelectStmt`'s
+/// first `NodeId` field is `columns: ResultColumnList`, and the list
+/// has exactly one child since we emit exactly one expression inside
+/// the wrapper.
+fn select_wrapper_arg_node(reader: &AnyParsedStatement<'_>) -> Option<AnyNodeId> {
+    let columns_list = first_node_field(reader, reader.root_id())?;
+    reader.list_children(columns_list)?.first().copied()
+}
+
+/// Return the first non-null `NodeId` field of `node`.  Used to walk
+/// the fixed-shape SELECT wrapper without depending on specific field
+/// indices.
+fn first_node_field(reader: &AnyParsedStatement<'_>, node: AnyNodeId) -> Option<AnyNodeId> {
+    let (_, fields) = reader.extract_fields(node)?;
+    for i in 0..fields.len() {
+        if let FieldValue::NodeId(id) = fields[i]
+            && !id.is_null()
+        {
+            return Some(id);
         }
     }
     None

--- a/syntaqlite/src/fmt/macro_structured.rs
+++ b/syntaqlite/src/fmt/macro_structured.rs
@@ -1,0 +1,202 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+//! Structured formatting of fallback macro-call arguments.
+//!
+//! In macro-fallback mode the outer parser keeps `foo!(a, b)` as a
+//! single `TK_ID` whose AST text spans the whole call.  The default
+//! formatter emits that source slice verbatim.  This module re-parses
+//! each argument as its own `SELECT arg;` expression and returns a
+//! pre-formatted `DocId` that the bytecode interpreter can splice in
+//! place of the verbatim slice.
+//!
+//! Each call is processed in isolation: parse an arg, run the
+//! interpreter against a throwaway arena that borrows the mini-parse,
+//! copy-own the result into the caller's arena, then drop the
+//! mini-parse.  No per-statement mini-parse state leaks out.
+
+use syntaqlite_syntax::ParserConfig;
+use syntaqlite_syntax::any::{
+    AnyNodeId, AnyParsedStatement, AnyParser, AnyTokenizer, FieldValue, MacroRewrite, ParseOutcome,
+};
+use syntaqlite_syntax::source::{StmtLen, StmtOffset, StmtRange, StmtText};
+
+use super::comment::CommentEntry;
+use super::doc::{DocArena, DocId};
+use super::interpret::{FmtCtx, InterpretScratch, interpret_core};
+use crate::dialect::AnyDialect;
+
+/// Compute structured `DocId`s for each top-level fallback macro call
+/// in `erased`.  The returned vector is index-aligned with the same
+/// `parent().is_none() && is_fallback()` filter applied by
+/// `Formatter::collect_side_channels`.
+pub(super) fn compute_macro_docs<'a>(
+    dialect: &AnyDialect,
+    erased: &AnyParsedStatement<'a>,
+    source: &'a StmtText,
+    tokenizer: &AnyTokenizer,
+    comments: &[CommentEntry],
+    arena: &mut DocArena<'a>,
+) -> Vec<Option<DocId>> {
+    erased
+        .macro_rewrites()
+        .filter(|r| r.parent().is_none() && r.is_fallback())
+        .map(|r| compute_one(dialect, &r, source, tokenizer, comments, arena))
+        .collect()
+}
+
+fn compute_one<'a>(
+    dialect: &AnyDialect,
+    r: &MacroRewrite<'_>,
+    source: &'a StmtText,
+    tokenizer: &AnyTokenizer,
+    comments: &[CommentEntry],
+    arena: &mut DocArena<'a>,
+) -> Option<DocId> {
+    let call_off = StmtOffset::from_raw(r.call_offset().as_u32());
+    let call_len = StmtLen::from(r.call_length());
+    let call_end = call_off + call_len;
+
+    // Defer to verbatim when the call has interior comments (the mini
+    // parser has no comment context, so they'd silently disappear),
+    // was hand-wrapped across multiple lines (authored layout wins),
+    // or has no args (nothing to restructure).
+    if comments
+        .iter()
+        .any(|c| c.offset >= call_off && c.offset < call_end)
+    {
+        return None;
+    }
+    let call_text = &source[StmtRange {
+        start: call_off,
+        end: call_end,
+    }];
+    if call_text.contains('\n') {
+        return None;
+    }
+
+    let arg_texts: Vec<&str> = r.args().map(|a| a.text()).collect();
+    if arg_texts.is_empty() {
+        return None;
+    }
+
+    let mut arg_docs: Vec<DocId> = Vec::with_capacity(arg_texts.len());
+    for arg_text in &arg_texts {
+        arg_docs.push(format_arg(dialect, arg_text, tokenizer, arena)?);
+    }
+
+    // Assemble `name!(arg0, arg1, ...)` in the outer arena.  `name`
+    // is borrowed from the parent buffer (stable across render), but
+    // we own-copy it anyway to keep `macro_structured` independent of
+    // the caller's buffer-lifetime story.
+    let name_doc = arena.own_text(r.name());
+    let open = arena.text("!(");
+    let close = arena.text(")");
+    let sep = arena.text(", ");
+    let mut d = arena.cat(name_doc, open);
+    for (i, ad) in arg_docs.iter().enumerate() {
+        if i > 0 {
+            d = arena.cat(d, sep);
+        }
+        d = arena.cat(d, *ad);
+    }
+    Some(arena.cat(d, close))
+}
+
+/// Byte offset of the first arg inside a synthetic `SELECT ` envelope.
+const SELECT_PREFIX_LEN: u32 = 7;
+const _: () = assert!(b"SELECT ".len() == SELECT_PREFIX_LEN as usize);
+
+/// Parse `arg_text` as an expression via a synthetic `SELECT arg;`
+/// mini-parse, format the expression subtree into a throwaway arena
+/// borrowing the mini-parse, then copy-own the result into `arena`.
+/// Returns `None` if the mini-parse fails or the expression subtree
+/// cannot be located.
+///
+/// On return, the mini-parse and its scratch arena have been dropped;
+/// the returned `DocId` is self-contained in `arena`.
+fn format_arg(
+    dialect: &AnyDialect,
+    arg_text: &str,
+    tokenizer: &AnyTokenizer,
+    arena: &mut DocArena<'_>,
+) -> Option<DocId> {
+    let mini_source = format!("SELECT {arg_text};");
+    let parser = AnyParser::with_config(
+        (**dialect).clone(),
+        &ParserConfig::default()
+            .with_collect_tokens(true)
+            .with_collect_node_extents(true)
+            .with_macro_fallback(dialect.has_macro_style()),
+    );
+    let mut session = parser.parse(&mini_source);
+    match session.next() {
+        ParseOutcome::Ok(_) => {}
+        _ => return None,
+    }
+    let stmt = session.arena_result();
+
+    // Expression subtree has extent `(SELECT_PREFIX_LEN, arg_text.len())`
+    // inside the synthetic source; the first AST node with that
+    // extent is the outermost expression node we want to format.
+    let target_off = StmtOffset::from_raw(SELECT_PREFIX_LEN);
+    let target_len = StmtLen::from_raw(u32::try_from(arg_text.len()).ok()?);
+    let expr_id = find_descendant_by_extent(&stmt, stmt.root_id(), target_off, target_len)?;
+
+    let mut sub_arena: DocArena<'_> = DocArena::new();
+    let sub_ctx = FmtCtx {
+        dialect: dialect.clone(),
+        reader: stmt,
+        comment_ctx: None,
+        macro_rewrites: Vec::new(),
+        macro_docs: Vec::new(),
+    };
+    let mut scratch = InterpretScratch::new();
+    let mut consumed: Vec<bool> = Vec::new();
+    let sub_doc = interpret_core(
+        &sub_ctx,
+        expr_id,
+        &mut sub_arena,
+        &mut scratch,
+        &mut consumed,
+        tokenizer,
+    );
+    Some(arena.copy_owned_from(&sub_arena, sub_doc))
+}
+
+/// Depth-first search for the first descendant of `root` whose source
+/// extent matches `(target_off, target_len)`.  First-match order
+/// yields the outermost matching node, which is what we want for
+/// formatting (an expression wrapper, not its inner leaf).
+fn find_descendant_by_extent(
+    reader: &AnyParsedStatement<'_>,
+    root: AnyNodeId,
+    target_off: StmtOffset,
+    target_len: StmtLen,
+) -> Option<AnyNodeId> {
+    if let Some((text, off)) = reader.node_text(root) {
+        let len = StmtLen::from_raw(u32::try_from(text.len()).ok()?);
+        if off == target_off && len == target_len {
+            return Some(root);
+        }
+    }
+    if let Some((_, fields)) = reader.extract_fields(root) {
+        for i in 0..fields.len() {
+            if let FieldValue::NodeId(child) = fields[i]
+                && !child.is_null()
+                && let Some(found) =
+                    find_descendant_by_extent(reader, child, target_off, target_len)
+            {
+                return Some(found);
+            }
+        }
+    }
+    if let Some(children) = reader.list_children(root) {
+        for &c in children {
+            if let Some(found) = find_descendant_by_extent(reader, c, target_off, target_len) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}

--- a/syntaqlite/src/fmt/mod.rs
+++ b/syntaqlite/src/fmt/mod.rs
@@ -33,6 +33,7 @@ mod doc;
 pub(crate) mod ffi;
 pub(crate) mod formatter;
 mod interpret;
+mod macro_structured;
 
 #[doc(inline)]
 pub use formatter::Formatter;

--- a/tests/perfetto_fmt_diff_tests/perfetto.py
+++ b/tests/perfetto_fmt_diff_tests/perfetto.py
@@ -76,6 +76,29 @@ class PerfettoMacroCallFormat(TestSuite):
             out="SELECT foo!(1 + 2), 3",
         )
 
+    def test_macro_arg_expression_canonicalized(self):
+        return DiffTestBlueprint(
+            sql="SELECT cast_int!(1+2)",
+            out="SELECT cast_int!(1 + 2)",
+        )
+
+    def test_macro_arg_single_row_value_canonicalized(self):
+        # One arg, a parenthesized expr list — interpreted as a
+        # row-value expression.  Inner expressions should be
+        # normalised (spaces around `+`, etc.) just like any other
+        # expression.
+        return DiffTestBlueprint(
+            sql="SELECT foo!((a+1,b*2,c))",
+            out="SELECT foo!((a + 1, b * 2, c))",
+        )
+
+    def test_macro_args_two_row_values_canonicalized(self):
+        # Two top-level args, each a parenthesized expr list.
+        return DiffTestBlueprint(
+            sql="SELECT foo!((a,b),(c,d))",
+            out="SELECT foo!((a, b), (c, d))",
+        )
+
     def test_macro_call_in_from(self):
         return DiffTestBlueprint(
             sql="SELECT * FROM my_macro!(t1)",


### PR DESCRIPTION
In macro-fallback mode the outer parser keeps `foo\!(a, b)` as a
single `TK_ID`, and the formatter emitted it verbatim.  This branch
canonicalises the argument expressions (spaces around operators,
keyword casing, etc.) while preserving the `name\!(...)` shape.

Each top-level fallback call's args are walked via the new
`MacroRewrite::args()` / `is_fallback()` / `parent_buffer()` API,
re-parsed independently as `SELECT arg;` expressions, interpreted
into a throwaway arena borrowing the mini-parse, then copied into
the outer arena with arena-owned text.  The mini-parse is dropped
immediately after — no per-statement mini-parse state leaks out.

- `fmt/doc.rs`: `Doc::Text`/`Doc::Keyword` hold `Cow<'a, str>`;
  `own_text`/`own_keyword` push `Cow::Owned`; `copy_owned_from`
  copies a doc tree from another arena owning all text.
- `fmt/interpret.rs`: `FmtCtx` carries a new `macro_docs` field
  alongside `macro_rewrites`; `interpret_core`'s signature stays
  as-is.
- `fmt/formatter.rs`: `try_macro_verbatim` becomes `try_macro`,
  consulting `ctx.macro_docs` before falling through to verbatim
  reindent.  The `collect_side_channels` filter narrows to
  `parent().is_none() && is_fallback()` rewrites.
- `fmt/macro_structured.rs` (new): the per-call workflow —
  trigger guards (comments / newlines / empty arg list → defer to
  verbatim), per-arg mini-parse, interpret-into-scratch, then
  `copy_owned_from` into the outer arena.
- `tests/perfetto_fmt_diff_tests/perfetto.py`: three new cases
  covering inner-expression canonicalisation and parenthesised
  expression-list args.

Fixes https://github.com/LalitMaganti/syntaqlite/issues/14