### PR TITLE
synq: type public-API offsets/lengths with named typedefs

### DIFF
--- a/python/syntaqlite/__init__.py
+++ b/python/syntaqlite/__init__.py
@@ -99,7 +99,12 @@ class RenderOptions:
 
 
 class Diagnostic:
-    """A single diagnostic from validation."""
+    """A single diagnostic from validation.
+
+    ``start_offset`` and ``end_offset`` are document-absolute byte
+    offsets into the SQL passed to :meth:`Syntaqlite.analyze` — measured
+    from byte 0 of the input, not relative to a statement.
+    """
 
     __slots__ = ("severity", "message", "start_offset", "end_offset", "code")
 
@@ -484,6 +489,9 @@ class Syntaqlite:
         """Tokenize SQL into a list of token dicts.
 
         Each dict has: text (str), offset (int), length (int), type (int), category (str).
+
+        ``offset`` is a document-absolute byte offset into ``sql`` (byte 0 =
+        first byte of input). ``length`` is the token's byte length.
         """
         return self._call("tokenize", sql=sql)["tokens"]
 

--- a/syntaqlite-syntax/include/syntaqlite/dialect.h
+++ b/syntaqlite-syntax/include/syntaqlite/dialect.h
@@ -33,6 +33,7 @@
 
 #include "syntaqlite/cflags.h"
 #include "syntaqlite/config.h"
+#include "syntaqlite/types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -72,16 +73,18 @@ typedef enum {
 typedef struct SynqParseCtx SynqParseCtx;
 
 typedef struct SynqParseToken {
-  const char* z;       // pointer to start of token in its buffer
-  uint32_t n;          // byte length of token
-  uint32_t type;       // token type ID (SYNTAQLITE_TK_*)
-  uint32_t token_idx;  // index into parser's token vec (0xFFFFFFFF if not
-                       // collecting)
-  uint32_t offset;     // byte offset within the token's buffer; set at
-                       // shift time so reductions don't depend on
-                       // ctx->source which may have been swapped back
-                       // after a macro expansion
-  uint32_t layer_id;   // 0 = original source, 1+ = expansion layer index
+  const char* z;                 // pointer to start of token in its buffer
+  SyntaqliteLength n;          // byte length of token
+  uint32_t type;                 // token type ID (SYNTAQLITE_TK_*)
+  SyntaqliteTokenIdx token_idx;  // index into parser's token vec
+                                 // (0xFFFFFFFF if not collecting)
+  SyntaqliteLayerOffset offset;  // byte offset within the token's buffer;
+                                 // set at shift time so reductions don't
+                                 // depend on ctx->source which may have
+                                 // been swapped back after a macro
+                                 // expansion
+  uint32_t layer_id;             // 0 = original source,
+                                 // 1+ = expansion layer index
 } SynqParseToken;
 
 typedef struct SyntaqliteFieldRangeMeta SyntaqliteFieldRangeMeta;

--- a/syntaqlite-syntax/include/syntaqlite/dialect.h
+++ b/syntaqlite-syntax/include/syntaqlite/dialect.h
@@ -74,7 +74,7 @@ typedef struct SynqParseCtx SynqParseCtx;
 
 typedef struct SynqParseToken {
   const char* z;                 // pointer to start of token in its buffer
-  SyntaqliteLength n;          // byte length of token
+  SyntaqliteLength n;            // byte length of token
   uint32_t type;                 // token type ID (SYNTAQLITE_TK_*)
   SyntaqliteTokenIdx token_idx;  // index into parser's token vec
                                  // (0xFFFFFFFF if not collecting)

--- a/syntaqlite-syntax/include/syntaqlite/incremental.h
+++ b/syntaqlite-syntax/include/syntaqlite/incremental.h
@@ -69,7 +69,7 @@ extern "C" {
 SYNTAQLITE_API int32_t syntaqlite_parser_feed_token(SyntaqliteParser* p,
                                                     uint32_t token_type,
                                                     const char* text,
-                                                    uint32_t len);
+                                                    SyntaqliteLength len);
 
 // Signal end-of-input. Synthesizes a SEMI if needed and sends EOF to the
 // parser. Returns a SYNTAQLITE_PARSE_* code.
@@ -109,7 +109,7 @@ syntaqlite_parser_completion_context(SyntaqliteParser* p);
 typedef int (*SyntaqliteMacroLookupFn)(void* user_data,
                                        SyntaqliteParser* parser,
                                        const char* name,
-                                       uint32_t name_len,
+                                       SyntaqliteLength name_len,
                                        const SyntaqliteToken* args,
                                        uint32_t arg_count);
 
@@ -127,18 +127,20 @@ syntaqlite_parser_set_macro_lookup(SyntaqliteParser* p,
 // Set the expanded body for the current macro invocation.
 // `def_line` / `def_col` are 1-based definition position for tracebacks
 // (pass 0/0 if unknown).
-SYNTAQLITE_API void syntaqlite_macro_expansion_set_result(SyntaqliteParser* p,
-                                                          const char* body,
-                                                          uint32_t body_len,
-                                                          uint32_t def_line,
-                                                          uint32_t def_col);
+SYNTAQLITE_API void syntaqlite_macro_expansion_set_result(
+    SyntaqliteParser* p,
+    const char* body,
+    SyntaqliteLength body_len,
+    SyntaqliteLineNumber def_line,
+    SyntaqliteColumnNumber def_col);
 
 // Describes where one macro argument was pasted into the expansion body.
 // Used by set_result_with_arg_map to enable span drilling through
 // $param substitutions.
 typedef struct SyntaqliteArgMapping {
-  uint32_t body_offset;  // Byte offset in `body` where arg text starts.
-  uint32_t arg_index;    // Index into the args array passed to the callback.
+  SyntaqliteLayerOffset body_offset;  // Byte offset in `body` where arg
+                                      // text starts.
+  uint32_t arg_index;  // Index into the args array passed to the callback.
 } SyntaqliteArgMapping;
 
 // Like set_result, but with arg-mapping metadata for span drilling.
@@ -148,9 +150,9 @@ typedef struct SyntaqliteArgMapping {
 SYNTAQLITE_API void syntaqlite_macro_expansion_set_result_with_arg_map(
     SyntaqliteParser* p,
     const char* body,
-    uint32_t body_len,
-    uint32_t def_line,
-    uint32_t def_col,
+    SyntaqliteLength body_len,
+    SyntaqliteLineNumber def_line,
+    SyntaqliteColumnNumber def_col,
     const SyntaqliteArgMapping* mappings,
     uint32_t mapping_count);
 
@@ -169,9 +171,9 @@ SYNTAQLITE_API void syntaqlite_macro_expansion_set_result_with_arg_map(
 SYNTAQLITE_API int syntaqlite_macro_expansion_expand_and_set_result(
     SyntaqliteParser* p,
     const char* body,
-    uint32_t body_len,
+    SyntaqliteLength body_len,
     const char* const* param_names,
-    const uint32_t* param_name_lens,
+    const SyntaqliteLength* param_name_lens,
     uint32_t param_count,
     uint32_t flags);
 

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -108,7 +108,7 @@ SYNTAQLITE_API SyntaqliteParser* syntaqlite_parser_create(
 // new input without reallocating — all previous nodes are invalidated.
 SYNTAQLITE_API void syntaqlite_parser_reset(SyntaqliteParser* p,
                                             const char* source,
-                                            SyntaqliteDocLen len);
+                                            SyntaqliteLength len);
 
 // Parse the next SQL statement. Call in a loop until SYNTAQLITE_PARSE_DONE.
 // Bare semicolons between statements are skipped automatically.
@@ -180,7 +180,7 @@ SYNTAQLITE_API SyntaqliteStmtOffset
 syntaqlite_result_error_offset(SyntaqliteParser* p);
 
 // Byte length of error token (0 = unknown).
-SYNTAQLITE_API SyntaqliteStmtLen
+SYNTAQLITE_API SyntaqliteLength
 syntaqlite_result_error_length(SyntaqliteParser* p);
 
 // A comment captured during parsing.
@@ -203,8 +203,8 @@ typedef uint8_t SyntaqliteCommentSide;
 #define SYNQ_COMMENT_TRAILING ((SyntaqliteCommentSide)1)
 
 typedef struct SyntaqliteComment {
-  SyntaqliteStmtOffset offset;   // Statement-relative byte offset.
-  SyntaqliteStmtLen length;      // Byte length.
+  SyntaqliteStmtOffset offset;
+  SyntaqliteLength length;
   SyntaqliteTokenIdx token_idx;  // Index of the owning token in p->tokens.
   uint8_t kind;  // 0 = line comment (--), 1 = block comment (/* */).
   uint8_t side;  // SYNQ_COMMENT_LEADING or SYNQ_COMMENT_TRAILING.
@@ -229,8 +229,8 @@ typedef uint32_t SyntaqliteParserTokenFlags;
 // positions should resolve the token's span via the parser's span
 // accessors rather than using `offset` directly.
 typedef struct SyntaqliteParserToken {
-  SyntaqliteLayerOffset offset;  // Byte offset in the token's layer buffer.
-  SyntaqliteLayerLen length;     // Byte length.
+  SyntaqliteLayerOffset offset;
+  SyntaqliteLength length;
   uint32_t type;  // Original token type from tokenizer (pre-fallback).
   SyntaqliteParserTokenFlags flags;  // Bitmask of SYNQ_TOKEN_FLAG_* values.
   uint32_t _layer_id;  // Internal: 0 = original source, >0 = expansion layer.
@@ -312,11 +312,11 @@ typedef struct SyntaqliteMacroRewrite {
   // Statement-relative when parent_idx == SYNTAQLITE_MACRO_PARENT_SOURCE,
   // otherwise relative to the parent entry's `expansion` buffer.
   SyntaqliteLayerOffset call_offset;
-  SyntaqliteLayerLen call_length;
+  SyntaqliteLength call_length;
   const char* expansion;
-  SyntaqliteLayerLen expansion_len;
+  SyntaqliteLength expansion_len;
   const char* name;
-  uint32_t name_len;
+  SyntaqliteLength name_len;
   SyntaqliteLineNumber def_line;
   SyntaqliteColumnNumber def_col;
   // Position of this call in the *parent's authored body*, computed by
@@ -330,7 +330,7 @@ typedef struct SyntaqliteMacroRewrite {
   // the parent is the authored source, so these equal call_offset /
   // call_length.
   SyntaqliteLayerOffset body_call_offset;
-  SyntaqliteLayerLen body_call_length;
+  SyntaqliteLength body_call_length;
   // The buffer the `call_offset` — and every arg offset returned by
   // syntaqlite_macro_rewrite_arg_at — indexes into.  For top-level
   // rewrites (parent_idx == SYNTAQLITE_MACRO_PARENT_SOURCE) this is
@@ -342,7 +342,7 @@ typedef struct SyntaqliteMacroRewrite {
   // Not NUL-terminated; use `parent_buffer_len`.  Owned by the
   // parser and valid until the next reset / next / destroy call.
   const char* parent_buffer;
-  SyntaqliteLayerLen parent_buffer_len;
+  SyntaqliteLength parent_buffer_len;
   // 1 if this call went down the fallback path (unregistered name!
   // kept verbatim as a TK_ID, no expansion, no $param substitutions);
   // 0 if it was expanded by a registered macro.  `expansion_len` is
@@ -376,12 +376,12 @@ syntaqlite_result_macro_rewrite_at(SyntaqliteParser* p, uint32_t idx);
 // arg segments.
 typedef struct SyntaqliteMacroArgSegment {
   SyntaqliteLayerOffset body_offset;
-  SyntaqliteLayerLen body_length;
+  SyntaqliteLength body_length;
   SyntaqliteLayerOffset expansion_offset;
-  SyntaqliteLayerLen expansion_length;
+  SyntaqliteLength expansion_length;
   uint32_t origin_parent_idx;
   SyntaqliteLayerOffset origin_offset;
-  SyntaqliteLayerLen origin_length;
+  SyntaqliteLength origin_length;
 } SyntaqliteMacroArgSegment;
 
 // Number of arg segments recorded on the rewrite at `rewrite_idx`.
@@ -410,7 +410,7 @@ syntaqlite_macro_rewrite_arg_segment_at(SyntaqliteParser* p,
 // trailing whitespace / comments are trimmed from the range.
 typedef struct SyntaqliteMacroCallArg {
   SyntaqliteLayerOffset offset;
-  SyntaqliteLayerLen length;
+  SyntaqliteLength length;
 } SyntaqliteMacroCallArg;
 
 // Number of top-level call-site arg spans recorded on the rewrite at
@@ -449,21 +449,25 @@ SYNTAQLITE_API const void* syntaqlite_parser_node(SyntaqliteParser* p,
 SYNTAQLITE_API const char* syntaqlite_parser_text(
     SyntaqliteParser* p,
     SyntaqliteDocOffset* out_offset,
-    SyntaqliteStmtLen* out_len);
+    SyntaqliteLength* out_len);
 
 // Full SQL source bound by the last reset() call.  For multi-statement
 // input, this is the whole input.
 SYNTAQLITE_API const char* syntaqlite_parser_full_text(
     SyntaqliteParser* p,
-    SyntaqliteDocLen* out_len);
+    SyntaqliteLength* out_len);
 
 // Post-expansion text for the current statement — materializes the
 // statement's source with every currently-active macro call replaced
 // by its expansion into a parser-owned scratch buffer.  The returned
 // pointer is valid until the next `*_expanded_text` call on the same
 // parser or until the parser advances to the next statement.
-SYNTAQLITE_API const char* syntaqlite_parser_expanded_text(SyntaqliteParser* p,
-                                                           uint32_t* out_len);
+//
+// `*out_len` receives the byte length of the materialized buffer,
+// which may differ from the authored statement length.
+SYNTAQLITE_API const char* syntaqlite_parser_expanded_text(
+    SyntaqliteParser* p,
+    SyntaqliteLength* out_len);
 
 // Return the number of nodes currently in the arena.
 SYNTAQLITE_API uint32_t syntaqlite_parser_node_count(SyntaqliteParser* p);
@@ -487,13 +491,13 @@ SYNTAQLITE_API uint32_t syntaqlite_parser_node_count(SyntaqliteParser* p);
 // within `snippet`.
 typedef struct SyntaqliteTracebackFrame {
   const char* name;
-  uint32_t name_len;
+  SyntaqliteLength name_len;
   SyntaqliteLineNumber line;
   SyntaqliteColumnNumber col;
   const char* snippet;
-  SyntaqliteLayerLen snippet_len;
+  SyntaqliteLength snippet_len;
   SyntaqliteLayerOffset offset_in_snippet;
-  SyntaqliteLayerLen length_in_snippet;
+  SyntaqliteLength length_in_snippet;
 } SyntaqliteTracebackFrame;
 
 // Build a traceback for a span and return a pointer to a parser-owned
@@ -523,15 +527,17 @@ SYNTAQLITE_API const SyntaqliteTracebackFrame* syntaqlite_parser_traceback(
 // Post-expansion text for `span` — the bytes the tokenizer actually saw.
 // For macro-free spans, a slice of the input source.  For spans inside a
 // macro expansion, a slice of the expansion layer's buffer.  Writes the
-// byte length to `*out_len`.  Always a direct slice — no allocation.
+// slice's byte length to `*out_len`.  Always a direct slice — no
+// allocation.
 //
 // Returns NULL (and writes 0 to `*out_len`) for empty or invalid spans.
 SYNTAQLITE_API const char* syntaqlite_parser_span_expanded_text(
     SyntaqliteParser* p,
     const SyntaqliteTextSpan* span,
-    uint32_t* out_len);
+    SyntaqliteLength* out_len);
 
-// Authored text for `span` — always a slice of the input source.
+// Authored text for `span` — always a slice of the current statement's
+// source (the same buffer `syntaqlite_parser_text` returns).
 //
 // For macro-free spans, identical to `span_expanded_text`.  For spans
 // inside a macro expansion, walks the expansion-layer chain:
@@ -539,35 +545,37 @@ SYNTAQLITE_API const char* syntaqlite_parser_span_expanded_text(
 //     to the arg's origin text in the caller's layer (recursively).
 //   - Otherwise, collapses to the outermost `name!(...)` call site.
 //
-// Always a direct slice of the source — no allocation.  Returns NULL
-// (and writes 0 to `*out_len`) for empty or invalid spans.
+// Always a direct slice of the statement source — no allocation.
+// Returns NULL (and writes 0 to `*out_len`) for empty or invalid spans.
 //
-// `out_offset` is optional; when non-NULL it receives the byte offset
-// in the input source where the returned slice begins (so callers can
-// compute source-relative positions without pointer arithmetic).
+// `out_offset` is optional; when non-NULL it receives the
+// statement-relative byte offset where the returned slice begins.
+// To convert to a document-absolute offset, add the offset
+// `syntaqlite_parser_text` writes to its own `out_offset`.
 // Written 0 for empty or invalid spans.
 SYNTAQLITE_API const char* syntaqlite_parser_span_text(
     SyntaqliteParser* p,
     const SyntaqliteTextSpan* span,
-    uint32_t* out_len,
-    uint32_t* out_offset);
+    SyntaqliteLength* out_len,
+    SyntaqliteStmtOffset* out_offset);
 
 // Authored source text for AST node `node_id` — the analogue of
 // `syntaqlite_parser_span_text` for whole nodes rather than spans.
+// Offsets are statement-relative, same as `syntaqlite_parser_span_text`.
 //
 // Requires per-node extent tracking to be enabled via
 // `syntaqlite_parser_set_collect_node_extents` before the first
-// `reset()`.  On success writes the slice length to `*out_len` and
-// its byte offset in the source to `*out_offset` (both optional) and
-// returns a direct slice of the input source — no allocation.
+// `reset()`.  Returns a direct slice of the current statement's
+// source — no allocation.
 //
 // Returns NULL (and writes 0 to `*out_len` / `*out_offset`) when
 // extent tracking is disabled, the node id is unknown, or no extent
 // was recorded for it.
-SYNTAQLITE_API const char* syntaqlite_parser_node_text(SyntaqliteParser* p,
-                                                       uint32_t node_id,
-                                                       uint32_t* out_len,
-                                                       uint32_t* out_offset);
+SYNTAQLITE_API const char* syntaqlite_parser_node_text(
+    SyntaqliteParser* p,
+    uint32_t node_id,
+    SyntaqliteLength* out_len,
+    SyntaqliteStmtOffset* out_offset);
 
 // Post-expansion text for AST node `node_id` — the analogue of
 // `syntaqlite_parser_span_expanded_text` for whole nodes.
@@ -591,7 +599,7 @@ SYNTAQLITE_API const char* syntaqlite_parser_node_text(SyntaqliteParser* p,
 SYNTAQLITE_API const char* syntaqlite_parser_node_expanded_text(
     SyntaqliteParser* p,
     uint32_t node_id,
-    uint32_t* out_len);
+    SyntaqliteLength* out_len);
 
 // ---------------------------------------------------------------------------
 // Macro-expansion queries

--- a/syntaqlite-syntax/include/syntaqlite/tokenizer.h
+++ b/syntaqlite-syntax/include/syntaqlite/tokenizer.h
@@ -27,6 +27,7 @@
 
 #include "syntaqlite/config.h"
 #include "syntaqlite/dialect.h"
+#include "syntaqlite/types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,9 +44,9 @@ typedef struct SyntaqliteTokenizer SyntaqliteTokenizer;
 // the source buffer bound by the last reset() call, so it is only valid
 // while that buffer is alive. The text is NOT null-terminated.
 typedef struct SyntaqliteToken {
-  const char* text;  // Pointer into source text.
-  uint32_t length;   // Token length in bytes.
-  uint32_t type;     // Token type ordinal.
+  const char* text;         // Pointer into source text.
+  SyntaqliteLength length;  // Token length in bytes.
+  uint32_t type;            // Token type ordinal.
 } SyntaqliteToken;
 
 // ---------------------------------------------------------------------------
@@ -65,7 +66,7 @@ SYNTAQLITE_API SyntaqliteTokenizer* syntaqlite_tokenizer_create_with_dialect(
 // again to tokenize a new input without reallocating.
 SYNTAQLITE_API void syntaqlite_tokenizer_reset(SyntaqliteTokenizer* tok,
                                                const char* source,
-                                               uint32_t len);
+                                               SyntaqliteLength len);
 
 // Advance to the next token. Returns 1 if a token was written to *out,
 // 0 at end-of-input. Every token is returned, including whitespace and

--- a/syntaqlite-syntax/include/syntaqlite/types.h
+++ b/syntaqlite-syntax/include/syntaqlite/types.h
@@ -22,29 +22,32 @@ extern "C" {
 // imposing any compile-time enforcement.  Mixing them at the call site is
 // not a type error in C.
 //
-// The kinds (all byte-based; UTF-16 positions are LSP-only and live on the
-// Rust side):
-//   - Stmt*       — byte offset/length measured from the start of the
-//                   current statement's source slice
-//                   (`syntaqlite_parser_text`).
-//   - Doc*        — byte offset/length measured from the start of the full
-//                   bound source (`syntaqlite_parser_full_text`).
-//   - Layer*      — byte offset/length measured from the start of an
-//                   expansion layer's internal buffer (e.g.
-//                   `SyntaqliteTextSpan`, `SyntaqliteMacroArgSegment`).
-//                   Resolve via the parser's span accessors; never use
-//                   directly as a source offset.
-//   - TokenIdx    — 0-based index into a statement's token stream.
+// Offsets describe a *position within a specific buffer*, so they are
+// split by the buffer they index into.  All are byte-based:
+//   - StmtOffset   — byte offset from the start of the current
+//                    statement's source slice (`syntaqlite_parser_text`).
+//   - DocOffset    — byte offset from the start of the full bound
+//                    source (`syntaqlite_parser_full_text`).
+//   - LayerOffset  — byte offset into an expansion layer's internal
+//                    buffer (e.g. `SyntaqliteTextSpan`,
+//                    `SyntaqliteMacroArgSegment`).  Resolve via the
+//                    parser's span accessors; never use directly as a
+//                    source offset.
+//
+// Lengths are unitless byte counts — a length of 5 means "5 bytes",
+// regardless of which buffer those bytes come from.  A single typedef
+// (`SyntaqliteLength`) flags a value as "byte count" rather than an
+// opaque id / flag / ordinal.
+//
+// Indices and numeric positions:
+//   - TokenIdx     — 0-based index into a statement's token stream.
 //   - LineNumber / ColumnNumber — 1-based, with `0` meaning "unknown".
 
 typedef uint32_t SyntaqliteStmtOffset;
-typedef uint32_t SyntaqliteStmtLen;
-
 typedef uint32_t SyntaqliteDocOffset;
-typedef uint32_t SyntaqliteDocLen;
-
 typedef uint32_t SyntaqliteLayerOffset;
-typedef uint32_t SyntaqliteLayerLen;
+
+typedef uint32_t SyntaqliteLength;
 
 typedef uint32_t SyntaqliteTokenIdx;
 
@@ -75,7 +78,7 @@ typedef uint32_t SyntaqliteCompletionContext;
 //     drill-through fidelity for spans inside substituted macro args.
 typedef struct SyntaqliteTextSpan {
   SyntaqliteLayerOffset offset;
-  SyntaqliteLayerLen length;
+  SyntaqliteLength length;
   uint32_t flags;
   uint32_t _layer_id;  // Internal: 0 = source, >0 = macro expansion layer.
 } SyntaqliteTextSpan;

--- a/syntaqlite/include/syntaqlite/analysis.h
+++ b/syntaqlite/include/syntaqlite/analysis.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include "syntaqlite/config.h"
 #include "syntaqlite/dialect.h"
+#include "syntaqlite/types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -67,11 +68,16 @@ typedef enum {
 
 // A single diagnostic from validation. Pointers are valid until the next
 // analyze() or destroy() call.
+//
+// `start_offset` / `end_offset` are document-absolute byte offsets into
+// the source buffer passed to the most recent `analyze()` /
+// `load_schema_ddl()` call — they are NOT statement-relative, even when
+// read via `syntaqlite_analyzer_statement_diagnostics`.
 typedef struct {
   SyntaqliteSeverity severity;
   const char* message;
-  uint32_t start_offset;
-  uint32_t end_offset;
+  SyntaqliteDocOffset start_offset;
+  SyntaqliteDocOffset end_offset;
   uint32_t kind_code;  // SyntaqliteDiagnosticCode value
 } SyntaqliteDiagnostic;
 
@@ -223,11 +229,12 @@ SYNTAQLITE_API void syntaqlite_analyzer_set_module_resolver(
 // separated by semicolons. DDL statements (CREATE TABLE, etc.) accumulate
 // in the internal catalog so that later statements can reference them.
 //
-// Returns the number of diagnostics produced.
+// Returns the number of diagnostics produced. Diagnostic offsets are
+// document-absolute (measured from `source[0]`).
 // The source buffer must remain valid only for the duration of this call.
 SYNTAQLITE_API uint32_t syntaqlite_analyzer_analyze(SyntaqliteAnalyzer* v,
                                                       const char* source,
-                                                      uint32_t len);
+                                                      SyntaqliteLength len);
 
 // Clear accumulated DDL from the catalog (document + connection layers).
 // The dialect layer (built-in functions, etc.) is preserved.
@@ -253,7 +260,7 @@ SYNTAQLITE_API void syntaqlite_analyzer_add_views(
 SYNTAQLITE_API uint32_t syntaqlite_analyzer_load_schema_ddl(
     SyntaqliteAnalyzer* v,
     const char* source,
-    uint32_t len);
+    SyntaqliteLength len);
 
 // Register a scalar / aggregate / window function overload in the database
 // layer. Repeat calls with the same `name` build up an overload set — any

--- a/syntaqlite/include/syntaqlite/formatter.h
+++ b/syntaqlite/include/syntaqlite/formatter.h
@@ -7,7 +7,7 @@
 //   SyntaqliteFormatter* f = syntaqlite_formatter_create_sqlite();
 //   if (syntaqlite_formatter_format(f, sql, len) == 0) {
 //     const char* out = syntaqlite_formatter_output(f);
-//     uint32_t out_len = syntaqlite_formatter_output_len(f);
+//     SyntaqliteLength out_len = syntaqlite_formatter_output_len(f);
 //     // use out[0..out_len]
 //   } else {
 //     const char* err = syntaqlite_formatter_error_msg(f);
@@ -24,6 +24,7 @@
 #include <stdint.h>
 #include "syntaqlite/config.h"
 #include "syntaqlite/dialect.h"
+#include "syntaqlite/types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,7 +69,7 @@ SYNTAQLITE_API void syntaqlite_formatter_destroy(SyntaqliteFormatter* f);
 // The source buffer must remain valid only for the duration of this call.
 SYNTAQLITE_API int32_t syntaqlite_formatter_format(SyntaqliteFormatter* f,
                                                     const char* source,
-                                                    uint32_t len);
+                                                    SyntaqliteLength len);
 
 // ---------------------------------------------------------------------------
 // Result access (valid until next format() or destroy())
@@ -79,9 +80,9 @@ SYNTAQLITE_API int32_t syntaqlite_formatter_format(SyntaqliteFormatter* f,
 SYNTAQLITE_API const char* syntaqlite_formatter_output(
     const SyntaqliteFormatter* f);
 
-// Length in bytes of the formatted output (excluding NUL terminator).
+// Byte length of the formatted output (excluding NUL terminator).
 // Returns 0 if format() has not been called or failed.
-SYNTAQLITE_API uint32_t syntaqlite_formatter_output_len(
+SYNTAQLITE_API SyntaqliteLength syntaqlite_formatter_output_len(
     const SyntaqliteFormatter* f);
 
 // NUL-terminated error message from the last failed format() call.

--- a/tests/c_api_tests/parser_driver.c
+++ b/tests/c_api_tests/parser_driver.c
@@ -126,7 +126,7 @@ int main(void) {
       int n = read_block(g_body, sizeof(g_body));
       if (n < 0) { printf("reset err no_terminator\n"); break; }
       if (!p) { printf("reset err no_handle\n"); continue; }
-      syntaqlite_parser_reset(p, g_body, (SyntaqliteDocLen)n);
+      syntaqlite_parser_reset(p, g_body, (SyntaqliteLength)n);
       printf("reset ok len=%d\n", n);
     } else if (!p) {
       printf("%s err no_handle\n", verb);
@@ -152,7 +152,7 @@ int main(void) {
       printf("node_count %u\n", syntaqlite_parser_node_count(p));
     } else if (strcmp(verb, "parser_text") == 0) {
       SyntaqliteDocOffset off = 0;
-      SyntaqliteStmtLen len = 0;
+      SyntaqliteLength len = 0;
       const char* t = syntaqlite_parser_text(p, &off, &len);
       if (!t) {
         printf("parser_text none\n");
@@ -163,7 +163,7 @@ int main(void) {
         printf(".\n");
       }
     } else if (strcmp(verb, "full_text") == 0) {
-      SyntaqliteDocLen len = 0;
+      SyntaqliteLength len = 0;
       const char* t = syntaqlite_parser_full_text(p, &len);
       if (!t) {
         printf("full_text none\n");
@@ -267,7 +267,7 @@ int main(void) {
     } else if (strcmp(verb, "error_info") == 0) {
       const char* msg = syntaqlite_result_error_msg(p);
       SyntaqliteStmtOffset off = syntaqlite_result_error_offset(p);
-      SyntaqliteStmtLen len = syntaqlite_result_error_length(p);
+      SyntaqliteLength len = syntaqlite_result_error_length(p);
       uint32_t recovery = syntaqlite_result_recovery_root(p);
       printf("error_info msg=\"%s\" off=%u len=%u recovery=%u\n",
              msg ? msg : "",


### PR DESCRIPTION
Offsets returned or accepted by the C / Python APIs were plain
uint32_t, leaving "statement-relative vs document-relative" implicit
and often un-documented. Types.h already defined Stmt/Doc/Layer offset
aliases; this propagates them through the public surface and collapses
the parallel *Len aliases into a single SyntaqliteLength, since a byte
count is unitless — the paired pointer tells you which buffer the
bytes come from.

- types.h: consolidate StmtLen/DocLen/LayerLen into SyntaqliteLength;
  refresh the header comment describing which buffer each *Offset
  names.
- analysis.h: SyntaqliteDiagnostic.start_offset/end_offset are now
  SyntaqliteDocOffset and documented as document-absolute even when
  read via statement_diagnostics; analyze/load_schema_ddl take
  SyntaqliteLength for source size.
- parser.h: span_text / node_text out_offset typed as StmtOffset
  (doc previously wrongly said "input source" — the implementation
  returns statement-relative); expanded_text / node_expanded_text /
  span_expanded_text out_len typed as SyntaqliteLength.
- tokenizer.h, dialect.h, incremental.h: typed token/offset/length
  fields on SyntaqliteToken, SynqParseToken, SyntaqliteArgMapping
  and macro expansion set_result APIs; line/col args use
  SyntaqliteLineNumber / ColumnNumber.
- formatter.h: source len and output_len typed as SyntaqliteLength.
- python bindings: docstring on Diagnostic clarifies offsets are
  document-absolute; tokenize() docs clarify the coordinate system.
- tests/c_api_tests/parser_driver.c: adapted to the renamed typedefs.

