### PR TITLE
synq: fix lineage outer-query tracking and fold upstream SQLite into main CI

### DIFF
--- a/.github/workflows/ci-docs-noop.yml
+++ b/.github/workflows/ci-docs-noop.yml
@@ -25,12 +25,6 @@ jobs:
     steps:
       - run: echo "docs-only change; main CI skipped"
 
-  upstream-sqlite-validation:
-    name: Upstream SQLite validation
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "docs-only change; main CI skipped"
-
   zed-extension:
     name: Zed extension build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
-# CI: run pre-push checks (fmt/clippy/C checks/public API/unit tests/integration suites),
-# upstream SQLite validation, amalgamation build, Zed extension, UI tests, and Playwright e2e tests
-# on every PR and push to main.
+# CI: run pre-push checks (fmt/clippy/C checks/public API/unit tests/integration suites)
+# plus upstream SQLite validation, amalgamation build, Zed extension, UI tests, and
+# Playwright e2e tests on every PR and push to main.
 name: CI
 
 on:
@@ -38,6 +38,9 @@ jobs:
           path: third_party
           key: third-party-${{ runner.os }}-${{ hashFiles('python/tools/install_build_deps.py') }}
 
+      - name: Install system dependencies (tcl-dev for upstream SQLite suite)
+        run: sudo apt-get update && sudo apt-get install -y tcl-dev
+
       - name: Install build dependencies
         run: python3 tools/install-build-deps
 
@@ -72,45 +75,15 @@ jobs:
           CC: clang
           CXX: clang++
 
+      - name: Run upstream SQLite validation tests
+        run: tools/run-integration-tests --suite upstream-sqlite --validate
+
       - name: Upload CLI binary
         uses: actions/upload-artifact@v6
         with:
           name: syntaqlite-cli
           path: target/debug/syntaqlite
           retention-days: 1
-
-  upstream-sqlite-validation:
-    name: Upstream SQLite validation
-    needs: [pre-push]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y tcl-dev
-
-      - name: Cache third_party
-        uses: actions/cache@v5
-        with:
-          path: third_party
-          key: third-party-${{ runner.os }}-${{ hashFiles('python/tools/install_build_deps.py') }}
-
-      - name: Install build dependencies
-        run: python3 tools/install-build-deps
-
-      - name: Download CLI binary
-        uses: actions/download-artifact@v7
-        with:
-          name: syntaqlite-cli
-          path: target/debug
-
-      - name: Make CLI binary executable
-        run: chmod +x target/debug/syntaqlite
-
-      - name: Run upstream SQLite validation tests
-        run: tools/run-integration-tests --suite upstream-sqlite --validate
 
   zed-extension:
     name: Zed extension build

--- a/syntaqlite/src/analysis/lineage/mod.rs
+++ b/syntaqlite/src/analysis/lineage/mod.rs
@@ -79,8 +79,9 @@ pub(crate) struct LineageCapture {
     per_query: HashMap<AnyNodeId, QuerySummary>,
     /// Stack of in-progress Queries; innermost on top.
     stack: Vec<InProgressQuery>,
-    /// The outermost Query in the statement — set from the first
-    /// `enter_query`. `None` when the statement isn't a query.
+    /// The outermost statement-level Query. Set from the first
+    /// `enter_query` at stack depth 0 that isn't a registered CTE body.
+    /// `None` when the statement isn't a query.
     outer_query: Option<AnyNodeId>,
 }
 
@@ -127,7 +128,12 @@ impl SemanticVisitor for LineageCapture {
     const WANTS_QUERY: bool = true;
 
     fn enter_query(&mut self, _stmt: &mut AnyParsedStatement<'_>, node_id: AnyNodeId) {
-        if self.outer_query.is_none() {
+        // Track the first statement-level Query. A WITH clause walks its
+        // CTE bodies (each a Query at stack depth 0) before the main
+        // body Query, so skip those — `on_cte_binding` has already
+        // registered their ids in `cte_bodies`.
+        let is_cte_body = self.cte_bodies.values().any(|id| *id == node_id);
+        if self.outer_query.is_none() && self.stack.is_empty() && !is_cte_body {
             self.outer_query = Some(node_id);
         }
         self.stack.push(InProgressQuery {

--- a/tests/lineage_diff_tests/expressions.py
+++ b/tests/lineage_diff_tests/expressions.py
@@ -52,7 +52,7 @@ class Expressions(TestSuite):
               status: complete
               target: (none)
               columns:
-                a as text <- (transformed)
+                cast(a as text) <- (transformed)
               relations:
                 t (table)
               physical_tables:
@@ -78,7 +78,7 @@ class Expressions(TestSuite):
               status: complete
               target: (none)
               columns:
-                sum(a <- (transformed)
+                sum(a) <- (transformed)
               relations:
                 t (table)
               physical_tables:


### PR DESCRIPTION
The lineage integration suite had four failures. Three came from a
CTE-body vs. outer-SELECT confusion in the forward-pass walker; the
other two were expected-output typos masking the real rendered text.
Also folds the standalone upstream SQLite validation CI job into the
main pre-push job so there is a single required check gating CI.

- **`syntaqlite/src/analysis/lineage/mod.rs`**: `outer_query` was set on
  the first `enter_query`, but a `WITH` clause walks each CTE body
  Query before the main SELECT — so the CTE body's lineage was what
  `build_lineage` returned. Now set `outer_query` only when entering
  a depth-0 Query that isn't a registered CTE body, preserving both
  the "show first branch" behavior for UNION/compound selects and the
  "show outer SELECT" behavior for WITH statements.
- **`tests/lineage_diff_tests/expressions.py`**: fix two expected-output
  typos — `sum(a <- (transformed)` → `sum(a) <- (transformed)` and
  `a as text` → `cast(a as text)`. The typos were hiding the correct
  rendered expression text.
- **`.github/workflows/ci.yml`**: merge the `upstream-sqlite-validation`
  job into the `pre-push` job. Apt-installs `tcl-dev` alongside the
  existing system dependency step, runs the upstream suite after the
  pre-push gate (reusing the same `third_party` cache and checkout),
  and drops the separate artifact download dance.
- **`.github/workflows/ci-docs-noop.yml`**: drop the matching
  `upstream-sqlite-validation` stub so the docs-only fallback mirrors
  the new required-check set.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

