### PR TITLE
synq: fix formatter crash + blank line on leading comments near untracked tokens

### DIFF
--- a/syntaqlite-buildtools/src/dialect_codegen/c_meta_codegen.rs
+++ b/syntaqlite-buildtools/src/dialect_codegen/c_meta_codegen.rs
@@ -136,13 +136,12 @@ impl AstModel<'_> {
 
         // ── Dispatch table ────────────────────────────────────────────────────
         let mut dispatch_table: Vec<u32> = vec![0xFFFF_0000; compiled.tag_count];
-        let mut ordinal_map: std::collections::HashMap<&str, usize> =
-            std::collections::HashMap::new();
-        let mut next_ordinal = 1usize;
-        for item in self.node_like_items() {
-            ordinal_map.insert(item.name(), next_ordinal);
-            next_ordinal += 1;
-        }
+        let ordinal_map: std::collections::HashMap<&str, usize> = self
+            .node_like_items()
+            .iter()
+            .enumerate()
+            .map(|(i, item)| (item.name(), i + 1))
+            .collect();
         for &(name, offset, length) in &node_ranges {
             if let Some(&ordinal) = ordinal_map.get(name) {
                 dispatch_table[ordinal] = (u32::from(offset) << 16) | u32::from(length);

--- a/syntaqlite-buildtools/src/util/grammar_parser.rs
+++ b/syntaqlite-buildtools/src/util/grammar_parser.rs
@@ -282,13 +282,9 @@ impl<'a, 'b> Parser<'a, 'b> {
                                 if end == "else" { /* include else branch */ }
                             }
                         }
-                        "ifndef" => {
-                            if parser.ifdef_is_defined() {
-                                let end = parser.skip_ifdef_block();
-                                if end == "else" { /* include else branch */ }
-                            } else {
-                                parser.skip_to_eol();
-                            }
+                        "ifndef" if parser.ifdef_is_defined() => {
+                            let end = parser.skip_ifdef_block();
+                            if end == "else" { /* include else branch */ }
                         }
                         "if" => {
                             if parser.if_should_include() {

--- a/syntaqlite-cli/src/config.rs
+++ b/syntaqlite-cli/src/config.rs
@@ -144,18 +144,16 @@ pub(crate) fn resolve_schemas(
 
 /// Simple glob matching using the `glob` crate's `Pattern`.
 fn glob_match(pattern: &str, path: &str) -> bool {
-    glob::Pattern::new(pattern)
-        .map(|p| {
-            p.matches_with(
-                path,
-                glob::MatchOptions {
-                    case_sensitive: true,
-                    require_literal_separator: true,
-                    require_literal_leading_dot: false,
-                },
-            )
-        })
-        .unwrap_or(false)
+    glob::Pattern::new(pattern).is_ok_and(|p| {
+        p.matches_with(
+            path,
+            glob::MatchOptions {
+                case_sensitive: true,
+                require_literal_separator: true,
+                require_literal_leading_dot: false,
+            },
+        )
+    })
 }
 
 #[cfg(test)]

--- a/syntaqlite/src/fmt/comment.rs
+++ b/syntaqlite/src/fmt/comment.rs
@@ -137,7 +137,7 @@ impl CommentCtx {
             if !skip_text_check {
                 let scan_end = before.min(source_end);
                 if t.end() < scan_end
-                    && has_non_comment_text(source, t.end(), scan_end, &self.comments, cursor + 1)
+                    && has_intervening_emitted_token(source, t.end(), scan_end, &self.tokens)
                 {
                     break;
                 }
@@ -188,7 +188,11 @@ impl CommentCtx {
                         let chunk = if next_is_contiguous_comment {
                             arena.cat(prefix, comment_doc)
                         } else {
-                            let hl2 = arena.hardline();
+                            // `comment_break` (not `hardline`) so that a
+                            // break op the fmt bytecode emits right after
+                            // this drain (e.g. a list element's leading
+                            // `line`) doesn't stack a second newline.
+                            let hl2 = arena.comment_break();
                             let inner = arena.cat(comment_doc, hl2);
                             arena.cat(prefix, inner)
                         };
@@ -345,37 +349,34 @@ impl CommentCtx {
     }
 }
 
-fn has_non_comment_text(
+/// Returns true if the token stream contains a token in `[start, end)` that
+/// the formatter will emit — i.e. any token other than a vestigial `(` / `)`.
+///
+/// The parser rule `expr ::= LP expr RP` is erased via `synq_pass`
+/// (parser-actions/expressions.y:30), so the inner `(` and `)` tokens remain
+/// in the token stream without any corresponding fmt opcode consuming them.
+/// They're not obstacles between a comment and its drain target; the drain
+/// must be allowed to step over them. All other token kinds (keywords,
+/// identifiers, operators, and paren tokens in tracked positions like
+/// function calls / IN / CAST) either sit at the drain target or will be
+/// emitted by some fmt opcode, so they *do* block a cross-drain.
+fn has_intervening_emitted_token(
     source: &StmtText,
     start: StmtOffset,
     end: StmtOffset,
-    comments: &[CommentEntry],
-    comment_start_idx: usize,
+    tokens: &[TokenEntry],
 ) -> bool {
-    let src = source.as_str().as_bytes();
-    let mut pos = start;
-    let mut ci = comment_start_idx;
-
-    while pos < end {
-        while ci < comments.len() {
-            let c_start = comments[ci].offset;
-            let c_end = comments[ci].end();
-            if pos >= c_start && pos < c_end {
-                pos = c_end;
-                ci += 1;
-                break;
-            } else if c_start > pos {
-                break;
-            }
-            ci += 1;
-        }
-        if pos >= end {
+    // Tokens are sorted by offset; binary-search for the first one that could
+    // overlap [start, end) to keep this O(log n + k) per call.
+    let first = tokens.partition_point(|t| t.end() <= start);
+    for tok in &tokens[first..] {
+        if tok.offset >= end {
             break;
         }
-        if !src[pos.as_usize()].is_ascii_whitespace() {
+        let text = &source[tok.range()];
+        if text != "(" && text != ")" {
             return true;
         }
-        pos += StmtLen::from_raw(1);
     }
     false
 }

--- a/syntaqlite/src/fmt/doc.rs
+++ b/syntaqlite/src/fmt/doc.rs
@@ -28,6 +28,15 @@ enum Doc<'a> {
     SoftLine,
     /// Always newline + indent.
     HardLine,
+    /// Like `HardLine`, but rendered as a no-op if the next emitted doc is
+    /// also a break (`Line` in break mode, `SoftLine` in break mode,
+    /// another `HardLine`, or another `CommentBreak`). Used by the
+    /// comment drain as the trailing break of a leading-comment chunk:
+    /// the next break op in the fmt stream would otherwise stack on top
+    /// and render a blank line. Intentional double-hardlines (e.g. blank
+    /// lines preserved between comment blocks) use `HardLine` directly
+    /// and are not affected.
+    CommentBreak,
     /// Concatenation of two documents.
     Cat { left: DocId, right: DocId },
     /// Increase indent by `indent` for `child`.
@@ -125,6 +134,7 @@ impl<'a> DocArena<'a> {
             Doc::Line => self.line(),
             Doc::SoftLine => self.softline(),
             Doc::HardLine => self.hardline(),
+            Doc::CommentBreak => self.comment_break(),
             Doc::BreakParent => self.break_parent(),
             Doc::Cat { left, right } => {
                 let l = self.copy_owned_from(src, *left);
@@ -156,6 +166,12 @@ impl<'a> DocArena<'a> {
 
     pub(crate) fn hardline(&mut self) -> DocId {
         self.push(Doc::HardLine)
+    }
+
+    /// A hardline that elides itself if followed immediately by another
+    /// break at render time. See `Doc::CommentBreak` for rationale.
+    pub(crate) fn comment_break(&mut self) -> DocId {
+        self.push(Doc::CommentBreak)
     }
 
     /// Concatenate two documents. If either operand is `NIL_DOC`, returns the other.
@@ -243,6 +259,12 @@ impl<'a> DocArena<'a> {
         let line_width_i32 = usize_to_i32(config.line_width());
         stack.push((0, Mode::Break, root));
 
+        // Set by a `CommentBreak` emission. Consumed by the immediately
+        // following break (any break variant) to avoid stacking a second
+        // newline on top of a leading-comment chunk. Cleared by any
+        // non-break, non-structural emission.
+        let mut just_emitted_comment_break = false;
+
         while let Some((indent, mode, doc_id)) = stack.pop() {
             if doc_id == NIL_DOC {
                 continue;
@@ -250,37 +272,56 @@ impl<'a> DocArena<'a> {
 
             match self.get(doc_id) {
                 Doc::Text(s) => {
+                    just_emitted_comment_break = false;
                     out.push_str(s);
                     pos += s.len();
                 }
 
                 Doc::Keyword(s) => {
+                    just_emitted_comment_break = false;
                     push_keyword(s, keyword_case, out);
                     pos += s.len();
                 }
 
-                Doc::Line => match mode {
-                    Mode::Flat => {
+                Doc::Line => {
+                    if matches!(mode, Mode::Flat) {
+                        just_emitted_comment_break = false;
                         out.push(' ');
                         pos += 1;
-                    }
-                    Mode::Break => {
+                    } else if !just_emitted_comment_break {
                         flush_line_suffixes(self, line_suffix_buf, config, out, &mut pos);
                         emit_newline(indent, out, &mut pos);
+                    } else {
+                        just_emitted_comment_break = false;
                     }
-                },
+                }
 
-                Doc::SoftLine => match mode {
-                    Mode::Flat => {}
-                    Mode::Break => {
-                        flush_line_suffixes(self, line_suffix_buf, config, out, &mut pos);
-                        emit_newline(indent, out, &mut pos);
+                Doc::SoftLine => {
+                    if matches!(mode, Mode::Break) {
+                        if just_emitted_comment_break {
+                            just_emitted_comment_break = false;
+                        } else {
+                            flush_line_suffixes(self, line_suffix_buf, config, out, &mut pos);
+                            emit_newline(indent, out, &mut pos);
+                        }
                     }
-                },
+                }
 
                 Doc::HardLine => {
-                    flush_line_suffixes(self, line_suffix_buf, config, out, &mut pos);
-                    emit_newline(indent, out, &mut pos);
+                    if just_emitted_comment_break {
+                        just_emitted_comment_break = false;
+                    } else {
+                        flush_line_suffixes(self, line_suffix_buf, config, out, &mut pos);
+                        emit_newline(indent, out, &mut pos);
+                    }
+                }
+
+                Doc::CommentBreak => {
+                    if !just_emitted_comment_break {
+                        flush_line_suffixes(self, line_suffix_buf, config, out, &mut pos);
+                        emit_newline(indent, out, &mut pos);
+                        just_emitted_comment_break = true;
+                    }
                 }
 
                 Doc::Cat { left, right } => {
@@ -352,7 +393,7 @@ impl<'a> DocArena<'a> {
                     remaining -= 1;
                 }
                 Doc::SoftLine | Doc::LineSuffix { .. } => {}
-                Doc::HardLine | Doc::BreakParent => {
+                Doc::HardLine | Doc::CommentBreak | Doc::BreakParent => {
                     return false;
                 }
                 Doc::Cat { left, right } => {
@@ -398,6 +439,9 @@ impl<'a> DocArena<'a> {
                 }
                 Doc::HardLine => {
                     let _ = writeln!(out, "{indent_str}HardLine");
+                }
+                Doc::CommentBreak => {
+                    let _ = writeln!(out, "{indent_str}CommentBreak");
                 }
                 Doc::BreakParent => {
                     let _ = writeln!(out, "{indent_str}BreakParent");

--- a/syntaqlite/tests/fmt_comments.rs
+++ b/syntaqlite/tests/fmt_comments.rs
@@ -152,3 +152,38 @@ fn comment_between_join_and_where_in_subquery() {
     let second_pass = fmt(&out);
     assert_eq!(out, second_pass, "formatting is not idempotent");
 }
+
+/// Regression: perfetto stdlib crash on a leading comment inside an untracked
+/// parenthesized expression. Reduced shape:
+///   WHERE a AND (
+///     -- leading comment inside untracked parens
+///     (b OR c)
+///   )
+/// The outer parens of `(b OR c)` have no `ParenExpr` AST node, so tokens like
+/// `(` are skipped by `peek_keyword_tokens`. When the drain of the statement's
+/// remaining comments fires, `prev_token_end()` has advanced past the comment's
+/// offset, producing a reversed `StmtRange` and a slice panic.
+#[test]
+fn leading_comment_inside_untracked_parens() {
+    let input = concat!(
+        "SELECT 1\n",
+        "WHERE\n",
+        "  a\n",
+        "  AND (\n",
+        "    -- leading comment inside untracked parens\n",
+        "    (\n",
+        "      b AND c\n",
+        "    )\n",
+        "    -- another\n",
+        "    OR (\n",
+        "      d AND e\n",
+        "    )\n",
+        "  );\n",
+    );
+    let out = fmt(input);
+    eprintln!("=== actual ===\n{out}=== end ===");
+    assert!(out.contains("-- leading comment inside untracked parens"));
+    assert!(out.contains("-- another"));
+    let second_pass = fmt(&out);
+    assert_eq!(out, second_pass, "formatting is not idempotent");
+}

--- a/tests/fmt_diff_tests/comments.py
+++ b/tests/fmt_diff_tests/comments.py
@@ -753,6 +753,32 @@ class ExprComment(TestSuite):
             """,
         )
 
+    def test_leading_comment_before_case_when(self):
+        return DiffTestBlueprint(
+            sql="""\
+                SELECT
+                  CASE value
+                    -- Display.STATE_OFF
+                    WHEN 1 THEN 'off'
+                    -- Display.STATE_ON
+                    WHEN 2 THEN 'on'
+                    ELSE 'unknown'
+                  END AS name
+                FROM t
+            """,
+            out="""\
+                SELECT
+                  CASE value
+                    -- Display.STATE_OFF
+                    WHEN 1 THEN 'off'
+                    -- Display.STATE_ON
+                    WHEN 2 THEN 'on'
+                    ELSE 'unknown'
+                  END AS name
+                FROM t;
+            """,
+        )
+
 
 # ── CREATE TABLE comments ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
Two formatter bugs surfaced by running the perfetto stdlib through the
formatter with the perfetto dialect. Both live in how
`drain_comments_before_child` interacts with tokens that the parser
keeps in the stream but no fmt opcode consumes.

- **fmt/comment.rs — crash on leading comment inside untracked parens.**
  `expr ::= LP expr RP` in `parser-actions/expressions.y:30` is erased
  via `synq_pass`, so the outer `(` / `)` tokens stay in the token
  stream without any corresponding fmt opcode. The old byte-scanning
  `has_non_comment_text` saw those `(` bytes as "real code" and bailed
  out of the drain, leaving the comment undrained until
  `drain_remaining` flushed it at end-of-statement — by which point
  `prev_token_end()` had advanced past the comment, producing a
  reversed `StmtRange` and a slice panic. Replaced with
  `has_intervening_emitted_token`, which walks the token array (via
  `partition_point` for `O(log n + k)`) and only blocks the drain on
  tokens whose text is not the literal `(` / `)`. Tracked parens in
  function calls / `IN` / `CAST` sit at the drain target, not inside
  the scan range, so they're unaffected.

- **fmt/doc.rs + fmt/comment.rs — blank line between a leading
  comment and its following element.** The leading-comment chunk ended
  with a `HardLine`; the child's own first `line` op (e.g. `CaseWhen`'s
  `line "WHEN "`) then stacked a second newline, rendering a blank
  line. Earlier attempts at a flag on the interpreter state drew
  pushback — the structural shape was that one `Doc::HardLine` from a
  comment drain and another from a fmt opcode are indistinguishable,
  even though they have different semantics. Encoded that distinction
  in the doc tree itself: a new `Doc::CommentBreak` variant renders as
  `HardLine` by default but elides itself if immediately followed by
  another break at render time. The dedup state is a single local bool
  in `render_into` tracking emission order — not interpreter state
  threaded across call frames. Intentional double-hardlines (blank
  lines preserved between comment blocks) use `HardLine` directly and
  are untouched. The comment drain's trailing break is the only caller
  of `arena.comment_break()`.

- **tests.** New `leading_comment_inside_untracked_parens` Rust test in
  `syntaqlite/tests/fmt_comments.rs` reproduces the exact panic class
  (`begin > end`) on a minimal SQLite-only input and asserts
  idempotency post-fix. New `ExprComment.test_leading_comment_before_case_when`
  diff test in `tests/fmt_diff_tests/comments.py` covers the CASE-WHEN
  blank-line bug, sourced from a perfetto stdlib pattern
  (`stdlib/android/screen_state.sql`).

