### PR TITLE
synq: fix release pipeline smoke test + linux wheel plat tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           target/release/${{ matrix.binary }} --version
           echo "select 1" | target/release/${{ matrix.binary }} fmt
-          echo "select 1" | target/release/${{ matrix.binary }} validate
+          echo "select 1" | target/release/${{ matrix.binary }} analyze
 
       # -- Package CLI archive --
       - name: Package CLI (tar.gz)
@@ -243,8 +243,17 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_deployment }}
         run: |
-          python -m pip install --upgrade build
+          python -m pip install --upgrade build wheel
           python -m build --wheel --outdir wheelhouse/ python/
+
+      # PyPI rejects plain linux_* wheels; retag the bundled-binary wheel to
+      # manylinux2014_* so upload goes through.
+      - name: Retag Linux wheel as manylinux
+        if: startsWith(matrix.name, 'linux-')
+        shell: bash
+        run: |
+          arch=$(echo "${{ matrix.name }}" | sed 's/^linux-//')
+          python -m wheel tags --remove --platform-tag "manylinux2014_${arch}" wheelhouse/*.whl
 
       - name: Upload wheel
         uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,17 +243,24 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_deployment }}
         run: |
-          python -m pip install --upgrade build wheel
+          python -m pip install --upgrade build
           python -m build --wheel --outdir wheelhouse/ python/
 
-      # PyPI rejects plain linux_* wheels; retag the bundled-binary wheel to
-      # manylinux2014_* so upload goes through.
-      - name: Retag Linux wheel as manylinux
+      # PyPI rejects plain linux_* wheels. Run auditwheel to validate the
+      # bundled CLI binary against manylinux and emit a correctly-tagged wheel.
+      - name: Repair Linux wheel with auditwheel
         if: startsWith(matrix.name, 'linux-')
         shell: bash
         run: |
+          python -m pip install auditwheel
           arch=$(echo "${{ matrix.name }}" | sed 's/^linux-//')
-          python -m wheel tags --remove --platform-tag "manylinux2014_${arch}" wheelhouse/*.whl
+          python -m auditwheel show wheelhouse/*.whl
+          python -m auditwheel repair \
+            --plat "manylinux_2_28_${arch}" \
+            --wheel-dir wheelhouse-repaired/ \
+            wheelhouse/*.whl
+          rm wheelhouse/*.whl
+          mv wheelhouse-repaired/*.whl wheelhouse/
 
       - name: Upload wheel
         uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,18 +221,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: linux-x86_64, runner: ubuntu-latest}
-          - {name: linux-aarch64, runner: ubuntu-24.04-arm}
+          - {name: linux-x86_64, runner: ubuntu-latest, container: "quay.io/pypa/manylinux_2_28_x86_64"}
+          - {name: linux-aarch64, runner: ubuntu-24.04-arm, container: "quay.io/pypa/manylinux_2_28_aarch64"}
           - {name: macos-arm64, runner: macos-latest, macos_deployment: "11.0"}
           - {name: macos-x86_64, runner: macos-26-intel, macos_deployment: "10.12"}
           - {name: windows-amd64, runner: windows-latest}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v6
 
+      # The manylinux image ships its own Pythons under /opt/python/; expose
+      # cp312 on PATH. Non-container runners use setup-python below instead.
+      - name: Use manylinux Python (Linux container)
+        if: ${{ matrix.container }}
+        shell: bash
+        run: echo "/opt/python/cp312-cp312/bin" >> "$GITHUB_PATH"
+
       - uses: actions/setup-python@v6
+        if: ${{ !matrix.container }}
         with:
           python-version: "3.12"
+
+      - name: Install Rust (Linux container)
+        if: ${{ matrix.container }}
+        shell: bash
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain stable --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Build CLI
         shell: bash
@@ -246,8 +263,10 @@ jobs:
           python -m pip install --upgrade build
           python -m build --wheel --outdir wheelhouse/ python/
 
-      # PyPI rejects plain linux_* wheels. Run auditwheel to validate the
-      # bundled CLI binary against manylinux and emit a correctly-tagged wheel.
+      # PyPI rejects plain linux_* wheels. auditwheel validates the bundled
+      # CLI binary against manylinux_2_28 and emits a correctly-tagged wheel;
+      # the build runs inside the matching manylinux container so the glibc
+      # symbol requirements line up.
       - name: Repair Linux wheel with auditwheel
         if: startsWith(matrix.name, 'linux-')
         shell: bash

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           syntaqlite --version
           echo "SELECT 1" | syntaqlite fmt
-          echo "SELECT 1" | syntaqlite validate
+          echo "SELECT 1" | syntaqlite analyze
 
   test-brew:
     name: Homebrew
@@ -53,7 +53,7 @@ jobs:
         run: |
           syntaqlite --version
           echo "SELECT 1" | syntaqlite fmt
-          echo "SELECT 1" | syntaqlite validate
+          echo "SELECT 1" | syntaqlite analyze
 
   test-npm:
     name: npm (browser e2e against registry)
@@ -131,4 +131,4 @@ jobs:
         run: |
           syntaqlite --version
           echo "SELECT 1" | syntaqlite fmt
-          echo "SELECT 1" | syntaqlite validate
+          echo "SELECT 1" | syntaqlite analyze

--- a/python/setup.py
+++ b/python/setup.py
@@ -14,7 +14,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from setuptools import setup
+from setuptools import Distribution, setup
 from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -41,11 +41,14 @@ if _bin_dir.exists() and any(_bin_dir.iterdir()):
     package_data["syntaqlite"] = ["bin/*"]
 
 
-class bdist_wheel(_bdist_wheel):
-    def finalize_options(self):
-        super().finalize_options()
-        self.root_is_pure = False
+class BinaryDistribution(Distribution):
+    # Forces a platlib wheel (Root-Is-Purelib: false) so auditwheel is willing
+    # to inspect the bundled CLI binary under syntaqlite/bin/.
+    def has_ext_modules(self):
+        return True
 
+
+class bdist_wheel(_bdist_wheel):
     def get_tag(self):
         _, _, plat = super().get_tag()
         return "py3", "none", plat
@@ -53,6 +56,7 @@ class bdist_wheel(_bdist_wheel):
 
 setup(
     name="syntaqlite",
+    distclass=BinaryDistribution,
     cmdclass={"bdist_wheel": bdist_wheel},
     package_data=package_data,
 )


### PR DESCRIPTION
The v0.5.0 release workflow broke in two places:

1. **Smoke test.** `release.yml` and `test-install.yml` call `syntaqlite validate`, but the subcommand was renamed to `analyze` in #225. Changed to `analyze`.
2. **PyPI platform tag.** `python -m build` emits Linux wheels tagged `py3-none-linux_x86_64` / `linux_aarch64`, which PyPI 400s. Retag to `manylinux2014_*` post-build using `wheel tags`.

Follow-up will bump to 0.5.1 and cut a clean release; 0.5.0 is being marked as a pre-release since crates.io/npm are already live.

## Test plan
- [ ] CI passes
- [ ] Verified by cutting 0.5.1