### PR TITLE
synq: bump version to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 0.5.0
+## 0.5.1
+
+> **Note:** 0.5.0 was tagged but never released. Its release workflow failed to upload Python wheels and CLI binaries (stale `validate` subcommand reference in the smoke test, and the `linux_*` wheel platform tag is not accepted by PyPI). 0.5.1 bundles every change originally intended for 0.5.0 plus the pipeline fixes.
 
 **Breaking:**
 - Renamed the `semantic` module to `analysis` across the Rust, C, Python, and CLI surfaces. Rust `syntaqlite::semantic` → `syntaqlite::analysis`, C symbols drop their `syntaqlite_semantic_` prefix for `syntaqlite_analysis_`, and Python `syntaqlite.semantic` → `syntaqlite.analysis` ([#225](https://github.com/LalitMaganti/syntaqlite/pull/225)).
@@ -10,7 +12,7 @@
 **CLI:**
 - Added `syntaqlite lineage [tables|columns] [FILES]`. Emits NDJSON (`schema_version: 0`, pre-stable) or human-readable text for column and table lineage, and exits 1 when any statement fails to parse or validate ([#163](https://github.com/LalitMaganti/syntaqlite/pull/163)).
 - Added `syntaqlite tokenize` for dumping the token stream, and regrouped dialect-management commands under a dedicated `syntaqlite dialect ...` subcommand group ([#178](https://github.com/LalitMaganti/syntaqlite/pull/178)).
-- Added `syntaqlite validate --output json` for structured diagnostics ([#177](https://github.com/LalitMaganti/syntaqlite/pull/177)).
+- Added `syntaqlite analyze --output json` for structured diagnostics ([#177](https://github.com/LalitMaganti/syntaqlite/pull/177)).
 
 **Analysis and validator:**
 - Added `StatementModel::unexpanded_views()`, exposing canonical names of views whose bodies were not available for expansion. Surfaces through C FFI as `SyntaqliteUnexpandedView` with aggregate and per-statement accessors, and in Python via `Lineage.unexpanded_views`.
@@ -30,6 +32,13 @@
 
 **MCP server:**
 - Tightened `keyword_case` argument validation and fixed the MCP server reporting the wrong dialect symbol ([#229](https://github.com/LalitMaganti/syntaqlite/pull/229)).
+
+**Release pipeline:**
+- Fixed the 0.5.0 release failure: smoke test now calls `syntaqlite analyze` instead of the renamed `validate`, and Linux wheels are built inside the `manylinux_2_28` container and validated with `auditwheel` so they publish to PyPI with a correct platform tag ([#233](https://github.com/LalitMaganti/syntaqlite/pull/233)).
+
+## 0.5.0
+
+*Never released. See the 0.5.1 notes above; everything intended for 0.5.0 ships there.*
 
 ## 0.4.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "benches"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "criterion",
  "syntaqlite",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "glob",
  "libloading",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-buildtools"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "cc",
  "clap",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "glob",
@@ -1075,11 +1075,11 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-common"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "syntaqlite-syntax"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "cc",
  "libloading",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-wasm"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ cargo install syntaqlite-cli
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.5.0", features = ["fmt"] }
+syntaqlite = { version = "0.5.1", features = ["fmt"] }
 ```
 
 **Python** ([API docs](https://docs.syntaqlite.com/latest/reference/python-api/))

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syntaqlite",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "SQLite SQL language server — diagnostics, formatting, completions, and semantic tokens",
   "author": {
     "name": "Lalit Maganti"

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "syntaqlite",
   "displayName": "syntaqlite",
   "description": "SQL language support powered by syntaqlite — diagnostics, formatting, completions, and semantic highlighting",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publisher": "syntaqlite",
   "license": "Apache-2.0",
   "icon": "icon.png",

--- a/integrations/zed/Cargo.toml
+++ b/integrations/zed/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "syntaqlite-zed"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 
 [lib]

--- a/integrations/zed/extension.toml
+++ b/integrations/zed/extension.toml
@@ -3,7 +3,7 @@
 
 id = "syntaqlite"
 name = "Syntaqlite"
-version = "0.5.0"
+version = "0.5.1"
 schema_version = 1
 authors = ["Lalit Maganti <lalitmaganti@gmail.com>"]
 description = "SQL language support powered by syntaqlite — tokenizer, parser, formatter and validator built on SQLite's own grammar."

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntaqlite"
-version = "0.5.0"
+version = "0.5.1"
 description = "SQLite SQL tools — parser, formatter, validator, and MCP server"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}

--- a/python/syntaqlite/__init__.py
+++ b/python/syntaqlite/__init__.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from .nodes import _wrap
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 
 # ── Binary discovery ──────────────────────────────────────────────────────────

--- a/syntaqlite-buildtools/Cargo.toml
+++ b/syntaqlite-buildtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-buildtools"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Internal codegen and build tools for syntaqlite — not intended for direct use"
 license = "Apache-2.0"
@@ -20,8 +20,8 @@ dist = false
 doc = false
 
 [dependencies]
-syntaqlite-common = { version = "0.5.0", path = "../syntaqlite-common" }
-syntaqlite-syntax = { version = "0.5.0", path = "../syntaqlite-syntax", default-features = false, features = ["embedded-sources"] }
+syntaqlite-common = { version = "0.5.1", path = "../syntaqlite-common" }
+syntaqlite-syntax = { version = "0.5.1", path = "../syntaqlite-syntax", default-features = false, features = ["embedded-sources"] }
 clap = { version = "4.5", features = ["derive"] }
 tempfile = "3.8"
 serde = { version = "1", features = ["derive"] }

--- a/syntaqlite-cli/Cargo.toml
+++ b/syntaqlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-cli"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 repository.workspace = true
 description = "Fast, accurate SQLite SQL formatter, validator, and language server — built on SQLite's own grammar"
@@ -42,8 +42,8 @@ rmcp = { version = "0.1", features = ["server", "transport-io"], optional = true
 schemars = { version = "0.8", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-syntaqlite = { version = "0.5.0", path = "../syntaqlite", default-features = false, features = ["fmt", "lsp", "analysis", "experimental-embedded", "serde-json"] }
-syntaqlite-syntax = { version = "0.5.0", path = "../syntaqlite-syntax" }
-syntaqlite-buildtools = { version = "0.5.0", path = "../syntaqlite-buildtools", optional = true }
+syntaqlite = { version = "0.5.1", path = "../syntaqlite", default-features = false, features = ["fmt", "lsp", "analysis", "experimental-embedded", "serde-json"] }
+syntaqlite-syntax = { version = "0.5.1", path = "../syntaqlite-syntax" }
+syntaqlite-buildtools = { version = "0.5.1", path = "../syntaqlite-buildtools", optional = true }
 tempfile = "3.8"
 tokio = { version = "1", features = ["rt", "macros", "io-std"], optional = true }

--- a/syntaqlite-common/Cargo.toml
+++ b/syntaqlite-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-common"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Internal shared primitives for syntaqlite — not intended for direct use"
 license = "Apache-2.0"

--- a/syntaqlite-syntax/Cargo.toml
+++ b/syntaqlite-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-syntax"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 links = "syntaqlite_syntax"
 description = "Internal parser and tokenizer for syntaqlite — not intended for direct use"

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! syntaqlite = { version = "0.5.0", default-features = false, features = ["sqlite"] }
+//! syntaqlite = { version = "0.5.1", default-features = false, features = ["sqlite"] }
 //! ```
 
 // ==== Public API ====

--- a/syntaqlite-wasm/Cargo.toml
+++ b/syntaqlite-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-wasm"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 repository.workspace = true
 

--- a/syntaqlite/Cargo.toml
+++ b/syntaqlite/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "syntaqlite"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Parser, formatter, validator, and language server for SQLite SQL — built on SQLite's own grammar"
 license = "Apache-2.0"
@@ -40,8 +40,8 @@ pin-cflags = ["sqlite", "syntaqlite-syntax/pin-cflags"]    # Pin compile-time fl
 workspace = true
 
 [dependencies]
-syntaqlite-common = { version = "0.5.0", path = "../syntaqlite-common" }
-syntaqlite-syntax = { version = "0.5.0", path = "../syntaqlite-syntax", default-features = false }
+syntaqlite-common = { version = "0.5.1", path = "../syntaqlite-common" }
+syntaqlite-syntax = { version = "0.5.1", path = "../syntaqlite-syntax", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 libloading = { version = "0.8", optional = true }

--- a/tests/benches/Cargo.toml
+++ b/tests/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benches"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 publish = false
 

--- a/tests/comparison/parser/Cargo.toml
+++ b/tests/comparison/parser/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "parser-bench"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [[bin]]

--- a/web/docs/content/guides/rust-api.md
+++ b/web/docs/content/guides/rust-api.md
@@ -10,7 +10,7 @@ weight = 1
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.5.0", features = ["fmt"] }
+syntaqlite = { version = "0.5.1", features = ["fmt"] }
 ```
 
 ## Format a query
@@ -127,7 +127,7 @@ Add the `analysis` and `sqlite` features:
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.5.0", features = ["analysis", "sqlite"] }
+syntaqlite = { version = "0.5.1", features = ["analysis", "sqlite"] }
 ```
 
 ```rust

--- a/web/syntaqlite-js/package.json
+++ b/web/syntaqlite-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syntaqlite",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "SQLite SQL parser, formatter, and validator for the browser — powered by WebAssembly",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Cuts the 0.5.1 release. 0.5.0 was tagged but never released (broken release workflow); 0.5.1 consolidates all of the 0.5.0 work plus the pipeline fix landed in #233.

## Test plan
- [ ] CI passes
- [ ] Release workflow uploads wheels and CLI archives after tag push