### PR TITLE
synq: make syntaqlite npm package work in Node and Bun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,12 @@ jobs:
           export PATH="$PWD/../../third_party/bin/linux-amd64/nodejs/bin:$PATH"
           npm run test:e2e:ci
 
+      - name: Run Node smoke test for syntaqlite-js
+        working-directory: web/syntaqlite-js
+        run: |
+          export PATH="$PWD/../../third_party/bin/linux-amd64/nodejs/bin:$PATH"
+          npm run test:node
+
       - name: Install Playwright browser for syntaqlite-js
         working-directory: web/syntaqlite-js
         run: |

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -56,6 +56,10 @@ jobs:
         working-directory: web/syntaqlite-js
         run: node scripts/verify-tarball.mjs
 
+      - name: Node smoke test
+        working-directory: web/syntaqlite-js
+        run: npm run test:node
+
       - name: Publish
         working-directory: web/syntaqlite-js
         run: npm publish --access public

--- a/python/tools/build_web_playground.py
+++ b/python/tools/build_web_playground.py
@@ -126,8 +126,14 @@ def main() -> int:
     target_rustflags += " -C link-arg=-sALLOW_TABLE_GROWTH"
     target_rustflags += " -C link-arg=-sALLOW_MEMORY_GROWTH"
     target_rustflags += (
-        " -C link-arg=-sEXPORTED_RUNTIME_METHODS=[\"loadDynamicLibrary\",\"ccall\",\"cwrap\"]"
+        " -C link-arg=-sEXPORTED_RUNTIME_METHODS="
+        "[\"loadDynamicLibrary\",\"ccall\",\"cwrap\",\"HEAPU8\"]"
     )
+    # Emit a factory function instead of relying on a global Module. This lets
+    # the same runtime load cleanly in browsers, Node, and Bun without the
+    # `var Module = ...` hoisting quirk that non-MODULARIZE outputs rely on.
+    target_rustflags += " -C link-arg=-sMODULARIZE=1"
+    target_rustflags += " -C link-arg=-sEXPORT_NAME=createSyntaqliteRuntime"
     # Emit DWARF debug info into a separate file so Chrome DevTools can
     # symbolize stack traces without bloating the served .wasm.
     target_rustflags += " -C link-arg=-g"
@@ -236,6 +242,15 @@ def main() -> int:
         dst = os.path.join(js_pkg_wasm_dir, name)
         shutil.copy2(src, dst)
         print("wrote %s" % dst)
+
+    # Mark wasm/ as CommonJS so Node's CJS loader handles syntaqlite-runtime.js.
+    # The parent syntaqlite-js package.json is "type": "module", so without
+    # this hint Node would try to parse the Emscripten output (which uses
+    # `require('fs')` and `module.exports`) as ESM and error out.
+    wasm_pkg_json = os.path.join(js_pkg_wasm_dir, "package.json")
+    with open(wasm_pkg_json, "w", encoding="utf-8") as f:
+        f.write('{"type": "commonjs"}\n')
+    print("wrote %s" % wasm_pkg_json)
 
     # Build Perfetto dialect wasm side module.
     perfetto_work_dir = os.path.join(ROOT_DIR, ".cache", "perfetto-wasm")

--- a/web/syntaqlite-js/README.md
+++ b/web/syntaqlite-js/README.md
@@ -21,7 +21,7 @@ npm install syntaqlite
 import { Engine } from "syntaqlite";
 
 const engine = new Engine();
-await engine.init();
+await engine.load();
 
 // Format SQL
 const result = engine.format("select id,name from users where id=1");

--- a/web/syntaqlite-js/package.json
+++ b/web/syntaqlite-js/package.json
@@ -23,6 +23,7 @@
     "build": "tsc",
     "check": "tsc --noEmit",
     "prepublishOnly": "node scripts/verify-tarball.mjs",
+    "test:node": "node tests/node-smoke.mjs",
     "test:package": "node tests/setup-fixture.mjs local && playwright test",
     "test:package:registry": "node tests/setup-fixture.mjs registry && playwright test"
   },

--- a/web/syntaqlite-js/src/dialect.ts
+++ b/web/syntaqlite-js/src/dialect.ts
@@ -11,9 +11,13 @@ export interface DialectPreset {
   symbol: string;
 }
 
+// Resolve relative to the bundled wasm/ directory so the default works in
+// both browsers (fetch) and Node (loadDynamicLibrary -> fs.readFile).
+const DEFAULT_SQLITE_WASM = new URL("../wasm/syntaqlite-sqlite.wasm", import.meta.url).href;
+
 export const BUILTIN_PRESETS: DialectPreset[] = [
   // SQLite is a side module; the runtime loads it via loadDynamicLibrary.
-  {id: "sqlite", label: "SQLite", wasmUrl: "syntaqlite-sqlite.wasm", symbol: "syntaqlite_sqlite_dialect_template"},
+  {id: "sqlite", label: "SQLite", wasmUrl: DEFAULT_SQLITE_WASM, symbol: "syntaqlite_sqlite_dialect_template"},
 ];
 
 export interface DialectManagerConfig {

--- a/web/syntaqlite-js/src/engine.ts
+++ b/web/syntaqlite-js/src/engine.ts
@@ -149,7 +149,7 @@ export class Engine {
   }
 
   private heapU8(): Uint8Array {
-    const heap = this.module!.HEAPU8 || window.HEAPU8;
+    const heap = this.module!.HEAPU8;
     if (!heap) throw new Error("runtime HEAPU8 is not available");
     return heap;
   }
@@ -426,32 +426,62 @@ export class Engine {
   }
 }
 
-function loadRuntimeModule(config: EngineConfig): Promise<EmscriptenModule> {
-  return new Promise<EmscriptenModule>((resolve, reject) => {
-    const jsPath = config.runtimeJsPath ?? DEFAULT_RUNTIME_JS;
-    const wasmPath = config.runtimeWasmPath ?? (config.runtimeJsPath ? config.runtimeJsPath.replace(/\.js$/, ".wasm") : DEFAULT_RUNTIME_WASM);
-    const moduleConfig: EmscriptenModuleConfig = {
-      noInitialRun: true,
-      locateFile(path: string) {
-        if (path === "syntaqlite_wasm.wasm" || path === "syntaqlite-wasm.wasm") {
-          return wasmPath;
+type RuntimeFactory = (config: EmscriptenModuleConfig) => Promise<EmscriptenModule>;
+
+// Global name the Emscripten MODULARIZE build assigns the factory to when
+// loaded as a classic <script> in the browser. Must match EXPORT_NAME in
+// tools/build-web-playground.
+const FACTORY_NAME = "createSyntaqliteRuntime";
+
+async function loadRuntimeModule(config: EngineConfig): Promise<EmscriptenModule> {
+  const jsPath = config.runtimeJsPath ?? DEFAULT_RUNTIME_JS;
+  const wasmPath = config.runtimeWasmPath
+    ?? (config.runtimeJsPath ? config.runtimeJsPath.replace(/\.js$/, ".wasm") : DEFAULT_RUNTIME_WASM);
+  const moduleConfig: EmscriptenModuleConfig = {
+    noInitialRun: true,
+    locateFile(path: string) {
+      if (path === "syntaqlite_wasm.wasm" || path === "syntaqlite-wasm.wasm") {
+        return wasmPath;
+      }
+      return path;
+    },
+  };
+  const factory = await loadFactory(jsPath);
+  return factory(moduleConfig);
+}
+
+function loadFactory(jsPath: string): Promise<RuntimeFactory> {
+  if (typeof document !== "undefined") {
+    // Browser: inject <script>; Emscripten assigns the factory to a global.
+    return new Promise((resolve, reject) => {
+      const existing = (globalThis as Record<string, unknown>)[FACTORY_NAME];
+      if (typeof existing === "function") {
+        resolve(existing as RuntimeFactory);
+        return;
+      }
+      const script = document.createElement("script");
+      script.src = jsPath;
+      script.async = true;
+      script.onload = () => {
+        const fn = (globalThis as Record<string, unknown>)[FACTORY_NAME];
+        if (typeof fn !== "function") {
+          reject(new Error(`${jsPath} did not define ${FACTORY_NAME}`));
+          return;
         }
-        return path;
-      },
-      onRuntimeInitialized() {
-        resolve(moduleConfig as unknown as EmscriptenModule);
-      },
-      onAbort(reason: string) {
-        reject(new Error(`runtime aborted: ${reason}`));
-      },
-    };
-
-    window.Module = moduleConfig;
-
-    const script = document.createElement("script");
-    script.src = jsPath;
-    script.async = true;
-    script.onerror = () => reject(new Error(`failed to load ${jsPath}`));
-    document.head.appendChild(script);
+        resolve(fn as RuntimeFactory);
+      };
+      script.onerror = () => reject(new Error(`failed to load ${jsPath}`));
+      document.head.appendChild(script);
+    });
+  }
+  // Node / Bun: dynamic import. The runtime ships with a wasm/package.json
+  // hint ({"type": "commonjs"}) so Node's CJS loader handles the Emscripten
+  // output; the factory comes back as the ESM default export.
+  return import(/* @vite-ignore */ /* webpackIgnore: true */ jsPath).then((mod) => {
+    const factory = (mod as {default?: unknown}).default ?? mod;
+    if (typeof factory !== "function") {
+      throw new Error(`${jsPath} did not export a factory function`);
+    }
+    return factory as RuntimeFactory;
   });
 }

--- a/web/syntaqlite-js/src/types.ts
+++ b/web/syntaqlite-js/src/types.ts
@@ -14,25 +14,16 @@ export interface EmscriptenModule {
   [key: `_${string}`]: ((...args: number[]) => number) | undefined;
 }
 
-/** Module config passed to Emscripten before initialization. */
+/** Module config passed to the Emscripten MODULARIZE factory. */
 export interface EmscriptenModuleConfig {
   noInitialRun: boolean;
   locateFile: (path: string) => string;
-  onRuntimeInitialized: () => void;
-  onAbort: (reason: string) => void;
-  // Emscripten populates these after init:
+  // Emscripten populates these after init (the factory returns the same object):
   HEAPU8?: Uint8Array;
   loadDynamicLibrary?: EmscriptenModule["loadDynamicLibrary"];
   ccall?: EmscriptenModule["ccall"];
   cwrap?: EmscriptenModule["cwrap"];
   [key: string]: unknown;
-}
-
-declare global {
-  interface Window {
-    Module: EmscriptenModuleConfig;
-    HEAPU8?: Uint8Array;
-  }
 }
 
 // ── AST JSON types ──

--- a/web/syntaqlite-js/tests/node-smoke.mjs
+++ b/web/syntaqlite-js/tests/node-smoke.mjs
@@ -1,0 +1,29 @@
+// Smoke-test the built package under Node. Run with:
+//   npm run build && node tests/node-smoke.mjs
+// Requires wasm/ to be populated (tools/build-web-playground --hermetic).
+import {Engine, DialectManager} from "../dist/index.js";
+
+const engine = new Engine();
+await engine.load();
+if (!engine.ready) throw new Error("engine.ready is false after load");
+
+const dm = new DialectManager();
+await dm.loadDefault(engine);
+if (!dm.active) throw new Error(`dialect did not load: ${engine.status}`);
+
+const fmt = engine.runFmt("select a,b from t where a=1", {
+  lineWidth: 80,
+  indentWidth: 2,
+  keywordCase: 1,
+  semicolons: true,
+});
+if (!fmt.ok) throw new Error(`fmt failed: ${fmt.text}`);
+if (!/SELECT a, b FROM t WHERE a = 1/.test(fmt.text)) {
+  throw new Error(`unexpected fmt output: ${fmt.text}`);
+}
+
+const diag = engine.runDiagnostics("selec 1 frm t");
+if (!diag.ok) throw new Error("diagnostics call failed");
+if (diag.diagnostics.length === 0) throw new Error("expected at least one diagnostic");
+
+console.log("node smoke test: OK");


### PR DESCRIPTION
The `Engine.load()` path hard-coded `window.Module = ...` plus a
`<script>` tag, so `new Engine()` blew up with `window is not defined`
the moment a Node or Bun consumer followed the README. Even naively
porting that to Node hits a subtler trap: Emscripten's non-MODULARIZE
output relies on `var Module = typeof Module !== 'undefined' ? Module
: {}` seeing an existing global `Module`, which only works at script
top level — inside Node's CJS module wrapper, `var` hoisting shadows
`global.Module` with `undefined` and the user's config is silently
dropped.

- tools/build-web-playground: rebuild the runtime with `-sMODULARIZE=1
  -sEXPORT_NAME=createSyntaqliteRuntime` so the output is a factory
  function instead of a globals-dependent script; add `HEAPU8` to
  `EXPORTED_RUNTIME_METHODS` so it lands on the returned module (it
  was only a factory-scoped variable before); write a
  `wasm/package.json` with `{"type":"commonjs"}` so Node's loader
  treats the Emscripten output as CJS under the ESM parent package.
- web/syntaqlite-js/src/engine.ts: consume the factory. Browser
  injects `<script>` and awaits `globalThis.createSyntaqliteRuntime`;
  Node/Bun uses dynamic `import()` (the wasm/ package.json hint makes
  this Just Work). Drops the dead `window.HEAPU8` fallback and the
  `onRuntimeInitialized`/`onAbort` callbacks, both subsumed by the
  factory Promise.
- web/syntaqlite-js/src/dialect.ts: default SQLite preset now uses an
  absolute `new URL(..., import.meta.url).href` so
  `loadDynamicLibrary` resolves in Node too.
- web/syntaqlite-js/src/types.ts: trim `EmscriptenModuleConfig` to
  what we still pass and drop the unused `Window.Module` global.
- web/syntaqlite-js/README.md: fix `engine.init()` → `engine.load()`.
- web/syntaqlite-js/tests/node-smoke.mjs (new) + `test:node` script:
  regression test that drives the full Node path (load → loadDefault
  → runFmt → runDiagnostics).
- .github/workflows/ci.yml, publish-npm.yml: run `npm run test:node`
  alongside the existing Playwright checks so a Node regression
  blocks merges and releases.

FIxes: https://github.com/LalitMaganti/syntaqlite/issues/241