### PR TITLE
synq: dedup analysis via shared DdlReader helpers

### DIFF
--- a/syntaqlite/src/analysis/catalog.rs
+++ b/syntaqlite/src/analysis/catalog.rs
@@ -15,12 +15,6 @@ use crate::dialect::{
     FIELD_ABSENT, FunctionCategory as DialectFunctionCategory, SemanticRole, is_function_available,
 };
 
-/// Convert a `u8` field index with [`FIELD_ABSENT`] sentinel to `Option<u8>`.
-#[inline]
-pub(super) fn opt_field(v: u8) -> Option<u8> {
-    (v != FIELD_ABSENT).then_some(v)
-}
-
 // ── Core layer types ─────────────────────────────────────────────────────────
 
 /// The category of a catalog function.
@@ -708,13 +702,13 @@ impl Catalog {
                 let Some(name_val) = reader.span_field_text(&fields, name) else {
                     return;
                 };
-                let cols = reader.extract_columns(&fields, opt_field(columns), opt_field(select));
+                let cols = reader.extract_columns(&fields, columns, select);
                 let is_without_rowid = without_rowid.field != FIELD_ABSENT
                     && matches!(
                         fields[without_rowid.field as usize],
                         FieldValue::Flags(f) if without_rowid.is_set(f)
                     );
-                layer.insert_table(name_val, cols, is_without_rowid);
+                layer.insert_table(name_val.to_string(), cols, is_without_rowid);
             }
             SemanticRole::DefineView {
                 name,
@@ -724,8 +718,8 @@ impl Catalog {
                 let Some(name_val) = reader.span_field_text(&fields, name) else {
                     return;
                 };
-                let cols = reader.extract_columns(&fields, opt_field(columns), Some(select));
-                layer.insert_view(name_val, cols);
+                let cols = reader.extract_columns(&fields, columns, select);
+                layer.insert_view(name_val.to_string(), cols);
             }
             SemanticRole::DefineFunction {
                 name,
@@ -736,10 +730,14 @@ impl Catalog {
                 let Some(name_val) = reader.span_field_text(&fields, name) else {
                     return;
                 };
-                let arity = reader.function_arity(&fields, opt_field(args));
-                layer.insert_function_overload(name_val.clone(), FunctionCategory::Scalar, arity);
-                if reader.is_table_returning(&fields, opt_field(return_type)) {
-                    layer.insert_table_function(name_val, AritySpec::Any, Vec::new());
+                let arity = reader.function_arity(&fields, args);
+                layer.insert_function_overload(
+                    name_val.to_string(),
+                    FunctionCategory::Scalar,
+                    arity,
+                );
+                if reader.is_table_returning(&fields, return_type) {
+                    layer.insert_table_function(name_val.to_string(), AritySpec::Any, Vec::new());
                 }
             }
             // Non-DDL roles are irrelevant to catalog accumulation.

--- a/syntaqlite/src/analysis/ddl.rs
+++ b/syntaqlite/src/analysis/ddl.rs
@@ -3,18 +3,19 @@
 
 //! DDL-shaped reads against a parsed statement.
 //!
-//! The catalog, the analyzer, and the lineage resolver all need to pull
-//! definition names, column lists, and SELECT-result columns out of a parsed
-//! statement.  Every operation here takes only `(stmt, roles)`, so they're
-//! grouped on a single [`DdlReader`] handle.
+//! The catalog, the analyzer, the lineage resolver, and the LSP all need to
+//! pull definition names, column lists, SELECT-result columns, and assorted
+//! span/role data out of a parsed statement. Every operation here takes only
+//! `(stmt, roles)`, so they're grouped on a single [`DdlReader`] handle.
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue, NodeFields};
 use syntaqlite_syntax::source::{DocRange, StmtLen, StmtOffset, StmtRange};
 
 use crate::analysis::catalog::AritySpec;
+use crate::analysis::model::DefinedRelation;
 use crate::dialect::{FIELD_ABSENT, SemanticRole};
 
-/// Read DDL-shaped data out of a parsed statement.
+/// Read DDL- and AST-shaped data out of a parsed statement.
 ///
 /// Cheap to construct (just two references); construct a fresh handle at each
 /// caller rather than threading one through.
@@ -29,60 +30,184 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
         Self { stmt, roles }
     }
 
-    fn role_for(&self, tag: impl Into<u32>) -> Option<SemanticRole> {
-        self.roles.get(tag.into() as usize).copied()
+    pub(crate) fn stmt(&self) -> &'a AnyParsedStatement<'stmt> {
+        self.stmt
     }
 
-    /// Expanded text of a span field, or `None` when the field is absent or
-    /// the span is empty.
-    pub(super) fn span_field_text(&self, fields: &NodeFields, idx: u8) -> Option<String> {
+    // ── Role lookup ──────────────────────────────────────────────────────
+
+    /// Role for `tag`; defaults to [`SemanticRole::Transparent`] for unknown
+    /// tags (matching the behavior expected by the walker).
+    pub(crate) fn role_for_tag(&self, tag: impl Into<u32>) -> SemanticRole {
+        self.roles
+            .get(tag.into() as usize)
+            .copied()
+            .unwrap_or(SemanticRole::Transparent)
+    }
+
+    /// `(role, fields)` for `node_id`, or `None` if the node has no fields.
+    pub(crate) fn role_for_node(&self, node_id: AnyNodeId) -> Option<(SemanticRole, NodeFields)> {
+        if node_id.is_null() {
+            return None;
+        }
+        let (tag, fields) = self.stmt.extract_fields(node_id)?;
+        Some((self.role_for_tag(tag), fields))
+    }
+
+    // ── Field accessors ──────────────────────────────────────────────────
+
+    /// `NodeId` stored at field `idx`, or `None` if absent / null / non-NodeId.
+    pub(crate) fn node_field(fields: &NodeFields, idx: u8) -> Option<AnyNodeId> {
+        if idx == FIELD_ABSENT {
+            return None;
+        }
+        match fields[idx as usize] {
+            FieldValue::NodeId(id) if !id.is_null() => Some(id),
+            _ => None,
+        }
+    }
+
+    /// Expanded text of a span field, or `None` if absent / empty / non-Span.
+    pub(crate) fn span_field_text(&self, fields: &NodeFields, idx: u8) -> Option<&'stmt str> {
+        if idx == FIELD_ABSENT {
+            return None;
+        }
+        match fields[idx as usize] {
+            FieldValue::Span(sp) if !sp.is_empty() => Some(self.stmt.span_expanded_text(sp)),
+            _ => None,
+        }
+    }
+
+    /// `(text, range)` of a span field; absolute document range.
+    pub(crate) fn span_field_range(
+        &self,
+        fields: &NodeFields,
+        idx: u8,
+    ) -> Option<(&'stmt str, DocRange)> {
+        if idx == FIELD_ABSENT {
+            return None;
+        }
         match fields[idx as usize] {
             FieldValue::Span(sp) if !sp.is_empty() => {
-                Some(self.stmt.span_expanded_text(sp).to_string())
+                let text = self.stmt.span_expanded_text(sp);
+                let (_, range) = self.stmt.span_text_abs(sp);
+                Some((text, range))
             }
             _ => None,
         }
     }
 
-    // ── DDL definition spans (go-to-definition) ──────────────────────────
+    /// `(text, range)` of a Name node's field-0 span (used by `IdentName` and
+    /// `Error` shapes where the identifier sits at field 0). Returns empty
+    /// strings when the node is null or shaped differently.
+    pub(crate) fn name_text(&self, node_id: Option<AnyNodeId>) -> (&'stmt str, DocRange) {
+        let Some(node_id) = node_id else {
+            return ("", DocRange::default());
+        };
+        let Some((_, fields)) = self.stmt.extract_fields(node_id) else {
+            return ("", DocRange::default());
+        };
+        if fields.is_empty() {
+            return ("", DocRange::default());
+        }
+        match fields[0] {
+            FieldValue::Span(sp) => {
+                let text = self.stmt.span_expanded_text(sp);
+                let (_, range) = self.stmt.span_text_abs(sp);
+                (text, range)
+            }
+            _ => ("", DocRange::default()),
+        }
+    }
+
+    /// First non-empty span anywhere in `node_id`'s fields. Used as a generic
+    /// "give me whatever identifier this node carries" probe.
+    pub(crate) fn first_span_text(&self, node_id: AnyNodeId) -> Option<&'stmt str> {
+        if node_id.is_null() {
+            return None;
+        }
+        let (_, fields) = self.stmt.extract_fields(node_id)?;
+        for i in 0..fields.len() {
+            if let FieldValue::Span(sp) = fields[i]
+                && !sp.is_empty()
+            {
+                return Some(self.stmt.span_expanded_text(sp));
+            }
+        }
+        None
+    }
+
+    /// Text of a "name-shaped" field that may be either a direct `Span` or a
+    /// `NodeId` pointing at a Name node. Mirrors the dual representation used
+    /// by `SourceRef.alias`, CTE names, and similar fields.
+    pub(crate) fn name_field_text(&self, fields: &NodeFields, idx: u8) -> Option<&'stmt str> {
+        if idx == FIELD_ABSENT {
+            return None;
+        }
+        match fields[idx as usize] {
+            FieldValue::Span(sp) if !sp.is_empty() => Some(self.stmt.span_expanded_text(sp)),
+            FieldValue::NodeId(id) if !id.is_null() => self.first_span_text(id),
+            _ => None,
+        }
+    }
+
+    // ── Result-column iteration ──────────────────────────────────────────
+
+    /// Visit each `ResultColumn` child of a column-list node, calling `f` with
+    /// the result column's fields and the indices of its `(flags, alias, expr)`
+    /// fields. `f` returns `false` to stop iteration early.
+    ///
+    /// Skips children that aren't `ResultColumn` (transparent wrappers,
+    /// commas, etc.) so callers don't have to.
+    pub(crate) fn for_each_result_column<F>(&self, list_id: AnyNodeId, mut f: F)
+    where
+        F: FnMut(&NodeFields, u8, u8, u8) -> bool,
+    {
+        let Some(children) = self.stmt.list_children(list_id) else {
+            return;
+        };
+        for &child_id in children {
+            if child_id.is_null() {
+                continue;
+            }
+            let Some((child_tag, child_fields)) = self.stmt.extract_fields(child_id) else {
+                continue;
+            };
+            let SemanticRole::ResultColumn { flags, alias, expr } = self.role_for_tag(child_tag)
+            else {
+                continue;
+            };
+            if !f(&child_fields, flags, alias, expr) {
+                return;
+            }
+        }
+    }
+
+    // ── DDL definition spans (go-to-definition, etc.) ────────────────────
 
     /// `(lowercase_name, range)` for `CREATE TABLE` / `CREATE VIEW`.
     /// Returns `None` for non-DDL statements.
     pub(crate) fn name_span(&self, root: AnyNodeId) -> Option<(String, DocRange)> {
-        let (tag, fields) = self.stmt.extract_fields(root)?;
+        let (role, fields) = self.role_for_node(root)?;
         let (SemanticRole::DefineTable { name: name_idx, .. }
-        | SemanticRole::DefineView { name: name_idx, .. }) = self.role_for(tag)?
+        | SemanticRole::DefineView { name: name_idx, .. }) = role
         else {
             return None;
         };
-        let FieldValue::Span(sp) = fields[name_idx as usize] else {
-            return None;
-        };
-        if sp.is_empty() {
-            return None;
-        }
-        let (s, range) = self.stmt.span_text_abs(sp);
-        Some((s.to_ascii_lowercase(), range))
+        let (text, range) = self.span_field_range(&fields, name_idx)?;
+        Some((text.to_ascii_lowercase(), range))
     }
 
     /// Per-column `(lowercase_name, range)` pairs for a `CREATE TABLE`.
     pub(crate) fn column_spans(&self, root: AnyNodeId) -> Vec<(String, DocRange)> {
         let mut out = Vec::new();
-        let Some((tag, fields)) = self.stmt.extract_fields(root) else {
+        let Some((SemanticRole::DefineTable { columns, .. }, fields)) = self.role_for_node(root)
+        else {
             return out;
         };
-        let Some(SemanticRole::DefineTable { columns, .. }) = self.role_for(tag) else {
+        let Some(col_list_id) = Self::node_field(&fields, columns) else {
             return out;
         };
-        if columns == FIELD_ABSENT {
-            return out;
-        }
-        let FieldValue::NodeId(col_list_id) = fields[columns as usize] else {
-            return out;
-        };
-        if col_list_id.is_null() {
-            return out;
-        }
         let Some(children) = self.stmt.list_children(col_list_id) else {
             return out;
         };
@@ -98,16 +223,12 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
     }
 
     fn column_def_name_span(&self, node_id: AnyNodeId) -> Option<(&'stmt str, DocRange)> {
-        let (tag, fields) = self.stmt.extract_fields(node_id)?;
-        let SemanticRole::ColumnDef { name: name_idx, .. } = self.role_for(tag)? else {
+        let (SemanticRole::ColumnDef { name: name_idx, .. }, fields) =
+            self.role_for_node(node_id)?
+        else {
             return None;
         };
-        let FieldValue::NodeId(name_id) = fields[name_idx as usize] else {
-            return None;
-        };
-        if name_id.is_null() {
-            return None;
-        }
+        let name_id = Self::node_field(&fields, name_idx)?;
         let (_, name_fields) = self.stmt.extract_fields(name_id)?;
         for j in 0..name_fields.len() {
             if let FieldValue::Span(sp) = name_fields[j]
@@ -120,36 +241,47 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
         None
     }
 
+    /// Relations defined by a DDL statement at `root` (`CREATE TABLE` or
+    /// `CREATE VIEW`). Returns at most one relation per statement.
+    pub(crate) fn defined_relations(&self, root: AnyNodeId) -> Vec<DefinedRelation> {
+        let Some((role, fields)) = self.role_for_node(root) else {
+            return Vec::new();
+        };
+        let (name_idx, is_view) = match role {
+            SemanticRole::DefineTable { name, .. } => (name, false),
+            SemanticRole::DefineView { name, .. } => (name, true),
+            _ => return Vec::new(),
+        };
+        match self.span_field_text(&fields, name_idx) {
+            Some(name) => vec![DefinedRelation {
+                name: name.to_string(),
+                is_view,
+            }],
+            None => Vec::new(),
+        }
+    }
+
     // ── Catalog accumulation inputs ───────────────────────────────────────
 
     /// Columns for a table or view DDL contribution.
     ///
     /// Tries the explicit column list first; falls back to inferring names
-    /// from the SELECT body.  `None` means inference was impossible (e.g.
+    /// from the SELECT body. `None` means inference was impossible (e.g.
     /// `SELECT *`) and the caller should accept any column reference.
     pub(super) fn extract_columns(
         &self,
         fields: &NodeFields,
-        columns_field: Option<u8>,
-        select_field: Option<u8>,
+        columns_field: u8,
+        select_field: u8,
     ) -> Option<Vec<String>> {
-        if let Some(col_idx) = columns_field
-            && let FieldValue::NodeId(col_list_id) = fields[col_idx as usize]
-            && !col_list_id.is_null()
-        {
+        if let Some(col_list_id) = Self::node_field(fields, columns_field) {
             let mut columns = Vec::new();
             self.columns_from_column_list(col_list_id, &mut columns);
             if !columns.is_empty() {
                 return Some(columns);
             }
         }
-        if let Some(sel_idx) = select_field
-            && let FieldValue::NodeId(select_id) = fields[sel_idx as usize]
-            && !select_id.is_null()
-        {
-            return self.columns_from_select(select_id);
-        }
-        None
+        Self::node_field(fields, select_field).and_then(|id| self.columns_from_select(id))
     }
 
     fn columns_from_column_list(&self, list_id: AnyNodeId, out: &mut Vec<String>) {
@@ -157,75 +289,30 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
             return;
         };
         for &child_id in children {
-            if child_id.is_null() {
-                continue;
-            }
-            let Some((child_tag, child_fields)) = self.stmt.extract_fields(child_id) else {
-                continue;
-            };
-            let Some(SemanticRole::ColumnDef { name: name_idx, .. }) = self.role_for(child_tag)
-            else {
-                continue;
-            };
-            let FieldValue::NodeId(name_id) = child_fields[name_idx as usize] else {
-                continue;
-            };
-            if name_id.is_null() {
-                continue;
-            }
-            let Some((_, name_fields)) = self.stmt.extract_fields(name_id) else {
-                continue;
-            };
-            for j in 0..name_fields.len() {
-                if let FieldValue::Span(sp) = name_fields[j]
-                    && !sp.is_empty()
-                {
-                    out.push(self.stmt.span_expanded_text(sp).to_ascii_lowercase());
-                    break;
-                }
+            if let Some((name, _)) = self.column_def_name_span(child_id) {
+                out.push(name.to_ascii_lowercase());
             }
         }
     }
 
     /// Whether a DDL function returns a table (has a `ReturnSpec` with
     /// non-empty columns).
-    pub(super) fn is_table_returning(
-        &self,
-        fields: &NodeFields,
-        return_type_field: Option<u8>,
-    ) -> bool {
-        let Some(rt_idx) = return_type_field else {
+    pub(super) fn is_table_returning(&self, fields: &NodeFields, return_type_field: u8) -> bool {
+        let Some(rt_id) = Self::node_field(fields, return_type_field) else {
             return false;
         };
-        let FieldValue::NodeId(rt_id) = fields[rt_idx as usize] else {
+        let Some((SemanticRole::ReturnSpec { columns }, rt_fields)) = self.role_for_node(rt_id)
+        else {
             return false;
         };
-        if rt_id.is_null() {
-            return false;
-        }
-        let Some((rt_tag, rt_fields)) = self.stmt.extract_fields(rt_id) else {
-            return false;
-        };
-        let Some(SemanticRole::ReturnSpec { columns }) = self.role_for(rt_tag) else {
-            return false;
-        };
-        if columns == FIELD_ABSENT {
-            return false;
-        }
-        matches!(rt_fields[columns as usize], FieldValue::NodeId(id) if !id.is_null())
+        Self::node_field(&rt_fields, columns).is_some()
     }
 
     /// Argument count for a DDL function declaration.
-    pub(super) fn function_arity(&self, fields: &NodeFields, args_field: Option<u8>) -> AritySpec {
-        let Some(args_idx) = args_field else {
+    pub(super) fn function_arity(&self, fields: &NodeFields, args_field: u8) -> AritySpec {
+        let Some(args_id) = Self::node_field(fields, args_field) else {
             return AritySpec::Any;
         };
-        let FieldValue::NodeId(args_id) = fields[args_idx as usize] else {
-            return AritySpec::Any;
-        };
-        if args_id.is_null() {
-            return AritySpec::Any;
-        }
         let Some(children) = self.stmt.list_children(args_id) else {
             return AritySpec::Any;
         };
@@ -241,48 +328,39 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
     /// when any column is `*` or otherwise unnameable, telling the caller to
     /// register the table conservatively.
     pub(crate) fn columns_from_select(&self, select_id: AnyNodeId) -> Option<Vec<String>> {
-        let (select_tag, select_fields) = self.stmt.extract_fields(select_id)?;
-        let SemanticRole::Query {
-            columns: cols_idx, ..
-        } = self.role_for(select_tag)?
+        let (
+            SemanticRole::Query {
+                columns: cols_idx, ..
+            },
+            select_fields,
+        ) = self.role_for_node(select_id)?
         else {
             return None;
         };
-        let FieldValue::NodeId(list_id) = select_fields[cols_idx as usize] else {
-            return None;
-        };
-        if list_id.is_null() {
-            return None;
-        }
-        let children = self.stmt.list_children(list_id)?;
+        let list_id = Self::node_field(&select_fields, cols_idx)?;
         let mut out = Vec::new();
-        for &child_id in children {
-            if child_id.is_null() {
-                continue;
-            }
-            let (child_tag, child_fields) = self.stmt.extract_fields(child_id)?;
-            let SemanticRole::ResultColumn {
-                flags: flags_idx,
-                alias: alias_idx,
-                expr: expr_idx,
-            } = self
-                .role_for(child_tag)
-                .unwrap_or(SemanticRole::Transparent)
-            else {
-                continue;
-            };
-            // STAR flag (bit 0) → wildcard: can't enumerate columns.
-            if let FieldValue::Flags(f) = child_fields[flags_idx as usize]
+        let mut bailed = false;
+        self.for_each_result_column(list_id, |fields, flags_idx, alias_idx, expr_idx| {
+            // STAR flag (bit 0) → wildcard: can't enumerate.
+            if let FieldValue::Flags(f) = fields[flags_idx as usize]
                 && f & 1 != 0
             {
-                return None;
+                bailed = true;
+                return false;
             }
-            match self.infer_result_col_name(&child_fields, alias_idx, expr_idx) {
-                Some(name) => out.push(name),
-                None => return None,
+            if let Some(name) = self.infer_result_col_name(fields, alias_idx, expr_idx) {
+                out.push(name);
+                true
+            } else {
+                bailed = true;
+                false
             }
+        });
+        if bailed || out.is_empty() {
+            None
+        } else {
+            Some(out)
         }
-        if out.is_empty() { None } else { Some(out) }
     }
 
     /// The output column name for a single result column.
@@ -292,38 +370,27 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
     /// 2. Bare `ColumnRef` with no alias → use the column-name span.
     /// 3. Any other expression → use the raw source text of the expression
     ///    (`SQLite` calls this `ENAME_SPAN`).
-    fn infer_result_col_name(
+    pub(crate) fn infer_result_col_name(
         &self,
         child_fields: &NodeFields,
         alias_idx: u8,
         expr_idx: u8,
     ) -> Option<String> {
-        if let FieldValue::NodeId(alias_id) = child_fields[alias_idx as usize]
-            && !alias_id.is_null()
-            && let Some((_, alias_fields)) = self.stmt.extract_fields(alias_id)
+        if let Some(alias_id) = Self::node_field(child_fields, alias_idx)
+            && let Some(name) = self.first_span_text(alias_id)
         {
-            for j in 0..alias_fields.len() {
-                if let FieldValue::Span(sp) = alias_fields[j]
-                    && !sp.is_empty()
-                {
-                    return Some(self.stmt.span_expanded_text(sp).to_ascii_lowercase());
-                }
-            }
+            return Some(name.to_ascii_lowercase());
         }
-        let FieldValue::NodeId(expr_id) = child_fields[expr_idx as usize] else {
-            return None;
-        };
-        if expr_id.is_null() {
-            return None;
-        }
-        let (expr_tag, expr_fields) = self.stmt.extract_fields(expr_id)?;
-        if let Some(SemanticRole::ColumnRef {
-            column: col_idx, ..
-        }) = self.role_for(expr_tag)
-            && let FieldValue::Span(sp) = expr_fields[col_idx as usize]
-            && !sp.is_empty()
+        let expr_id = Self::node_field(child_fields, expr_idx)?;
+        if let Some((
+            SemanticRole::ColumnRef {
+                column: col_idx, ..
+            },
+            expr_fields,
+        )) = self.role_for_node(expr_id)
+            && let Some(name) = self.span_field_text(&expr_fields, col_idx)
         {
-            return Some(self.stmt.span_expanded_text(sp).to_ascii_lowercase());
+            return Some(name.to_ascii_lowercase());
         }
         self.expr_source_text(expr_id).map(str::to_ascii_lowercase)
     }

--- a/syntaqlite/src/analysis/engine/helpers.rs
+++ b/syntaqlite/src/analysis/engine/helpers.rs
@@ -1,44 +1,13 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-//! Pure helper functions used by the analyzer: source extraction, definition
-//! span lookup, macro registration extraction, rowid aliasing.
+//! Pure helper functions used by the analyzer: parse-error span lookup,
+//! macro registration extraction, rowid aliasing.
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParseError, AnyParsedStatement, FieldValue};
 use syntaqlite_syntax::source::{DocLen, DocOffset, DocRange, StmtLen};
 
-use crate::analysis::model::DefinedRelation;
-use crate::dialect::{FIELD_ABSENT, MacroDef, SemanticRole};
-
-/// Extract relations defined by a DDL statement (CREATE TABLE / CREATE VIEW).
-pub(super) fn extract_defined_relations(
-    stmt: &AnyParsedStatement<'_>,
-    root: AnyNodeId,
-    roles: &[SemanticRole],
-) -> Vec<DefinedRelation> {
-    let Some((tag, fields)) = stmt.extract_fields(root) else {
-        return Vec::new();
-    };
-    let idx = u32::from(tag) as usize;
-    let Some(&role) = roles.get(idx) else {
-        return Vec::new();
-    };
-    let (name_field, is_view) = match role {
-        SemanticRole::DefineTable { name, .. } => (name, false),
-        SemanticRole::DefineView { name, .. } => (name, true),
-        _ => return Vec::new(),
-    };
-    if let FieldValue::Span(sp) = fields[name_field as usize]
-        && !sp.is_empty()
-    {
-        vec![DefinedRelation {
-            name: stmt.span_expanded_text(sp).to_string(),
-            is_view,
-        }]
-    } else {
-        Vec::new()
-    }
-}
+use crate::dialect::{FIELD_ABSENT, MacroDef};
 
 pub(super) fn parse_error_span(err: &AnyParseError<'_>, source: &str) -> DocRange {
     let base = err.statement_base();

--- a/syntaqlite/src/analysis/engine/mod.rs
+++ b/syntaqlite/src/analysis/engine/mod.rs
@@ -22,7 +22,9 @@ use super::diagnostics::{Diagnostic, DiagnosticMessage};
 use super::model::{Analysis, StatementAnalysis};
 use super::{AnalysisContext, AnalysisMode};
 
-use helpers::{extract_defined_relations, extract_macro_registration, parse_error_span};
+use helpers::{extract_macro_registration, parse_error_span};
+
+use super::ddl::DdlReader;
 
 mod helpers;
 mod pass;
@@ -327,7 +329,7 @@ impl Analyzer {
 
         let lineage = super::lineage::compute_lineage(erased, root_id, ctx.catalog, roles);
 
-        let defined_relations = extract_defined_relations(erased, root_id, roles);
+        let defined_relations = DdlReader::new(erased, roles).defined_relations(root_id);
 
         StatementAnalysis::new(
             erased.text().as_str().to_owned(),

--- a/syntaqlite/src/analysis/engine/walker.rs
+++ b/syntaqlite/src/analysis/engine/walker.rs
@@ -206,26 +206,17 @@ fn walk_node<P: WalkPass>(
     let Some((tag, fields)) = stmt.extract_fields(node_id) else {
         return;
     };
-    let idx = u32::from(tag) as usize;
-    let role = cx
-        .roles
-        .get(idx)
-        .copied()
-        .unwrap_or(SemanticRole::Transparent);
+    let role = DdlReader::new(stmt, cx.roles).role_for_tag(tag);
 
     match role {
         SemanticRole::DefineTable { select, .. } | SemanticRole::DefineView { select, .. } => {
             if P::WANTS_RELATION_DEFINITION || P::WANTS_COLUMN_DEFINITION {
                 emit_ddl_definitions(stmt, cx.roles, pass, node_id);
             }
-            if select != FIELD_ABSENT {
-                walk_opt(stmt, cx, pass, field_node_id(&fields, select));
-            }
+            walk_opt(stmt, cx, pass, DdlReader::node_field(&fields, select));
         }
         SemanticRole::DefineFunction { select, .. } => {
-            if select != FIELD_ABSENT {
-                walk_opt(stmt, cx, pass, field_node_id(&fields, select));
-            }
+            walk_opt(stmt, cx, pass, DdlReader::node_field(&fields, select));
         }
         SemanticRole::ReturnSpec { .. } | SemanticRole::Import { .. } => {}
 
@@ -310,38 +301,6 @@ fn walk_opt<P: WalkPass>(
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-pub(crate) fn field_node_id(fields: &NodeFields, idx: u8) -> Option<AnyNodeId> {
-    match fields[idx as usize] {
-        FieldValue::NodeId(id) if !id.is_null() => Some(id),
-        _ => None,
-    }
-}
-
-/// Extract `(text, range)` from a `Name` node (`IdentName` or `Error`) whose
-/// span lives at field 0.
-pub(crate) fn name_text<'b>(
-    stmt: &AnyParsedStatement<'b>,
-    node_id: Option<AnyNodeId>,
-) -> (&'b str, DocRange) {
-    let Some(node_id) = node_id else {
-        return ("", DocRange::default());
-    };
-    let Some((_, fields)) = stmt.extract_fields(node_id) else {
-        return ("", DocRange::default());
-    };
-    if fields.is_empty() {
-        return ("", DocRange::default());
-    }
-    match fields[0] {
-        FieldValue::Span(sp) => {
-            let name = stmt.span_expanded_text(sp);
-            let (_, range) = stmt.span_text_abs(sp);
-            (name, range)
-        }
-        _ => ("", DocRange::default()),
-    }
-}
-
 fn emit_ddl_definitions<P: WalkPass>(
     stmt: &AnyParsedStatement<'_>,
     roles: &'static [SemanticRole],
@@ -373,14 +332,10 @@ fn walk_source_ref<P: WalkPass>(
     name_idx: u8,
     alias_idx: u8,
 ) {
-    let FieldValue::Span(sp) = fields[name_idx as usize] else {
+    let reader = DdlReader::new(stmt, cx.roles);
+    let Some((name, range)) = reader.span_field_range(fields, name_idx) else {
         return;
     };
-    if sp.is_empty() {
-        return;
-    }
-    let name = stmt.span_expanded_text(sp);
-    let (_, range) = stmt.span_text_abs(sp);
 
     let is_known = cx.catalog.resolve_relation(name) || cx.catalog.resolve_table_function(name);
     let (columns, without_rowid) = cx.catalog.table_source_info(name);
@@ -396,7 +351,9 @@ fn walk_source_ref<P: WalkPass>(
         pass.on_source_ref(stmt, cx, ev);
     }
 
-    let (alias, _) = name_text(stmt, field_node_id(fields, alias_idx));
+    let alias = DdlReader::new(stmt, cx.roles)
+        .name_text(DdlReader::node_field(fields, alias_idx))
+        .0;
     let scope_name = if alias.is_empty() { name } else { alias };
     cx.scope
         .add_table(scope_name, columns, without_rowid.into());
@@ -411,13 +368,9 @@ fn walk_call<P: WalkPass>(
     name_idx: u8,
     args_idx: u8,
 ) {
-    if let FieldValue::Span(sp) = fields[name_idx as usize]
-        && !sp.is_empty()
-    {
-        let name = stmt.span_expanded_text(sp);
-        let (_, range) = stmt.span_text_abs(sp);
-        let args_id = field_node_id(fields, args_idx);
-        let arg_count = args_id
+    let reader = DdlReader::new(stmt, cx.roles);
+    if let Some((name, range)) = reader.span_field_range(fields, name_idx) {
+        let arg_count = DdlReader::node_field(fields, args_idx)
             .and_then(|id| stmt.list_children(id))
             .map_or(0, <[_]>::len);
         let result = cx.catalog.check_function(name, arg_count);
@@ -504,13 +457,14 @@ fn walk_scoped_source<P: WalkPass>(
     body_idx: u8,
     alias_idx: u8,
 ) {
+    let body_id = DdlReader::node_field(fields, body_idx);
     cx.scope.push();
-    walk_opt(stmt, cx, pass, field_node_id(fields, body_idx));
+    walk_opt(stmt, cx, pass, body_id);
     cx.scope.pop();
 
-    let (alias, _) = name_text(stmt, field_node_id(fields, alias_idx));
-    let cols = field_node_id(fields, body_idx)
-        .and_then(|id| DdlReader::new(stmt, cx.roles).columns_from_select(id));
+    let reader = DdlReader::new(stmt, cx.roles);
+    let alias = reader.name_text(DdlReader::node_field(fields, alias_idx)).0;
+    let cols = body_id.and_then(|id| reader.columns_from_select(id));
     if alias.is_empty() {
         cx.scope.add_anonymous(cols);
     } else {
@@ -535,8 +489,8 @@ fn walk_query<P: WalkPass>(
     // Push a fresh scope so that tables registered by walk_source_ref are
     // visible when we visit SELECT columns, WHERE, ORDER BY, etc.
     cx.scope.push();
-    walk_opt(stmt, cx, pass, field_node_id(fields, from));
-    walk_opt(stmt, cx, pass, field_node_id(fields, columns));
+    walk_opt(stmt, cx, pass, DdlReader::node_field(fields, from));
+    walk_opt(stmt, cx, pass, DdlReader::node_field(fields, columns));
 
     // Collect SELECT aliases so they are visible in WHERE, GROUP BY, HAVING,
     // ORDER BY, and LIMIT — matching SQLite's resolution rules.
@@ -547,7 +501,7 @@ fn walk_query<P: WalkPass>(
     }
 
     for idx in [where_clause, groupby, having, orderby, limit_clause] {
-        walk_opt(stmt, cx, pass, field_node_id(fields, idx));
+        walk_opt(stmt, cx, pass, DdlReader::node_field(fields, idx));
     }
     cx.scope.pop();
 }
@@ -559,35 +513,18 @@ fn collect_select_aliases(
     columns_idx: u8,
 ) -> Vec<String> {
     let mut aliases = Vec::new();
-    let Some(list_id) = field_node_id(fields, columns_idx) else {
+    let Some(list_id) = DdlReader::node_field(fields, columns_idx) else {
         return aliases;
     };
-    let Some(children) = stmt.list_children(list_id) else {
-        return aliases;
-    };
-    for &child_id in children {
-        if child_id.is_null() {
-            continue;
-        }
-        let Some((child_tag, child_fields)) = stmt.extract_fields(child_id) else {
-            continue;
-        };
-        let child_role = roles
-            .get(u32::from(child_tag) as usize)
-            .copied()
-            .unwrap_or(SemanticRole::Transparent);
-        let SemanticRole::ResultColumn {
-            alias: alias_idx, ..
-        } = child_role
-        else {
-            continue;
-        };
-        let alias_node = field_node_id(&child_fields, alias_idx);
-        let (alias_text, _) = name_text(stmt, alias_node);
+    let reader = DdlReader::new(stmt, roles);
+    reader.for_each_result_column(list_id, |child_fields, _flags, alias_idx, _expr| {
+        let alias_node = DdlReader::node_field(child_fields, alias_idx);
+        let (alias_text, _) = reader.name_text(alias_node);
         if !alias_text.is_empty() {
             aliases.push(alias_text.to_string());
         }
-    }
+        true
+    });
     aliases
 }
 
@@ -602,8 +539,8 @@ fn walk_trigger_scope<P: WalkPass>(
     cx.scope.push();
     cx.scope.add_table("OLD", None, RowIdPolicy::WithRowId);
     cx.scope.add_table("NEW", None, RowIdPolicy::WithRowId);
-    walk_opt(stmt, cx, pass, field_node_id(fields, when_idx));
-    walk_opt(stmt, cx, pass, field_node_id(fields, body_idx));
+    walk_opt(stmt, cx, pass, DdlReader::node_field(fields, when_idx));
+    walk_opt(stmt, cx, pass, DdlReader::node_field(fields, body_idx));
     cx.scope.pop();
 }
 
@@ -620,7 +557,7 @@ fn walk_cte_scope<P: WalkPass>(
 ) {
     cx.catalog.push_query_scope();
     register_cte_bindings(stmt, cx, pass, fields, recursive_idx, bindings_idx);
-    walk_opt(stmt, cx, pass, field_node_id(fields, body_idx));
+    walk_opt(stmt, cx, pass, DdlReader::node_field(fields, body_idx));
     cx.catalog.pop_query_scope();
 }
 
@@ -695,7 +632,7 @@ fn register_cte_bindings<P: WalkPass>(
     }
     let is_recursive = recursive_idx != FIELD_ABSENT
         && matches!(fields[recursive_idx as usize], FieldValue::Bool(true));
-    let cte_ids: &[AnyNodeId] = field_node_id(fields, bindings_idx)
+    let cte_ids: &[AnyNodeId] = DdlReader::node_field(fields, bindings_idx)
         .and_then(|id| stmt.list_children(id))
         .unwrap_or(&[]);
 
@@ -762,54 +699,40 @@ fn extract_cte_binding<'b>(
     roles: &'static [SemanticRole],
     cte_id: AnyNodeId,
 ) -> Option<CteBindingInfo<'b>> {
-    if cte_id.is_null() {
-        return None;
-    }
-    let (tag, fields) = stmt.extract_fields(cte_id)?;
-    let SemanticRole::CteBinding {
-        name: name_idx,
-        columns: cols_idx,
-        body: body_idx,
-    } = roles
-        .get(u32::from(tag) as usize)
-        .copied()
-        .unwrap_or(SemanticRole::Transparent)
+    let reader = DdlReader::new(stmt, roles);
+    let (
+        SemanticRole::CteBinding {
+            name: name_idx,
+            columns: cols_idx,
+            body: body_idx,
+        },
+        fields,
+    ) = reader.role_for_node(cte_id)?
     else {
         return None;
     };
 
-    let (name, name_range) = match fields[name_idx as usize] {
-        FieldValue::Span(sp) => {
-            let name = stmt.span_expanded_text(sp);
-            let (_, range) = stmt.span_text_abs(sp);
-            (name, range)
-        }
-        _ => ("", DocRange::default()),
-    };
+    let (name, name_range) = reader
+        .span_field_range(&fields, name_idx)
+        .unwrap_or_default();
     Some(CteBindingInfo {
         name,
         name_range,
-        body_id: field_node_id(&fields, body_idx),
-        declared_cols: extract_declared_cols(stmt, &fields, cols_idx),
+        body_id: DdlReader::node_field(&fields, body_idx),
+        declared_cols: extract_declared_cols(&reader, &fields, cols_idx),
     })
 }
 
 fn extract_declared_cols<'b>(
-    stmt: &mut AnyParsedStatement<'b>,
+    reader: &DdlReader<'_, 'b>,
     fields: &NodeFields,
     cols_idx: u8,
 ) -> Option<Vec<(&'b str, DocRange)>> {
-    if cols_idx == FIELD_ABSENT {
-        return None;
-    }
-    let list_id = field_node_id(fields, cols_idx)?;
-    let children = stmt.list_children(list_id)?;
+    let list_id = DdlReader::node_field(fields, cols_idx)?;
+    let children = reader.stmt().list_children(list_id)?;
     let mut names: Vec<(&'b str, DocRange)> = Vec::with_capacity(children.len());
     for &id in children {
-        if id.is_null() {
-            continue;
-        }
-        let (text, range) = name_text(stmt, Some(id));
+        let (text, range) = reader.name_text(Some(id));
         if !text.is_empty() {
             names.push((text, range));
         }
@@ -823,46 +746,31 @@ fn count_result_columns(
     body_id: Option<AnyNodeId>,
 ) -> Option<usize> {
     let body_id = body_id?;
-    let (body_tag, body_fields) = stmt.extract_fields(body_id)?;
-    let SemanticRole::Query {
-        columns: cols_idx, ..
-    } = roles
-        .get(u32::from(body_tag) as usize)
-        .copied()
-        .unwrap_or(SemanticRole::Transparent)
+    let reader = DdlReader::new(stmt, roles);
+    let (
+        SemanticRole::Query {
+            columns: cols_idx, ..
+        },
+        body_fields,
+    ) = reader.role_for_node(body_id)?
     else {
         return None;
     };
-
-    let list_id = field_node_id(&body_fields, cols_idx)?;
-    let children = stmt.list_children(list_id)?;
+    let list_id = DdlReader::node_field(&body_fields, cols_idx)?;
 
     let mut count = 0usize;
-    for &child_id in children {
-        if child_id.is_null() {
-            continue;
-        }
-        let Some((child_tag, child_fields)) = stmt.extract_fields(child_id) else {
-            continue;
-        };
-        let SemanticRole::ResultColumn {
-            flags: flags_idx, ..
-        } = roles
-            .get(u32::from(child_tag) as usize)
-            .copied()
-            .unwrap_or(SemanticRole::Transparent)
-        else {
-            continue;
-        };
-        // STAR flag (bit 0) means wildcard — skip count check entirely.
-        if let FieldValue::Flags(f) = child_fields[flags_idx as usize]
+    let mut saw_star = false;
+    reader.for_each_result_column(list_id, |fields, flags_idx, _alias, _expr| {
+        if let FieldValue::Flags(f) = fields[flags_idx as usize]
             && f & 1 != 0
         {
-            return None;
+            saw_star = true;
+            return false;
         }
         count += 1;
-    }
-    Some(count)
+        true
+    });
+    if saw_star { None } else { Some(count) }
 }
 
 fn emit_select_column_definitions<P: WalkPass>(
@@ -873,41 +781,25 @@ fn emit_select_column_definitions<P: WalkPass>(
     table_name: &str,
 ) {
     let Some(body_id) = body_id else { return };
-    let Some((tag, fields)) = stmt.extract_fields(body_id) else {
-        return;
-    };
-    let Some(&SemanticRole::Query {
-        columns: cols_idx, ..
-    }) = roles.get(u32::from(tag) as usize)
+    let reader = DdlReader::new(stmt, roles);
+    let Some((
+        SemanticRole::Query {
+            columns: cols_idx, ..
+        },
+        fields,
+    )) = reader.role_for_node(body_id)
     else {
         return;
     };
-    let Some(list_id) = field_node_id(&fields, cols_idx) else {
+    let Some(list_id) = DdlReader::node_field(&fields, cols_idx) else {
         return;
     };
-    let Some(children) = stmt.list_children(list_id) else {
-        return;
-    };
-    for &child_id in children {
-        if child_id.is_null() {
-            continue;
-        }
-        let Some((child_tag, child_fields)) = stmt.extract_fields(child_id) else {
-            continue;
-        };
-        let SemanticRole::ResultColumn {
-            alias: alias_idx, ..
-        } = roles
-            .get(u32::from(child_tag) as usize)
-            .copied()
-            .unwrap_or(SemanticRole::Transparent)
-        else {
-            continue;
-        };
-        let alias_node = field_node_id(&child_fields, alias_idx);
-        let (alias_text, alias_range) = name_text(stmt, alias_node);
+    reader.for_each_result_column(list_id, |child_fields, _flags, alias_idx, _expr| {
+        let alias_node = DdlReader::node_field(child_fields, alias_idx);
+        let (alias_text, alias_range) = reader.name_text(alias_node);
         if !alias_text.is_empty() {
             pass.on_column_definition(table_name, alias_text, alias_range);
         }
-    }
+        true
+    });
 }

--- a/syntaqlite/src/analysis/lineage/resolver.rs
+++ b/syntaqlite/src/analysis/lineage/resolver.rs
@@ -8,6 +8,7 @@ use std::collections::{HashMap, HashSet};
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue};
 
 use crate::analysis::catalog::Catalog;
+use crate::analysis::ddl::DdlReader;
 use crate::dialect::SemanticRole;
 
 use super::types::{
@@ -38,11 +39,19 @@ struct SourceInfo {
     kind: SourceKind,
 }
 
+/// One result-column slot, captured before tracing kicks off.
+enum ColumnSpec {
+    Star,
+    Named {
+        name: String,
+        expr_id: Option<AnyNodeId>,
+    },
+}
+
 /// Walks the AST to compute column lineage.
 pub(super) struct LineageResolver<'a, 'b> {
-    stmt: &'a AnyParsedStatement<'b>,
+    reader: DdlReader<'a, 'b>,
     catalog: &'a Catalog,
-    roles: &'a [SemanticRole],
     /// CTE name -> body node ID (from WITH clause, before FROM is walked).
     cte_bodies: HashMap<String, AnyNodeId>,
     /// Body nodes currently being traced (cycle detection for recursive CTEs).
@@ -58,13 +67,16 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
         roles: &'a [SemanticRole],
     ) -> Self {
         Self {
-            stmt,
+            reader: DdlReader::new(stmt, roles),
             catalog,
-            roles,
             cte_bodies: HashMap::new(),
             tracing: HashSet::new(),
             complete: true,
         }
+    }
+
+    fn stmt(&self) -> &'a AnyParsedStatement<'b> {
+        self.reader.stmt()
     }
 
     /// Entry point: find the outermost SELECT and resolve its lineage.
@@ -73,35 +85,22 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
     }
 
     fn resolve_node(&mut self, node_id: AnyNodeId) -> Option<QueryLineage> {
-        if node_id.is_null() {
-            return None;
-        }
-        let (tag, fields) = self.stmt.extract_fields(node_id)?;
-        let role = self.role_for(tag);
-
+        let (role, fields) = self.reader.role_for_node(node_id)?;
         match role {
             SemanticRole::CteScope { bindings, body, .. } => {
-                if let FieldValue::NodeId(bindings_id) = fields[bindings as usize] {
+                if let Some(bindings_id) = DdlReader::node_field(&fields, bindings) {
                     self.collect_cte_bindings(bindings_id);
                 }
-                if let FieldValue::NodeId(body_id) = fields[body as usize] {
-                    return self.resolve_node(body_id);
-                }
-                None
+                DdlReader::node_field(&fields, body).and_then(|id| self.resolve_node(id))
             }
             SemanticRole::Query { .. } => self.resolve_select(node_id),
             SemanticRole::DefineTable { select, .. }
             | SemanticRole::DefineView { select, .. }
             | SemanticRole::DefineFunction { select, .. } => {
-                if select != crate::dialect::FIELD_ABSENT
-                    && let FieldValue::NodeId(select_id) = fields[select as usize]
-                {
-                    return self.resolve_node(select_id);
-                }
-                None
+                DdlReader::node_field(&fields, select).and_then(|id| self.resolve_node(id))
             }
             SemanticRole::Transparent | SemanticRole::DmlScope { .. } => {
-                for child_id in self.stmt.child_node_ids(node_id) {
+                for child_id in self.stmt().child_node_ids(node_id) {
                     if let Some(result) = self.resolve_node(child_id) {
                         return Some(result);
                     }
@@ -113,10 +112,7 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
     }
 
     fn collect_cte_bindings(&mut self, bindings_id: AnyNodeId) {
-        if bindings_id.is_null() {
-            return;
-        }
-        let Some(children) = self.stmt.list_children(bindings_id) else {
+        let Some(children) = self.stmt().list_children(bindings_id) else {
             self.try_register_cte(bindings_id);
             return;
         };
@@ -126,94 +122,56 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
     }
 
     fn try_register_cte(&mut self, node_id: AnyNodeId) {
-        if node_id.is_null() {
-            return;
-        }
-        let Some((tag, fields)) = self.stmt.extract_fields(node_id) else {
+        let Some((SemanticRole::CteBinding { name, body, .. }, fields)) =
+            self.reader.role_for_node(node_id)
+        else {
             return;
         };
-        let role = self.role_for(tag);
-
-        if let SemanticRole::CteBinding { name, body, .. } = role {
-            let cte_name = match fields[name as usize] {
-                FieldValue::Span(sp) if !sp.is_empty() => {
-                    Some(self.stmt.span_expanded_text(sp).to_ascii_lowercase())
-                }
-                FieldValue::NodeId(id) if !id.is_null() => {
-                    self.span_text(id).map(|s| s.to_ascii_lowercase())
-                }
-                _ => None,
-            };
-            if let Some(cte_name) = cte_name
-                && let FieldValue::NodeId(body_id) = fields[body as usize]
-            {
-                self.cte_bodies.insert(cte_name, body_id);
-            }
+        let Some(cte_name) = self.reader.name_field_text(&fields, name) else {
+            return;
+        };
+        if let Some(body_id) = DdlReader::node_field(&fields, body) {
+            self.cte_bodies
+                .insert(cte_name.to_ascii_lowercase(), body_id);
         }
     }
 
     // ── SELECT resolution ────────────────────────────────────────────────
 
     fn resolve_select(&mut self, select_id: AnyNodeId) -> Option<QueryLineage> {
-        let (tag, fields) = self.stmt.extract_fields(select_id)?;
-        let role = self.role_for(tag);
-
-        let SemanticRole::Query {
-            from,
-            columns: cols_idx,
-            ..
-        } = role
+        let (
+            SemanticRole::Query {
+                from,
+                columns: cols_idx,
+                ..
+            },
+            fields,
+        ) = self.reader.role_for_node(select_id)?
         else {
             return None;
         };
 
         // 1. Walk FROM to build the source map.
         let mut sources = HashMap::new();
-        if let FieldValue::NodeId(from_id) = fields[from as usize] {
+        if let Some(from_id) = DdlReader::node_field(&fields, from) {
             self.collect_sources(from_id, &mut sources);
         }
 
         // 2. Resolve result columns.
-        let columns = self.resolve_result_columns(select_id, cols_idx, &sources)?;
+        let columns = self.resolve_result_columns(cols_idx, &fields, &sources)?;
 
         // 3. Build relations (catalog only) and physical_tables (transitive).
         let mut relations = Vec::new();
         let mut physical_tables = Vec::new();
         let mut unexpanded_views = Vec::new();
-        for info in sources.values() {
-            match info.kind {
-                SourceKind::Table => {
-                    relations.push(RelationAccess {
-                        name: info.canonical.clone(),
-                        kind: RelationKind::Table,
-                    });
-                    physical_tables.push(PhysicalTableAccess {
-                        name: info.canonical.clone(),
-                    });
-                }
-                SourceKind::View => {
-                    relations.push(RelationAccess {
-                        name: info.canonical.clone(),
-                        kind: RelationKind::View,
-                    });
-                    physical_tables.push(PhysicalTableAccess {
-                        name: info.canonical.clone(),
-                    });
-                    unexpanded_views.push(info.canonical.clone());
-                    self.complete = false;
-                }
-                SourceKind::Cte(body) | SourceKind::Subquery(body) => {
-                    if self.tracing.insert(body) {
-                        self.collect_physical_tables(
-                            body,
-                            &mut relations,
-                            &mut physical_tables,
-                            &mut unexpanded_views,
-                        );
-                        self.tracing.remove(&body);
-                    }
-                }
-            }
+        let source_snapshot: Vec<SourceInfo> = sources.values().cloned().collect();
+        for info in &source_snapshot {
+            self.flatten_source(
+                info,
+                &mut relations,
+                &mut physical_tables,
+                &mut unexpanded_views,
+            );
         }
 
         relations.sort_by(|a, b| a.name.cmp(&b.name));
@@ -232,33 +190,68 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
         })
     }
 
+    /// Flatten one source into `relations`/`physical_tables`/`unexpanded_views`.
+    /// CTE/subquery bodies are recursively traced.
+    fn flatten_source(
+        &mut self,
+        info: &SourceInfo,
+        relations: &mut Vec<RelationAccess>,
+        physical_tables: &mut Vec<PhysicalTableAccess>,
+        unexpanded_views: &mut Vec<String>,
+    ) {
+        match info.kind {
+            SourceKind::Table => {
+                relations.push(RelationAccess {
+                    name: info.canonical.clone(),
+                    kind: RelationKind::Table,
+                });
+                physical_tables.push(PhysicalTableAccess {
+                    name: info.canonical.clone(),
+                });
+            }
+            SourceKind::View => {
+                relations.push(RelationAccess {
+                    name: info.canonical.clone(),
+                    kind: RelationKind::View,
+                });
+                physical_tables.push(PhysicalTableAccess {
+                    name: info.canonical.clone(),
+                });
+                unexpanded_views.push(info.canonical.clone());
+                self.complete = false;
+            }
+            SourceKind::Cte(body) | SourceKind::Subquery(body) => {
+                if self.tracing.insert(body) {
+                    self.collect_physical_tables(
+                        body,
+                        relations,
+                        physical_tables,
+                        unexpanded_views,
+                    );
+                    self.tracing.remove(&body);
+                }
+            }
+        }
+    }
+
     // ── FROM source collection ───────────────────────────────────────────
 
     /// Walk a FROM clause and populate `target` with source entries.
-    ///
-    /// Used both for the outer query and when tracing through CTE/subquery bodies.
     fn collect_sources(&self, from_id: AnyNodeId, target: &mut HashMap<String, SourceInfo>) {
-        if from_id.is_null() {
-            return;
-        }
-        let Some((tag, fields)) = self.stmt.extract_fields(from_id) else {
+        let Some((role, fields)) = self.reader.role_for_node(from_id) else {
             return;
         };
-        let role = self.role_for(tag);
-
         match role {
             SemanticRole::SourceRef { name, alias, .. } => {
-                let Some(ref sn) = self.span_text_from_field(&fields, name) else {
+                let Some(sn) = self.reader.name_field_text(&fields, name) else {
                     return;
                 };
-                let alias_name = self.span_text_from_field(&fields, alias);
-                let display = alias_name.as_ref().unwrap_or(sn).to_ascii_lowercase();
+                let alias_name = self.reader.name_field_text(&fields, alias);
+                let display = alias_name.unwrap_or(sn).to_ascii_lowercase();
                 let canonical = sn.to_ascii_lowercase();
 
                 let (columns, kind) = if let Some(&body) = self.cte_bodies.get(&canonical) {
-                    let cols = super::super::ddl::DdlReader::new(self.stmt, self.roles)
-                        .columns_from_select(body);
-                    (cols, SourceKind::Cte(body))
+                    (self.reader.columns_from_select(body), SourceKind::Cte(body))
                 } else {
                     let (cols, _) = self.catalog.table_source_info(&canonical);
                     let kind = if self.catalog.is_view(&canonical) {
@@ -279,24 +272,25 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
                 );
             }
             SemanticRole::ScopedSource { body, alias } => {
-                if let Some(alias_text) = self.span_text_from_field(&fields, alias)
-                    && let FieldValue::NodeId(body_id) = fields[body as usize]
-                {
-                    let alias_lower = alias_text.to_ascii_lowercase();
-                    let cols = super::super::ddl::DdlReader::new(self.stmt, self.roles)
-                        .columns_from_select(body_id);
-                    target.insert(
-                        alias_lower.clone(),
-                        SourceInfo {
-                            canonical: alias_lower,
-                            columns: cols,
-                            kind: SourceKind::Subquery(body_id),
-                        },
-                    );
-                }
+                let Some(alias_text) = self.reader.name_field_text(&fields, alias) else {
+                    return;
+                };
+                let Some(body_id) = DdlReader::node_field(&fields, body) else {
+                    return;
+                };
+                let alias_lower = alias_text.to_ascii_lowercase();
+                let cols = self.reader.columns_from_select(body_id);
+                target.insert(
+                    alias_lower.clone(),
+                    SourceInfo {
+                        canonical: alias_lower,
+                        columns: cols,
+                        kind: SourceKind::Subquery(body_id),
+                    },
+                );
             }
             _ => {
-                for child_id in self.stmt.child_node_ids(from_id) {
+                for child_id in self.stmt().child_node_ids(from_id) {
                     self.collect_sources(child_id, target);
                 }
             }
@@ -314,52 +308,19 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
         let Some(select_id) = self.find_select_node(body_id) else {
             return;
         };
-        let Some((tag, fields)) = self.stmt.extract_fields(select_id) else {
+        let Some((SemanticRole::Query { from, .. }, fields)) = self.reader.role_for_node(select_id)
+        else {
             return;
         };
-        let SemanticRole::Query { from, .. } = self.role_for(tag) else {
-            return;
-        };
-        let FieldValue::NodeId(from_id) = fields[from as usize] else {
+        let Some(from_id) = DdlReader::node_field(&fields, from) else {
             return;
         };
 
         let mut inner_sources = HashMap::new();
         self.collect_sources(from_id, &mut inner_sources);
-        for info in inner_sources.values() {
-            match info.kind {
-                SourceKind::Table => {
-                    relations.push(RelationAccess {
-                        name: info.canonical.clone(),
-                        kind: RelationKind::Table,
-                    });
-                    physical_tables.push(PhysicalTableAccess {
-                        name: info.canonical.clone(),
-                    });
-                }
-                SourceKind::View => {
-                    relations.push(RelationAccess {
-                        name: info.canonical.clone(),
-                        kind: RelationKind::View,
-                    });
-                    physical_tables.push(PhysicalTableAccess {
-                        name: info.canonical.clone(),
-                    });
-                    unexpanded_views.push(info.canonical.clone());
-                    self.complete = false;
-                }
-                SourceKind::Cte(body) | SourceKind::Subquery(body) => {
-                    if self.tracing.insert(body) {
-                        self.collect_physical_tables(
-                            body,
-                            relations,
-                            physical_tables,
-                            unexpanded_views,
-                        );
-                        self.tracing.remove(&body);
-                    }
-                }
-            }
+        let snapshot: Vec<SourceInfo> = inner_sources.into_values().collect();
+        for info in &snapshot {
+            self.flatten_source(info, relations, physical_tables, unexpanded_views);
         }
     }
 
@@ -367,48 +328,26 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
 
     fn resolve_result_columns(
         &mut self,
-        select_id: AnyNodeId,
         cols_idx: u8,
+        select_fields: &syntaqlite_syntax::any::NodeFields,
         sources: &HashMap<String, SourceInfo>,
     ) -> Option<Vec<ColumnLineage>> {
-        let (_, fields) = self.stmt.extract_fields(select_id)?;
-        let FieldValue::NodeId(list_id) = fields[cols_idx as usize] else {
-            return None;
-        };
-        if list_id.is_null() {
-            return None;
-        }
+        let list_id = DdlReader::node_field(select_fields, cols_idx)?;
+        let specs = self.collect_column_specs(list_id);
 
-        let children = self.stmt.list_children(list_id)?;
         let mut result = Vec::new();
         let mut index: u32 = 0;
 
-        for &child_id in children {
-            if child_id.is_null() {
-                continue;
-            }
-            let Some((child_tag, child_fields)) = self.stmt.extract_fields(child_id) else {
-                continue;
-            };
-            let child_role = self.role_for(child_tag);
-
-            let SemanticRole::ResultColumn {
-                flags: flags_idx,
-                alias: alias_idx,
-                expr: expr_idx,
-            } = child_role
-            else {
-                continue;
-            };
-
-            // Check for STAR (SELECT *).
-            if let FieldValue::Flags(f) = child_fields[flags_idx as usize]
-                && f & 1 != 0
-            {
-                for info in sources.values() {
-                    if let Some(cols) = &info.columns {
+        for spec in specs {
+            match spec {
+                ColumnSpec::Star => {
+                    for info in sources.values() {
+                        let Some(cols) = info.columns.clone() else {
+                            continue;
+                        };
+                        let canonical = info.canonical.clone();
                         for col in cols {
-                            let origin = self.trace_column(&info.canonical, col, sources);
+                            let origin = self.trace_column(&canonical, &col, sources);
                             result.push(ColumnLineage {
                                 name: col.to_ascii_lowercase(),
                                 index,
@@ -418,21 +357,44 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
                         }
                     }
                 }
-                continue;
+                ColumnSpec::Named { name, expr_id } => {
+                    let origin = expr_id.and_then(|id| self.trace_expr_origin(id, sources));
+                    result.push(ColumnLineage {
+                        name,
+                        index,
+                        origin,
+                    });
+                    index += 1;
+                }
             }
-
-            let col_name = self.infer_column_name(&child_fields, alias_idx, expr_idx);
-            let origin = self.trace_expr_origin(&child_fields, expr_idx, sources);
-
-            result.push(ColumnLineage {
-                name: col_name.unwrap_or_default(),
-                index,
-                origin,
-            });
-            index += 1;
         }
 
         Some(result)
+    }
+
+    /// Snapshot result-column specs (Star vs. Named) so the borrow on
+    /// `self.reader` from iteration doesn't conflict with `&mut self` used by
+    /// the trace_* methods.
+    fn collect_column_specs(&self, list_id: AnyNodeId) -> Vec<ColumnSpec> {
+        let mut specs = Vec::new();
+        let reader = self.reader;
+        reader.for_each_result_column(list_id, |fields, flags_idx, alias_idx, expr_idx| {
+            let is_star = matches!(
+                fields[flags_idx as usize],
+                FieldValue::Flags(f) if f & 1 != 0
+            );
+            if is_star {
+                specs.push(ColumnSpec::Star);
+            } else {
+                let name = reader
+                    .infer_result_col_name(fields, alias_idx, expr_idx)
+                    .unwrap_or_default();
+                let expr_id = DdlReader::node_field(fields, expr_idx);
+                specs.push(ColumnSpec::Named { name, expr_id });
+            }
+            true
+        });
+        specs
     }
 
     // ── Column tracing ───────────────────────────────────────────────────
@@ -480,92 +442,69 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
         col_name: &str,
     ) -> Option<ColumnOrigin> {
         let select_id = self.find_select_node(body_id)?;
-        let (tag, fields) = self.stmt.extract_fields(select_id)?;
-        let SemanticRole::Query {
-            from,
-            columns: cols_idx,
-            ..
-        } = self.role_for(tag)
+        let (
+            SemanticRole::Query {
+                from,
+                columns: cols_idx,
+                ..
+            },
+            fields,
+        ) = self.reader.role_for_node(select_id)?
         else {
             return None;
         };
 
         // Build inner source map for this body.
         let mut inner_sources = HashMap::new();
-        if let FieldValue::NodeId(from_id) = fields[from as usize] {
+        if let Some(from_id) = DdlReader::node_field(&fields, from) {
             self.collect_sources(from_id, &mut inner_sources);
         }
 
-        // Find the matching result column and trace it.
-        let FieldValue::NodeId(list_id) = fields[cols_idx as usize] else {
-            return None;
-        };
-        if list_id.is_null() {
-            return None;
-        }
+        let list_id = DdlReader::node_field(&fields, cols_idx)?;
 
-        let children = self.stmt.list_children(list_id)?;
-        for &child_id in children {
-            if child_id.is_null() {
-                continue;
+        // Find the matching result column's expression node.
+        let mut found_expr_id: Option<AnyNodeId> = None;
+        let target = col_name.to_ascii_lowercase();
+        let reader = self.reader;
+        reader.for_each_result_column(list_id, |child_fields, _flags, alias_idx, expr_idx| {
+            let name = reader.infer_result_col_name(child_fields, alias_idx, expr_idx);
+            if name
+                .as_deref()
+                .is_some_and(|n| n.eq_ignore_ascii_case(&target))
+            {
+                found_expr_id = DdlReader::node_field(child_fields, expr_idx);
+                return false;
             }
-            let (child_tag, child_fields) = self.stmt.extract_fields(child_id)?;
-            let SemanticRole::ResultColumn {
-                alias: alias_idx,
-                expr: expr_idx,
-                ..
-            } = self.role_for(child_tag)
-            else {
-                continue;
-            };
+            true
+        });
 
-            let name = self.infer_column_name(&child_fields, alias_idx, expr_idx)?;
-            if !name.eq_ignore_ascii_case(col_name) {
-                continue;
-            }
-
-            // Found matching column — trace its expression.
-            return self.trace_expr_origin(&child_fields, expr_idx, &inner_sources);
-        }
-
-        None
+        let expr_id = found_expr_id?;
+        self.trace_expr_origin(expr_id, &inner_sources)
     }
 
     fn trace_expr_origin(
         &mut self,
-        child_fields: &syntaqlite_syntax::any::NodeFields,
-        expr_idx: u8,
+        expr_id: AnyNodeId,
         sources: &HashMap<String, SourceInfo>,
     ) -> Option<ColumnOrigin> {
-        let FieldValue::NodeId(expr_id) = child_fields[expr_idx as usize] else {
-            return None;
-        };
-        if expr_id.is_null() {
-            return None;
-        }
-
-        let (expr_tag, expr_fields) = self.stmt.extract_fields(expr_id)?;
-        let SemanticRole::ColumnRef {
-            column: col_idx,
-            table: tbl_idx,
-        } = self.role_for(expr_tag)
+        let (
+            SemanticRole::ColumnRef {
+                column: col_idx,
+                table: tbl_idx,
+            },
+            expr_fields,
+        ) = self.reader.role_for_node(expr_id)?
         else {
             return None;
         };
 
-        let col_name = match expr_fields[col_idx as usize] {
-            FieldValue::Span(sp) if !sp.is_empty() => {
-                self.stmt.span_expanded_text(sp).to_ascii_lowercase()
-            }
-            _ => return None,
-        };
-
-        let source_name = if let FieldValue::Span(sp) = expr_fields[tbl_idx as usize]
-            && !sp.is_empty()
-        {
-            self.stmt.span_expanded_text(sp).to_ascii_lowercase()
-        } else {
-            find_source_for_column(sources, &col_name)?
+        let col_name = self
+            .reader
+            .span_field_text(&expr_fields, col_idx)?
+            .to_ascii_lowercase();
+        let source_name = match self.reader.span_field_text(&expr_fields, tbl_idx) {
+            Some(t) => t.to_ascii_lowercase(),
+            None => find_source_for_column(sources, &col_name)?,
         };
 
         self.trace_column(&source_name, &col_name, sources)
@@ -574,111 +513,20 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
     // ── AST navigation helpers ───────────────────────────────────────────
 
     fn find_select_node(&self, node_id: AnyNodeId) -> Option<AnyNodeId> {
-        if node_id.is_null() {
-            return None;
-        }
-        let (tag, fields) = self.stmt.extract_fields(node_id)?;
-        match self.role_for(tag) {
+        let (role, fields) = self.reader.role_for_node(node_id)?;
+        match role {
             SemanticRole::Query { .. } => Some(node_id),
             SemanticRole::CteScope { body, .. } => {
-                if let FieldValue::NodeId(body_id) = fields[body as usize] {
-                    self.find_select_node(body_id)
-                } else {
-                    None
-                }
+                DdlReader::node_field(&fields, body).and_then(|id| self.find_select_node(id))
             }
             SemanticRole::Transparent => {
-                for child_id in self.stmt.child_node_ids(node_id) {
+                for child_id in self.stmt().child_node_ids(node_id) {
                     if let Some(result) = self.find_select_node(child_id) {
                         return Some(result);
                     }
                 }
                 None
             }
-            _ => None,
-        }
-    }
-
-    fn infer_column_name(
-        &self,
-        child_fields: &syntaqlite_syntax::any::NodeFields,
-        alias_idx: u8,
-        expr_idx: u8,
-    ) -> Option<String> {
-        // Try alias first.
-        if let FieldValue::NodeId(alias_id) = child_fields[alias_idx as usize]
-            && !alias_id.is_null()
-            && let Some((_, alias_fields)) = self.stmt.extract_fields(alias_id)
-        {
-            for j in 0..alias_fields.len() {
-                if let FieldValue::Span(sp) = alias_fields[j]
-                    && !sp.is_empty()
-                {
-                    return Some(self.stmt.span_expanded_text(sp).to_ascii_lowercase());
-                }
-            }
-        }
-
-        // Try bare column ref.
-        if let FieldValue::NodeId(expr_id) = child_fields[expr_idx as usize]
-            && !expr_id.is_null()
-            && let Some((expr_tag, expr_fields)) = self.stmt.extract_fields(expr_id)
-            && let SemanticRole::ColumnRef {
-                column: col_idx, ..
-            } = self.role_for(expr_tag)
-            && let FieldValue::Span(sp) = expr_fields[col_idx as usize]
-            && !sp.is_empty()
-        {
-            return Some(self.stmt.span_expanded_text(sp).to_ascii_lowercase());
-        }
-
-        // Fallback: use expression source text.
-        if let FieldValue::NodeId(expr_id) = child_fields[expr_idx as usize]
-            && !expr_id.is_null()
-        {
-            return super::super::ddl::DdlReader::new(self.stmt, self.roles)
-                .expr_source_text(expr_id)
-                .map(str::to_ascii_lowercase);
-        }
-
-        None
-    }
-
-    fn role_for(&self, tag: syntaqlite_syntax::any::AnyNodeTag) -> SemanticRole {
-        self.roles
-            .get(u32::from(tag) as usize)
-            .copied()
-            .unwrap_or(SemanticRole::Transparent)
-    }
-
-    fn span_text(&self, node_id: AnyNodeId) -> Option<String> {
-        if node_id.is_null() {
-            return None;
-        }
-        let (_, fields) = self.stmt.extract_fields(node_id)?;
-        for i in 0..fields.len() {
-            if let FieldValue::Span(sp) = fields[i]
-                && !sp.is_empty()
-            {
-                return Some(self.stmt.span_expanded_text(sp).to_owned());
-            }
-        }
-        None
-    }
-
-    fn span_text_from_field(
-        &self,
-        fields: &syntaqlite_syntax::any::NodeFields,
-        field_idx: u8,
-    ) -> Option<String> {
-        if field_idx == crate::dialect::FIELD_ABSENT {
-            return None;
-        }
-        match fields[field_idx as usize] {
-            FieldValue::Span(sp) if !sp.is_empty() => {
-                Some(self.stmt.span_expanded_text(sp).to_owned())
-            }
-            FieldValue::NodeId(id) if !id.is_null() => self.span_text(id),
             _ => None,
         }
     }


### PR DESCRIPTION
The walker, lineage resolver, ddl reader, and engine helpers each had
their own copy of the role-table lookup, span/node-id field accessors,
and ResultColumn iteration loop. They drifted slightly (e.g. lineage's
infer_column_name was a byte-for-byte clone of DdlReader::infer_result_col_name),
which is a real correctness hazard: bug fixes in one would skip the other.

This consolidates those primitives onto DdlReader so every analysis
consumer reads roles/spans/nodes the same way.

* analysis/ddl.rs: add role_for_tag, role_for_node, node_field,
  span_field_text, span_field_range, name_text, first_span_text,
  name_field_text, for_each_result_column, defined_relations.
  Existing DDL helpers (name_span, column_spans, extract_columns,
  function_arity, is_table_returning) are rewritten on top of these,
  and the FIELD_ABSENT sentinel is now handled inside node_field
  rather than at every call site.
* analysis/engine/walker.rs: roles.get(...).unwrap_or(Transparent)
  and span/node-id extraction route through DdlReader. The three
  ResultColumn iteration loops (count_result_columns,
  emit_select_column_definitions, collect_select_aliases) now share
  for_each_result_column.
* analysis/engine/helpers.rs: drop extract_defined_relations
  (now DdlReader::defined_relations).
* analysis/engine/mod.rs: call DdlReader::defined_relations directly.
* analysis/lineage/resolver.rs: drop the resolver's own role_for,
  infer_column_name, span_text, span_text_from_field. Result-column
  resolution snapshots a Vec<ColumnSpec> (Star vs Named) so the
  shared-borrow on self.reader during iteration doesn't conflict
  with the &mut self trace_* calls.
* analysis/catalog.rs: drop opt_field; extract_columns/function_arity/
  is_table_returning take u8 directly and rely on
  DdlReader::node_field to handle FIELD_ABSENT.

Net: ~570 lines smaller across the analysis tree with no behavior
change. All workspace tests pass.

