### PR TITLE
synq: bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,35 @@
 # Changelog
 
-## Unreleased
+## 0.5.0
 
 **Breaking:**
-- Renamed `TableAccess` → `PhysicalTableAccess` and `StatementModel::tables_accessed()` → `physical_tables_accessed()` in the Rust API. The corresponding C symbols `SyntaqliteTableAccess`, `syntaqlite_validator_table_count`, `syntaqlite_validator_tables`, `syntaqlite_validator_statement_table_count`, and `syntaqlite_validator_statement_tables` are renamed with a `physical_` infix. The Python `Lineage` attribute is renamed `tables` → `physical_tables`.
+- Renamed the `semantic` module to `analysis` across the Rust, C, Python, and CLI surfaces. Rust `syntaqlite::semantic` → `syntaqlite::analysis`, C symbols drop their `syntaqlite_semantic_` prefix for `syntaqlite_analysis_`, and Python `syntaqlite.semantic` → `syntaqlite.analysis` ([#225](https://github.com/LalitMaganti/syntaqlite/pull/225)).
+- Renamed `TableAccess` to `PhysicalTableAccess` and `StatementModel::tables_accessed()` to `physical_tables_accessed()`. The corresponding C symbols (`SyntaqliteTableAccess`, `syntaqlite_validator_table_count`, `syntaqlite_validator_tables`, and the per-statement variants) gain a `physical_` infix, and the Python `Lineage` attribute renames `tables` to `physical_tables`.
+- Python bindings no longer link against `libsyntaqlite` directly. They now shell out to the `syntaqlite` CLI binary over msgpack RPC, so `pip install syntaqlite` pulls the CLI in as part of the package ([#196](https://github.com/LalitMaganti/syntaqlite/pull/196)).
 
-**Added:**
-- New `syntaqlite lineage [tables|columns] [FILES]` CLI subcommand. Emits NDJSON (`schema_version: 0`, pre-stable) or human-readable text for column and table lineage. Exit 1 when any statement fails to parse or validate.
-- New `StatementModel::unexpanded_views()` accessor — canonical names of views whose bodies weren't available for expansion (surfaces as a structured partial-reason in the CLI output).
-- Matching C FFI: `SyntaqliteUnexpandedView` struct plus aggregate (`syntaqlite_validator_unexpanded_view_count` / `syntaqlite_validator_unexpanded_views`) and per-statement (`syntaqlite_validator_statement_unexpanded_view_count` / `syntaqlite_validator_statement_unexpanded_views`) accessors. Python `Lineage` objects expose the same data via `unexpanded_views: list[str]`.
+**CLI:**
+- Added `syntaqlite lineage [tables|columns] [FILES]`. Emits NDJSON (`schema_version: 0`, pre-stable) or human-readable text for column and table lineage, and exits 1 when any statement fails to parse or validate ([#163](https://github.com/LalitMaganti/syntaqlite/pull/163)).
+- Added `syntaqlite tokenize` for dumping the token stream, and regrouped dialect-management commands under a dedicated `syntaqlite dialect ...` subcommand group ([#178](https://github.com/LalitMaganti/syntaqlite/pull/178)).
+- Added `syntaqlite validate --output json` for structured diagnostics ([#177](https://github.com/LalitMaganti/syntaqlite/pull/177)).
+
+**Analysis and validator:**
+- Added `StatementModel::unexpanded_views()`, exposing canonical names of views whose bodies were not available for expansion. Surfaces through C FFI as `SyntaqliteUnexpandedView` with aggregate and per-statement accessors, and in Python via `Lineage.unexpanded_views`.
+- Added C FFI setters for per-check toggles, `strict-schema`, and the fuzzy suggestion threshold on the validator ([#180](https://github.com/LalitMaganti/syntaqlite/pull/180)). Those knobs are now sticky across schema reloads ([#181](https://github.com/LalitMaganti/syntaqlite/pull/181)).
+- Added C FFI for registering custom scalar and table-valued functions against a dialect ([#185](https://github.com/LalitMaganti/syntaqlite/pull/185)).
+- Diagnostics now carry a stable code (e.g. `unknown-table`) exposed via the C FFI and the Python `Diagnostic.code` attribute ([#184](https://github.com/LalitMaganti/syntaqlite/pull/184)).
+- SQLite's double-quoted string (DQS) fallback is now applied when a double-quoted column reference cannot be resolved, matching real SQLite behavior ([#224](https://github.com/LalitMaganti/syntaqlite/pull/224)).
+
+**C API:**
+- Added the `SYNTAQLITE_OMIT_RUNTIME` build flag for compiling cdylib dialect plugins that reuse the host process's runtime symbols instead of bundling their own copy ([#174](https://github.com/LalitMaganti/syntaqlite/pull/174)).
+
+**Macros and formatter:**
+- Fixed the formatter dropping text that appeared after a macro invocation ([#172](https://github.com/LalitMaganti/syntaqlite/pull/172)).
+- Fixed macro expansion when the replacement text is shorter than the original call site ([#173](https://github.com/LalitMaganti/syntaqlite/pull/173)).
+- Fallback (unresolved) macro-call arguments are now formatted with structure rather than as an opaque blob ([#221](https://github.com/LalitMaganti/syntaqlite/pull/221)).
+- `MacroRewrite` now exposes the call-site arguments for each expansion, not just the expanded body ([#227](https://github.com/LalitMaganti/syntaqlite/pull/227)).
+
+**MCP server:**
+- Tightened `keyword_case` argument validation and fixed the MCP server reporting the wrong dialect symbol ([#229](https://github.com/LalitMaganti/syntaqlite/pull/229)).
 
 ## 0.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Breaking:**
 - Renamed the `semantic` module to `analysis` across the Rust, C, Python, and CLI surfaces. Rust `syntaqlite::semantic` → `syntaqlite::analysis`, C symbols drop their `syntaqlite_semantic_` prefix for `syntaqlite_analysis_`, and Python `syntaqlite.semantic` → `syntaqlite.analysis` ([#225](https://github.com/LalitMaganti/syntaqlite/pull/225)).
 - Renamed `TableAccess` to `PhysicalTableAccess` and `StatementModel::tables_accessed()` to `physical_tables_accessed()`. The corresponding C symbols (`SyntaqliteTableAccess`, `syntaqlite_validator_table_count`, `syntaqlite_validator_tables`, and the per-statement variants) gain a `physical_` infix, and the Python `Lineage` attribute renames `tables` to `physical_tables`.
-- Python bindings no longer link against `libsyntaqlite` directly. They now shell out to the `syntaqlite` CLI binary over msgpack RPC, so `pip install syntaqlite` pulls the CLI in as part of the package ([#196](https://github.com/LalitMaganti/syntaqlite/pull/196)).
+- Python bindings no longer link against `libsyntaqlite` directly. They now shell out to the `syntaqlite` CLI binary over JSON-RPC, so `pip install syntaqlite` pulls the CLI in as part of the package ([#196](https://github.com/LalitMaganti/syntaqlite/pull/196)).
 
 **CLI:**
 - Added `syntaqlite lineage [tables|columns] [FILES]`. Emits NDJSON (`schema_version: 0`, pre-stable) or human-readable text for column and table lineage, and exits 1 when any statement fails to parse or validate ([#163](https://github.com/LalitMaganti/syntaqlite/pull/163)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "benches"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "syntaqlite",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "glob",
  "libloading",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-buildtools"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "cc",
  "clap",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-cli"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "clap",
  "glob",
@@ -1075,11 +1075,11 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-common"
-version = "0.4.2"
+version = "0.5.0"
 
 [[package]]
 name = "syntaqlite-syntax"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "cc",
  "libloading",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-wasm"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ cargo install syntaqlite-cli
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.4.2", features = ["fmt"] }
+syntaqlite = { version = "0.5.0", features = ["fmt"] }
 ```
 
 **Python** ([API docs](https://docs.syntaqlite.com/latest/reference/python-api/))

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syntaqlite",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "SQLite SQL language server — diagnostics, formatting, completions, and semantic tokens",
   "author": {
     "name": "Lalit Maganti"

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "syntaqlite",
   "displayName": "syntaqlite",
   "description": "SQL language support powered by syntaqlite — diagnostics, formatting, completions, and semantic highlighting",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "publisher": "syntaqlite",
   "license": "Apache-2.0",
   "icon": "icon.png",

--- a/integrations/zed/Cargo.toml
+++ b/integrations/zed/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "syntaqlite-zed"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 
 [lib]

--- a/integrations/zed/extension.toml
+++ b/integrations/zed/extension.toml
@@ -3,7 +3,7 @@
 
 id = "syntaqlite"
 name = "Syntaqlite"
-version = "0.4.2"
+version = "0.5.0"
 schema_version = 1
 authors = ["Lalit Maganti <lalitmaganti@gmail.com>"]
 description = "SQL language support powered by syntaqlite — tokenizer, parser, formatter and validator built on SQLite's own grammar."

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntaqlite"
-version = "0.4.2"
+version = "0.5.0"
 description = "SQLite SQL tools — parser, formatter, validator, and MCP server"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}

--- a/python/syntaqlite/__init__.py
+++ b/python/syntaqlite/__init__.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from .nodes import _wrap
 
-__version__ = "0.4.2"
+__version__ = "0.5.0"
 
 
 # ── Binary discovery ──────────────────────────────────────────────────────────

--- a/syntaqlite-buildtools/Cargo.toml
+++ b/syntaqlite-buildtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-buildtools"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 description = "Internal codegen and build tools for syntaqlite — not intended for direct use"
 license = "Apache-2.0"
@@ -20,8 +20,8 @@ dist = false
 doc = false
 
 [dependencies]
-syntaqlite-common = { version = "0.4.2", path = "../syntaqlite-common" }
-syntaqlite-syntax = { version = "0.4.2", path = "../syntaqlite-syntax", default-features = false, features = ["embedded-sources"] }
+syntaqlite-common = { version = "0.5.0", path = "../syntaqlite-common" }
+syntaqlite-syntax = { version = "0.5.0", path = "../syntaqlite-syntax", default-features = false, features = ["embedded-sources"] }
 clap = { version = "4.5", features = ["derive"] }
 tempfile = "3.8"
 serde = { version = "1", features = ["derive"] }

--- a/syntaqlite-cli/Cargo.toml
+++ b/syntaqlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-cli"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 repository.workspace = true
 description = "Fast, accurate SQLite SQL formatter, validator, and language server — built on SQLite's own grammar"
@@ -42,8 +42,8 @@ rmcp = { version = "0.1", features = ["server", "transport-io"], optional = true
 schemars = { version = "0.8", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-syntaqlite = { version = "0.4.2", path = "../syntaqlite", default-features = false, features = ["fmt", "lsp", "analysis", "experimental-embedded", "serde-json"] }
-syntaqlite-syntax = { version = "0.4.2", path = "../syntaqlite-syntax" }
-syntaqlite-buildtools = { version = "0.4.2", path = "../syntaqlite-buildtools", optional = true }
+syntaqlite = { version = "0.5.0", path = "../syntaqlite", default-features = false, features = ["fmt", "lsp", "analysis", "experimental-embedded", "serde-json"] }
+syntaqlite-syntax = { version = "0.5.0", path = "../syntaqlite-syntax" }
+syntaqlite-buildtools = { version = "0.5.0", path = "../syntaqlite-buildtools", optional = true }
 tempfile = "3.8"
 tokio = { version = "1", features = ["rt", "macros", "io-std"], optional = true }

--- a/syntaqlite-common/Cargo.toml
+++ b/syntaqlite-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-common"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 description = "Internal shared primitives for syntaqlite — not intended for direct use"
 license = "Apache-2.0"

--- a/syntaqlite-syntax/Cargo.toml
+++ b/syntaqlite-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-syntax"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 links = "syntaqlite_syntax"
 description = "Internal parser and tokenizer for syntaqlite — not intended for direct use"

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! syntaqlite = { version = "0.4.2", default-features = false, features = ["sqlite"] }
+//! syntaqlite = { version = "0.5.0", default-features = false, features = ["sqlite"] }
 //! ```
 
 // ==== Public API ====

--- a/syntaqlite-wasm/Cargo.toml
+++ b/syntaqlite-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-wasm"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 repository.workspace = true
 

--- a/syntaqlite/Cargo.toml
+++ b/syntaqlite/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "syntaqlite"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 description = "Parser, formatter, validator, and language server for SQLite SQL — built on SQLite's own grammar"
 license = "Apache-2.0"
@@ -40,8 +40,8 @@ pin-cflags = ["sqlite", "syntaqlite-syntax/pin-cflags"]    # Pin compile-time fl
 workspace = true
 
 [dependencies]
-syntaqlite-common = { version = "0.4.2", path = "../syntaqlite-common" }
-syntaqlite-syntax = { version = "0.4.2", path = "../syntaqlite-syntax", default-features = false }
+syntaqlite-common = { version = "0.5.0", path = "../syntaqlite-common" }
+syntaqlite-syntax = { version = "0.5.0", path = "../syntaqlite-syntax", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 libloading = { version = "0.8", optional = true }

--- a/tests/benches/Cargo.toml
+++ b/tests/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benches"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 publish = false
 

--- a/tests/comparison/parser/Cargo.toml
+++ b/tests/comparison/parser/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "parser-bench"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 
 [[bin]]

--- a/web/docs/content/guides/rust-api.md
+++ b/web/docs/content/guides/rust-api.md
@@ -10,7 +10,7 @@ weight = 1
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.4.2", features = ["fmt"] }
+syntaqlite = { version = "0.5.0", features = ["fmt"] }
 ```
 
 ## Format a query
@@ -127,7 +127,7 @@ Add the `analysis` and `sqlite` features:
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.4.2", features = ["analysis", "sqlite"] }
+syntaqlite = { version = "0.5.0", features = ["analysis", "sqlite"] }
 ```
 
 ```rust

--- a/web/syntaqlite-js/package.json
+++ b/web/syntaqlite-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syntaqlite",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "SQLite SQL parser, formatter, and validator for the browser — powered by WebAssembly",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Cuts the 0.5.0 release. CHANGELOG entries inline below.

**Breaking:**
- Renamed the `semantic` module to `analysis` across Rust, C, Python, and CLI (#225).
- Renamed `TableAccess` → `PhysicalTableAccess` (Rust/C/Python).
- Python bindings now shell out to the `syntaqlite` CLI over JSON-RPC (#196).

**CLI:**
- Added `syntaqlite lineage`, `syntaqlite tokenize`, and `validate --output json`.

**Analysis and validator:**
- `unexpanded_views()` surfaced on Rust/C/Python.
- C FFI setters for per-check toggles, `strict-schema`, suggestion threshold, now sticky across schema loads.
- C FFI for registering custom scalar and table-valued functions.
- Stable diagnostic codes on the C FFI and Python `Diagnostic.code`.
- Apply SQLite DQS fallback for unresolved double-quoted column refs.

**C API:**
- Added `SYNTAQLITE_OMIT_RUNTIME` for cdylib dialect plugins.

**Macros and formatter:**
- Fixed formatter dropping text after a macro invocation.
- Fixed macro expansion when replacement text is shorter than the call site.
- Structured formatting of fallback macro-call arguments.
- `MacroRewrite` exposes call-site arguments.

**MCP server:**
- Stricter `keyword_case` validation and correct reported dialect symbol.

## Test plan
- [ ] CI passes
- [ ] Release workflows kick off after tag push