### PR TITLE
synq: docs audit + stricter MCP keyword_case + correct dialect symbol

### DIFF
--- a/syntaqlite-cli/src/cli.rs
+++ b/syntaqlite-cli/src/cli.rs
@@ -91,8 +91,8 @@ pub(crate) struct Cli {
     pub(crate) dialect_path: Option<String>,
 
     /// Dialect name for symbol lookup.
-    /// When omitted, the loader resolves `syntaqlite_grammar`.
-    /// With a name, it resolves `syntaqlite_<name>_grammar`.
+    /// When omitted, the loader resolves `syntaqlite_dialect_template`.
+    /// With a name, it resolves `syntaqlite_<name>_dialect_template`.
     #[cfg(feature = "dynload")]
     #[arg(long, requires = "dialect_path", global = true)]
     pub(crate) dialect_name: Option<String>,

--- a/syntaqlite-cli/src/commands/mcp.rs
+++ b/syntaqlite-cli/src/commands/mcp.rs
@@ -65,10 +65,7 @@ impl McpServer {
     /// Format a SQL string.
     #[tool(description = "Format a SQL string")]
     fn format_sql(&self, #[tool(aggr)] params: FormatParams) -> Result<String, String> {
-        let case = match params.keyword_case.as_str() {
-            "lower" => KeywordCase::Lower,
-            _ => KeywordCase::Upper,
-        };
+        let case = parse_keyword_case(&params.keyword_case)?;
         let config = FormatConfig::default()
             .with_line_width(params.line_width)
             .with_keyword_case(case)
@@ -158,6 +155,16 @@ impl ServerHandler for McpServer {
     }
 }
 
+fn parse_keyword_case(s: &str) -> Result<KeywordCase, String> {
+    match s {
+        "upper" => Ok(KeywordCase::Upper),
+        "lower" => Ok(KeywordCase::Lower),
+        other => Err(format!(
+            "invalid keyword_case {other:?}: expected \"upper\" or \"lower\""
+        )),
+    }
+}
+
 pub(crate) fn run(dialect: AnyDialect) -> Result<(), String> {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -176,4 +183,23 @@ pub(crate) fn run(dialect: AnyDialect) -> Result<(), String> {
                 .map_err(|e| format!("MCP server error: {e}"))?;
             Ok(())
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_keyword_case_accepts_upper_and_lower() {
+        assert_eq!(parse_keyword_case("upper"), Ok(KeywordCase::Upper));
+        assert_eq!(parse_keyword_case("lower"), Ok(KeywordCase::Lower));
+    }
+
+    #[test]
+    fn parse_keyword_case_rejects_unknown() {
+        let err = parse_keyword_case("preserve").expect_err("preserve is not valid");
+        assert!(err.contains("preserve"));
+        assert!(err.contains("upper"));
+        assert!(err.contains("lower"));
+    }
 }

--- a/web/docs/content/concepts/validation.md
+++ b/web/docs/content/concepts/validation.md
@@ -51,7 +51,7 @@ discovers DDL in the file automatically via the Document layer, and the Dialect
 layer knows which functions are available for the target SQLite version.
 
 The source is in
-[`catalog.rs`](https://github.com/LalitMaganti/syntaqlite/blob/main/syntaqlite/src/semantic/catalog.rs).
+[`catalog.rs`](https://github.com/LalitMaganti/syntaqlite/blob/main/syntaqlite/src/analysis/catalog.rs).
 
 ### Known vs. unknown columns
 
@@ -64,9 +64,8 @@ an ORM definition but not have the full DDL.
 ## Scope resolution
 
 Each SELECT statement gets its own scope frame that tracks which tables are
-visible. The
-[`ValidationPass`](https://github.com/LalitMaganti/syntaqlite/blob/main/syntaqlite/src/semantic/analyzer.rs)
-manages these frames automatically:
+visible. These frames are pushed and popped by the analyzer as it walks
+([`query_scope.rs`](https://github.com/LalitMaganti/syntaqlite/blob/main/syntaqlite/src/analysis/engine/query_scope.rs)):
 
 1. Entering a SELECT pushes a new frame
 2. FROM/JOIN clauses register tables (with aliases) into that frame
@@ -90,7 +89,7 @@ columns. Recursive CTEs work: the CTE name is visible within its own body.
 When a name doesn't resolve, the analyzer computes case-insensitive
 [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance)
 against all candidates in scope
-([`fuzzy.rs`](https://github.com/LalitMaganti/syntaqlite/blob/main/syntaqlite/src/semantic/fuzzy.rs)).
+([`fuzzy.rs`](https://github.com/LalitMaganti/syntaqlite/blob/main/syntaqlite/src/analysis/diagnostics/fuzzy.rs)).
 If a candidate is within the threshold (default: 2 edits), a "did you mean?"
 suggestion is attached to the diagnostic.
 

--- a/web/docs/content/contributing/architecture.md
+++ b/web/docs/content/contributing/architecture.md
@@ -98,7 +98,7 @@ of truth for AST node structure. `syntaqlite-buildtools` generates from them:
 - **C headers** — struct layouts for AST nodes, parser action code, node
   metadata (field names, field counts, list ranges), semantic role byte
   tables, and formatter dispatch tables
-- **Rust code** — typed AST node wrappers and the `semantic_roles.rs` table
+- **Rust code** — typed AST node wrappers
 
 ### The arena
 
@@ -115,7 +115,7 @@ pointers are handled. The rest of the Rust code sees safe `Parser`,
 `Tokenizer`, and `ParseSession` types.
 
 **Outbound** (Rust → C): `syntaqlite/src/fmt/ffi.rs` and
-`syntaqlite/src/semantic/ffi.rs` export the formatter and validator as opaque
+`syntaqlite/src/analysis/ffi/` export the formatter and analyzer as opaque
 C handles (`SyntaqliteFormatter*`, `SyntaqliteAnalyzer*`) with lifecycle
 functions (create, use, destroy).
 

--- a/web/docs/content/getting-started/_index.md
+++ b/web/docs/content/getting-started/_index.md
@@ -48,7 +48,7 @@ SELECT id, name FROM users WHERE active = 1 AND role = 'admin';
 Format a file in place with `syntaqlite fmt -i query.sql`, or check formatting
 in CI with `syntaqlite fmt --check "**/*.sql"`.
 
-## Validate
+## Analyze
 
 syntaqlite reads your `CREATE TABLE` statements to build a schema, then
 validates queries against it without needing a database. It finds **all** errors in

--- a/web/docs/content/getting-started/c-parser.md
+++ b/web/docs/content/getting-started/c-parser.md
@@ -1,14 +1,20 @@
 +++
-title = "C parser"
+title = "C library"
 description = "Parse SQL from C using the source amalgamation."
 weight = 5
 +++
 
-# Parse SQL from C
+# Using syntaqlite from C
 
-This tutorial walks you through parsing a SQL query from C using the
-syntaqlite source amalgamation. By the end you'll have a small program that
-parses a query and prints its AST with no dependencies beyond a C compiler.
+This tutorial walks you through parsing SQL from C. By the end you'll have a
+small program that parses queries, prints their AST, recovers from errors, and
+lists tokens — with nothing to install beyond a C compiler.
+
+syntaqlite ships two C distributions. This tutorial uses the **source
+amalgamation**, which provides the parser and tokenizer as two C files you
+compile directly into your project. The prebuilt shared library also adds
+formatting and validation; see the [C integration guide](@/guides/c-api.md)
+once you're done here.
 
 ## 1. Download the amalgamation
 
@@ -153,7 +159,7 @@ for (uint32_t i = 0; i < count; i++) {
 
 ## Next steps
 
-- The source amalgamation gives you the **parser and tokenizer**. For the
-  **formatter and validator**, use the [prebuilt shared library](@/guides/c-api.md#option-2-prebuilt-shared-library-full-api).
-- See the [C API reference](@/reference/c-api.md) for the full list of
-  parser, tokenizer, formatter, and validator functions.
+- [C integration guide](@/guides/c-api.md) — switch to the prebuilt shared
+  library to format and validate SQL from C
+- [C API reference](@/reference/c-api.md) — all parser, tokenizer, formatter,
+  and analyzer functions

--- a/web/docs/content/getting-started/cli.md
+++ b/web/docs/content/getting-started/cli.md
@@ -108,8 +108,8 @@ Use `--check` to verify files are formatted without modifying them. See the
 - [Project setup guide](@/guides/project-setup.md) — configure
   `syntaqlite.toml` for a real project
 - [Python library tutorial](@/getting-started/python.md) — use `parse`,
-  `format_sql`, `validate` from Python
-- [CLI reference](@/reference/cli.md) — all flags for `fmt`, `validate`,
+  `format_sql`, `analyze` from Python
+- [CLI reference](@/reference/cli.md) — all flags for `fmt`, `analyze`,
   `parse`, and `lsp`
 - [Config file reference](@/reference/config-file.md) — `syntaqlite.toml`
   format

--- a/web/docs/content/getting-started/python.md
+++ b/web/docs/content/getting-started/python.md
@@ -68,10 +68,10 @@ order by
   name;
 ```
 
-## 4. Validate against a schema
+## 4. Analyze against a schema
 
 Build a `Schema` with the tables you want to check against and pass it to
-`validate()`:
+`analyze()`:
 
 ```python
 from syntaqlite import Schema, Table

--- a/web/docs/content/getting-started/rust.md
+++ b/web/docs/content/getting-started/rust.md
@@ -144,7 +144,6 @@ fn main() {
 
 ## Next steps
 
-- [Using from Rust](@/guides/rust-api.md) — quick reference for formatting,
-  parsing, and config options
+- [Using from Rust](@/guides/rust-api.md) — formatting, parsing, validation,
+  and config options
 - [Rust API reference](@/reference/rust-api.md) — all types and methods
-- [Using from Rust](@/guides/rust-api.md) — validation via the Rust API

--- a/web/docs/content/guides/custom-dialects.md
+++ b/web/docs/content/guides/custom-dialects.md
@@ -6,26 +6,25 @@ weight = 10
 
 # Custom dialects
 
-> **Experimental: work in progress.** The dialect API is under active
-> development and may change significantly between releases. The `.synq` format,
-> codegen output, and shared library ABI are not yet stable.
+> **Experimental.** The dialect API, `.synq` format, codegen output, and
+> shared-library ABI are not yet stable and can change between releases.
+> Pin your syntaqlite version when you ship a dialect.
 
-syntaqlite's grammar is extensible. If you have a SQL dialect that adds syntax
-on top of SQLite (custom statements, additional functions, new clauses), you
-can define a dialect that syntaqlite will use for parsing, formatting, and
-validation.
+If you have SQL that extends SQLite — custom statements, extra functions,
+new clauses — you can package it as a dialect that syntaqlite's parser,
+formatter, and analyzer will understand. This guide walks an end-to-end
+dialect from source files to a loaded shared library, using the in-tree
+[Perfetto dialect](https://github.com/LalitMaganti/syntaqlite/tree/main/dialects/perfetto)
+as a running example.
 
-## Defining a dialect
+## 1. Write the grammar
 
-A dialect is a shared library loaded at runtime with `--dialect /path/to/lib.so`.
-It extends SQLite's parser, formatter, and validator with custom rules.
+A dialect is a directory of `.synq` node definitions plus optional `.y`
+grammar action files. `.synq` is syntaqlite's grammar DSL: each `node`
+declares an AST shape with typed fields, optional semantic annotations,
+and a `fmt` block for pretty-printing.
 
-Dialects are defined using `.synq` files, the same grammar definition language
-syntaqlite uses internally. A `.synq` file declares nodes, enums, formatting
-rules, and semantic annotations.
-
-Here's a minimal example from the Perfetto dialect, which adds a
-`CREATE PERFETTO MACRO` statement:
+Minimal example (from `dialects/perfetto/nodes/perfetto.synq`):
 
 ```synq
 node CreatePerfettoMacroStmt {
@@ -46,26 +45,105 @@ node CreatePerfettoMacroStmt {
 }
 ```
 
-## Building a dialect
+`.y` action files in a parallel `actions/` directory hook the dialect's
+rules into the base SQLite grammar; simple dialects that only add functions
+or reserved words may not need any.
 
-Use the `syntaqlite dialect generate` command to generate C sources and Rust
-bindings from your `.synq` definitions:
+## 2. Generate C sources
 
-```bash
-syntaqlite dialect generate --name mydialect --nodes-dir path/to/nodes --output-dir generated/
-```
-
-Then compile the generated sources into a shared library. See the
-[Perfetto dialect](https://github.com/LalitMaganti/syntaqlite/tree/main/dialects/perfetto)
-in the repository for a complete working example.
-
-## Dialect naming
-
-By default, syntaqlite looks for a symbol called `syntaqlite_grammar` in the
-shared library. If your dialect has a specific name, use `--dialect-name`:
+`syntaqlite dialect generate` reads your `.synq` (and optional `.y`) files
+and emits a C amalgamation — the runtime plus your dialect, inlined into a
+single `.h`/`.c` pair:
 
 ```bash
-syntaqlite fmt --dialect /path/to/lib.so --dialect-name perfetto query.sql
+syntaqlite dialect generate \
+  --name perfetto \
+  --nodes-dir dialects/perfetto/nodes \
+  --actions-dir dialects/perfetto/actions \
+  --output-dir out \
+  --output-type full
 ```
 
-This looks for the symbol `syntaqlite_perfetto_grammar`.
+Produces:
+
+```
+out/syntaqlite_perfetto.h
+out/syntaqlite_perfetto.c
+```
+
+The `--name` flag drives all generated symbol names: the dialect exposes
+`syntaqlite_perfetto_dialect_template()`, which is what the loader looks for
+at runtime.
+
+Other `--output-type` values split the artifacts differently (`raw` for
+flat C files per module, `runtime-only` to skip the dialect body); `full`
+is the right default for shipping a self-contained shared library.
+
+## 3. Compile to a shared library
+
+The generated `.c` is pure C, no Rust toolchain required. Build it as a
+shared library for the target platform:
+
+```bash
+# Linux / macOS
+cc -O2 -shared -fPIC -o libperfetto.dylib out/syntaqlite_perfetto.c
+```
+
+On Linux the extension is `.so`; on Windows, build a `.dll` with your C
+compiler's equivalent of `-shared`.
+
+Confirm the loader symbol is exported:
+
+```bash
+nm libperfetto.dylib | grep dialect_template
+# T _syntaqlite_perfetto_dialect_template
+```
+
+## 4. Use the dialect at runtime
+
+Pass the library and dialect name to any `syntaqlite` subcommand:
+
+```bash
+syntaqlite fmt \
+  --dialect ./libperfetto.dylib \
+  --dialect-name perfetto \
+  -e "create perfetto macro m() returns int as 42"
+```
+
+```sql
+CREATE PERFETTO MACRO m()
+RETURNS int
+AS 42;
+```
+
+The `--dialect-name` matches the `--name` you passed to `dialect generate`.
+Omit it to resolve the default `syntaqlite_dialect_template` symbol, which
+is what an unnamed dialect exports.
+
+To bake the choice into a project, set the dialect in `syntaqlite.toml`;
+see the [config reference](@/reference/config-file.md).
+
+## Alternative: compile the dialect into your binary
+
+Dynamic loading is the fastest path to "works with the stock CLI", but it
+adds a runtime dependency and a symbol-resolution step. If you're shipping
+your own binary (for example, a `syntaqlite-mydialect` wrapper), compile
+the dialect in directly via the Rust `CliApp` trait. See
+[`syntaqlite-cli/examples/cli_wrapper.rs`](https://github.com/LalitMaganti/syntaqlite/blob/main/syntaqlite-cli/examples/cli_wrapper.rs)
+for a complete example.
+
+Trade-offs:
+
+| | Dynamic (`--dialect`) | Static (`CliApp`) |
+|---|---|---|
+| Distribution | One shared library, stock CLI | Single binary, your own name |
+| Startup cost | `dlopen` on every invocation | None |
+| ABI stability | Needed — library and CLI must match | Not needed — compiled together |
+| Tooling | Works with any `syntaqlite` install | Requires the Rust toolchain to build |
+
+## Next steps
+
+- [Perfetto dialect source](https://github.com/LalitMaganti/syntaqlite/tree/main/dialects/perfetto)
+  — complete working example including advanced `.synq` features
+- [Architecture: grammar system](@/contributing/architecture.md#grammar-system)
+  — how `.synq` flows through codegen into the parser, formatter, and analyzer

--- a/web/docs/content/guides/mcp.md
+++ b/web/docs/content/guides/mcp.md
@@ -1,34 +1,22 @@
 +++
 title = "MCP server setup"
-description = "Set up the syntaqlite MCP server for Claude Desktop, Cursor, and Windsurf."
+description = "Wire the syntaqlite MCP server into Claude Desktop, Cursor, Windsurf, or any MCP client."
 weight = 9
 +++
 
 # MCP server
 
-syntaqlite includes an MCP server for Claude Desktop, Cursor, Windsurf, and
-other MCP-compatible clients.
+The `syntaqlite` binary ships a stdio-based MCP server. Any MCP-compatible
+agent can spawn it and call its tools to format, analyze, and parse SQL.
+This guide wires it up.
 
-## Install syntaqlite
+Prerequisite: `syntaqlite` on your `$PATH`. See the
+[CLI tutorial](@/getting-started/cli.md) for install options.
 
-The MCP server is built into the `syntaqlite` binary. If you haven't installed
-it yet:
+## Add the server to your client's config
 
-```bash
-curl -sSf https://raw.githubusercontent.com/LalitMaganti/syntaqlite/main/tools/syntaqlite | python3 - install
-```
-
-See the [CLI tutorial](@/getting-started/cli.md) for other install methods.
-
-## Claude Desktop
-
-Open your config file:
-
-- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- Linux: `~/.config/Claude/claude_desktop_config.json`
-- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
-
-Add the syntaqlite server:
+Every MCP client points at the same command. Drop this block into your
+client's MCP config file:
 
 ```json
 {
@@ -41,55 +29,41 @@ Add the syntaqlite server:
 }
 ```
 
-Restart Claude Desktop. You can now ask Claude to format or validate SQL, and
-it will use syntaqlite's tools.
+If the config file already has an `mcpServers` object, merge the `syntaqlite`
+entry into it.
 
-## Cursor
+## Config file location
 
-Add to `.cursor/mcp.json` in your project:
+| Client | Path |
+|--------|------|
+| Claude Desktop (macOS) | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Claude Desktop (Linux) | `~/.config/Claude/claude_desktop_config.json` |
+| Claude Desktop (Windows) | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Cursor | `.cursor/mcp.json` in your project |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` |
 
-```json
-{
-  "mcpServers": {
-    "syntaqlite": {
-      "command": "syntaqlite",
-      "args": ["mcp"]
-    }
-  }
-}
-```
+Other MCP-compatible clients follow the same schema; consult their docs for
+the config path.
 
-Restart Cursor. Try asking it to format a SQL query. It will use syntaqlite's
-`format_sql` tool.
+## Restart and verify
 
-## Windsurf
-
-Add to `~/.codeium/windsurf/mcp_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "syntaqlite": {
-      "command": "syntaqlite",
-      "args": ["mcp"]
-    }
-  }
-}
-```
-
-Restart Windsurf.
-
-## Try it out
-
-Ask your AI assistant something like:
+Restart the client so it picks up the new server. Then ask it to format some
+SQL, for example:
 
 > Format this SQL: `select id,name from users where active=1`
 
-It should call syntaqlite's `format_sql` tool and return:
+The client should invoke syntaqlite's `format_sql` tool and return:
 
 ```sql
 SELECT id, name FROM users WHERE active = 1;
 ```
 
-See the [MCP tools reference](@/reference/mcp-tools.md) for all available
-tools and their parameters.
+If nothing happens, check the client's MCP/server log for spawn errors; the
+usual cause is `syntaqlite` not being on the `$PATH` seen by the GUI app (GUI
+apps often don't inherit your shell's environment — specify an absolute path
+to `syntaqlite` in the `command` field if needed).
+
+## Next steps
+
+- [MCP tools reference](@/reference/mcp-tools.md) — every tool the server
+  exposes and its parameters

--- a/web/docs/content/guides/rust-api.md
+++ b/web/docs/content/guides/rust-api.md
@@ -123,7 +123,7 @@ fn walk(stmt: &AnyParsedStatement, node_id: u32, depth: usize) {
 
 ## Validate SQL
 
-Add the `validation` and `sqlite` features:
+Add the `analysis` and `sqlite` features:
 
 ```toml
 [dependencies]

--- a/web/docs/content/reference/c-api.md
+++ b/web/docs/content/reference/c-api.md
@@ -56,7 +56,7 @@ typedef struct {
 | Function | Description |
 |----------|-------------|
 | `syntaqlite_parser_create(mem)` | Create a parser for the built-in SQLite dialect. `mem` may be `NULL` |
-| `syntaqlite_parser_create_with_grammar(mem, grammar)` | Create with a custom grammar |
+| `syntaqlite_parser_create_with_dialect(mem, dialect)` | Create with a custom dialect |
 | `syntaqlite_parser_reset(p, source, len)` | Set source text for parsing |
 | `syntaqlite_parser_next(p)` | Parse the next statement. Returns `0` on success, `1` on error, `-1` when done |
 | `syntaqlite_parser_destroy(p)` | Free the parser. No-op if `NULL` |
@@ -98,7 +98,7 @@ typedef struct {
 | Function | Description |
 |----------|-------------|
 | `syntaqlite_tokenizer_create(mem)` | Create a tokenizer for the built-in SQLite dialect. `mem` may be `NULL` |
-| `syntaqlite_tokenizer_create_with_grammar(mem, grammar)` | Create with a custom grammar |
+| `syntaqlite_tokenizer_create_with_dialect(mem, dialect)` | Create with a custom dialect |
 | `syntaqlite_tokenizer_reset(tok, source, len)` | Set source text for tokenizing |
 | `syntaqlite_tokenizer_next(tok, &out)` | Read the next token into `out`. Returns the token type, `0` for EOF |
 | `syntaqlite_tokenizer_destroy(tok)` | Free the tokenizer. No-op if `NULL` |
@@ -145,12 +145,12 @@ Return codes from `syntaqlite_formatter_format()`:
 | `syntaqlite_formatter_error_msg(f)` | NUL-terminated error message, or `NULL` after success |
 | `syntaqlite_formatter_destroy(f)` | Free the formatter. No-op if `NULL` |
 
-## Validator
+## Analyzer
 
 ### Types
 
 ```c
-// Opaque validator handle.
+// Opaque analyzer handle.
 typedef struct SyntaqliteAnalyzer SyntaqliteAnalyzer;
 
 // Diagnostic severity levels.
@@ -223,7 +223,7 @@ typedef struct {
 
 | Function | Description |
 |----------|-------------|
-| `syntaqlite_analyzer_create_sqlite()` | Create a validator with default mode (`DOCUMENT`) |
+| `syntaqlite_analyzer_create_sqlite()` | Create an analyzer with default mode (`DOCUMENT`) |
 | `syntaqlite_analyzer_set_mode(v, mode)` | Set `DOCUMENT` or `EXECUTE` mode |
 | `syntaqlite_analyzer_add_tables(v, tables, count)` | Register schema tables from `SyntaqliteRelationDef` array |
 | `syntaqlite_analyzer_add_views(v, views, count)` | Register schema views from `SyntaqliteRelationDef` array |
@@ -244,7 +244,7 @@ typedef struct {
 | `syntaqlite_analyzer_statement_unexpanded_view_count(v, idx)` | Number of unexpanded views in statement `idx` |
 | `syntaqlite_analyzer_statement_unexpanded_views(v, idx)` | Pointer to `SyntaqliteUnexpandedView` array for statement `idx`, or `NULL` |
 | `syntaqlite_analyzer_reset_catalog(v)` | Clear registered schema (preserves dialect builtins) |
-| `syntaqlite_analyzer_destroy(v)` | Free the validator. No-op if `NULL` |
+| `syntaqlite_analyzer_destroy(v)` | Free the analyzer. No-op if `NULL` |
 
 ## Utility
 
@@ -261,7 +261,7 @@ typedef struct {
 
 ## Memory model
 
-- Parser, formatter, and validator handles are **reusable**: create once, call
+- Parser, formatter, and analyzer handles are **reusable**: create once, call
   repeatedly.
 - Output strings from `syntaqlite_formatter_output()`,
   `syntaqlite_analyzer_diagnostics()`, and lineage accessors

--- a/web/docs/content/reference/cli.md
+++ b/web/docs/content/reference/cli.md
@@ -194,6 +194,6 @@ These options are available on all subcommands:
 | Option | Description |
 |--------|-------------|
 | `--dialect <PATH>` | Load a custom dialect from a shared library |
-| `--dialect-name <NAME>` | Symbol name for the dialect (default: `syntaqlite_grammar`, with name: `syntaqlite_<NAME>_grammar`) |
+| `--dialect-name <NAME>` | Symbol name for the dialect (default: `syntaqlite_dialect_template`, with name: `syntaqlite_<NAME>_dialect_template`) |
 | `--sqlite-version <VER>` | Emulate a specific SQLite version |
 | `--sqlite-cflag <FLAG>` | Enable a SQLite compile-time flag (can be specified multiple times) |

--- a/web/docs/content/reference/mcp-tools.md
+++ b/web/docs/content/reference/mcp-tools.md
@@ -20,7 +20,7 @@ Format a SQL string.
 |-----------|------|---------|-------------|
 | `sql` | string | *(required)* | The SQL to format |
 | `line_width` | integer | `80` | Maximum line width |
-| `keyword_case` | string | `"upper"` | `"upper"`, `"lower"`, or `"preserve"` |
+| `keyword_case` | string | `"upper"` | `"upper"` or `"lower"` |
 | `semicolons` | boolean | `true` | Append trailing semicolons |
 
 **Returns:** The formatted SQL as a string. On parse error, returns

--- a/web/docs/content/reference/python-api.md
+++ b/web/docs/content/reference/python-api.md
@@ -218,7 +218,7 @@ After `close()`, any method call raises
 
 ### `syntaqlite.Schema`
 
-A catalog schema. Everything that contributes to the validator's catalog
+A catalog schema. Everything that contributes to the analyzer's catalog
 lives here — pick whichever combination fits your use case.
 
 ```python

--- a/web/docs/content/reference/rust-api.md
+++ b/web/docs/content/reference/rust-api.md
@@ -11,10 +11,10 @@ weight = 4
 | Feature | What it enables |
 |---------|----------------|
 | `fmt` | Formatter |
-| `validation` | Analysis (unknown tables, columns, functions) |
+| `analysis` | Analysis (unknown tables, columns, functions, lineage) |
 | `sqlite` | Built-in SQLite dialect (enabled by default) |
 | `lsp` | Language server protocol implementation |
-| `serde-json` | JSON serialization for AST and diagnostics |
+| `serde` | `serde::Serialize`/`Deserialize` for AST nodes and diagnostics |
 | `dynload` | Load custom dialects from shared libraries at runtime |
 
 ## Formatter
@@ -55,7 +55,7 @@ It recovers from errors and continues parsing subsequent statements.
 
 Zero-copy: tokens reference byte offsets into the source string.
 
-## Validator
+## Analyzer
 
 | Type / Method | Description |
 |---------------|-------------|


### PR DESCRIPTION
Systematic sweep for Diátaxis fit and freshness after the semantic → analysis rename, plus two code fixes surfaced during the audit.

- Getting-started: align c-parser with peers ("C library", "Using syntaqlite from C"); trim the choice-exposing "two C distributions" section; `## Validate` → `## Analyze` where commands beneath use `syntaqlite analyze`; drop duplicate Next-steps link on rust.md.
- Guides: rewrite mcp.md as a goal-oriented how-to (one config block + per-client path table); expand custom-dialects.md from stub to end-to-end walkthrough (write → generate → compile → load) with a dynamic-vs-static trade-off table. All commands verified against the in-tree Perfetto dialect.
- Reference: rename `## Validator` sections to `## Analyzer` in c-api and rust-api; fix stale feature names (`validation` → `analysis`, `serde-json` → `serde`); drop invalid `"preserve"` from mcp-tools `keyword_case`; correct fictional `*_create_with_grammar` → `*_create_with_dialect`; update `--dialect-name` doc to name the real loader symbol.
- Concepts/contributing: GitHub source links point at `src/analysis/…`; replace the removed `ValidationPass` reference with `query_scope.rs`; drop the fictional `semantic_roles.rs` Rust file claim in architecture.md.
- MCP server: `format_sql` now rejects unknown `keyword_case` with a helpful error instead of silently defaulting to Upper; adds a `parse_keyword_case` helper with unit tests.
- CLI: `--dialect-name` clap help now names the symbol the loader actually resolves (`syntaqlite_<name>_dialect_template`), visible in `syntaqlite --help`.

Test plan: tools/pre-push (fmt, clippy, tests, buildtools) passes; zola build clean (30 pages, 0 orphans); new parse_keyword_case unit tests pass.

