### PR TITLE
synq: bump version to 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.4
+
+**JavaScript package:**
+- Fixed the `syntaqlite` npm package crashing with `window is not defined` under Node and Bun. The WASM runtime is now built as an Emscripten `MODULARIZE` factory and consumed via dynamic `import()` in Node/Bun (and an injected `<script>` in the browser), so `new Engine().load()` works on all three runtimes. The default SQLite preset also switched to an absolute `import.meta.url` URL so `loadDynamicLibrary` resolves in Node ([#242](https://github.com/LalitMaganti/syntaqlite/pull/242)).
+- Added a Node smoke test (`npm run test:node`) that exercises the full `load → loadDefault → runFmt → runDiagnostics` path, wired into CI and the npm publish workflow ([#242](https://github.com/LalitMaganti/syntaqlite/pull/242)).
+
 ## 0.5.3
 
 **Formatter:**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "benches"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "criterion",
  "syntaqlite",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "glob",
  "libloading",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-buildtools"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "cc",
  "clap",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-cli"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "clap",
  "glob",
@@ -1075,11 +1075,11 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-common"
-version = "0.5.3"
+version = "0.5.4"
 
 [[package]]
 name = "syntaqlite-syntax"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "cc",
  "libloading",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-wasm"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ cargo install syntaqlite-cli
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.5.3", features = ["fmt"] }
+syntaqlite = { version = "0.5.4", features = ["fmt"] }
 ```
 
 **Python** ([API docs](https://docs.syntaqlite.com/latest/reference/python-api/))

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syntaqlite",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "SQLite SQL language server — diagnostics, formatting, completions, and semantic tokens",
   "author": {
     "name": "Lalit Maganti"

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "syntaqlite",
   "displayName": "syntaqlite",
   "description": "SQL language support powered by syntaqlite — diagnostics, formatting, completions, and semantic highlighting",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "publisher": "syntaqlite",
   "license": "Apache-2.0",
   "icon": "icon.png",

--- a/integrations/zed/Cargo.toml
+++ b/integrations/zed/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "syntaqlite-zed"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 
 [lib]

--- a/integrations/zed/extension.toml
+++ b/integrations/zed/extension.toml
@@ -3,7 +3,7 @@
 
 id = "syntaqlite"
 name = "Syntaqlite"
-version = "0.5.3"
+version = "0.5.4"
 schema_version = 1
 authors = ["Lalit Maganti <lalitmaganti@gmail.com>"]
 description = "SQL language support powered by syntaqlite — tokenizer, parser, formatter and validator built on SQLite's own grammar."

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntaqlite"
-version = "0.5.3"
+version = "0.5.4"
 description = "SQLite SQL tools — parser, formatter, validator, and MCP server"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}

--- a/python/syntaqlite/__init__.py
+++ b/python/syntaqlite/__init__.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from .nodes import _wrap
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 
 
 # ── Binary discovery ──────────────────────────────────────────────────────────

--- a/syntaqlite-buildtools/Cargo.toml
+++ b/syntaqlite-buildtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-buildtools"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 description = "Internal codegen and build tools for syntaqlite — not intended for direct use"
 license = "Apache-2.0"
@@ -20,8 +20,8 @@ dist = false
 doc = false
 
 [dependencies]
-syntaqlite-common = { version = "0.5.3", path = "../syntaqlite-common" }
-syntaqlite-syntax = { version = "0.5.3", path = "../syntaqlite-syntax", default-features = false, features = ["embedded-sources"] }
+syntaqlite-common = { version = "0.5.4", path = "../syntaqlite-common" }
+syntaqlite-syntax = { version = "0.5.4", path = "../syntaqlite-syntax", default-features = false, features = ["embedded-sources"] }
 clap = { version = "4.5", features = ["derive"] }
 tempfile = "3.8"
 serde = { version = "1", features = ["derive"] }

--- a/syntaqlite-cli/Cargo.toml
+++ b/syntaqlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-cli"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 repository.workspace = true
 description = "Fast, accurate SQLite SQL formatter, validator, and language server — built on SQLite's own grammar"
@@ -42,8 +42,8 @@ rmcp = { version = "0.1", features = ["server", "transport-io"], optional = true
 schemars = { version = "0.8", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-syntaqlite = { version = "0.5.3", path = "../syntaqlite", default-features = false, features = ["fmt", "lsp", "analysis", "experimental-embedded", "serde-json"] }
-syntaqlite-syntax = { version = "0.5.3", path = "../syntaqlite-syntax" }
-syntaqlite-buildtools = { version = "0.5.3", path = "../syntaqlite-buildtools", optional = true }
+syntaqlite = { version = "0.5.4", path = "../syntaqlite", default-features = false, features = ["fmt", "lsp", "analysis", "experimental-embedded", "serde-json"] }
+syntaqlite-syntax = { version = "0.5.4", path = "../syntaqlite-syntax" }
+syntaqlite-buildtools = { version = "0.5.4", path = "../syntaqlite-buildtools", optional = true }
 tempfile = "3.8"
 tokio = { version = "1", features = ["rt", "macros", "io-std"], optional = true }

--- a/syntaqlite-common/Cargo.toml
+++ b/syntaqlite-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-common"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 description = "Internal shared primitives for syntaqlite — not intended for direct use"
 license = "Apache-2.0"

--- a/syntaqlite-syntax/Cargo.toml
+++ b/syntaqlite-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-syntax"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 links = "syntaqlite_syntax"
 description = "Internal parser and tokenizer for syntaqlite — not intended for direct use"

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! syntaqlite = { version = "0.5.3", default-features = false, features = ["sqlite"] }
+//! syntaqlite = { version = "0.5.4", default-features = false, features = ["sqlite"] }
 //! ```
 
 // ==== Public API ====

--- a/syntaqlite-wasm/Cargo.toml
+++ b/syntaqlite-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-wasm"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 repository.workspace = true
 

--- a/syntaqlite/Cargo.toml
+++ b/syntaqlite/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "syntaqlite"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 description = "Parser, formatter, validator, and language server for SQLite SQL — built on SQLite's own grammar"
 license = "Apache-2.0"
@@ -40,8 +40,8 @@ pin-cflags = ["sqlite", "syntaqlite-syntax/pin-cflags"]    # Pin compile-time fl
 workspace = true
 
 [dependencies]
-syntaqlite-common = { version = "0.5.3", path = "../syntaqlite-common" }
-syntaqlite-syntax = { version = "0.5.3", path = "../syntaqlite-syntax", default-features = false }
+syntaqlite-common = { version = "0.5.4", path = "../syntaqlite-common" }
+syntaqlite-syntax = { version = "0.5.4", path = "../syntaqlite-syntax", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 libloading = { version = "0.8", optional = true }

--- a/tests/benches/Cargo.toml
+++ b/tests/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benches"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 publish = false
 

--- a/tests/comparison/parser/Cargo.toml
+++ b/tests/comparison/parser/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "parser-bench"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 
 [[bin]]

--- a/web/docs/content/guides/rust-api.md
+++ b/web/docs/content/guides/rust-api.md
@@ -10,7 +10,7 @@ weight = 1
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.5.3", features = ["fmt"] }
+syntaqlite = { version = "0.5.4", features = ["fmt"] }
 ```
 
 ## Format a query
@@ -127,7 +127,7 @@ Add the `analysis` and `sqlite` features:
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.5.3", features = ["analysis", "sqlite"] }
+syntaqlite = { version = "0.5.4", features = ["analysis", "sqlite"] }
 ```
 
 ```rust

--- a/web/syntaqlite-js/package.json
+++ b/web/syntaqlite-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syntaqlite",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "SQLite SQL parser, formatter, and validator for the browser — powered by WebAssembly",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Motivation

Cut the 0.5.4 release.

## Changes

- Bumps version to 0.5.4 across all Cargo.toml / pyproject.toml / integration manifests / README / docs.
- Adds 0.5.4 CHANGELOG entry.

Release notes:

**JavaScript package:**
- Fixed the `syntaqlite` npm package crashing with `window is not defined` under Node and Bun. The WASM runtime is now built as an Emscripten `MODULARIZE` factory and consumed via dynamic `import()` in Node/Bun (and an injected `<script>` in the browser), so `new Engine().load()` works on all three runtimes. The default SQLite preset also switched to an absolute `import.meta.url` URL so `loadDynamicLibrary` resolves in Node (#242).
- Added a Node smoke test (`npm run test:node`) that exercises the full `load → loadDefault → runFmt → runDiagnostics` path, wired into CI and the npm publish workflow (#242).