### PR TITLE
synq: expose call-site args on MacroRewrite

### DIFF
--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -726,6 +726,21 @@ syntaqlite_macro_rewrite_arg_segment_at(SyntaqliteParser* p,
   (void)segment_idx;
   return (SyntaqliteMacroArgSegment){0};
 }
+SYNTAQLITE_API uint32_t
+syntaqlite_macro_rewrite_arg_count(SyntaqliteParser* p, uint32_t rewrite_idx) {
+  (void)p;
+  (void)rewrite_idx;
+  return 0;
+}
+SYNTAQLITE_API SyntaqliteMacroCallArg
+syntaqlite_macro_rewrite_arg_at(SyntaqliteParser* p,
+                                uint32_t rewrite_idx,
+                                uint32_t arg_idx) {
+  (void)p;
+  (void)rewrite_idx;
+  (void)arg_idx;
+  return (SyntaqliteMacroCallArg){0};
+}
 #else
 SYNTAQLITE_API uint32_t syntaqlite_result_macro_count(SyntaqliteParser* p) {
   uint32_t total = syntaqlite_vec_len(&p->macro.layers);
@@ -748,6 +763,22 @@ syntaqlite_result_macro_rewrite_at(SyntaqliteParser* p, uint32_t idx) {
   uint32_t parent_idx = lyr->parent_layer_id == 0
                             ? SYNTAQLITE_MACRO_PARENT_SOURCE
                             : lyr->parent_layer_id - 1;
+  // Resolve the buffer that `call_offset` and every arg offset
+  // measure into, so consumers can slice directly without walking
+  // the parent chain.  Top-level layers measure into the current
+  // statement slice; nested layers measure into the parent layer's
+  // expansion buffer.
+  const char* parent_buffer;
+  uint32_t parent_buffer_len;
+  if (lyr->parent_layer_id == 0) {
+    parent_buffer = p->stmt_source;
+    parent_buffer_len = p->stmt_end_offset - p->stmt_start_offset;
+  } else {
+    const SynqExpansionLayer* parent =
+        &p->macro.layers.data[lyr->parent_layer_id];
+    parent_buffer = parent->expansion_data;
+    parent_buffer_len = parent->expansion_len;
+  }
   return (SyntaqliteMacroRewrite){
       .parent_idx = parent_idx,
       .call_offset = lyr->call_offset,
@@ -760,6 +791,9 @@ syntaqlite_result_macro_rewrite_at(SyntaqliteParser* p, uint32_t idx) {
       .def_col = lyr->def_col,
       .body_call_offset = lyr->body_call_offset,
       .body_call_length = lyr->body_call_length,
+      .parent_buffer = parent_buffer,
+      .parent_buffer_len = parent_buffer_len,
+      .is_fallback = lyr->is_fallback,
   };
 }
 
@@ -796,6 +830,31 @@ syntaqlite_macro_rewrite_arg_segment_at(SyntaqliteParser* p,
       .origin_parent_idx = origin_parent_idx,
       .origin_offset = seg->origin_offset,
       .origin_length = seg->origin_length,
+  };
+}
+
+SYNTAQLITE_API uint32_t
+syntaqlite_macro_rewrite_arg_count(SyntaqliteParser* p, uint32_t rewrite_idx) {
+  uint32_t layer_idx = rewrite_idx + 1;
+  if (layer_idx >= syntaqlite_vec_len(&p->macro.layers))
+    return 0;
+  return p->macro.layers.data[layer_idx].arg_count;
+}
+
+SYNTAQLITE_API SyntaqliteMacroCallArg
+syntaqlite_macro_rewrite_arg_at(SyntaqliteParser* p,
+                                uint32_t rewrite_idx,
+                                uint32_t arg_idx) {
+  uint32_t layer_idx = rewrite_idx + 1;
+  if (layer_idx >= syntaqlite_vec_len(&p->macro.layers))
+    return (SyntaqliteMacroCallArg){0};
+  const SynqExpansionLayer* lyr = &p->macro.layers.data[layer_idx];
+  if (arg_idx >= lyr->arg_count)
+    return (SyntaqliteMacroCallArg){0};
+  const SynqMacroArg* arg = &lyr->args[arg_idx];
+  return (SyntaqliteMacroCallArg){
+      .offset = arg->offset,
+      .length = arg->length,
   };
 }
 #endif

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -101,6 +101,22 @@ typedef struct SynqExpansionLayer {
   SynqArgSegment* arg_segments;
   uint32_t arg_segment_count;
 
+  // Top-level call-site argument spans, populated on every layer
+  // that went through `synq_parser_scan_macro_args` (both registered
+  // and fallback paths).  Offsets are in the same coordinate system
+  // as `call_offset`: statement-relative for top-level layers,
+  // otherwise relative to the parent layer's buffer.  Allocated via
+  // p->mem and freed in reset_stmt / destroy.  NULL when `name!()`
+  // has zero args or the scan overflowed the stack buffer.
+  SynqMacroArg* args;
+  uint32_t arg_count;
+
+  // 1 if this layer is a fallback layer (unregistered `name!(args)`
+  // kept verbatim as a TK_ID — no expansion buffer, no $param
+  // substitutions).  0 for registered macros that expanded into
+  // `expansion_data`.
+  uint32_t is_fallback;
+
   // Position of this nested call in the *parent's authored body*,
   // computed by inverting the length shifts from the parent's $param
   // substitutions.  Both fields equal SYNTAQLITE_MACRO_BODY_CALL_ARG_INTERNAL

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -184,6 +184,8 @@ void synq_layers_free_owned(SynqExpansionLayerVec* layers,
       mem.xFree((void*)lyr->expansion_data);
     if (lyr->arg_segments)
       mem.xFree(lyr->arg_segments);
+    if (lyr->args)
+      mem.xFree(lyr->args);
   }
 }
 
@@ -211,10 +213,15 @@ static void layer_free_data(SyntaqliteParser* p, SynqExpansionLayer* lyr) {
     p->mem.xFree((void*)lyr->expansion_data);
   if (lyr->arg_segments)
     p->mem.xFree(lyr->arg_segments);
+  if (lyr->args)
+    p->mem.xFree(lyr->args);
   lyr->expansion_data = NULL;
   lyr->expansion_len = 0;
   lyr->arg_segments = NULL;
   lyr->arg_segment_count = 0;
+  lyr->args = NULL;
+  lyr->arg_count = 0;
+  lyr->is_fallback = 0;
 }
 
 SYNTAQLITE_API void syntaqlite_macro_expansion_set_result(SyntaqliteParser* p,
@@ -423,6 +430,7 @@ int synq_parser_expand_and_feed_macro(SyntaqliteParser* p,
   begin_macro_expansion(p, id_offset, call_length, buf + id_offset, id_len);
 
   uint32_t new_layer_idx = syntaqlite_vec_len(&p->macro.layers) - 1;
+
   p->macro.pending_layer = new_layer_idx;
   p->macro.expansion_args = token_args;
   p->macro.expansion_arg_count = token_arg_count;
@@ -438,6 +446,8 @@ int synq_parser_expand_and_feed_macro(SyntaqliteParser* p,
       p->mem.xFree((void*)lyr->expansion_data);
     if (lyr->arg_segments)
       p->mem.xFree(lyr->arg_segments);
+    if (lyr->args)
+      p->mem.xFree(lyr->args);
     p->macro.layers.count--;
     p->macro.depth--;
     if (rc == -2)
@@ -445,8 +455,25 @@ int synq_parser_expand_and_feed_macro(SyntaqliteParser* p,
     return -1;
   }
 
-  // The callback wrote expansion_data/len/def_line/def_col onto the layer.
+  // The callback wrote expansion_data/len/def_line/def_col onto the
+  // layer.  Persist the call-site arg spans now (after the callback,
+  // since `set_result` calls `layer_free_data` which would wipe them
+  // otherwise) so downstream consumers — formatter, spans API,
+  // traceback — can read them without re-running scan_macro_args.
+  // Offsets in `args[]` are buf-relative; rebase top-level layers to
+  // statement-relative so they match how `begin_macro_expansion`
+  // stored `call_offset`.
   SynqExpansionLayer* lyr = &p->macro.layers.data[new_layer_idx];
+  if (token_arg_count > 0) {
+    SynqMacroArg* heap = p->mem.xMalloc(token_arg_count * sizeof(SynqMacroArg));
+    uint32_t shift = lyr->parent_layer_id == 0 ? p->stmt_start_offset : 0;
+    for (uint32_t i = 0; i < token_arg_count; i++) {
+      heap[i].offset = args[i].offset - shift;
+      heap[i].length = args[i].length;
+    }
+    lyr->args = heap;
+    lyr->arg_count = token_arg_count;
+  }
   const char* data = lyr->expansion_data;
   uint32_t data_len = lyr->expansion_len;
 
@@ -633,18 +660,47 @@ int synq_parser_try_macro_call(SyntaqliteParser* p,
   // No callback — fall through to TK_ID fallback.
   // (We already checked macro_style/macro_fallback at the top.)
 
-  // Scan balanced parens to find the end of name!(args).
+  // Scan balanced parens to find the end of name!(args) and capture
+  // the top-level arg spans so downstream consumers (notably the
+  // formatter's structured-arg pass) don't need to retokenize the
+  // call body.  64 is well above any realistic macro arity; calls
+  // exceeding that are handled correctly for `end_offset` but have
+  // their arg spans dropped (still scanned, just not recorded).
+  enum { SYNQ_FALLBACK_ARG_STACK_CAP = 64 };
   uint32_t end_offset = 0;
-  synq_parser_scan_macro_args(p, p->source, p->source_len, bang_offset, NULL, 0,
-                              &end_offset);
+  SynqMacroArg args_stack[SYNQ_FALLBACK_ARG_STACK_CAP];
+  uint32_t arg_count = synq_parser_scan_macro_args(
+      p, p->source, p->source_len, bang_offset, args_stack,
+      SYNQ_FALLBACK_ARG_STACK_CAP, &end_offset);
   if (end_offset == 0)
     return -1;  // Unbalanced parens — still an error.
 
   uint32_t call_length = end_offset - id_offset;
 
   // Record macro region so formatter emits verbatim (no expansion data).
-  begin_macro_expansion(p, id_offset, call_length, NULL, 0);
+  // Pass the macro name (a source slice) so downstream consumers can
+  // read it from the rewrite directly without reparsing the call text.
+  begin_macro_expansion(p, id_offset, call_length, (const char*)z + id_offset,
+                        id_len);
   p->ctx.layer_id = syntaqlite_vec_len(&p->macro.layers) - 1;
+
+  // Attach captured arg spans to the fresh layer and flag it as a
+  // fallback.  scan_macro_args returns source-absolute offsets;
+  // begin_macro_expansion rebases top-level call_offset to
+  // statement-relative, so apply the same shift to the arg spans.
+  SynqExpansionLayer* lyr = &p->macro.layers.data[p->ctx.layer_id];
+  lyr->is_fallback = 1;
+  if (arg_count > 0 && arg_count <= SYNQ_FALLBACK_ARG_STACK_CAP) {
+    SynqMacroArg* heap = p->mem.xMalloc(arg_count * sizeof(SynqMacroArg));
+    uint32_t shift = lyr->parent_layer_id == 0 ? p->stmt_start_offset : 0;
+    for (uint32_t i = 0; i < arg_count; i++) {
+      heap[i].offset = args_stack[i].offset - shift;
+      heap[i].length = args_stack[i].length;
+    }
+    lyr->args = heap;
+    lyr->arg_count = arg_count;
+  }
+
   synq_end_macro(p);
 
   // Feed the whole name!(args) span as a single TK_ID to Lemon.

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -331,6 +331,24 @@ typedef struct SyntaqliteMacroRewrite {
   // call_length.
   SyntaqliteLayerOffset body_call_offset;
   SyntaqliteLayerLen body_call_length;
+  // The buffer the `call_offset` — and every arg offset returned by
+  // syntaqlite_macro_rewrite_arg_at — indexes into.  For top-level
+  // rewrites (parent_idx == SYNTAQLITE_MACRO_PARENT_SOURCE) this is
+  // the current statement source slice; for nested rewrites it is
+  // the parent entry's `expansion` buffer.  Consumers can slice the
+  // call text as `parent_buffer + call_offset` and the arg texts
+  // likewise, without resolving parent_idx themselves.
+  //
+  // Not NUL-terminated; use `parent_buffer_len`.  Owned by the
+  // parser and valid until the next reset / next / destroy call.
+  const char* parent_buffer;
+  SyntaqliteLayerLen parent_buffer_len;
+  // 1 if this call went down the fallback path (unregistered name!
+  // kept verbatim as a TK_ID, no expansion, no $param substitutions);
+  // 0 if it was expanded by a registered macro.  `expansion_len` is
+  // also a useful tell (0 for fallback), but this flag is the
+  // authoritative signal.
+  uint32_t is_fallback;
 } SyntaqliteMacroRewrite;
 
 // Number of macro rewrites recorded for the current statement.
@@ -379,6 +397,36 @@ SYNTAQLITE_API SyntaqliteMacroArgSegment
 syntaqlite_macro_rewrite_arg_segment_at(SyntaqliteParser* p,
                                         uint32_t rewrite_idx,
                                         uint32_t segment_idx);
+
+// One top-level argument of a macro call, as written at the call
+// site.  Populated for both registered (expanded) and fallback calls:
+// the parser scans `name!(a, b, c)` the same way regardless of
+// whether `name` resolved to a registered macro.
+//
+// `offset` is in the same coordinate system as the enclosing
+// rewrite's `call_offset`, and indexes into the enclosing rewrite's
+// `parent_buffer`.  Slice the arg text as
+// `rewrite.parent_buffer + offset` for `length` bytes.  Leading and
+// trailing whitespace / comments are trimmed from the range.
+typedef struct SyntaqliteMacroCallArg {
+  SyntaqliteLayerOffset offset;
+  SyntaqliteLayerLen length;
+} SyntaqliteMacroCallArg;
+
+// Number of top-level call-site arg spans recorded on the rewrite at
+// `rewrite_idx`.  Returns 0 for `name!()` with no args, calls whose
+// arity exceeded the scan buffer (rare; >64 args), or out-of-range
+// indices.
+SYNTAQLITE_API uint32_t
+syntaqlite_macro_rewrite_arg_count(SyntaqliteParser* p, uint32_t rewrite_idx);
+
+// Returns the call-site arg at `arg_idx` on the rewrite at
+// `rewrite_idx`.  Returns a zero-initialized struct if either index
+// is out of range.
+SYNTAQLITE_API SyntaqliteMacroCallArg
+syntaqlite_macro_rewrite_arg_at(SyntaqliteParser* p,
+                                uint32_t rewrite_idx,
+                                uint32_t arg_idx);
 
 // ---------------------------------------------------------------------------
 // Arena accessors

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -89,7 +89,8 @@ pub mod any {
     #[doc(inline)]
     pub use crate::parser::{
         AnyIncrementalParseSession, AnyParseError, AnyParseSession, AnyParsedStatement, AnyParser,
-        AnyParserToken, ArgOrigin, MacroArgSegment, MacroRewrite, ParseOutcome, TracebackFrame,
+        AnyParserToken, ArgOrigin, MacroArgSegment, MacroCallArg, MacroRewrite, ParseOutcome,
+        TracebackFrame,
     };
     #[doc(inline)]
     pub use crate::tokenizer::{AnyToken, AnyTokenizer};

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -128,6 +128,15 @@ pub(crate) struct CMacroRewrite {
     /// substitution and has no body position.
     pub(crate) body_call_offset: u32,
     pub(crate) body_call_length: u32,
+    /// The buffer that `call_offset` (and each arg's offset) indexes
+    /// into — the statement source for top-level rewrites, or the
+    /// parent rewrite's expansion buffer otherwise.  Not NUL-terminated.
+    pub(crate) parent_buffer: *const u8,
+    /// Length of `parent_buffer`.
+    pub(crate) parent_buffer_len: u32,
+    /// 1 if this rewrite is a fallback (unregistered name! kept as a
+    /// `TK_ID` with no expansion); 0 for registered macros.
+    pub(crate) is_fallback: u32,
 }
 
 /// One $param substitution within a macro expansion.
@@ -151,6 +160,17 @@ pub(crate) struct CMacroArgSegment {
     pub(crate) origin_offset: u32,
     /// Byte length of the arg text in the origin.
     pub(crate) origin_length: u32,
+}
+
+/// One top-level argument of a macro call, at the call site.
+///
+/// Mirrors C `SyntaqliteMacroCallArg` from
+/// `include/syntaqlite/parser.h`.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub(crate) struct CMacroCallArg {
+    pub(crate) offset: u32,
+    pub(crate) length: u32,
 }
 
 /// One frame in a traceback produced by the span traceback API.
@@ -564,6 +584,33 @@ impl CParser {
         }
     }
 
+    pub(crate) unsafe fn macro_rewrite_arg_count(&self, rewrite_idx: RewriteIdx) -> u32 {
+        // SAFETY: self is a valid CParser pointer; the C side clamps
+        // out-of-range indices to zero.
+        unsafe {
+            syntaqlite_macro_rewrite_arg_count(
+                std::ptr::from_ref::<Self>(self).cast_mut(),
+                rewrite_idx.as_u32(),
+            )
+        }
+    }
+
+    pub(crate) unsafe fn macro_rewrite_arg_at(
+        &self,
+        rewrite_idx: RewriteIdx,
+        arg_idx: u32,
+    ) -> CMacroCallArg {
+        // SAFETY: self is a valid CParser pointer; the C side clamps
+        // out-of-range indices to a zero-initialized arg.
+        unsafe {
+            syntaqlite_macro_rewrite_arg_at(
+                std::ptr::from_ref::<Self>(self).cast_mut(),
+                rewrite_idx.as_u32(),
+                arg_idx,
+            )
+        }
+    }
+
     // Arena accessors
     pub(crate) unsafe fn node(&self, node_id: u32) -> *const u32 {
         // SAFETY: self is a valid, non-null CParser pointer; node_id is a
@@ -678,6 +725,12 @@ unsafe extern "C" {
         rewrite_idx: u32,
         segment_idx: u32,
     ) -> CMacroArgSegment;
+    fn syntaqlite_macro_rewrite_arg_count(p: *mut CParser, rewrite_idx: u32) -> u32;
+    fn syntaqlite_macro_rewrite_arg_at(
+        p: *mut CParser,
+        rewrite_idx: u32,
+        arg_idx: u32,
+    ) -> CMacroCallArg;
 
     // Arena accessors
     fn syntaqlite_parser_node(p: *mut CParser, node_id: u32) -> *const u32;

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -35,8 +35,8 @@ pub use incremental::{AnyIncrementalParseSession, TypedIncrementalParseSession};
 pub use session::{ParseError, ParseSession, ParsedStatement, Parser, ParserToken};
 pub use types::{
     AnyParserToken, ArgOrigin, Comment, CommentKind, CommentSide, CommentSpan, CompletionContext,
-    MACRO_BODY_CALL_ARG_INTERNAL, MacroArgSegment, MacroRewrite, ParseOutcome, ParserTokenFlags,
-    TracebackFrame, TypedParserToken,
+    MACRO_BODY_CALL_ARG_INTERNAL, MacroArgSegment, MacroCallArg, MacroRewrite, ParseOutcome,
+    ParserTokenFlags, TracebackFrame, TypedParserToken,
 };
 
 /// A single macro argument as presented to the lookup callback.
@@ -713,6 +713,21 @@ impl<'a> AnyParsedStatement<'a> {
             } else {
                 Some(RewriteIdx::from_raw(r.parent_idx))
             };
+            let parent_buffer: &'a LayerText = if r.parent_buffer.is_null() {
+                LayerText::new("")
+            } else {
+                // SAFETY: `parent_buffer` points to `parent_buffer_len`
+                // bytes owned by the parser (statement source or parent
+                // layer's expansion buffer), valid for 'a.  UTF-8 by
+                // construction — both sources are UTF-8.
+                let s = unsafe {
+                    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+                        r.parent_buffer,
+                        r.parent_buffer_len as usize,
+                    ))
+                };
+                LayerText::new(s)
+            };
             MacroRewrite {
                 parent,
                 rewrite_idx: RewriteIdx::from_raw(i),
@@ -724,6 +739,8 @@ impl<'a> AnyParsedStatement<'a> {
                 def_col: ColumnNumber::from_raw(r.def_col),
                 body_call_offset: LayerOffset::from_raw(r.body_call_offset),
                 body_call_length: LayerLen::from_raw(r.body_call_length),
+                parent_buffer,
+                is_fallback: r.is_fallback != 0,
                 parser: self.raw,
                 _lifetime: PhantomData,
             }

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -494,7 +494,9 @@ mod tests {
     use std::panic::{self, AssertUnwindSafe};
     use std::rc::Rc;
 
-    use crate::source::{LayerLen, LayerOffset, RewriteIdx, StmtLen, StmtOffset, TokenIdx};
+    use crate::source::{
+        LayerLen, LayerOffset, LayerRange, RewriteIdx, StmtLen, StmtOffset, TokenIdx,
+    };
 
     use super::{ParseErrorKind, ParseOutcome, Parser, ParserConfig, ParserToken};
     use crate::parser::{MacroArg, MacroLookup, MacroOutput};
@@ -1174,8 +1176,7 @@ mod tests {
         let outer = &rewrites[0];
         assert_eq!(outer.parent(), None);
         assert_eq!(outer.name(), "mwrap");
-        let outer_range =
-            crate::source::LayerRange::from_offset_len(outer.call_offset(), outer.call_length());
+        let outer_range = LayerRange::from_offset_len(outer.call_offset(), outer.call_length());
         let outer_call = &source[outer_range.start.as_usize()..outer_range.end.as_usize()];
         assert_eq!(outer_call, "mwrap!(42)");
         assert_eq!(outer.expansion(), "mpass!(42)");
@@ -1187,8 +1188,7 @@ mod tests {
         assert_eq!(inner.parent(), Some(RewriteIdx::from_raw(0)));
         assert_eq!(inner.name(), "mpass");
         let outer_exp = outer.expansion();
-        let inner_range =
-            crate::source::LayerRange::from_offset_len(inner.call_offset(), inner.call_length());
+        let inner_range = LayerRange::from_offset_len(inner.call_offset(), inner.call_length());
         let inner_call = &outer_exp[inner_range];
         assert_eq!(inner_call, "mpass!(42)");
         assert_eq!(inner.expansion(), "42");
@@ -1409,10 +1409,8 @@ mod tests {
             ArgOrigin::Rewrite(RewriteIdx::from_raw(0))
         );
         let m_expansion = rewrites[0].expansion();
-        let n_arg_range = crate::source::LayerRange::from_offset_len(
-            n_segs[0].origin_offset(),
-            n_segs[0].origin_length(),
-        );
+        let n_arg_range =
+            LayerRange::from_offset_len(n_segs[0].origin_offset(), n_segs[0].origin_length());
         let n_arg_in_m_expansion = &m_expansion[n_arg_range];
         assert_eq!(n_arg_in_m_expansion, "nonexistent_col");
 
@@ -1793,7 +1791,7 @@ mod tests {
         );
         assert_eq!(frames[0].name, None, "root frame after drill");
         assert_eq!(frames[0].snippet, source);
-        let range = crate::source::LayerRange::from_offset_len(
+        let range = LayerRange::from_offset_len(
             frames[0].offset_in_snippet,
             LayerLen::from_raw(u32::try_from("authored".len()).unwrap()),
         );
@@ -2091,5 +2089,168 @@ mod tests {
             !erased.node_is_macro_free(erased.root_id()),
             "should return false when extent tracking is disabled"
         );
+    }
+
+    // ── Tests for the call-site arg / is_fallback / parent_buffer API ──
+
+    #[test]
+    fn fallback_call_is_fallback_with_args_and_call_text() {
+        // Unregistered macro goes down the fallback path; the parser
+        // keeps the whole `foo!(...)` as a TK_ID but still exposes the
+        // top-level arg spans so consumers can reformat without
+        // retokenizing.
+        let parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let source = "SELECT foo!(a, 1 + 2, 'x');";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+
+        let rewrites: Vec<_> = stmt.macro_rewrites().collect();
+        assert_eq!(rewrites.len(), 1);
+        let r = &rewrites[0];
+        assert!(r.is_fallback(), "unregistered call should be fallback");
+        assert_eq!(r.name(), "foo");
+        assert_eq!(r.call_text(), "foo!(a, 1 + 2, 'x')");
+        // No expansion buffer on a fallback.
+        assert_eq!(r.expansion().as_str(), "");
+
+        let arg_texts: Vec<&str> = r.args().map(|a| a.text()).collect();
+        assert_eq!(arg_texts, vec!["a", "1 + 2", "'x'"]);
+    }
+
+    #[test]
+    fn registered_call_args_come_from_call_site_not_expansion() {
+        // `args()` returns call-site arg text for registered macros
+        // too — so the same consumer code works uniformly and does
+        // not have to branch on is_fallback().  `is_fallback()` is
+        // false because an expansion was produced.
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let mut reg = TestMacroRegistry::new();
+        reg.register("id", &["x", "y"], "($x + $y)");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "SELECT id!(3, 4);";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+
+        let rewrites: Vec<_> = stmt.macro_rewrites().collect();
+        assert_eq!(rewrites.len(), 1);
+        let r = &rewrites[0];
+        assert!(!r.is_fallback());
+        assert_eq!(r.call_text(), "id!(3, 4)");
+        assert_eq!(r.expansion().as_str(), "(3 + 4)");
+
+        let arg_texts: Vec<&str> = r.args().map(|a| a.text()).collect();
+        assert_eq!(arg_texts, vec!["3", "4"]);
+    }
+
+    #[test]
+    fn empty_call_has_no_args() {
+        let parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let source = "SELECT foo!();";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+        let rewrites: Vec<_> = stmt.macro_rewrites().collect();
+        assert_eq!(rewrites.len(), 1);
+        assert!(rewrites[0].is_fallback());
+        assert_eq!(rewrites[0].args().count(), 0);
+        assert_eq!(rewrites[0].call_text(), "foo!()");
+    }
+
+    #[test]
+    fn top_level_parent_buffer_matches_stmt_text() {
+        // For top-level rewrites the parent buffer *is* the current
+        // statement slice: same bytes, so any call or arg offset can
+        // be resolved by indexing into either one.
+        let parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let source = "SELECT foo!(a);";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+        let stmt_text = stmt.text();
+        let rewrites: Vec<_> = stmt.macro_rewrites().collect();
+        let r = &rewrites[0];
+        assert_eq!(r.parent_buffer().as_str(), stmt_text.as_str());
+    }
+
+    #[test]
+    fn arg_buffer_matches_enclosing_parent_buffer() {
+        // `MacroCallArg::buffer()` must equal the enclosing rewrite's
+        // `parent_buffer()`; the invariant is what lets callers treat
+        // `a.text()` as equivalent to slicing `r.parent_buffer()` at
+        // `a.offset()`/`a.length()`.
+        let parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let source = "SELECT foo!(x, y);";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+        let rewrites: Vec<_> = stmt.macro_rewrites().collect();
+        let r = &rewrites[0];
+        let pb = r.parent_buffer();
+        for a in r.args() {
+            assert!(
+                std::ptr::eq(std::ptr::from_ref(a.buffer()), std::ptr::from_ref(pb)),
+                "arg buffer must be the same reference as the rewrite's parent_buffer",
+            );
+            let end = LayerOffset::from_raw(a.offset().as_u32() + a.length().as_u32());
+            let manual = &pb[LayerRange {
+                start: a.offset(),
+                end,
+            }];
+            assert_eq!(a.text(), manual);
+        }
+    }
+
+    #[test]
+    fn nested_call_parent_buffer_is_parent_expansion() {
+        // For a nested rewrite, `parent_buffer` is the *parent
+        // rewrite's* expansion buffer — exactly the thing nested
+        // `call_offset` / `args()` are measured into.  This lets a
+        // consumer resolve nested-call text without pulling the
+        // parent chain apart manually.
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let mut reg = TestMacroRegistry::new();
+        reg.register("mpass", &["x"], "$x");
+        reg.register("mwrap", &["x"], "mpass!($x)");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "SELECT mwrap!(42);";
+        let mut session = parser.parse(source);
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
+        };
+
+        let rewrites: Vec<_> = stmt.macro_rewrites().collect();
+        assert_eq!(rewrites.len(), 2, "mwrap + mpass");
+        let outer = &rewrites[0];
+        let inner = &rewrites[1];
+        assert_eq!(inner.parent(), Some(RewriteIdx::from_raw(0)));
+        assert_eq!(
+            inner.parent_buffer().as_str(),
+            outer.expansion().as_str(),
+            "nested rewrite's parent_buffer == parent's expansion"
+        );
+        assert_eq!(inner.call_text(), "mpass!(42)");
+        let inner_arg_texts: Vec<&str> = inner.args().map(|a| a.text()).collect();
+        assert_eq!(inner_arg_texts, vec!["42"]);
     }
 }

--- a/syntaqlite-syntax/src/parser/types.rs
+++ b/syntaqlite-syntax/src/parser/types.rs
@@ -295,6 +295,11 @@ pub struct MacroRewrite<'a> {
     pub(crate) def_col: ColumnNumber,
     pub(crate) body_call_offset: LayerOffset,
     pub(crate) body_call_length: LayerLen,
+    /// Buffer that [`call_offset`](Self::call_offset) and every
+    /// [`MacroCallArg::offset`] indexes into — statement source for
+    /// top-level rewrites, parent rewrite's expansion otherwise.
+    pub(crate) parent_buffer: &'a LayerText,
+    pub(crate) is_fallback: bool,
     pub(crate) parser: std::ptr::NonNull<crate::parser::ffi::CParser>,
     pub(crate) _lifetime: std::marker::PhantomData<&'a ()>,
 }
@@ -361,6 +366,72 @@ impl<'a> MacroRewrite<'a> {
     pub fn body_call_length(&self) -> LayerLen {
         self.body_call_length
     }
+    /// 1 if this rewrite is a fallback call — an unregistered
+    /// `name!(args)` the parser kept verbatim as a `TK_ID` — and 0
+    /// if it was expanded by a registered macro.  Distinct from
+    /// "`expansion()` is empty", since a registered macro *could*
+    /// theoretically expand to the empty string.
+    pub fn is_fallback(&self) -> bool {
+        self.is_fallback
+    }
+
+    /// The buffer that [`call_offset`](Self::call_offset) and every
+    /// argument offset from [`args`](Self::args) indexes into.  For
+    /// top-level rewrites this is the current statement's source
+    /// slice; for nested rewrites it is the parent rewrite's
+    /// [`expansion`](Self::expansion) buffer.  Returned so consumers
+    /// can slice arbitrary sub-ranges without walking
+    /// [`parent`](Self::parent) themselves.
+    pub fn parent_buffer(&self) -> &'a LayerText {
+        self.parent_buffer
+    }
+
+    /// The text of the full `name!(...)` call, sliced from
+    /// [`parent_buffer`](Self::parent_buffer).  Equivalent to
+    /// `&parent_buffer()[call_offset..call_offset + call_length]`.
+    pub fn call_text(&self) -> &'a str {
+        let end = LayerOffset::from_raw(self.call_offset.as_u32() + self.call_length.as_u32());
+        &self.parent_buffer[crate::source::LayerRange {
+            start: self.call_offset,
+            end,
+        }]
+    }
+
+    /// Iterator over the top-level argument spans of this macro call
+    /// at the call site.  Populated for both registered and fallback
+    /// calls — the parser scans `name!(a, b, c)` the same way in
+    /// either path.  Each arg's offset indexes into the same
+    /// [`parent_buffer`](Self::parent_buffer) as
+    /// [`call_offset`](Self::call_offset); call
+    /// [`text()`](MacroCallArg::text) on the arg to slice directly.
+    /// Leading and trailing whitespace / comments are trimmed.
+    ///
+    /// Yields an empty iterator for `name!()` calls with zero args
+    /// and for calls whose arity exceeded the parser's scan buffer
+    /// (rare; >64 args, falls through gracefully).
+    pub fn args(&self) -> impl Iterator<Item = MacroCallArg<'a>> + use<'_, 'a> {
+        // SAFETY: the parser pointer is live for 'a (the parsed
+        // statement's lifetime); the C accessors clamp out-of-range
+        // indices so count is authoritative.
+        let count = unsafe {
+            self.parser
+                .as_ref()
+                .macro_rewrite_arg_count(self.rewrite_idx)
+        };
+        let rewrite_idx = self.rewrite_idx;
+        let parser = self.parser;
+        let buffer = self.parent_buffer;
+        (0..count).map(move |i| {
+            // SAFETY: i < count; the C side returns a valid arg.
+            let a = unsafe { parser.as_ref().macro_rewrite_arg_at(rewrite_idx, i) };
+            MacroCallArg {
+                buffer,
+                offset: LayerOffset::from_raw(a.offset),
+                length: LayerLen::from_raw(a.length),
+            }
+        })
+    }
+
     /// Iterator over the `$param` substitutions recorded on this rewrite.
     pub fn arg_segments(&self) -> impl Iterator<Item = MacroArgSegment<'a>> + use<'_, 'a> {
         // SAFETY: the parser pointer is live for 'a (the parsed
@@ -392,6 +463,51 @@ impl<'a> MacroRewrite<'a> {
                 _lifetime: std::marker::PhantomData,
             }
         })
+    }
+}
+
+/// One top-level argument of a macro call, at the call site.
+///
+/// Produced by [`MacroRewrite::args`] for both registered (expanded)
+/// and fallback calls — the parser scans `name!(a, b, c)` the same
+/// way regardless of whether `name` resolved to a registered macro.
+/// Leading and trailing whitespace and comments are trimmed from the
+/// range.
+///
+/// The arg carries the buffer it indexes into ([`buffer`](Self::buffer),
+/// always equal to the enclosing rewrite's
+/// [`parent_buffer`](MacroRewrite::parent_buffer)), so callers can
+/// slice the text directly via [`text`](Self::text) without having
+/// to walk the rewrite's parent chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MacroCallArg<'a> {
+    pub(crate) buffer: &'a LayerText,
+    pub(crate) offset: LayerOffset,
+    pub(crate) length: LayerLen,
+}
+
+impl<'a> MacroCallArg<'a> {
+    /// Byte offset of the arg text, measured into
+    /// [`buffer`](Self::buffer).
+    pub fn offset(&self) -> LayerOffset {
+        self.offset
+    }
+    /// Byte length of the arg text.
+    pub fn length(&self) -> LayerLen {
+        self.length
+    }
+    /// The buffer the arg's offset indexes into — the enclosing
+    /// rewrite's [`parent_buffer`](MacroRewrite::parent_buffer).
+    pub fn buffer(&self) -> &'a LayerText {
+        self.buffer
+    }
+    /// The arg's source text, sliced from [`buffer`](Self::buffer).
+    pub fn text(&self) -> &'a str {
+        let end = LayerOffset::from_raw(self.offset.as_u32() + self.length.as_u32());
+        &self.buffer[crate::source::LayerRange {
+            start: self.offset,
+            end,
+        }]
     }
 }
 

--- a/tests/c_api_tests/parser.py
+++ b/tests/c_api_tests/parser.py
@@ -386,3 +386,63 @@ SelectStmt
 .
 """,
         )
+
+
+class MacroRewrites(CApiTestSuite):
+    """Macro rewrite API — call-site args and self-resolving buffers.
+
+    These verify the shape C consumers actually see: `args()` populated
+    for top-level fallback calls, `is_fallback` flag set, and
+    `parent_buffer + offset` giving back the authored text.
+    """
+
+    def test_fallback_call_exposes_args(self):
+        return CApiScenario(
+            input="""\
+create
+macro_fallback 1
+reset
+SELECT foo!(a, 1 + 2, 'x');
+.
+parse_one
+dump_macros
+""",
+            expected="""\
+create ok
+macro_fallback ok
+reset ok len=27
+parse_one ok root=3 recovery=0
+macros count=1
+mac[0] parent=source call_off=7 call_len=19 is_fallback=1 name="foo"
+  call_text="foo!(a, 1 + 2, 'x')"
+  args count=3
+    arg[0] off=12 len=1 text="a"
+    arg[1] off=15 len=5 text="1 + 2"
+    arg[2] off=22 len=3 text="'x'"
+.
+""",
+        )
+
+    def test_empty_fallback_call_has_no_args(self):
+        return CApiScenario(
+            input="""\
+create
+macro_fallback 1
+reset
+SELECT foo!();
+.
+parse_one
+dump_macros
+""",
+            expected="""\
+create ok
+macro_fallback ok
+reset ok len=14
+parse_one ok root=3 recovery=0
+macros count=1
+mac[0] parent=source call_off=7 call_len=6 is_fallback=1 name="foo"
+  call_text="foo!()"
+  args count=0
+.
+""",
+        )

--- a/tests/c_api_tests/parser_driver.c
+++ b/tests/c_api_tests/parser_driver.c
@@ -27,6 +27,8 @@
 //   token_comments <idx>  Leading + trailing comments for token idx.
 //   node_text <id>        Authored text slice for node (needs extents).
 //   error_info            error_msg/off/len/recovery_root dump.
+//   macro_fallback 0|1    Configure (must be before first reset).
+//   dump_macros           All macro rewrites with parent_buffer + args.
 
 // Needed for strtok_r under glibc when compiling with -std=c11.
 #define _POSIX_C_SOURCE 200809L
@@ -220,6 +222,48 @@ int main(void) {
         if (len == 0 || t[len - 1] != '\n') fputc('\n', stdout);
         printf(".\n");
       }
+    } else if (strcmp(verb, "macro_fallback") == 0) {
+      if (argc < 2) { printf("macro_fallback err bad_arg\n"); continue; }
+      int32_t rc = syntaqlite_parser_set_macro_fallback(
+          p, (uint32_t)strtoul(argv[1], NULL, 10));
+      printf("macro_fallback %s\n", cfg_rc_str(rc));
+    } else if (strcmp(verb, "dump_macros") == 0) {
+      uint32_t count = syntaqlite_result_macro_count(p);
+      printf("macros count=%u\n", count);
+      for (uint32_t i = 0; i < count; i++) {
+        SyntaqliteMacroRewrite r = syntaqlite_result_macro_rewrite_at(p, i);
+        const char* parent_str =
+            r.parent_idx == SYNTAQLITE_MACRO_PARENT_SOURCE ? "source" : "idx";
+        if (r.parent_idx == SYNTAQLITE_MACRO_PARENT_SOURCE) {
+          printf(
+              "mac[%u] parent=%s call_off=%u call_len=%u is_fallback=%u "
+              "name=\"%.*s\"\n",
+              i, parent_str, r.call_offset, r.call_length, r.is_fallback,
+              (int)r.name_len, r.name ? r.name : "");
+        } else {
+          printf(
+              "mac[%u] parent=%s(%u) call_off=%u call_len=%u is_fallback=%u "
+              "name=\"%.*s\"\n",
+              i, parent_str, r.parent_idx, r.call_offset, r.call_length,
+              r.is_fallback, (int)r.name_len, r.name ? r.name : "");
+        }
+        // Slice call text via parent_buffer to exercise the
+        // self-resolving API: a C consumer can get call text without
+        // walking the parent chain.
+        if (r.parent_buffer && r.call_offset + r.call_length <= r.parent_buffer_len) {
+          printf("  call_text=\"%.*s\"\n",
+                 (int)r.call_length, r.parent_buffer + r.call_offset);
+        }
+        uint32_t acount = syntaqlite_macro_rewrite_arg_count(p, i);
+        printf("  args count=%u\n", acount);
+        for (uint32_t j = 0; j < acount; j++) {
+          SyntaqliteMacroCallArg a = syntaqlite_macro_rewrite_arg_at(p, i, j);
+          printf("    arg[%u] off=%u len=%u text=\"%.*s\"\n",
+                 j, a.offset, a.length, (int)a.length,
+                 r.parent_buffer + a.offset);
+        }
+      }
+      printf(".\n");
     } else if (strcmp(verb, "error_info") == 0) {
       const char* msg = syntaqlite_result_error_msg(p);
       SyntaqliteStmtOffset off = syntaqlite_result_error_offset(p);

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -719,6 +719,7 @@ impl<'a> core::convert::From<syntaqlite_syntax::typed::TypedNodeList<'a, syntaql
 impl<'a> syntaqlite_syntax::Comment<'a>
 impl<'a> syntaqlite_syntax::ParserToken<'a>
 impl<'a> syntaqlite_syntax::any::AnyParsedStatement<'a>
+impl<'a> syntaqlite_syntax::any::MacroCallArg<'a>
 impl<'a> syntaqlite_syntax::any::MacroRewrite<'a>
 impl<'a> syntaqlite_syntax::nodes::AggregateFunctionCall<'a>
 impl<'a> syntaqlite_syntax::nodes::AlterTableStmt<'a>
@@ -1134,16 +1135,24 @@ pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin(&self) -> syntaqlite_
 pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin_length(&self) -> syntaqlite_syntax::source::LayerLen
 pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin_offset(&self) -> syntaqlite_syntax::source::LayerOffset
 pub fn syntaqlite_syntax::any::MacroArgSegment<'_>::origin_parent(&self) -> core::option::Option<syntaqlite_syntax::source::RewriteIdx>
+pub fn syntaqlite_syntax::any::MacroCallArg<'a>::buffer(&self) -> &'a syntaqlite_syntax::source::LayerText
+pub fn syntaqlite_syntax::any::MacroCallArg<'a>::length(&self) -> syntaqlite_syntax::source::LayerLen
+pub fn syntaqlite_syntax::any::MacroCallArg<'a>::offset(&self) -> syntaqlite_syntax::source::LayerOffset
+pub fn syntaqlite_syntax::any::MacroCallArg<'a>::text(&self) -> &'a str
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::arg_segments(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroArgSegment<'a>> + use<'_, 'a>
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::args(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroCallArg<'a>> + use<'_, 'a>
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::body_call_length(&self) -> syntaqlite_syntax::source::LayerLen
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::body_call_offset(&self) -> syntaqlite_syntax::source::LayerOffset
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::call_length(&self) -> syntaqlite_syntax::source::LayerLen
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::call_offset(&self) -> syntaqlite_syntax::source::LayerOffset
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::call_text(&self) -> &'a str
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::def_col(&self) -> syntaqlite_syntax::source::ColumnNumber
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::def_line(&self) -> syntaqlite_syntax::source::LineNumber
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::expansion(&self) -> &'a syntaqlite_syntax::source::LayerText
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::is_fallback(&self) -> bool
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::name(&self) -> &'a str
 pub fn syntaqlite_syntax::any::MacroRewrite<'a>::parent(&self) -> core::option::Option<syntaqlite_syntax::source::RewriteIdx>
+pub fn syntaqlite_syntax::any::MacroRewrite<'a>::parent_buffer(&self) -> &'a syntaqlite_syntax::source::LayerText
 pub fn syntaqlite_syntax::any::NodeFields::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn syntaqlite_syntax::any::NodeFields::index(&self, idx: usize) -> &syntaqlite_syntax::any::FieldValue
 pub fn syntaqlite_syntax::any::NodeFields::is_empty(&self) -> bool
@@ -1994,6 +2003,7 @@ pub struct syntaqlite_syntax::any::AnyParsedStatement<'a>
 pub struct syntaqlite_syntax::any::FieldMeta<'a>(_)
 pub struct syntaqlite_syntax::any::KeywordEntry
 pub struct syntaqlite_syntax::any::MacroArgSegment<'a>
+pub struct syntaqlite_syntax::any::MacroCallArg<'a>
 pub struct syntaqlite_syntax::any::MacroRewrite<'a>
 pub struct syntaqlite_syntax::any::NodeFields
 pub struct syntaqlite_syntax::any::TracebackFrame<'a>


### PR DESCRIPTION
The C/Rust parser already segments `name\!(a, b, c)` the same way
regardless of whether the call is expanded or kept as a fallback
`TK_ID`.  Consumers of `MacroRewrite` that want to understand what
was between the parens had to retokenize the call text and walk
paren-depth themselves.  Expose the work the parser already did:

- `syntaqlite-syntax/include/syntaqlite/parser.h` +
  `syntaqlite-syntax/csrc/parser*.{c,h}`: add
  `SyntaqliteMacroCallArg` plus `parent_buffer`/`is_fallback` on
  `SyntaqliteMacroRewrite`, and the
  `syntaqlite_macro_rewrite_arg_count` /
  `syntaqlite_macro_rewrite_arg_at` accessors.
- `syntaqlite-syntax/src/parser/{ffi,mod,types}.rs`: mirror the C
  additions.  `MacroRewrite` gains `args()`, `is_fallback()`,
  `parent_buffer()`, `call_text()`; new `MacroCallArg` type with
  `offset`/`length`/`text`/`buffer`.  `parent_buffer` is the
  statement source for top-level rewrites and the parent's
  expansion otherwise, so `offset` + `buffer` round-trips without
  walking the parent chain.
- `syntaqlite-syntax/src/lib.rs` re-exports `MacroCallArg`.
- Tests: `syntaqlite-syntax/src/parser/session.rs` adds six Rust
  unit tests (fallback/registered args, empty call, top-level vs
  nested `parent_buffer`, buffer-identity invariant).
  `tests/c_api_tests/{parser.py,parser_driver.c}` adds
  `dump_macros` + `macro_fallback` verbs and two C-side scenarios.
- `tests/public-api/syntaqlite-syntax.txt` pins the new surface.

