### PR TITLE
synq: push parse-tree convenience to parser; rename DdlReader

### DIFF
--- a/syntaqlite-syntax/include/syntaqlite/types.h
+++ b/syntaqlite-syntax/include/syntaqlite/types.h
@@ -91,18 +91,28 @@ typedef struct SyntaqliteTextSpan {
 // addition to SYNTAQLITE_SPAN_FLAG_QUOTED.  Only one of these is set at a
 // time.  Consumers (e.g. SQLite's double-quoted-string bug-compat in the
 // analyzer) need to distinguish `"..."` from `` `...` `` and `[...]`,
-// which the analyzer can't recover from the dequoted span alone.
+// which they can't recover from the dequoted span alone.
 #define SYNTAQLITE_SPAN_FLAG_QUOTE_DOUBLE ((uint32_t)2u)
 #define SYNTAQLITE_SPAN_FLAG_QUOTE_BACKTICK ((uint32_t)4u)
 #define SYNTAQLITE_SPAN_FLAG_QUOTE_BRACKET ((uint32_t)8u)
 
-static inline int synq_span_is_quoted(SyntaqliteTextSpan sp) {
+// True if the identifier was quoted in source.  See
+// syntaqlite_span_quote_char to recover which quote character.
+static inline int syntaqlite_span_is_quoted(SyntaqliteTextSpan sp) {
   return (sp.flags & SYNTAQLITE_SPAN_FLAG_QUOTED) != 0;
 }
 
-static inline SyntaqliteTextSpan synq_span_set_quoted(SyntaqliteTextSpan sp) {
-  sp.flags |= SYNTAQLITE_SPAN_FLAG_QUOTED;
-  return sp;
+// The quote character that bracketed this identifier in source —
+// '"', '`', or '['.  Returns 0 if the span was unquoted.  The closing
+// bracket for '[' is always ']'; only the opener is reported.
+static inline char syntaqlite_span_quote_char(SyntaqliteTextSpan sp) {
+  if (sp.flags & SYNTAQLITE_SPAN_FLAG_QUOTE_DOUBLE)
+    return '"';
+  if (sp.flags & SYNTAQLITE_SPAN_FLAG_QUOTE_BACKTICK)
+    return '`';
+  if (sp.flags & SYNTAQLITE_SPAN_FLAG_QUOTE_BRACKET)
+    return '[';
+  return 0;
 }
 
 #ifdef __cplusplus

--- a/syntaqlite-syntax/include/syntaqlite/types.h
+++ b/syntaqlite-syntax/include/syntaqlite/types.h
@@ -82,29 +82,31 @@ typedef struct SyntaqliteTextSpan {
 
 // ── Span flags ───────────────────────────────────────────────────────────────
 
-// Identifier was quoted in source (`"..."`, `` `...` ``, or `[...]`).
-// The span points to the dequoted inner text; the formatter re-wraps in
-// `"..."`.
-#define SYNTAQLITE_SPAN_FLAG_QUOTED ((uint32_t)1u)
+// Quote character flags on `SyntaqliteTextSpan.flags`.  At most one is
+// set; none means the identifier was unquoted.  Prefer the accessors
+// below over reading these bits directly.
+//
+// The span's offset/length point at the *dequoted* inner text — the
+// surrounding quote bytes are not part of the span.  These flags are
+// the only way to recover which character bracketed the identifier
+// after dequoting.
+#define SYNTAQLITE_SPAN_FLAG_QUOTE_DOUBLE ((uint32_t)1u)    // "..."
+#define SYNTAQLITE_SPAN_FLAG_QUOTE_BACKTICK ((uint32_t)2u)  // `...`
+#define SYNTAQLITE_SPAN_FLAG_QUOTE_BRACKET ((uint32_t)4u)   // [...]
 
-// Which quote character bracketed the identifier in source.  Set in
-// addition to SYNTAQLITE_SPAN_FLAG_QUOTED.  Only one of these is set at a
-// time.  Consumers (e.g. SQLite's double-quoted-string bug-compat in the
-// analyzer) need to distinguish `"..."` from `` `...` `` and `[...]`,
-// which they can't recover from the dequoted span alone.
-#define SYNTAQLITE_SPAN_FLAG_QUOTE_DOUBLE ((uint32_t)2u)
-#define SYNTAQLITE_SPAN_FLAG_QUOTE_BACKTICK ((uint32_t)4u)
-#define SYNTAQLITE_SPAN_FLAG_QUOTE_BRACKET ((uint32_t)8u)
+#define SYNTAQLITE_SPAN_QUOTE_MASK                                           \
+  (SYNTAQLITE_SPAN_FLAG_QUOTE_DOUBLE | SYNTAQLITE_SPAN_FLAG_QUOTE_BACKTICK | \
+   SYNTAQLITE_SPAN_FLAG_QUOTE_BRACKET)
 
-// True if the identifier was quoted in source.  See
-// syntaqlite_span_quote_char to recover which quote character.
+// Was this identifier quoted in source?  Returns nonzero if `sp` came
+// from any of `"..."`, `` `...` ``, or `[...]`.
 static inline int syntaqlite_span_is_quoted(SyntaqliteTextSpan sp) {
-  return (sp.flags & SYNTAQLITE_SPAN_FLAG_QUOTED) != 0;
+  return (sp.flags & SYNTAQLITE_SPAN_QUOTE_MASK) != 0;
 }
 
-// The quote character that bracketed this identifier in source —
-// '"', '`', or '['.  Returns 0 if the span was unquoted.  The closing
-// bracket for '[' is always ']'; only the opener is reported.
+// The character that opened this identifier's quotes in source: `"`,
+// `` ` ``, or `[`.  Returns 0 if the span was unquoted.  For `[...]`
+// only the opener is reported; the closer is always `]`.
 static inline char syntaqlite_span_quote_char(SyntaqliteTextSpan sp) {
   if (sp.flags & SYNTAQLITE_SPAN_FLAG_QUOTE_DOUBLE)
     return '"';

--- a/syntaqlite-syntax/include/syntaqlite/types.h
+++ b/syntaqlite-syntax/include/syntaqlite/types.h
@@ -87,6 +87,15 @@ typedef struct SyntaqliteTextSpan {
 // `"..."`.
 #define SYNTAQLITE_SPAN_FLAG_QUOTED ((uint32_t)1u)
 
+// Which quote character bracketed the identifier in source.  Set in
+// addition to SYNTAQLITE_SPAN_FLAG_QUOTED.  Only one of these is set at a
+// time.  Consumers (e.g. SQLite's double-quoted-string bug-compat in the
+// analyzer) need to distinguish `"..."` from `` `...` `` and `[...]`,
+// which the analyzer can't recover from the dequoted span alone.
+#define SYNTAQLITE_SPAN_FLAG_QUOTE_DOUBLE ((uint32_t)2u)
+#define SYNTAQLITE_SPAN_FLAG_QUOTE_BACKTICK ((uint32_t)4u)
+#define SYNTAQLITE_SPAN_FLAG_QUOTE_BRACKET ((uint32_t)8u)
+
 static inline int synq_span_is_quoted(SyntaqliteTextSpan sp) {
   return (sp.flags & SYNTAQLITE_SPAN_FLAG_QUOTED) != 0;
 }

--- a/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
@@ -384,12 +384,16 @@ static inline SyntaqliteTextSpan synq_span_dequote(SynqParseCtx* ctx,
     char close = tok.z[tok.n - 1];
     if ((open == '"' && close == '"') || (open == '`' && close == '`') ||
         (open == '[' && close == ']')) {
+      uint32_t kind_flag = (open == '"')   ? SYNTAQLITE_SPAN_FLAG_QUOTE_DOUBLE
+                           : (open == '`') ? SYNTAQLITE_SPAN_FLAG_QUOTE_BACKTICK
+                                           : SYNTAQLITE_SPAN_FLAG_QUOTE_BRACKET;
       SyntaqliteTextSpan sp = {
           .offset = tok.offset + 1,
           .length = tok.n - 2,
+          .flags = SYNTAQLITE_SPAN_FLAG_QUOTED | kind_flag,
           ._layer_id = tok.layer_id,
       };
-      return synq_span_set_quoted(sp);
+      return sp;
     }
   }
   return (SyntaqliteTextSpan){

--- a/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
@@ -372,8 +372,8 @@ static inline SyntaqliteTextSpan synq_span(SynqParseCtx* ctx,
 // Like synq_span() but strips surrounding quote characters from quoted
 // identifiers, matching SQLite's tokenExpr() dequoting behavior.
 // Handles "...", `...`, and [...] forms.  For unquoted tokens, equivalent
-// to synq_span().  Sets SYNTAQLITE_SPAN_FLAG_QUOTED when quotes are stripped
-// so the formatter can re-wrap in standard double quotes.
+// to synq_span().  Records which quote character bracketed the identifier
+// in the span flags so consumers can recover the original quote style.
 static inline SyntaqliteTextSpan synq_span_dequote(SynqParseCtx* ctx,
                                                    SynqParseToken tok) {
   (void)ctx;
@@ -390,7 +390,7 @@ static inline SyntaqliteTextSpan synq_span_dequote(SynqParseCtx* ctx,
       SyntaqliteTextSpan sp = {
           .offset = tok.offset + 1,
           .length = tok.n - 2,
-          .flags = SYNTAQLITE_SPAN_FLAG_QUOTED | kind_flag,
+          .flags = kind_flag,
           ._layer_id = tok.layer_id,
       };
       return sp;

--- a/syntaqlite-syntax/src/ast.rs
+++ b/syntaqlite-syntax/src/ast.rs
@@ -474,8 +474,11 @@ mod ffi {
         pub(crate) _layer_id: u32,
     }
 
-    /// Mirror of C `SYNTAQLITE_SPAN_FLAG_QUOTED` from `types.h`.
+    /// Mirrors of C `SYNTAQLITE_SPAN_FLAG_*` from `types.h`.
     const SPAN_FLAG_QUOTED: u32 = 1;
+    const SPAN_FLAG_QUOTE_DOUBLE: u32 = 2;
+    const SPAN_FLAG_QUOTE_BACKTICK: u32 = 4;
+    const SPAN_FLAG_QUOTE_BRACKET: u32 = 8;
 
     impl CTextSpan {
         /// Returns `true` if the span covers zero bytes.
@@ -486,9 +489,26 @@ mod ffi {
         /// Returns `true` if the span was quoted in source (`"..."`,
         /// `` `...` ``, or `[...]`).  The span points at the dequoted inner
         /// text; the formatter re-wraps quoted spans in standard double
-        /// quotes.
+        /// quotes.  Use [`Self::quote_char`] to recover which quote
+        /// character bracketed the identifier.
         pub fn is_quoted(self) -> bool {
             (self.flags & SPAN_FLAG_QUOTED) != 0
+        }
+
+        /// The quote character that bracketed this identifier in source —
+        /// `'"'`, `` '`' ``, or `'['` — or `None` if the span was unquoted.
+        /// The closing bracket for `'['` is always `']'`; only the opener
+        /// is reported.
+        pub fn quote_char(self) -> Option<char> {
+            if self.flags & SPAN_FLAG_QUOTE_DOUBLE != 0 {
+                Some('"')
+            } else if self.flags & SPAN_FLAG_QUOTE_BACKTICK != 0 {
+                Some('`')
+            } else if self.flags & SPAN_FLAG_QUOTE_BRACKET != 0 {
+                Some('[')
+            } else {
+                None
+            }
         }
 
         /// Returns `true` if the span was tokenized from the original

--- a/syntaqlite-syntax/src/ast.rs
+++ b/syntaqlite-syntax/src/ast.rs
@@ -474,11 +474,12 @@ mod ffi {
         pub(crate) _layer_id: u32,
     }
 
-    /// Mirrors of C `SYNTAQLITE_SPAN_FLAG_*` from `types.h`.
-    const SPAN_FLAG_QUOTED: u32 = 1;
-    const SPAN_FLAG_QUOTE_DOUBLE: u32 = 2;
-    const SPAN_FLAG_QUOTE_BACKTICK: u32 = 4;
-    const SPAN_FLAG_QUOTE_BRACKET: u32 = 8;
+    // Mirrors of C `SYNTAQLITE_SPAN_FLAG_*` from `types.h`.
+    const SPAN_FLAG_QUOTE_DOUBLE: u32 = 1;
+    const SPAN_FLAG_QUOTE_BACKTICK: u32 = 2;
+    const SPAN_FLAG_QUOTE_BRACKET: u32 = 4;
+    const SPAN_QUOTE_MASK: u32 =
+        SPAN_FLAG_QUOTE_DOUBLE | SPAN_FLAG_QUOTE_BACKTICK | SPAN_FLAG_QUOTE_BRACKET;
 
     impl CTextSpan {
         /// Returns `true` if the span covers zero bytes.
@@ -486,19 +487,21 @@ mod ffi {
             self.length == 0
         }
 
-        /// Returns `true` if the span was quoted in source (`"..."`,
-        /// `` `...` ``, or `[...]`).  The span points at the dequoted inner
-        /// text; the formatter re-wraps quoted spans in standard double
-        /// quotes.  Use [`Self::quote_char`] to recover which quote
-        /// character bracketed the identifier.
+        /// Was this identifier quoted in source?  True for `"..."`,
+        /// `` `...` ``, and `[...]` forms; false otherwise.  Use
+        /// [`Self::quote_char`] to distinguish which quote character
+        /// bracketed it.
+        ///
+        /// Note that the span itself points at the *dequoted* inner text —
+        /// the surrounding quote bytes are not part of `offset`/`length`.
         pub fn is_quoted(self) -> bool {
-            (self.flags & SPAN_FLAG_QUOTED) != 0
+            (self.flags & SPAN_QUOTE_MASK) != 0
         }
 
-        /// The quote character that bracketed this identifier in source —
-        /// `'"'`, `` '`' ``, or `'['` — or `None` if the span was unquoted.
-        /// The closing bracket for `'['` is always `']'`; only the opener
-        /// is reported.
+        /// The character that opened this identifier's quotes in source:
+        /// `'"'`, `` '`' ``, or `'['`.  `None` if the span was unquoted.
+        /// For `[...]` only the opener is reported; the closer is always
+        /// `']'`.
         pub fn quote_char(self) -> Option<char> {
             if self.flags & SPAN_FLAG_QUOTE_DOUBLE != 0 {
                 Some('"')

--- a/syntaqlite-syntax/src/ast.rs
+++ b/syntaqlite-syntax/src/ast.rs
@@ -217,6 +217,15 @@ pub enum FieldValue {
     Enum(u32),
 }
 
+/// Sentinel for "absent field index" in role-table-driven schemas.
+///
+/// Field indices in `SemanticRole`-style enums use this value to mean
+/// "this field doesn't exist for this node shape." The convenience
+/// accessors on [`NodeFields`] and
+/// [`AnyParsedStatement`](crate::parser::AnyParsedStatement) treat
+/// `FIELD_ABSENT` as a None hit so callers don't have to special-case it.
+pub const FIELD_ABSENT: u8 = 0xFF;
+
 /// Compact reflected field collection for one AST node.
 ///
 /// Returned by [`AnyParsedStatement::extract_fields`](crate::parser::AnyParsedStatement::extract_fields)
@@ -253,6 +262,18 @@ impl NodeFields {
     /// Whether there are no fields.
     pub fn is_empty(&self) -> bool {
         self.len == 0
+    }
+
+    /// `NodeId` stored at field `idx`, or `None` if `idx` is [`FIELD_ABSENT`],
+    /// the field is null, or the field is not a `NodeId`.
+    pub fn node_id_at(&self, idx: u8) -> Option<AnyNodeId> {
+        if idx == FIELD_ABSENT {
+            return None;
+        }
+        match self[idx as usize] {
+            FieldValue::NodeId(id) if !id.is_null() => Some(id),
+            _ => None,
+        }
     }
 }
 

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -82,7 +82,8 @@ pub mod util;
 pub mod any {
     #[doc(inline)]
     pub use crate::ast::{
-        AnyNode, AnyNodeId, AnyNodeTag, AnyTokenType, FieldValue, NodeFields, TextSpan,
+        AnyNode, AnyNodeId, AnyNodeTag, AnyTokenType, FIELD_ABSENT, FieldValue, NodeFields,
+        TextSpan,
     };
     #[doc(inline)]
     pub use crate::dialect::{AnyDialect, FieldKind, FieldMeta, KeywordEntry, TokenCategory};

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -1020,6 +1020,158 @@ impl<'a> AnyParsedStatement<'a> {
         Some((tag, fields))
     }
 
+    // ── Field-shaped convenience accessors ──────────────────────────────
+    //
+    // These wrap the common patterns of "extract fields, then look at one
+    // field" so callers don't repeat the empty/null/wrong-kind boilerplate
+    // every time. They handle the [`crate::ast::FIELD_ABSENT`] sentinel as
+    // a None hit so callers can pass field indices read from role tables
+    // without pre-checking.
+
+    /// Expanded text of a span field, or `None` if the index is
+    /// [`crate::ast::FIELD_ABSENT`], the field is empty, or the field is
+    /// not a span.
+    pub fn span_field_text(&self, fields: &crate::ast::NodeFields, idx: u8) -> Option<&'a str> {
+        if idx == crate::ast::FIELD_ABSENT {
+            return None;
+        }
+        match fields[idx as usize] {
+            crate::ast::FieldValue::Span(sp) if !sp.is_empty() => Some(self.span_expanded_text(sp)),
+            _ => None,
+        }
+    }
+
+    /// `(text, range)` of a span field. `range` is the document-absolute
+    /// extent. `None` under the same conditions as
+    /// [`Self::span_field_text`].
+    pub fn span_field_range(
+        &self,
+        fields: &crate::ast::NodeFields,
+        idx: u8,
+    ) -> Option<(&'a str, DocRange)> {
+        if idx == crate::ast::FIELD_ABSENT {
+            return None;
+        }
+        match fields[idx as usize] {
+            crate::ast::FieldValue::Span(sp) if !sp.is_empty() => {
+                let text = self.span_expanded_text(sp);
+                let (_, range) = self.span_text_abs(sp);
+                Some((text, range))
+            }
+            _ => None,
+        }
+    }
+
+    /// `(text, range)` of a Name node's field-0 span — used by
+    /// `IdentName`-shaped and `Error`-shaped nodes where the identifier
+    /// always sits at field 0. Returns empty strings when the node is
+    /// `None`, null, or shaped differently.
+    pub fn name_text(&self, node_id: Option<AnyNodeId>) -> (&'a str, DocRange) {
+        let Some(node_id) = node_id else {
+            return ("", DocRange::default());
+        };
+        let Some((_, fields)) = self.extract_fields(node_id) else {
+            return ("", DocRange::default());
+        };
+        if fields.is_empty() {
+            return ("", DocRange::default());
+        }
+        match fields[0] {
+            crate::ast::FieldValue::Span(sp) => {
+                let text = self.span_expanded_text(sp);
+                let (_, range) = self.span_text_abs(sp);
+                (text, range)
+            }
+            _ => ("", DocRange::default()),
+        }
+    }
+
+    /// First non-empty span anywhere in `node_id`'s fields. Used as a
+    /// generic "give me whatever identifier this node carries" probe.
+    pub fn first_span_text(&self, node_id: AnyNodeId) -> Option<&'a str> {
+        if node_id.is_null() {
+            return None;
+        }
+        let (_, fields) = self.extract_fields(node_id)?;
+        for i in 0..fields.len() {
+            if let crate::ast::FieldValue::Span(sp) = fields[i]
+                && !sp.is_empty()
+            {
+                return Some(self.span_expanded_text(sp));
+            }
+        }
+        None
+    }
+
+    /// Text of a "name-shaped" field that may be either a direct `Span`
+    /// or a `NodeId` pointing at a Name node. Mirrors the dual
+    /// representation used by `SourceRef.alias`, CTE names, and similar
+    /// fields where the codegen sometimes emits a span and sometimes
+    /// emits a child node.
+    pub fn name_field_text(&self, fields: &crate::ast::NodeFields, idx: u8) -> Option<&'a str> {
+        if idx == crate::ast::FIELD_ABSENT {
+            return None;
+        }
+        match fields[idx as usize] {
+            crate::ast::FieldValue::Span(sp) if !sp.is_empty() => Some(self.span_expanded_text(sp)),
+            crate::ast::FieldValue::NodeId(id) if !id.is_null() => self.first_span_text(id),
+            _ => None,
+        }
+    }
+
+    /// Statement-source slice spanning every byte covered by `id`'s
+    /// subtree. Walks all spans reachable from `id`, finds the min/max
+    /// offset pair, and returns the source between them. `None` if no
+    /// spans are reachable.
+    pub fn expr_source_text(&self, id: AnyNodeId) -> Option<&'a str> {
+        let mut min = StmtOffset::from_raw(u32::MAX);
+        let mut max = StmtOffset::default();
+        self.collect_expr_spans(id, &mut min, &mut max);
+        if min < max {
+            Some(
+                &self.text()[StmtRange {
+                    start: min,
+                    end: max,
+                }],
+            )
+        } else {
+            None
+        }
+    }
+
+    fn collect_expr_spans(&self, id: AnyNodeId, min: &mut StmtOffset, max: &mut StmtOffset) {
+        if id.is_null() {
+            return;
+        }
+        if let Some((_, fields)) = self.extract_fields(id) {
+            for i in 0..fields.len() {
+                match fields[i] {
+                    crate::ast::FieldValue::Span(sp) if !sp.is_empty() => {
+                        let (text, off) = self.span_text(sp);
+                        let start = off;
+                        let end = start
+                            + StmtLen::from_raw(u32::try_from(text.len()).unwrap_or(u32::MAX));
+                        if start < *min {
+                            *min = start;
+                        }
+                        if end > *max {
+                            *max = end;
+                        }
+                    }
+                    crate::ast::FieldValue::NodeId(child) if !child.is_null() => {
+                        self.collect_expr_spans(child, min, max);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if let Some(children) = self.list_children(id) {
+            for &child in children {
+                self.collect_expr_spans(child, min, max);
+            }
+        }
+    }
+
     /// Return child node IDs if `id` is a list node.
     pub fn list_children(&self, id: AnyNodeId) -> Option<&'a [AnyNodeId]> {
         let (_, tag) = self.node_ptr(id)?;

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -1119,59 +1119,6 @@ impl<'a> AnyParsedStatement<'a> {
         }
     }
 
-    /// Statement-source slice spanning every byte covered by `id`'s
-    /// subtree. Walks all spans reachable from `id`, finds the min/max
-    /// offset pair, and returns the source between them. `None` if no
-    /// spans are reachable.
-    pub fn expr_source_text(&self, id: AnyNodeId) -> Option<&'a str> {
-        let mut min = StmtOffset::from_raw(u32::MAX);
-        let mut max = StmtOffset::default();
-        self.collect_expr_spans(id, &mut min, &mut max);
-        if min < max {
-            Some(
-                &self.text()[StmtRange {
-                    start: min,
-                    end: max,
-                }],
-            )
-        } else {
-            None
-        }
-    }
-
-    fn collect_expr_spans(&self, id: AnyNodeId, min: &mut StmtOffset, max: &mut StmtOffset) {
-        if id.is_null() {
-            return;
-        }
-        if let Some((_, fields)) = self.extract_fields(id) {
-            for i in 0..fields.len() {
-                match fields[i] {
-                    crate::ast::FieldValue::Span(sp) if !sp.is_empty() => {
-                        let (text, off) = self.span_text(sp);
-                        let start = off;
-                        let end = start
-                            + StmtLen::from_raw(u32::try_from(text.len()).unwrap_or(u32::MAX));
-                        if start < *min {
-                            *min = start;
-                        }
-                        if end > *max {
-                            *max = end;
-                        }
-                    }
-                    crate::ast::FieldValue::NodeId(child) if !child.is_null() => {
-                        self.collect_expr_spans(child, min, max);
-                    }
-                    _ => {}
-                }
-            }
-        }
-        if let Some(children) = self.list_children(id) {
-            for &child in children {
-                self.collect_expr_spans(child, min, max);
-            }
-        }
-    }
-
     /// Return child node IDs if `id` is a list node.
     pub fn list_children(&self, id: AnyNodeId) -> Option<&'a [AnyNodeId]> {
         let (_, tag) = self.node_ptr(id)?;

--- a/syntaqlite/src/analysis/catalog.rs
+++ b/syntaqlite/src/analysis/catalog.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, HashSet};
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue};
 
-use super::ddl::DdlReader;
+use super::ddl::SemanticPropertyExtractor;
 use crate::dialect::AnyDialect;
 use crate::dialect::{
     FIELD_ABSENT, FunctionCategory as DialectFunctionCategory, SemanticRole, is_function_available,
@@ -689,7 +689,7 @@ impl Catalog {
         let Some(&role) = dialect.roles().get(u32::from(tag) as usize) else {
             return;
         };
-        let reader = DdlReader::new(stmt, dialect.roles());
+        let reader = SemanticPropertyExtractor::new(stmt, dialect.roles());
         let layer = &mut self.layers[target.index()];
 
         match role {
@@ -699,7 +699,7 @@ impl Catalog {
                 select,
                 without_rowid,
             } => {
-                let Some(name_val) = reader.span_field_text(&fields, name) else {
+                let Some(name_val) = stmt.span_field_text(&fields, name) else {
                     return;
                 };
                 let cols = reader.extract_columns(&fields, columns, select);
@@ -715,7 +715,7 @@ impl Catalog {
                 columns,
                 select,
             } => {
-                let Some(name_val) = reader.span_field_text(&fields, name) else {
+                let Some(name_val) = stmt.span_field_text(&fields, name) else {
                     return;
                 };
                 let cols = reader.extract_columns(&fields, columns, select);
@@ -727,7 +727,7 @@ impl Catalog {
                 return_type,
                 ..
             } => {
-                let Some(name_val) = reader.span_field_text(&fields, name) else {
+                let Some(name_val) = stmt.span_field_text(&fields, name) else {
                     return;
                 };
                 let arity = reader.function_arity(&fields, args);

--- a/syntaqlite/src/analysis/ddl.rs
+++ b/syntaqlite/src/analysis/ddl.rs
@@ -1,31 +1,65 @@
 // Copyright 2025 The syntaqlite Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-//! DDL-shaped reads against a parsed statement.
+//! Role-table-driven property extraction from a parsed statement.
 //!
-//! The catalog, the analyzer, the lineage resolver, and the LSP all need to
-//! pull definition names, column lists, SELECT-result columns, and assorted
-//! span/role data out of a parsed statement. Every operation here takes only
-//! `(stmt, roles)`, so they're grouped on a single [`DdlReader`] handle.
+//! [`SemanticPropertyExtractor`] is the analysis crate's view of a parsed
+//! statement through the dialect's `SemanticRole` table. It bundles
+//! `(stmt, roles)` so call sites don't repeat both args, and exposes
+//! methods that answer questions like "what does this `CREATE TABLE`
+//! define?", "iterate this WITH clause's CTE bindings", "what columns
+//! does this SELECT body produce?".
+//!
+//! Field-shaped accessors that don't need the role table
+//! (`span_field_text`, `name_text`, `expr_source_text`, etc.) live on
+//! [`AnyParsedStatement`] in `syntaqlite-syntax` directly — they're raw
+//! parse-tree convenience, not analysis.
 
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue, NodeFields};
-use syntaqlite_syntax::source::{DocRange, StmtLen, StmtOffset, StmtRange};
+use syntaqlite_syntax::source::DocRange;
 
 use crate::analysis::catalog::AritySpec;
 use crate::analysis::model::DefinedRelation;
-use crate::dialect::{FIELD_ABSENT, SemanticRole};
+use crate::dialect::SemanticRole;
 
-/// Read DDL- and AST-shaped data out of a parsed statement.
+/// Bundles `(stmt, roles)` and exposes role-table-driven extraction.
 ///
-/// Cheap to construct (just two references); construct a fresh handle at each
-/// caller rather than threading one through.
+/// Cheap to construct — just two references — so call sites build a
+/// fresh handle locally rather than thread one through.
 #[derive(Clone, Copy)]
-pub(crate) struct DdlReader<'a, 'stmt> {
+pub(crate) struct SemanticPropertyExtractor<'a, 'stmt> {
     stmt: &'a AnyParsedStatement<'stmt>,
     roles: &'a [SemanticRole],
 }
 
-impl<'a, 'stmt> DdlReader<'a, 'stmt> {
+/// A single binding inside a CTE list (`WITH name(cols) AS (body), ...`).
+/// Borrowed view; lives only for the duration of one
+/// [`SemanticPropertyExtractor::for_each_cte_binding`] callback.
+///
+/// Use [`SemanticPropertyExtractor::cte_declared_cols`] to materialize the
+/// declared column list when the consumer actually needs it — the iterator
+/// itself stays cheap.
+pub(crate) struct CteBindingView<'b> {
+    pub(crate) name: &'b str,
+    pub(crate) body_id: Option<AnyNodeId>,
+}
+
+/// A single FROM-clause source, after walking through transparent wrappers
+/// and joins. Aliases are extracted but not lowercased — callers do that.
+pub(crate) enum FromSource<'b> {
+    /// A relation reference: catalog table, view, CTE, or table-valued function.
+    Relation {
+        name: &'b str,
+        alias: Option<&'b str>,
+    },
+    /// A bracketed subquery in FROM, with its body and (optional) alias.
+    Subquery {
+        alias: Option<&'b str>,
+        body_id: AnyNodeId,
+    },
+}
+
+impl<'a, 'stmt> SemanticPropertyExtractor<'a, 'stmt> {
     pub(crate) fn new(stmt: &'a AnyParsedStatement<'stmt>, roles: &'a [SemanticRole]) -> Self {
         Self { stmt, roles }
     }
@@ -36,8 +70,8 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
 
     // ── Role lookup ──────────────────────────────────────────────────────
 
-    /// Role for `tag`; defaults to [`SemanticRole::Transparent`] for unknown
-    /// tags (matching the behavior expected by the walker).
+    /// Role for `tag`; defaults to [`SemanticRole::Transparent`] for
+    /// unknown tags (matching what the walker assumes).
     pub(crate) fn role_for_tag(&self, tag: impl Into<u32>) -> SemanticRole {
         self.roles
             .get(tag.into() as usize)
@@ -45,7 +79,8 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
             .unwrap_or(SemanticRole::Transparent)
     }
 
-    /// `(role, fields)` for `node_id`, or `None` if the node has no fields.
+    /// `(role, fields)` for `node_id`, or `None` when the node is null or
+    /// has no extractable fields.
     pub(crate) fn role_for_node(&self, node_id: AnyNodeId) -> Option<(SemanticRole, NodeFields)> {
         if node_id.is_null() {
             return None;
@@ -54,108 +89,11 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
         Some((self.role_for_tag(tag), fields))
     }
 
-    // ── Field accessors ──────────────────────────────────────────────────
+    // ── Iteration ────────────────────────────────────────────────────────
 
-    /// `NodeId` stored at field `idx`, or `None` if absent / null / non-NodeId.
-    pub(crate) fn node_field(fields: &NodeFields, idx: u8) -> Option<AnyNodeId> {
-        if idx == FIELD_ABSENT {
-            return None;
-        }
-        match fields[idx as usize] {
-            FieldValue::NodeId(id) if !id.is_null() => Some(id),
-            _ => None,
-        }
-    }
-
-    /// Expanded text of a span field, or `None` if absent / empty / non-Span.
-    pub(crate) fn span_field_text(&self, fields: &NodeFields, idx: u8) -> Option<&'stmt str> {
-        if idx == FIELD_ABSENT {
-            return None;
-        }
-        match fields[idx as usize] {
-            FieldValue::Span(sp) if !sp.is_empty() => Some(self.stmt.span_expanded_text(sp)),
-            _ => None,
-        }
-    }
-
-    /// `(text, range)` of a span field; absolute document range.
-    pub(crate) fn span_field_range(
-        &self,
-        fields: &NodeFields,
-        idx: u8,
-    ) -> Option<(&'stmt str, DocRange)> {
-        if idx == FIELD_ABSENT {
-            return None;
-        }
-        match fields[idx as usize] {
-            FieldValue::Span(sp) if !sp.is_empty() => {
-                let text = self.stmt.span_expanded_text(sp);
-                let (_, range) = self.stmt.span_text_abs(sp);
-                Some((text, range))
-            }
-            _ => None,
-        }
-    }
-
-    /// `(text, range)` of a Name node's field-0 span (used by `IdentName` and
-    /// `Error` shapes where the identifier sits at field 0). Returns empty
-    /// strings when the node is null or shaped differently.
-    pub(crate) fn name_text(&self, node_id: Option<AnyNodeId>) -> (&'stmt str, DocRange) {
-        let Some(node_id) = node_id else {
-            return ("", DocRange::default());
-        };
-        let Some((_, fields)) = self.stmt.extract_fields(node_id) else {
-            return ("", DocRange::default());
-        };
-        if fields.is_empty() {
-            return ("", DocRange::default());
-        }
-        match fields[0] {
-            FieldValue::Span(sp) => {
-                let text = self.stmt.span_expanded_text(sp);
-                let (_, range) = self.stmt.span_text_abs(sp);
-                (text, range)
-            }
-            _ => ("", DocRange::default()),
-        }
-    }
-
-    /// First non-empty span anywhere in `node_id`'s fields. Used as a generic
-    /// "give me whatever identifier this node carries" probe.
-    pub(crate) fn first_span_text(&self, node_id: AnyNodeId) -> Option<&'stmt str> {
-        if node_id.is_null() {
-            return None;
-        }
-        let (_, fields) = self.stmt.extract_fields(node_id)?;
-        for i in 0..fields.len() {
-            if let FieldValue::Span(sp) = fields[i]
-                && !sp.is_empty()
-            {
-                return Some(self.stmt.span_expanded_text(sp));
-            }
-        }
-        None
-    }
-
-    /// Text of a "name-shaped" field that may be either a direct `Span` or a
-    /// `NodeId` pointing at a Name node. Mirrors the dual representation used
-    /// by `SourceRef.alias`, CTE names, and similar fields.
-    pub(crate) fn name_field_text(&self, fields: &NodeFields, idx: u8) -> Option<&'stmt str> {
-        if idx == FIELD_ABSENT {
-            return None;
-        }
-        match fields[idx as usize] {
-            FieldValue::Span(sp) if !sp.is_empty() => Some(self.stmt.span_expanded_text(sp)),
-            FieldValue::NodeId(id) if !id.is_null() => self.first_span_text(id),
-            _ => None,
-        }
-    }
-
-    // ── Result-column iteration ──────────────────────────────────────────
-
-    /// Visit each `ResultColumn` child of a column-list node, calling `f` with
-    /// the result column's fields and the indices of its `(flags, alias, expr)`
-    /// fields. `f` returns `false` to stop iteration early.
+    /// Visit each `ResultColumn` child of a column-list node, calling `f`
+    /// with the result column's fields and the indices of its `(flags,
+    /// alias, expr)` fields. `f` returns `false` to stop iteration early.
     ///
     /// Skips children that aren't `ResultColumn` (transparent wrappers,
     /// commas, etc.) so callers don't have to.
@@ -183,7 +121,121 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
         }
     }
 
-    // ── DDL definition spans (go-to-definition, etc.) ────────────────────
+    /// Visit each `CteBinding` child under `bindings_id` (a CTE list
+    /// node). Skips non-binding children and malformed bindings.
+    ///
+    /// The view only carries `(name, body_id)` — the cheap part.
+    /// Consumers that need the declared column list call
+    /// [`Self::cte_declared_cols`] with the binding's node id. The
+    /// iterator stays cheap for callers (lineage) that don't need
+    /// declared columns at all.
+    pub(crate) fn for_each_cte_binding<F>(&self, bindings_id: AnyNodeId, mut f: F)
+    where
+        F: FnMut(CteBindingView<'stmt>),
+    {
+        let Some(children) = self.stmt.list_children(bindings_id) else {
+            return;
+        };
+        for &cte_id in children {
+            if cte_id.is_null() {
+                continue;
+            }
+            let Some((
+                SemanticRole::CteBinding {
+                    name: name_idx,
+                    body: body_idx,
+                    ..
+                },
+                fields,
+            )) = self.role_for_node(cte_id)
+            else {
+                continue;
+            };
+            let name = self.stmt.span_field_text(&fields, name_idx).unwrap_or("");
+            f(CteBindingView {
+                name,
+                body_id: fields.node_id_at(body_idx),
+            });
+        }
+    }
+
+    /// Declared column list for a `CteBinding` node, when the binding
+    /// wrote out the parenthesized `(col1, col2, ...)` part. Returns
+    /// `None` when no column list was declared (the body's columns are
+    /// inferred instead).
+    pub(crate) fn cte_declared_cols(
+        &self,
+        binding_node: AnyNodeId,
+    ) -> Option<Vec<(&'stmt str, DocRange)>> {
+        let (
+            SemanticRole::CteBinding {
+                columns: cols_idx, ..
+            },
+            fields,
+        ) = self.role_for_node(binding_node)?
+        else {
+            return None;
+        };
+        let list_id = fields.node_id_at(cols_idx)?;
+        let children = self.stmt.list_children(list_id)?;
+        let mut names: Vec<(&'stmt str, DocRange)> = Vec::with_capacity(children.len());
+        for &id in children {
+            let (text, range) = self.stmt.name_text(Some(id));
+            if !text.is_empty() {
+                names.push((text, range));
+            }
+        }
+        if names.is_empty() { None } else { Some(names) }
+    }
+
+    /// Visit each FROM-clause source under `from_id`, recursing through
+    /// transparent wrappers and join nodes. Both `SourceRef` (catalog
+    /// relations) and `ScopedSource` (subqueries) are reported.
+    pub(crate) fn for_each_from_source<F>(&self, from_id: AnyNodeId, mut f: F)
+    where
+        F: FnMut(FromSource<'stmt>),
+    {
+        self.walk_from(from_id, &mut f);
+    }
+
+    fn walk_from<F>(&self, from_id: AnyNodeId, f: &mut F)
+    where
+        F: FnMut(FromSource<'stmt>),
+    {
+        let Some((role, fields)) = self.role_for_node(from_id) else {
+            return;
+        };
+        match role {
+            SemanticRole::SourceRef {
+                name: name_idx,
+                alias: alias_idx,
+                ..
+            } => {
+                let Some(name) = self.stmt.span_field_text(&fields, name_idx) else {
+                    return;
+                };
+                let alias = self.stmt.name_field_text(&fields, alias_idx);
+                f(FromSource::Relation { name, alias });
+            }
+            SemanticRole::ScopedSource {
+                body: body_idx,
+                alias: alias_idx,
+            } => {
+                let Some(body_id) = fields.node_id_at(body_idx) else {
+                    return;
+                };
+                let alias = self.stmt.name_field_text(&fields, alias_idx);
+                f(FromSource::Subquery { alias, body_id });
+            }
+            _ => {
+                for child in self.stmt.child_node_ids(from_id) {
+                    self.walk_from(child, f);
+                }
+            }
+        }
+    }
+
+    // ── DDL definition extraction ───────────────────────────────────────
 
     /// `(lowercase_name, range)` for `CREATE TABLE` / `CREATE VIEW`.
     /// Returns `None` for non-DDL statements.
@@ -194,7 +246,7 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
         else {
             return None;
         };
-        let (text, range) = self.span_field_range(&fields, name_idx)?;
+        let (text, range) = self.stmt.span_field_range(&fields, name_idx)?;
         Some((text.to_ascii_lowercase(), range))
     }
 
@@ -205,7 +257,7 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
         else {
             return out;
         };
-        let Some(col_list_id) = Self::node_field(&fields, columns) else {
+        let Some(col_list_id) = fields.node_id_at(columns) else {
             return out;
         };
         let Some(children) = self.stmt.list_children(col_list_id) else {
@@ -228,7 +280,7 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
         else {
             return None;
         };
-        let name_id = Self::node_field(&fields, name_idx)?;
+        let name_id = fields.node_id_at(name_idx)?;
         let (_, name_fields) = self.stmt.extract_fields(name_id)?;
         for j in 0..name_fields.len() {
             if let FieldValue::Span(sp) = name_fields[j]
@@ -252,7 +304,7 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
             SemanticRole::DefineView { name, .. } => (name, true),
             _ => return Vec::new(),
         };
-        match self.span_field_text(&fields, name_idx) {
+        match self.stmt.span_field_text(&fields, name_idx) {
             Some(name) => vec![DefinedRelation {
                 name: name.to_string(),
                 is_view,
@@ -261,27 +313,27 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
         }
     }
 
-    // ── Catalog accumulation inputs ───────────────────────────────────────
-
     /// Columns for a table or view DDL contribution.
     ///
-    /// Tries the explicit column list first; falls back to inferring names
-    /// from the SELECT body. `None` means inference was impossible (e.g.
-    /// `SELECT *`) and the caller should accept any column reference.
+    /// Tries the explicit column list first; falls back to inferring
+    /// names from the SELECT body. `None` means inference was impossible
+    /// (e.g. `SELECT *`) and the caller should accept any column reference.
     pub(super) fn extract_columns(
         &self,
         fields: &NodeFields,
         columns_field: u8,
         select_field: u8,
     ) -> Option<Vec<String>> {
-        if let Some(col_list_id) = Self::node_field(fields, columns_field) {
+        if let Some(col_list_id) = fields.node_id_at(columns_field) {
             let mut columns = Vec::new();
             self.columns_from_column_list(col_list_id, &mut columns);
             if !columns.is_empty() {
                 return Some(columns);
             }
         }
-        Self::node_field(fields, select_field).and_then(|id| self.columns_from_select(id))
+        fields
+            .node_id_at(select_field)
+            .and_then(|id| self.columns_from_select(id))
     }
 
     fn columns_from_column_list(&self, list_id: AnyNodeId, out: &mut Vec<String>) {
@@ -298,19 +350,19 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
     /// Whether a DDL function returns a table (has a `ReturnSpec` with
     /// non-empty columns).
     pub(super) fn is_table_returning(&self, fields: &NodeFields, return_type_field: u8) -> bool {
-        let Some(rt_id) = Self::node_field(fields, return_type_field) else {
+        let Some(rt_id) = fields.node_id_at(return_type_field) else {
             return false;
         };
         let Some((SemanticRole::ReturnSpec { columns }, rt_fields)) = self.role_for_node(rt_id)
         else {
             return false;
         };
-        Self::node_field(&rt_fields, columns).is_some()
+        rt_fields.node_id_at(columns).is_some()
     }
 
     /// Argument count for a DDL function declaration.
     pub(super) fn function_arity(&self, fields: &NodeFields, args_field: u8) -> AritySpec {
-        let Some(args_id) = Self::node_field(fields, args_field) else {
+        let Some(args_id) = fields.node_id_at(args_field) else {
             return AritySpec::Any;
         };
         let Some(children) = self.stmt.list_children(args_id) else {
@@ -319,14 +371,14 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
         AritySpec::Exact(children.len())
     }
 
-    // ── SELECT-shaped column inference (used by analyzer + lineage) ──────
+    // ── SELECT-shaped column inference (analyzer + lineage) ─────────────
 
     /// Names produced by a SELECT body.
     ///
-    /// Returns `Some(names)` when every result column has an inferable name
-    /// (alias, bare column ref, or expression source text). Returns `None`
-    /// when any column is `*` or otherwise unnameable, telling the caller to
-    /// register the table conservatively.
+    /// Returns `Some(names)` when every result column has an inferable
+    /// name (alias, bare column ref, or expression source text). Returns
+    /// `None` when any column is `*` or otherwise unnameable, telling
+    /// the caller to register the table conservatively.
     pub(crate) fn columns_from_select(&self, select_id: AnyNodeId) -> Option<Vec<String>> {
         let (
             SemanticRole::Query {
@@ -337,7 +389,7 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
         else {
             return None;
         };
-        let list_id = Self::node_field(&select_fields, cols_idx)?;
+        let list_id = select_fields.node_id_at(cols_idx)?;
         let mut out = Vec::new();
         let mut bailed = false;
         self.for_each_result_column(list_id, |fields, flags_idx, alias_idx, expr_idx| {
@@ -368,80 +420,32 @@ impl<'a, 'stmt> DdlReader<'a, 'stmt> {
     /// Mirrors `SQLite`'s `sqlite3ExprListSetName` / `sqlite3ExprListSetSpan`:
     /// 1. Explicit alias → use alias text.
     /// 2. Bare `ColumnRef` with no alias → use the column-name span.
-    /// 3. Any other expression → use the raw source text of the expression
-    ///    (`SQLite` calls this `ENAME_SPAN`).
+    /// 3. Any other expression → use the raw source text of the
+    ///    expression (`SQLite` calls this `ENAME_SPAN`).
     pub(crate) fn infer_result_col_name(
         &self,
         child_fields: &NodeFields,
         alias_idx: u8,
         expr_idx: u8,
     ) -> Option<String> {
-        if let Some(alias_id) = Self::node_field(child_fields, alias_idx)
-            && let Some(name) = self.first_span_text(alias_id)
+        if let Some(alias_id) = child_fields.node_id_at(alias_idx)
+            && let Some(name) = self.stmt.first_span_text(alias_id)
         {
             return Some(name.to_ascii_lowercase());
         }
-        let expr_id = Self::node_field(child_fields, expr_idx)?;
+        let expr_id = child_fields.node_id_at(expr_idx)?;
         if let Some((
             SemanticRole::ColumnRef {
                 column: col_idx, ..
             },
             expr_fields,
         )) = self.role_for_node(expr_id)
-            && let Some(name) = self.span_field_text(&expr_fields, col_idx)
+            && let Some(name) = self.stmt.span_field_text(&expr_fields, col_idx)
         {
             return Some(name.to_ascii_lowercase());
         }
-        self.expr_source_text(expr_id).map(str::to_ascii_lowercase)
-    }
-
-    /// Source slice spanning every byte covered by `id`'s subtree.
-    pub(crate) fn expr_source_text(&self, id: AnyNodeId) -> Option<&'stmt str> {
-        let mut min = StmtOffset::from_raw(u32::MAX);
-        let mut max = StmtOffset::default();
-        self.collect_spans(id, &mut min, &mut max);
-        if min < max {
-            Some(
-                &self.stmt.text()[StmtRange {
-                    start: min,
-                    end: max,
-                }],
-            )
-        } else {
-            None
-        }
-    }
-
-    fn collect_spans(&self, id: AnyNodeId, min: &mut StmtOffset, max: &mut StmtOffset) {
-        if id.is_null() {
-            return;
-        }
-        if let Some((_, fields)) = self.stmt.extract_fields(id) {
-            for i in 0..fields.len() {
-                match fields[i] {
-                    FieldValue::Span(sp) if !sp.is_empty() => {
-                        let (text, off) = self.stmt.span_text(sp);
-                        let start = off;
-                        let end = start
-                            + StmtLen::from_raw(u32::try_from(text.len()).unwrap_or(u32::MAX));
-                        if start < *min {
-                            *min = start;
-                        }
-                        if end > *max {
-                            *max = end;
-                        }
-                    }
-                    FieldValue::NodeId(child) if !child.is_null() => {
-                        self.collect_spans(child, min, max);
-                    }
-                    _ => {}
-                }
-            }
-        }
-        if let Some(children) = self.stmt.list_children(id) {
-            for &child in children {
-                self.collect_spans(child, min, max);
-            }
-        }
+        self.stmt
+            .expr_source_text(expr_id)
+            .map(str::to_ascii_lowercase)
     }
 }

--- a/syntaqlite/src/analysis/ddl.rs
+++ b/syntaqlite/src/analysis/ddl.rs
@@ -444,8 +444,12 @@ impl<'a, 'stmt> SemanticPropertyExtractor<'a, 'stmt> {
         {
             return Some(name.to_ascii_lowercase());
         }
+        // Fall back to the parser's recorded extent for this node — its
+        // source-text slice covers the full expression including any
+        // operators/punctuation. Requires `with_collect_node_extents` on
+        // the parser config, which the analyzer enables.
         self.stmt
-            .expr_source_text(expr_id)
-            .map(str::to_ascii_lowercase)
+            .node_text(expr_id)
+            .map(|(text, _)| text.to_ascii_lowercase())
     }
 }

--- a/syntaqlite/src/analysis/engine/mod.rs
+++ b/syntaqlite/src/analysis/engine/mod.rs
@@ -211,6 +211,7 @@ impl Analyzer {
             syntax,
             &ParserConfig::default()
                 .with_collect_tokens(true)
+                .with_collect_node_extents(true)
                 .with_macro_fallback(self.macro_fallback),
         );
 

--- a/syntaqlite/src/analysis/engine/mod.rs
+++ b/syntaqlite/src/analysis/engine/mod.rs
@@ -24,7 +24,7 @@ use super::{AnalysisContext, AnalysisMode};
 
 use helpers::{extract_macro_registration, parse_error_span};
 
-use super::ddl::DdlReader;
+use super::ddl::SemanticPropertyExtractor;
 
 mod helpers;
 mod pass;
@@ -329,7 +329,8 @@ impl Analyzer {
 
         let lineage = super::lineage::compute_lineage(erased, root_id, ctx.catalog, roles);
 
-        let defined_relations = DdlReader::new(erased, roles).defined_relations(root_id);
+        let defined_relations =
+            SemanticPropertyExtractor::new(erased, roles).defined_relations(root_id);
 
         StatementAnalysis::new(
             erased.text().as_str().to_owned(),

--- a/syntaqlite/src/analysis/engine/walker.rs
+++ b/syntaqlite/src/analysis/engine/walker.rs
@@ -20,7 +20,7 @@ use syntaqlite_syntax::any::{
 use syntaqlite_syntax::source::DocRange;
 
 use crate::analysis::catalog::{Catalog, ColumnResolution, FunctionCheckResult};
-use crate::analysis::ddl::DdlReader;
+use crate::analysis::ddl::SemanticPropertyExtractor;
 use crate::dialect::{FIELD_ABSENT, SemanticRole};
 
 use super::query_scope::{QueryScope, RowIdPolicy};
@@ -206,17 +206,17 @@ fn walk_node<P: WalkPass>(
     let Some((tag, fields)) = stmt.extract_fields(node_id) else {
         return;
     };
-    let role = DdlReader::new(stmt, cx.roles).role_for_tag(tag);
+    let role = SemanticPropertyExtractor::new(stmt, cx.roles).role_for_tag(tag);
 
     match role {
         SemanticRole::DefineTable { select, .. } | SemanticRole::DefineView { select, .. } => {
             if P::WANTS_RELATION_DEFINITION || P::WANTS_COLUMN_DEFINITION {
                 emit_ddl_definitions(stmt, cx.roles, pass, node_id);
             }
-            walk_opt(stmt, cx, pass, DdlReader::node_field(&fields, select));
+            walk_opt(stmt, cx, pass, fields.node_id_at(select));
         }
         SemanticRole::DefineFunction { select, .. } => {
-            walk_opt(stmt, cx, pass, DdlReader::node_field(&fields, select));
+            walk_opt(stmt, cx, pass, fields.node_id_at(select));
         }
         SemanticRole::ReturnSpec { .. } | SemanticRole::Import { .. } => {}
 
@@ -307,7 +307,7 @@ fn emit_ddl_definitions<P: WalkPass>(
     pass: &mut P,
     node_id: AnyNodeId,
 ) {
-    let reader = DdlReader::new(stmt, roles);
+    let reader = SemanticPropertyExtractor::new(stmt, roles);
     let Some((table_name, table_range)) = reader.name_span(node_id) else {
         return;
     };
@@ -332,8 +332,7 @@ fn walk_source_ref<P: WalkPass>(
     name_idx: u8,
     alias_idx: u8,
 ) {
-    let reader = DdlReader::new(stmt, cx.roles);
-    let Some((name, range)) = reader.span_field_range(fields, name_idx) else {
+    let Some((name, range)) = stmt.span_field_range(fields, name_idx) else {
         return;
     };
 
@@ -351,9 +350,7 @@ fn walk_source_ref<P: WalkPass>(
         pass.on_source_ref(stmt, cx, ev);
     }
 
-    let alias = DdlReader::new(stmt, cx.roles)
-        .name_text(DdlReader::node_field(fields, alias_idx))
-        .0;
+    let alias = stmt.name_text(fields.node_id_at(alias_idx)).0;
     let scope_name = if alias.is_empty() { name } else { alias };
     cx.scope
         .add_table(scope_name, columns, without_rowid.into());
@@ -368,9 +365,9 @@ fn walk_call<P: WalkPass>(
     name_idx: u8,
     args_idx: u8,
 ) {
-    let reader = DdlReader::new(stmt, cx.roles);
-    if let Some((name, range)) = reader.span_field_range(fields, name_idx) {
-        let arg_count = DdlReader::node_field(fields, args_idx)
+    if let Some((name, range)) = stmt.span_field_range(fields, name_idx) {
+        let arg_count = fields
+            .node_id_at(args_idx)
             .and_then(|id| stmt.list_children(id))
             .map_or(0, <[_]>::len);
         let result = cx.catalog.check_function(name, arg_count);
@@ -457,14 +454,14 @@ fn walk_scoped_source<P: WalkPass>(
     body_idx: u8,
     alias_idx: u8,
 ) {
-    let body_id = DdlReader::node_field(fields, body_idx);
+    let body_id = fields.node_id_at(body_idx);
     cx.scope.push();
     walk_opt(stmt, cx, pass, body_id);
     cx.scope.pop();
 
-    let reader = DdlReader::new(stmt, cx.roles);
-    let alias = reader.name_text(DdlReader::node_field(fields, alias_idx)).0;
-    let cols = body_id.and_then(|id| reader.columns_from_select(id));
+    let alias = stmt.name_text(fields.node_id_at(alias_idx)).0;
+    let cols = body_id
+        .and_then(|id| SemanticPropertyExtractor::new(stmt, cx.roles).columns_from_select(id));
     if alias.is_empty() {
         cx.scope.add_anonymous(cols);
     } else {
@@ -489,8 +486,8 @@ fn walk_query<P: WalkPass>(
     // Push a fresh scope so that tables registered by walk_source_ref are
     // visible when we visit SELECT columns, WHERE, ORDER BY, etc.
     cx.scope.push();
-    walk_opt(stmt, cx, pass, DdlReader::node_field(fields, from));
-    walk_opt(stmt, cx, pass, DdlReader::node_field(fields, columns));
+    walk_opt(stmt, cx, pass, fields.node_id_at(from));
+    walk_opt(stmt, cx, pass, fields.node_id_at(columns));
 
     // Collect SELECT aliases so they are visible in WHERE, GROUP BY, HAVING,
     // ORDER BY, and LIMIT — matching SQLite's resolution rules.
@@ -501,7 +498,7 @@ fn walk_query<P: WalkPass>(
     }
 
     for idx in [where_clause, groupby, having, orderby, limit_clause] {
-        walk_opt(stmt, cx, pass, DdlReader::node_field(fields, idx));
+        walk_opt(stmt, cx, pass, fields.node_id_at(idx));
     }
     cx.scope.pop();
 }
@@ -513,13 +510,13 @@ fn collect_select_aliases(
     columns_idx: u8,
 ) -> Vec<String> {
     let mut aliases = Vec::new();
-    let Some(list_id) = DdlReader::node_field(fields, columns_idx) else {
+    let Some(list_id) = fields.node_id_at(columns_idx) else {
         return aliases;
     };
-    let reader = DdlReader::new(stmt, roles);
+    let reader = SemanticPropertyExtractor::new(stmt, roles);
     reader.for_each_result_column(list_id, |child_fields, _flags, alias_idx, _expr| {
-        let alias_node = DdlReader::node_field(child_fields, alias_idx);
-        let (alias_text, _) = reader.name_text(alias_node);
+        let alias_node = child_fields.node_id_at(alias_idx);
+        let (alias_text, _) = reader.stmt().name_text(alias_node);
         if !alias_text.is_empty() {
             aliases.push(alias_text.to_string());
         }
@@ -539,8 +536,8 @@ fn walk_trigger_scope<P: WalkPass>(
     cx.scope.push();
     cx.scope.add_table("OLD", None, RowIdPolicy::WithRowId);
     cx.scope.add_table("NEW", None, RowIdPolicy::WithRowId);
-    walk_opt(stmt, cx, pass, DdlReader::node_field(fields, when_idx));
-    walk_opt(stmt, cx, pass, DdlReader::node_field(fields, body_idx));
+    walk_opt(stmt, cx, pass, fields.node_id_at(when_idx));
+    walk_opt(stmt, cx, pass, fields.node_id_at(body_idx));
     cx.scope.pop();
 }
 
@@ -557,7 +554,7 @@ fn walk_cte_scope<P: WalkPass>(
 ) {
     cx.catalog.push_query_scope();
     register_cte_bindings(stmt, cx, pass, fields, recursive_idx, bindings_idx);
-    walk_opt(stmt, cx, pass, DdlReader::node_field(fields, body_idx));
+    walk_opt(stmt, cx, pass, fields.node_id_at(body_idx));
     cx.catalog.pop_query_scope();
 }
 
@@ -632,7 +629,8 @@ fn register_cte_bindings<P: WalkPass>(
     }
     let is_recursive = recursive_idx != FIELD_ABSENT
         && matches!(fields[recursive_idx as usize], FieldValue::Bool(true));
-    let cte_ids: &[AnyNodeId] = DdlReader::node_field(fields, bindings_idx)
+    let cte_ids: &[AnyNodeId] = fields
+        .node_id_at(bindings_idx)
         .and_then(|id| stmt.list_children(id))
         .unwrap_or(&[]);
 
@@ -686,9 +684,9 @@ fn register_cte_bindings<P: WalkPass>(
             if P::WANTS_COLUMN_DEFINITION {
                 emit_select_column_definitions(stmt, cx.roles, pass, binding.body_id, binding.name);
             }
-            binding
-                .body_id
-                .and_then(|id| DdlReader::new(stmt, cx.roles).columns_from_select(id))
+            binding.body_id.and_then(|id| {
+                SemanticPropertyExtractor::new(stmt, cx.roles).columns_from_select(id)
+            })
         };
         cx.catalog.add_query_table(binding.name, cols);
     }
@@ -699,12 +697,12 @@ fn extract_cte_binding<'b>(
     roles: &'static [SemanticRole],
     cte_id: AnyNodeId,
 ) -> Option<CteBindingInfo<'b>> {
-    let reader = DdlReader::new(stmt, roles);
+    let reader = SemanticPropertyExtractor::new(stmt, roles);
     let (
         SemanticRole::CteBinding {
             name: name_idx,
-            columns: cols_idx,
             body: body_idx,
+            ..
         },
         fields,
     ) = reader.role_for_node(cte_id)?
@@ -713,31 +711,15 @@ fn extract_cte_binding<'b>(
     };
 
     let (name, name_range) = reader
+        .stmt()
         .span_field_range(&fields, name_idx)
         .unwrap_or_default();
     Some(CteBindingInfo {
         name,
         name_range,
-        body_id: DdlReader::node_field(&fields, body_idx),
-        declared_cols: extract_declared_cols(&reader, &fields, cols_idx),
+        body_id: fields.node_id_at(body_idx),
+        declared_cols: reader.cte_declared_cols(cte_id),
     })
-}
-
-fn extract_declared_cols<'b>(
-    reader: &DdlReader<'_, 'b>,
-    fields: &NodeFields,
-    cols_idx: u8,
-) -> Option<Vec<(&'b str, DocRange)>> {
-    let list_id = DdlReader::node_field(fields, cols_idx)?;
-    let children = reader.stmt().list_children(list_id)?;
-    let mut names: Vec<(&'b str, DocRange)> = Vec::with_capacity(children.len());
-    for &id in children {
-        let (text, range) = reader.name_text(Some(id));
-        if !text.is_empty() {
-            names.push((text, range));
-        }
-    }
-    if names.is_empty() { None } else { Some(names) }
 }
 
 fn count_result_columns(
@@ -746,7 +728,7 @@ fn count_result_columns(
     body_id: Option<AnyNodeId>,
 ) -> Option<usize> {
     let body_id = body_id?;
-    let reader = DdlReader::new(stmt, roles);
+    let reader = SemanticPropertyExtractor::new(stmt, roles);
     let (
         SemanticRole::Query {
             columns: cols_idx, ..
@@ -756,7 +738,7 @@ fn count_result_columns(
     else {
         return None;
     };
-    let list_id = DdlReader::node_field(&body_fields, cols_idx)?;
+    let list_id = body_fields.node_id_at(cols_idx)?;
 
     let mut count = 0usize;
     let mut saw_star = false;
@@ -781,7 +763,7 @@ fn emit_select_column_definitions<P: WalkPass>(
     table_name: &str,
 ) {
     let Some(body_id) = body_id else { return };
-    let reader = DdlReader::new(stmt, roles);
+    let reader = SemanticPropertyExtractor::new(stmt, roles);
     let Some((
         SemanticRole::Query {
             columns: cols_idx, ..
@@ -791,12 +773,12 @@ fn emit_select_column_definitions<P: WalkPass>(
     else {
         return;
     };
-    let Some(list_id) = DdlReader::node_field(&fields, cols_idx) else {
+    let Some(list_id) = fields.node_id_at(cols_idx) else {
         return;
     };
     reader.for_each_result_column(list_id, |child_fields, _flags, alias_idx, _expr| {
-        let alias_node = DdlReader::node_field(child_fields, alias_idx);
-        let (alias_text, alias_range) = reader.name_text(alias_node);
+        let alias_node = child_fields.node_id_at(alias_idx);
+        let (alias_text, alias_range) = reader.stmt().name_text(alias_node);
         if !alias_text.is_empty() {
             pass.on_column_definition(table_name, alias_text, alias_range);
         }

--- a/syntaqlite/src/analysis/engine/walker.rs
+++ b/syntaqlite/src/analysis/engine/walker.rs
@@ -15,7 +15,7 @@
 //! grep-able.
 
 use syntaqlite_syntax::any::{
-    AnyNodeId, AnyParseError, AnyParsedStatement, FieldValue, NodeFields, TextSpan,
+    AnyNodeId, AnyParseError, AnyParsedStatement, FieldValue, NodeFields,
 };
 use syntaqlite_syntax::source::DocRange;
 
@@ -413,7 +413,10 @@ fn walk_column_ref<P: WalkPass>(
         _ => None,
     };
     let (_, range) = stmt.span_text_abs(col_sp);
-    let dqs_candidate = is_double_quoted_span(stmt, col_sp);
+    // SQLite's DQS bug-compat applies only to identifiers that were
+    // written with `"..."` quotes (not backticks or brackets) and that
+    // came from the original source (not a macro expansion).
+    let dqs_candidate = col_sp.is_macro_free() && col_sp.quote_char() == Some('"');
 
     let resolution = cx.scope.resolve_column(table, column);
 
@@ -429,21 +432,6 @@ fn walk_column_ref<P: WalkPass>(
         };
         pass.on_column_ref(stmt, cx, ev);
     }
-}
-
-/// True iff `sp` is a macro-free span whose opening quote in the authored
-/// statement text is `"` (not `` ` `` or `[`).  Callers use this to apply
-/// `SQLite`'s DQS fallback, which only applies to double-quoted identifiers.
-fn is_double_quoted_span(stmt: &AnyParsedStatement<'_>, sp: TextSpan) -> bool {
-    if !sp.is_quoted() || !sp.is_macro_free() {
-        return false;
-    }
-    let (_, off) = stmt.span_text(sp);
-    let off = off.as_usize();
-    if off == 0 {
-        return false;
-    }
-    stmt.text().as_str().as_bytes().get(off - 1) == Some(&b'"')
 }
 
 fn walk_scoped_source<P: WalkPass>(

--- a/syntaqlite/src/analysis/lineage/resolver.rs
+++ b/syntaqlite/src/analysis/lineage/resolver.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use syntaqlite_syntax::any::{AnyNodeId, AnyParsedStatement, FieldValue};
 
 use crate::analysis::catalog::Catalog;
-use crate::analysis::ddl::DdlReader;
+use crate::analysis::ddl::{FromSource, SemanticPropertyExtractor};
 use crate::dialect::SemanticRole;
 
 use super::types::{
@@ -50,7 +50,7 @@ enum ColumnSpec {
 
 /// Walks the AST to compute column lineage.
 pub(super) struct LineageResolver<'a, 'b> {
-    reader: DdlReader<'a, 'b>,
+    sema: SemanticPropertyExtractor<'a, 'b>,
     catalog: &'a Catalog,
     /// CTE name -> body node ID (from WITH clause, before FROM is walked).
     cte_bodies: HashMap<String, AnyNodeId>,
@@ -67,7 +67,7 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
         roles: &'a [SemanticRole],
     ) -> Self {
         Self {
-            reader: DdlReader::new(stmt, roles),
+            sema: SemanticPropertyExtractor::new(stmt, roles),
             catalog,
             cte_bodies: HashMap::new(),
             tracing: HashSet::new(),
@@ -76,7 +76,7 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
     }
 
     fn stmt(&self) -> &'a AnyParsedStatement<'b> {
-        self.reader.stmt()
+        self.sema.stmt()
     }
 
     /// Entry point: find the outermost SELECT and resolve its lineage.
@@ -85,20 +85,20 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
     }
 
     fn resolve_node(&mut self, node_id: AnyNodeId) -> Option<QueryLineage> {
-        let (role, fields) = self.reader.role_for_node(node_id)?;
+        let (role, fields) = self.sema.role_for_node(node_id)?;
         match role {
             SemanticRole::CteScope { bindings, body, .. } => {
-                if let Some(bindings_id) = DdlReader::node_field(&fields, bindings) {
+                if let Some(bindings_id) = fields.node_id_at(bindings) {
                     self.collect_cte_bindings(bindings_id);
                 }
-                DdlReader::node_field(&fields, body).and_then(|id| self.resolve_node(id))
+                fields.node_id_at(body).and_then(|id| self.resolve_node(id))
             }
             SemanticRole::Query { .. } => self.resolve_select(node_id),
             SemanticRole::DefineTable { select, .. }
             | SemanticRole::DefineView { select, .. }
-            | SemanticRole::DefineFunction { select, .. } => {
-                DdlReader::node_field(&fields, select).and_then(|id| self.resolve_node(id))
-            }
+            | SemanticRole::DefineFunction { select, .. } => fields
+                .node_id_at(select)
+                .and_then(|id| self.resolve_node(id)),
             SemanticRole::Transparent | SemanticRole::DmlScope { .. } => {
                 for child_id in self.stmt().child_node_ids(node_id) {
                     if let Some(result) = self.resolve_node(child_id) {
@@ -112,27 +112,19 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
     }
 
     fn collect_cte_bindings(&mut self, bindings_id: AnyNodeId) {
-        let Some(children) = self.stmt().list_children(bindings_id) else {
-            self.try_register_cte(bindings_id);
-            return;
-        };
-        for &child_id in children {
-            self.try_register_cte(child_id);
-        }
-    }
-
-    fn try_register_cte(&mut self, node_id: AnyNodeId) {
-        let Some((SemanticRole::CteBinding { name, body, .. }, fields)) =
-            self.reader.role_for_node(node_id)
-        else {
-            return;
-        };
-        let Some(cte_name) = self.reader.name_field_text(&fields, name) else {
-            return;
-        };
-        if let Some(body_id) = DdlReader::node_field(&fields, body) {
-            self.cte_bodies
-                .insert(cte_name.to_ascii_lowercase(), body_id);
+        // Collect into a temp Vec so the iterator borrow on self.sema doesn't
+        // conflict with the &mut self.cte_bodies write.
+        let mut entries: Vec<(String, AnyNodeId)> = Vec::new();
+        self.sema.for_each_cte_binding(bindings_id, |binding| {
+            if binding.name.is_empty() {
+                return;
+            }
+            if let Some(body_id) = binding.body_id {
+                entries.push((binding.name.to_ascii_lowercase(), body_id));
+            }
+        });
+        for (name, body_id) in entries {
+            self.cte_bodies.insert(name, body_id);
         }
     }
 
@@ -146,16 +138,16 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
                 ..
             },
             fields,
-        ) = self.reader.role_for_node(select_id)?
+        ) = self.sema.role_for_node(select_id)?
         else {
             return None;
         };
 
         // 1. Walk FROM to build the source map.
-        let mut sources = HashMap::new();
-        if let Some(from_id) = DdlReader::node_field(&fields, from) {
-            self.collect_sources(from_id, &mut sources);
-        }
+        let sources = match fields.node_id_at(from) {
+            Some(from_id) => self.collect_sources(from_id),
+            None => HashMap::new(),
+        };
 
         // 2. Resolve result columns.
         let columns = self.resolve_result_columns(cols_idx, &fields, &sources)?;
@@ -236,65 +228,53 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
 
     // ── FROM source collection ───────────────────────────────────────────
 
-    /// Walk a FROM clause and populate `target` with source entries.
-    fn collect_sources(&self, from_id: AnyNodeId, target: &mut HashMap<String, SourceInfo>) {
-        let Some((role, fields)) = self.reader.role_for_node(from_id) else {
-            return;
-        };
-        match role {
-            SemanticRole::SourceRef { name, alias, .. } => {
-                let Some(sn) = self.reader.name_field_text(&fields, name) else {
-                    return;
-                };
-                let alias_name = self.reader.name_field_text(&fields, alias);
-                let display = alias_name.unwrap_or(sn).to_ascii_lowercase();
-                let canonical = sn.to_ascii_lowercase();
-
-                let (columns, kind) = if let Some(&body) = self.cte_bodies.get(&canonical) {
-                    (self.reader.columns_from_select(body), SourceKind::Cte(body))
-                } else {
-                    let (cols, _) = self.catalog.table_source_info(&canonical);
-                    let kind = if self.catalog.is_view(&canonical) {
-                        SourceKind::View
+    /// Walk a FROM clause and return a map of display-name → `SourceInfo`.
+    /// Uses [`SemanticPropertyExtractor::for_each_from_source`] so the
+    /// SourceRef/ScopedSource role-dispatch is shared with the analyzer.
+    fn collect_sources(&self, from_id: AnyNodeId) -> HashMap<String, SourceInfo> {
+        let mut target: HashMap<String, SourceInfo> = HashMap::new();
+        self.sema
+            .for_each_from_source(from_id, |source| match source {
+                FromSource::Relation { name, alias, .. } => {
+                    let display = alias.unwrap_or(name).to_ascii_lowercase();
+                    let canonical = name.to_ascii_lowercase();
+                    let (columns, kind) = if let Some(&body) = self.cte_bodies.get(&canonical) {
+                        (self.sema.columns_from_select(body), SourceKind::Cte(body))
                     } else {
-                        SourceKind::Table
+                        let (cols, _) = self.catalog.table_source_info(&canonical);
+                        let kind = if self.catalog.is_view(&canonical) {
+                            SourceKind::View
+                        } else {
+                            SourceKind::Table
+                        };
+                        (cols, kind)
                     };
-                    (cols, kind)
-                };
-
-                target.insert(
-                    display,
-                    SourceInfo {
-                        canonical,
-                        columns,
-                        kind,
-                    },
-                );
-            }
-            SemanticRole::ScopedSource { body, alias } => {
-                let Some(alias_text) = self.reader.name_field_text(&fields, alias) else {
-                    return;
-                };
-                let Some(body_id) = DdlReader::node_field(&fields, body) else {
-                    return;
-                };
-                let alias_lower = alias_text.to_ascii_lowercase();
-                let cols = self.reader.columns_from_select(body_id);
-                target.insert(
-                    alias_lower.clone(),
-                    SourceInfo {
-                        canonical: alias_lower,
-                        columns: cols,
-                        kind: SourceKind::Subquery(body_id),
-                    },
-                );
-            }
-            _ => {
-                for child_id in self.stmt().child_node_ids(from_id) {
-                    self.collect_sources(child_id, target);
+                    target.insert(
+                        display,
+                        SourceInfo {
+                            canonical,
+                            columns,
+                            kind,
+                        },
+                    );
                 }
-            }
-        }
+                FromSource::Subquery { alias, body_id, .. } => {
+                    let Some(alias_text) = alias else {
+                        return;
+                    };
+                    let alias_lower = alias_text.to_ascii_lowercase();
+                    let cols = self.sema.columns_from_select(body_id);
+                    target.insert(
+                        alias_lower.clone(),
+                        SourceInfo {
+                            canonical: alias_lower,
+                            columns: cols,
+                            kind: SourceKind::Subquery(body_id),
+                        },
+                    );
+                }
+            });
+        target
     }
 
     /// Recursively collect physical tables and catalog relations from a CTE/subquery body.
@@ -308,16 +288,15 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
         let Some(select_id) = self.find_select_node(body_id) else {
             return;
         };
-        let Some((SemanticRole::Query { from, .. }, fields)) = self.reader.role_for_node(select_id)
+        let Some((SemanticRole::Query { from, .. }, fields)) = self.sema.role_for_node(select_id)
         else {
             return;
         };
-        let Some(from_id) = DdlReader::node_field(&fields, from) else {
+        let Some(from_id) = fields.node_id_at(from) else {
             return;
         };
 
-        let mut inner_sources = HashMap::new();
-        self.collect_sources(from_id, &mut inner_sources);
+        let inner_sources = self.collect_sources(from_id);
         let snapshot: Vec<SourceInfo> = inner_sources.into_values().collect();
         for info in &snapshot {
             self.flatten_source(info, relations, physical_tables, unexpanded_views);
@@ -332,7 +311,7 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
         select_fields: &syntaqlite_syntax::any::NodeFields,
         sources: &HashMap<String, SourceInfo>,
     ) -> Option<Vec<ColumnLineage>> {
-        let list_id = DdlReader::node_field(select_fields, cols_idx)?;
+        let list_id = select_fields.node_id_at(cols_idx)?;
         let specs = self.collect_column_specs(list_id);
 
         let mut result = Vec::new();
@@ -373,12 +352,12 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
     }
 
     /// Snapshot result-column specs (Star vs. Named) so the borrow on
-    /// `self.reader` from iteration doesn't conflict with `&mut self` used by
+    /// `self.sema` from iteration doesn't conflict with `&mut self` used by
     /// the trace_* methods.
     fn collect_column_specs(&self, list_id: AnyNodeId) -> Vec<ColumnSpec> {
         let mut specs = Vec::new();
-        let reader = self.reader;
-        reader.for_each_result_column(list_id, |fields, flags_idx, alias_idx, expr_idx| {
+        let sema = self.sema;
+        sema.for_each_result_column(list_id, |fields, flags_idx, alias_idx, expr_idx| {
             let is_star = matches!(
                 fields[flags_idx as usize],
                 FieldValue::Flags(f) if f & 1 != 0
@@ -386,10 +365,10 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
             if is_star {
                 specs.push(ColumnSpec::Star);
             } else {
-                let name = reader
+                let name = sema
                     .infer_result_col_name(fields, alias_idx, expr_idx)
                     .unwrap_or_default();
-                let expr_id = DdlReader::node_field(fields, expr_idx);
+                let expr_id = fields.node_id_at(expr_idx);
                 specs.push(ColumnSpec::Named { name, expr_id });
             }
             true
@@ -449,30 +428,30 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
                 ..
             },
             fields,
-        ) = self.reader.role_for_node(select_id)?
+        ) = self.sema.role_for_node(select_id)?
         else {
             return None;
         };
 
         // Build inner source map for this body.
-        let mut inner_sources = HashMap::new();
-        if let Some(from_id) = DdlReader::node_field(&fields, from) {
-            self.collect_sources(from_id, &mut inner_sources);
-        }
+        let inner_sources = match fields.node_id_at(from) {
+            Some(from_id) => self.collect_sources(from_id),
+            None => HashMap::new(),
+        };
 
-        let list_id = DdlReader::node_field(&fields, cols_idx)?;
+        let list_id = fields.node_id_at(cols_idx)?;
 
         // Find the matching result column's expression node.
         let mut found_expr_id: Option<AnyNodeId> = None;
         let target = col_name.to_ascii_lowercase();
-        let reader = self.reader;
-        reader.for_each_result_column(list_id, |child_fields, _flags, alias_idx, expr_idx| {
-            let name = reader.infer_result_col_name(child_fields, alias_idx, expr_idx);
+        let sema = self.sema;
+        sema.for_each_result_column(list_id, |child_fields, _flags, alias_idx, expr_idx| {
+            let name = sema.infer_result_col_name(child_fields, alias_idx, expr_idx);
             if name
                 .as_deref()
-                .is_some_and(|n| n.eq_ignore_ascii_case(&target))
+                .is_some_and(|n: &str| n.eq_ignore_ascii_case(&target))
             {
-                found_expr_id = DdlReader::node_field(child_fields, expr_idx);
+                found_expr_id = child_fields.node_id_at(expr_idx);
                 return false;
             }
             true
@@ -493,16 +472,16 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
                 table: tbl_idx,
             },
             expr_fields,
-        ) = self.reader.role_for_node(expr_id)?
+        ) = self.sema.role_for_node(expr_id)?
         else {
             return None;
         };
 
-        let col_name = self
-            .reader
+        let stmt = self.stmt();
+        let col_name = stmt
             .span_field_text(&expr_fields, col_idx)?
             .to_ascii_lowercase();
-        let source_name = match self.reader.span_field_text(&expr_fields, tbl_idx) {
+        let source_name = match stmt.span_field_text(&expr_fields, tbl_idx) {
             Some(t) => t.to_ascii_lowercase(),
             None => find_source_for_column(sources, &col_name)?,
         };
@@ -513,12 +492,12 @@ impl<'a, 'b> LineageResolver<'a, 'b> {
     // ── AST navigation helpers ───────────────────────────────────────────
 
     fn find_select_node(&self, node_id: AnyNodeId) -> Option<AnyNodeId> {
-        let (role, fields) = self.reader.role_for_node(node_id)?;
+        let (role, fields) = self.sema.role_for_node(node_id)?;
         match role {
             SemanticRole::Query { .. } => Some(node_id),
-            SemanticRole::CteScope { body, .. } => {
-                DdlReader::node_field(&fields, body).and_then(|id| self.find_select_node(id))
-            }
+            SemanticRole::CteScope { body, .. } => fields
+                .node_id_at(body)
+                .and_then(|id| self.find_select_node(id)),
             SemanticRole::Transparent => {
                 for child_id in self.stmt().child_node_ids(node_id) {
                     if let Some(result) = self.find_select_node(child_id) {

--- a/syntaqlite/src/lsp/host.rs
+++ b/syntaqlite/src/lsp/host.rs
@@ -707,7 +707,7 @@ fn record_external_definitions(
 ) {
     use syntaqlite_syntax::ParseOutcome;
 
-    use crate::analysis::ddl::DdlReader;
+    use crate::analysis::ddl::SemanticPropertyExtractor;
 
     let parser = syntaqlite_syntax::Parser::new();
     let mut session = parser.parse(ddl);
@@ -720,7 +720,7 @@ fn record_external_definitions(
         let Some(root) = stmt.root() else { continue };
         let root_id = root.node_id().into();
         let erased = stmt.erase();
-        let reader = DdlReader::new(&erased, dialect.roles());
+        let reader = SemanticPropertyExtractor::new(&erased, dialect.roles());
         if let Some((name, range)) = reader.name_span(root_id) {
             defs.insert_relation(&name, file_uri, range);
             for (col_name, col_range) in reader.column_spans(root_id) {

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -1100,7 +1100,6 @@ pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::child_node_ids(&self, id:
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::comment_spans(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::CommentSpan> + use<'_>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::comments(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>> + use<'_, 'a>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::expanded_text(&self) -> &'a str
-pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::expr_source_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a str>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::extract_fields(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(syntaqlite_syntax::any::AnyNodeTag, syntaqlite_syntax::any::NodeFields)>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::first_span_text(&self, node_id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a str>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::full_text(&self) -> &'a syntaqlite_syntax::source::DocText
@@ -1168,6 +1167,7 @@ pub fn syntaqlite_syntax::any::NodeFields::node_id_at(&self, idx: u8) -> core::o
 pub fn syntaqlite_syntax::any::TextSpan::is_empty(self) -> bool
 pub fn syntaqlite_syntax::any::TextSpan::is_macro_free(self) -> bool
 pub fn syntaqlite_syntax::any::TextSpan::is_quoted(self) -> bool
+pub fn syntaqlite_syntax::any::TextSpan::quote_char(self) -> core::option::Option<char>
 pub fn syntaqlite_syntax::nodes::AggregateFunctionCall<'_>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn syntaqlite_syntax::nodes::AggregateFunctionCall<'a>::args(&self) -> core::option::Option<syntaqlite_syntax::nodes::ExprList<'a>>
 pub fn syntaqlite_syntax::nodes::AggregateFunctionCall<'a>::filter_clause(&self) -> core::option::Option<syntaqlite_syntax::nodes::Expr<'a>>

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -928,6 +928,7 @@ pub const fn syntaqlite_syntax::source::Utf16Line::as_u32(self) -> u32
 pub const fn syntaqlite_syntax::source::Utf16Line::as_usize(self) -> usize
 pub const fn syntaqlite_syntax::source::Utf16Line::from_raw(v: u32) -> Self
 pub const syntaqlite_syntax::MACRO_BODY_CALL_ARG_INTERNAL: syntaqlite_syntax::source::LayerOffset
+pub const syntaqlite_syntax::any::FIELD_ABSENT: u8
 pub enum syntaqlite_syntax::CommentKind
 pub enum syntaqlite_syntax::CommentSide
 pub enum syntaqlite_syntax::ParseOutcome<T, E>
@@ -1099,17 +1100,23 @@ pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::child_node_ids(&self, id:
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::comment_spans(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::CommentSpan> + use<'_>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::comments(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>> + use<'_, 'a>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::expanded_text(&self) -> &'a str
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::expr_source_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a str>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::extract_fields(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(syntaqlite_syntax::any::AnyNodeTag, syntaqlite_syntax::any::NodeFields)>
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::first_span_text(&self, node_id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a str>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::full_text(&self) -> &'a syntaqlite_syntax::source::DocText
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::is_macro_free(&self) -> bool
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::list_children(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a [syntaqlite_syntax::any::AnyNodeId]>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::macro_rewrites(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRewrite<'a>> + use<'_, 'a>
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::name_field_text(&self, fields: &syntaqlite_syntax::any::NodeFields, idx: u8) -> core::option::Option<&'a str>
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::name_text(&self, node_id: core::option::Option<syntaqlite_syntax::any::AnyNodeId>) -> (&'a str, syntaqlite_syntax::source::DocRange)
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_expanded_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a str>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_is_macro_free(&self, id: syntaqlite_syntax::any::AnyNodeId) -> bool
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(&'a str, syntaqlite_syntax::source::StmtOffset)>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_id(&self) -> syntaqlite_syntax::any::AnyNodeId
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_node(&self) -> core::option::Option<syntaqlite_syntax::any::AnyNode<'_>>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_expanded_text(&self, span: syntaqlite_syntax::any::TextSpan) -> &'a str
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_field_range(&self, fields: &syntaqlite_syntax::any::NodeFields, idx: u8) -> core::option::Option<(&'a str, syntaqlite_syntax::source::DocRange)>
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_field_text(&self, fields: &syntaqlite_syntax::any::NodeFields, idx: u8) -> core::option::Option<&'a str>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_text(&self, span: syntaqlite_syntax::any::TextSpan) -> (&'a str, syntaqlite_syntax::source::StmtOffset)
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_text_abs(&self, span: syntaqlite_syntax::any::TextSpan) -> (&'a str, syntaqlite_syntax::source::DocRange)
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::statement_base(&self) -> syntaqlite_syntax::source::StatementBase
@@ -1157,6 +1164,7 @@ pub fn syntaqlite_syntax::any::NodeFields::fmt(&self, f: &mut core::fmt::Formatt
 pub fn syntaqlite_syntax::any::NodeFields::index(&self, idx: usize) -> &syntaqlite_syntax::any::FieldValue
 pub fn syntaqlite_syntax::any::NodeFields::is_empty(&self) -> bool
 pub fn syntaqlite_syntax::any::NodeFields::len(&self) -> usize
+pub fn syntaqlite_syntax::any::NodeFields::node_id_at(&self, idx: u8) -> core::option::Option<syntaqlite_syntax::any::AnyNodeId>
 pub fn syntaqlite_syntax::any::TextSpan::is_empty(self) -> bool
 pub fn syntaqlite_syntax::any::TextSpan::is_macro_free(self) -> bool
 pub fn syntaqlite_syntax::any::TextSpan::is_quoted(self) -> bool


### PR DESCRIPTION
The analysis crate's DdlReader had two unrelated jobs jammed together:
field-shaped parse-tree convenience (poke at a span field, follow a
NodeId, read a Name node) and role-table-driven extraction (what does
this CREATE TABLE define, iterate this WITH clause's bindings). The
field-shaped half had no business living in analysis — it's just AST
poking that any consumer of the parser benefits from. The DdlReader
name was actively misleading, since most of its methods weren't about
DDL.

This PR splits the two:

* syntaqlite-syntax: AnyParsedStatement gains span_field_text,
  span_field_range, name_text, first_span_text, name_field_text,
  expr_source_text. NodeFields gains node_id_at. FIELD_ABSENT moves
  here too (the sentinel pattern is part of the parser's field-index
  abstraction). All field-shaped poking now lives where it belongs.

* syntaqlite analysis: DdlReader → SemanticPropertyExtractor.
  Shrinks to just the role-aware methods (role_for_tag, the
  for_each_* iterators, name_span/column_spans/defined_relations,
  columns_from_select, infer_result_col_name, cte_declared_cols).
  The struct still earns its place — it bundles (stmt, roles) so
  call sites don't repeat both args, and every method genuinely
  needs the role table.

* Iterator additions: for_each_cte_binding and for_each_from_source.
  Lineage's collect_cte_bindings and collect_sources now use them
  instead of re-implementing role dispatch.

* Call sites updated: catalog, walker, lineage, lsp/host. Methods
  that were `reader.span_field_text(...)` are now `stmt.span_field_text(...)`
  — the (stmt, roles) bundle is reserved for things that actually
  need both.

All workspace tests pass.

