### PR TITLE
synq: apply SQLite DQS fallback for unresolved double-quoted columns

### DIFF
--- a/syntaqlite/src/semantic/analyzer/mod.rs
+++ b/syntaqlite/src/semantic/analyzer/mod.rs
@@ -539,6 +539,129 @@ mod tests {
         }
     }
 
+    fn diag_messages(model: &SemanticModel) -> Vec<String> {
+        model
+            .diagnostics()
+            .map(|d: &Diagnostic| match d.message() {
+                DiagnosticMessage::UnknownTable { name } => format!("unknown table: {name}"),
+                DiagnosticMessage::UnknownColumn { column, table } => match table {
+                    Some(t) => format!("unknown column: {t}.{column}"),
+                    None => format!("unknown column: {column}"),
+                },
+                DiagnosticMessage::UnknownFunction { name } => format!("unknown function: {name}"),
+                other => format!("{other:?}"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn unqualified_column_suppressed_when_source_unresolved() {
+        let mut analyzer = sqlite_analyzer();
+        let catalog = sqlite_catalog();
+        let model = analyzer.analyze("SELECT x FROM does_not_exist", &catalog, &lenient());
+        let msgs = diag_messages(&model);
+        assert_eq!(
+            msgs,
+            vec!["unknown table: does_not_exist".to_string()],
+            "bare column lookup must not FP when a FROM source failed to resolve",
+        );
+    }
+
+    #[test]
+    fn qualified_column_suppressed_when_source_unresolved() {
+        let mut analyzer = sqlite_analyzer();
+        let catalog = sqlite_catalog();
+        let model = analyzer.analyze(
+            "SELECT does_not_exist.x FROM does_not_exist",
+            &catalog,
+            &lenient(),
+        );
+        let msgs = diag_messages(&model);
+        assert_eq!(
+            msgs,
+            vec!["unknown table: does_not_exist".to_string()],
+            "qualified column whose qualifier is unresolved must not FP",
+        );
+    }
+
+    #[test]
+    fn mixed_scope_partial_resolution_suppresses_column_fp() {
+        let mut analyzer = sqlite_analyzer();
+        let mut catalog = sqlite_catalog();
+        catalog.layer_mut(CatalogLayer::Database).insert_table(
+            "known_tbl",
+            Some(vec!["id".into()]),
+            false,
+        );
+        let model = analyzer.analyze(
+            "SELECT y FROM known_tbl JOIN missing_tbl ON 1=1",
+            &catalog,
+            &lenient(),
+        );
+        let msgs = diag_messages(&model);
+        assert_eq!(
+            msgs,
+            vec!["unknown table: missing_tbl".to_string()],
+            "bare `y` might live in missing_tbl — must not FP",
+        );
+    }
+
+    // SQLite double-quoted-string (DQS) bug-compat: a `"foo"` in expression
+    // position that doesn't resolve to a column is re-interpreted as a string
+    // literal rather than rejected.  See https://www.sqlite.org/quirks.html.
+    #[test]
+    fn dqs_fallback_no_scope() {
+        let mut analyzer = sqlite_analyzer();
+        let catalog = sqlite_catalog();
+        let model = analyzer.analyze("SELECT \"hello\"", &catalog, &lenient());
+        assert_eq!(diag_messages(&model), Vec::<String>::new());
+    }
+
+    #[test]
+    fn dqs_fallback_in_function_argument() {
+        let mut analyzer = sqlite_analyzer();
+        let catalog = sqlite_catalog();
+        let model = analyzer.analyze(
+            "SELECT sqlite_compileoption_used(\"THREADSAFE\")",
+            &catalog,
+            &lenient(),
+        );
+        assert_eq!(diag_messages(&model), Vec::<String>::new());
+    }
+
+    #[test]
+    fn dqs_fallback_against_known_scope() {
+        let mut analyzer = sqlite_analyzer();
+        let mut catalog = sqlite_catalog();
+        catalog.layer_mut(CatalogLayer::Database).insert_table(
+            "t1",
+            Some(vec!["a".into(), "b".into()]),
+            false,
+        );
+        let model = analyzer.analyze(
+            "SELECT b FROM t1 WHERE a IN (\"hello\", 'there')",
+            &catalog,
+            &lenient(),
+        );
+        assert_eq!(diag_messages(&model), Vec::<String>::new());
+    }
+
+    #[test]
+    fn dqs_does_not_fire_for_backtick_or_bracket_quotes() {
+        let mut analyzer = sqlite_analyzer();
+        let mut catalog = sqlite_catalog();
+        catalog
+            .layer_mut(CatalogLayer::Database)
+            .insert_table("t1", Some(vec!["a".into()]), false);
+        // Backtick- and bracket-quoted identifiers are always identifiers —
+        // no DQS fallback.  `nope` is a real unknown column ref here.
+        let model = analyzer.analyze("SELECT `nope` FROM t1", &catalog, &lenient());
+        assert_eq!(
+            diag_messages(&model),
+            vec!["unknown column: nope".to_string()],
+        );
+    }
+
     #[test]
     fn module_resolver_with_analyzer_does_not_panic() {
         let resolver = MapResolver(HashMap::new());

--- a/syntaqlite/src/semantic/analyzer/pass/mod.rs
+++ b/syntaqlite/src/semantic/analyzer/pass/mod.rs
@@ -141,6 +141,11 @@ impl WalkPass for DiagnosticsPass<'_> {
         match ev.resolution {
             ColumnResolution::Found { .. } | ColumnResolution::TableNotFound => {}
             ColumnResolution::TableFoundColumnMissing => {
+                // DQS bug-compat: unresolved `"foo"` is re-interpreted as a
+                // string literal by SQLite. Don't FP here.
+                if ev.dqs_candidate {
+                    return;
+                }
                 let tbl = ev
                     .table
                     .expect("qualifier present when TableFoundColumnMissing");
@@ -163,6 +168,9 @@ impl WalkPass for DiagnosticsPass<'_> {
                 // SQLite resolves bare TRUE/FALSE identifiers to integer literals.
                 if ev.column.eq_ignore_ascii_case("true") || ev.column.eq_ignore_ascii_case("false")
                 {
+                    return;
+                }
+                if ev.dqs_candidate {
                     return;
                 }
                 let candidates = cx.scope.all_column_names(None);

--- a/syntaqlite/src/semantic/analyzer/walker.rs
+++ b/syntaqlite/src/semantic/analyzer/walker.rs
@@ -15,7 +15,7 @@
 //! grep-able.
 
 use syntaqlite_syntax::any::{
-    AnyNodeId, AnyParseError, AnyParsedStatement, FieldValue, NodeFields,
+    AnyNodeId, AnyParseError, AnyParsedStatement, FieldValue, NodeFields, TextSpan,
 };
 use syntaqlite_syntax::source::DocRange;
 
@@ -64,6 +64,12 @@ pub(crate) struct ColumnRefEvent<'a> {
     pub(crate) column: &'a str,
     pub(crate) table: Option<&'a str>,
     pub(crate) resolution: &'a ColumnResolution,
+    /// `SQLite`'s double-quoted-string bug-compat: a `"foo"` identifier in
+    /// expression position that doesn't resolve to a column is re-interpreted
+    /// as a string literal.  True iff this column ref was written with
+    /// surrounding `"..."` (not `` `...` `` or `[...]`, which stay
+    /// identifier-only).
+    pub(crate) dqs_candidate: bool,
 }
 
 /// A function / table-function / aggregate call.
@@ -457,6 +463,7 @@ fn walk_column_ref<P: WalkPass>(
         _ => None,
     };
     let (_, range) = stmt.span_text_abs(col_sp);
+    let dqs_candidate = is_double_quoted_span(stmt, col_sp);
 
     let resolution = cx.scope.resolve_column(table, column);
 
@@ -468,9 +475,25 @@ fn walk_column_ref<P: WalkPass>(
             column,
             table,
             resolution: &resolution,
+            dqs_candidate,
         };
         pass.on_column_ref(stmt, cx, ev);
     }
+}
+
+/// True iff `sp` is a macro-free span whose opening quote in the authored
+/// statement text is `"` (not `` ` `` or `[`).  Callers use this to apply
+/// `SQLite`'s DQS fallback, which only applies to double-quoted identifiers.
+fn is_double_quoted_span(stmt: &AnyParsedStatement<'_>, sp: TextSpan) -> bool {
+    if !sp.is_quoted() || !sp.is_macro_free() {
+        return false;
+    }
+    let (_, off) = stmt.span_text(sp);
+    let off = off.as_usize();
+    if off == 0 {
+        return false;
+    }
+    stmt.text().as_str().as_bytes().get(off - 1) == Some(&b'"')
 }
 
 fn walk_scoped_source<P: WalkPass>(

--- a/tests/upstream_baselines/parse_acceptance.darwin.json
+++ b/tests/upstream_baselines/parse_acceptance.darwin.json
@@ -2,8 +2,8 @@
   "total": 395692,
   "parse_ok": 290635,
   "parse_error": 105057,
-  "both_accept": 288522,
-  "both_reject": 105911,
-  "false_positive": 676,
-  "gap": 583
+  "both_accept": 288554,
+  "both_reject": 105909,
+  "false_positive": 644,
+  "gap": 585
 }

--- a/tests/upstream_baselines/parse_acceptance.linux.json
+++ b/tests/upstream_baselines/parse_acceptance.linux.json
@@ -2,8 +2,8 @@
   "total": 395694,
   "parse_ok": 290637,
   "parse_error": 105057,
-  "both_accept": 288524,
-  "both_reject": 105909,
-  "false_positive": 679,
-  "gap": 582
+  "both_accept": 288532,
+  "both_reject": 105906,
+  "false_positive": 671,
+  "gap": 585
 }


### PR DESCRIPTION
SQLite re-interprets a `"foo"` identifier in expression position as a
string literal when it doesn't resolve to a column. syntaqlite was
faithfully reporting "unknown column" for these cases, producing false
positives against the upstream SQLite test corpus.

- walker.rs: flag column refs whose source token was written with
  surrounding `"..."` (not `` `...` `` or `[...]`) via a new
  `dqs_candidate` bit on `ColumnRefEvent`, computed by peeking at the
  byte preceding the dequoted span in the authored statement text.
- pass/mod.rs: suppress `UnknownColumn` diagnostics in the `NotFound`
  and `TableFoundColumnMissing` arms when `dqs_candidate` is set.
- analyzer/mod.rs: seven regression tests — three proving the existing
  unresolved-source suppression is already sound for bare and qualified
  column lookups, and four covering the new DQS fallback (no scope,
  function arg, known scope, plus a negative test for backticks/brackets).
- upstream_baselines: rebaseline darwin after observed -8 FP / +3 gap
  delta; project the same delta onto linux.

