### PR TITLE
synq: unify token-feeding and surface expansion tokens layer-aware

### DIFF
--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -113,7 +113,7 @@ static void reset_stmt(SyntaqliteParser* p) {
   p->stmt_source = p->source;
 }
 
-// Handle a statement boundary after feed_one_token returns 1.
+// Handle a statement boundary after shift_token returns 1.
 // Reinitializes Lemon and classifies the completed statement:
 //   SYNTAQLITE_PARSE_OK    — successful statement (root is set)
 //   SYNTAQLITE_PARSE_ERROR — statement with syntax error(s)
@@ -213,39 +213,91 @@ SYNTAQLITE_API void syntaqlite_parser_destroy(SyntaqliteParser* p) {
 // Returns: 0 = keep going, 1 = statement completed, -1 = unrecoverable error.
 // ---------------------------------------------------------------------------
 
-int synq_parser_feed_one_token(SyntaqliteParser* p,
-                               uint32_t token_type,
-                               const char* text,
-                               uint32_t len,
-                               uint32_t token_idx) {
-  // Only called from layer-0 paths — macro expansion bypasses this —
-  // so the offset Lemon stores into TextSpans is statement-relative.
-  uint32_t tok_offset = text ? (uint32_t)(text - p->stmt_source) : 0;
+// Unified token shift: push the token to `p->tokens` (when
+// `collect_tokens` is on and `text` is non-null), build the
+// `SynqParseToken` with a real `token_idx`, feed Lemon, and maintain
+// per-layer parser bookkeeping.  The sole path that terminals take
+// into Lemon — called by the main tokenizer loop, by the macro
+// expansion loop, by the fallback-macro consolidator, and by the
+// low-level incremental feed API.
+//
+// `text` points to the token bytes in their owning buffer (the source
+// for layer 0, an expansion layer's buffer for layer N).  May be NULL
+// for synthesized tokens (SEMI/EOF at end-of-input); in that case no
+// vec entry is pushed and the shift markers do not advance.
+//
+// `layer_offset` is the token's offset within its owning buffer:
+//   - for layer 0: statement-relative (identical to `text - stmt_source`)
+//   - for layer N: position within the expansion buffer
+// `p->ctx.layer_id` must already reflect the token's layer.
+//
+// Returns 1 if Lemon flagged the statement as completed, 0 otherwise.
+// Layer-N callers (macro expansion) handle their own error messages
+// and clear `p->ctx.error` themselves; for them, this function sets
+// `p->had_error` but leaves the error flag intact.
+int synq_parser_shift_token(SyntaqliteParser* p,
+                            uint32_t token_type,
+                            const char* text,
+                            uint32_t len,
+                            uint32_t layer_offset) {
+  uint32_t layer_id = p->ctx.layer_id;
+  uint32_t tidx = 0xFFFFFFFF;
+
+  if (p->collect_tokens && text) {
+    SyntaqliteParserToken tp = {layer_offset, len, token_type, 0, layer_id};
+    syntaqlite_vec_push(&p->tokens, tp, p->mem);
+    tidx = syntaqlite_vec_len(&p->tokens) - 1;
+    // Drives same-line trailing-comment attachment.  Only advanced for
+    // layer-0 tokens so comments emitted from the main tokenizer loop
+    // attach relative to the last user-authored token, not relative to
+    // some layer-N expansion token.
+    if (layer_id == 0) {
+      p->last_layer0_token_end = p->stmt_start_offset + layer_offset + len;
+    }
+  }
+
+  // BEFORE-style empty-rule markers (ast_builder.h:117) are documented
+  // as valid for layer-0 shifts only.  Publish cur_shift_start before
+  // SYNQ_PARSER_FEED so reductions firing inside the feed observe it.
+  if (layer_id == 0) {
+    p->ctx.cur_shift_start = layer_offset;
+  }
+
   SynqParseToken minor = {
       .z = text,
       .n = len,
       .type = token_type,
-      .token_idx = token_idx,
-      .offset = tok_offset,
-      .layer_id = p->ctx.layer_id,
+      .token_idx = tidx,
+      .offset = layer_offset,
+      .layer_id = layer_id,
   };
   SYNQ_PARSER_FEED(p->dialect.tmpl, p->lemon, (int)token_type, minor);
   p->last_token_type = token_type;
 
+  // AFTER-style markers: also layer-0.  Advance after feed so reductions
+  // inside feed saw the previous terminal's end.
+  if (layer_id == 0) {
+    p->ctx.last_shifted_end = layer_offset + len;
+  }
+
   if (p->ctx.error) {
     p->had_error = 1;
-    if (p->error_msg[0] == '\0') {
-      if (text) {
-        p->ctx.error_offset = (uint32_t)(text - p->stmt_source);
-        p->ctx.error_length = (uint32_t)len;
-        snprintf(p->error_msg, sizeof(p->error_msg), "syntax error near '%.*s'",
-                 len, text);
-      } else {
-        snprintf(p->error_msg, sizeof(p->error_msg),
-                 "incomplete SQL statement");
+    if (layer_id == 0) {
+      if (p->error_msg[0] == '\0') {
+        if (text) {
+          p->ctx.error_offset = layer_offset;
+          p->ctx.error_length = len;
+          snprintf(p->error_msg, sizeof(p->error_msg),
+                   "syntax error near '%.*s'", len, text);
+        } else {
+          snprintf(p->error_msg, sizeof(p->error_msg),
+                   "incomplete SQL statement");
+        }
       }
+      p->ctx.error = 0;  // Lemon is now driving recovery.
     }
-    p->ctx.error = 0;  // Lemon is now driving recovery.
+    // Layer-N: leave p->ctx.error set; expand_and_feed builds a
+    // macro-specific message and clears the flag.
     return 0;
   }
 
@@ -258,7 +310,7 @@ int synq_parser_feed_one_token(SyntaqliteParser* p,
 }
 
 // Local shorthand for the cross-file helper.
-#define feed_one_token synq_parser_feed_one_token
+#define shift_token synq_parser_shift_token
 
 // ---------------------------------------------------------------------------
 // Internal: synthesize SEMI + EOF to finish parsing.
@@ -280,7 +332,7 @@ static int finish_input(SyntaqliteParser* p) {
 
   // Synthesize SEMI if the last token wasn't one.
   if (p->last_token_type != SYNTAQLITE_TK_SEMI) {
-    int rc = feed_one_token(p, SYNTAQLITE_TK_SEMI, NULL, 0, 0xFFFFFFFF);
+    int rc = shift_token(p, SYNTAQLITE_TK_SEMI, NULL, 0, 0);
     if (rc == 1) {
       int32_t status = stmt_boundary(p);
       if (status != SYNTAQLITE_PARSE_DONE) {
@@ -330,42 +382,6 @@ static int finish_input(SyntaqliteParser* p) {
 // ---------------------------------------------------------------------------
 // Internal: token recording and feeding
 // ---------------------------------------------------------------------------
-
-// Record a token and feed it to Lemon.  Returns 1 if a real statement
-// boundary was reached (caller should return stmt_boundary()), 0 otherwise.
-// Always called at layer 0; stores offsets relative to stmt_source.
-int synq_parser_record_and_feed(SyntaqliteParser* p,
-                                uint32_t cur_type,
-                                uint32_t cur_offset,
-                                uint32_t cur_len) {
-  uint32_t tidx = 0xFFFFFFFF;
-  uint32_t cur_offset_rel = cur_offset - p->stmt_start_offset;
-  if (p->collect_tokens) {
-    SyntaqliteParserToken tp = {cur_offset_rel, cur_len, cur_type, 0,
-                                p->ctx.layer_id};
-    syntaqlite_vec_push(&p->tokens, tp, p->mem);
-    tidx = syntaqlite_vec_len(&p->tokens) - 1;
-    p->last_layer0_token_end = cur_offset + cur_len;
-  }
-  // Publish the upcoming token's start *before* Lemon processes it so
-  // that BEFORE-style empty-marker reductions firing inside feed_one_token
-  // see the start of the token about to be shifted (whitespace between
-  // the previous terminal and this one is excluded).
-  p->ctx.cur_shift_start = cur_offset_rel;
-  int rc = feed_one_token(p, cur_type, p->source + cur_offset, cur_len, tidx);
-  // Advance the "last shifted terminal end" cursor *after* Lemon finishes
-  // processing `cur`, so that any empty-rule reductions that fired inside
-  // feed_one_token observed the previous shifted token's end.  AFTER-style
-  // markers use this to capture the end position of a non-terminal.
-  p->ctx.last_shifted_end = cur_offset_rel + cur_len;
-  // After parse_failure, Lemon stops reducing — force a boundary on SEMI
-  // so errors don't bleed into subsequent statements.
-  if (p->had_error && rc == 0 && cur_type == SYNTAQLITE_TK_SEMI)
-    rc = 1;
-  if (rc == 1 && (p->ctx.root != SYNTAQLITE_NULL_NODE || p->had_error))
-    return 1;
-  return 0;
-}
 
 // Record a comment token (outlined from the hot loop).
 //
@@ -572,9 +588,17 @@ SYNTAQLITE_API int32_t syntaqlite_parser_next(SyntaqliteParser* p) {
     }
 #endif
 
-    // Normal token (or macro fallthrough): record + feed to Lemon.
-    if (synq_parser_record_and_feed(p, cur_type, cur_offset,
-                                    (uint32_t)cur_len)) {
+    // Normal token (or macro fallthrough): shift into Lemon.
+    // After parse_failure Lemon stops reducing — force a boundary on
+    // SEMI so errors don't bleed into the next statement.  And filter
+    // bare-semicolon rc==1 (no root, no error) so the main loop keeps
+    // tokenizing instead of closing an empty statement.
+    uint32_t main_layer_offset = cur_offset - p->stmt_start_offset;
+    int main_rc = shift_token(p, cur_type, p->source + cur_offset,
+                              (uint32_t)cur_len, main_layer_offset);
+    if (p->had_error && main_rc == 0 && cur_type == SYNTAQLITE_TK_SEMI)
+      main_rc = 1;
+    if (main_rc == 1 && (p->ctx.root != SYNTAQLITE_NULL_NODE || p->had_error)) {
       // Eagerly consume same-line trailing comments after the statement
       // terminator so they attach to this statement's last token instead
       // of the next statement's first.  Stop at the first newline or
@@ -908,6 +932,41 @@ SYNTAQLITE_API const char* syntaqlite_parser_text(SyntaqliteParser* p,
   return p->stmt_source;
 }
 
+SYNTAQLITE_API const char* syntaqlite_parser_layer_text(
+    SyntaqliteParser* p,
+    uint32_t layer_id,
+    SyntaqliteLength* out_len) {
+  if (out_len) {
+    *out_len = 0;
+  }
+  if (layer_id == 0) {
+    // Authored source for the current statement.  Identical to
+    // `syntaqlite_parser_text` but typed for the layer-indexed API.
+    if (p->stmt_start_offset == UINT32_MAX ||
+        p->stmt_end_offset <= p->stmt_start_offset ||
+        p->stmt_end_offset > p->source_len) {
+      return NULL;
+    }
+    if (out_len) {
+      *out_len = p->stmt_end_offset - p->stmt_start_offset;
+    }
+    return p->stmt_source;
+  }
+#ifdef SYNTAQLITE_OMIT_MACROS
+  (void)layer_id;
+  return NULL;
+#else
+  if (layer_id >= syntaqlite_vec_len(&p->macro.layers)) {
+    return NULL;
+  }
+  const SynqExpansionLayer* lyr = &p->macro.layers.data[layer_id];
+  if (out_len) {
+    *out_len = lyr->expansion_len;
+  }
+  return lyr->expansion_data;
+#endif
+}
+
 SYNTAQLITE_API const char* syntaqlite_parser_expanded_text(SyntaqliteParser* p,
                                                            uint32_t* out_len) {
 #ifdef SYNTAQLITE_OMIT_MACROS
@@ -973,17 +1032,8 @@ SYNTAQLITE_API int32_t syntaqlite_parser_feed_token(SyntaqliteParser* p,
     return set_result_status(p, SYNTAQLITE_PARSE_DONE);
   }
 
-  // Capture non-whitespace, non-comment token positions.
-  uint32_t tidx = 0xFFFFFFFF;
-  if (p->collect_tokens && text) {
-    SyntaqliteParserToken tp = {(uint32_t)(text - p->stmt_source), len,
-                                token_type, 0, p->ctx.layer_id};
-    syntaqlite_vec_push(&p->tokens, tp, p->mem);
-    tidx = syntaqlite_vec_len(&p->tokens) - 1;
-    p->last_layer0_token_end = (uint32_t)(text - p->source) + len;
-  }
-
-  int rc = feed_one_token(p, token_type, text, len, tidx);
+  uint32_t layer_offset = text ? (uint32_t)(text - p->stmt_source) : 0;
+  int rc = shift_token(p, token_type, text, len, layer_offset);
   if (rc < 0)
     return set_result_status(p, SYNTAQLITE_PARSE_ERROR);
 

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -251,18 +251,25 @@ void synq_parser_record_comment(SyntaqliteParser* p,
 // parser_macros.c as a convenient exit helper).
 int32_t synq_parser_set_result_status(SyntaqliteParser* p, int32_t rc);
 
-// Feed one token to Lemon. Returns 0/1/-1 (see parser.c for semantics).
-int synq_parser_feed_one_token(SyntaqliteParser* p,
-                               uint32_t token_type,
-                               const char* text,
-                               uint32_t len,
-                               uint32_t token_idx);
-
-// Record a token into p->tokens (if enabled) and feed it to Lemon.
-int synq_parser_record_and_feed(SyntaqliteParser* p,
-                                uint32_t cur_type,
-                                uint32_t cur_offset,
-                                uint32_t cur_len);
+// Unified token shift — the sole path that terminals take into Lemon.
+// Pushes to p->tokens (if collect_tokens is on and text is non-null),
+// builds the SynqParseToken with a real token_idx, feeds Lemon, and
+// updates per-layer parser bookkeeping.
+//
+// `layer_offset` is interpreted layer-locally:
+//   - layer 0: statement-relative
+//   - layer N: buffer-local (offset into the expansion layer)
+// `p->ctx.layer_id` must already reflect the token's layer.
+//
+// Returns 1 if Lemon flagged `stmt_completed`, 0 otherwise.  Layer-N
+// callers (macro expansion) handle their own error messages and clear
+// `p->ctx.error` themselves — this function sets `p->had_error` but
+// leaves `p->ctx.error` intact when layer_id != 0.
+int synq_parser_shift_token(SyntaqliteParser* p,
+                            uint32_t token_type,
+                            const char* text,
+                            uint32_t len,
+                            uint32_t layer_offset);
 
 #ifndef SYNTAQLITE_OMIT_MACROS
 

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -354,17 +354,15 @@ static int expand_and_feed(SyntaqliteParser* p,
       }
     }
 
-    // Feed token to Lemon.  `pos` is the offset within the expansion
-    // layer; `p->ctx.layer_id` was set to the current expansion's index
-    // before expand_and_feed was called.
-    SynqParseToken minor = {.z = buf + pos,
-                            .n = (uint32_t)tlen,
-                            .type = ttype,
-                            .token_idx = 0xFFFFFFFF,
-                            .offset = pos,
-                            .layer_id = p->ctx.layer_id};
-    SYNQ_PARSER_FEED(p->dialect.tmpl, p->lemon, (int)ttype, minor);
-    p->last_token_type = ttype;
+    // Feed the token through the unified shift path: it pushes to
+    // `p->tokens` with a real `token_idx` (tagged with the current
+    // expansion layer) and then feeds Lemon.  `pos` is the token's
+    // offset within the expansion buffer; `p->ctx.layer_id` was set
+    // to the current expansion's index before expand_and_feed was
+    // called.  For layer-N the shift function leaves `p->ctx.error`
+    // intact so we can attach a macro-specific error message here.
+    int frc = synq_parser_shift_token(p, ttype, buf + pos, (uint32_t)tlen,
+                                      (uint32_t)pos);
 
     if (p->ctx.error) {
       p->had_error = 1;
@@ -376,7 +374,7 @@ static int expand_and_feed(SyntaqliteParser* p,
       p->ctx.error = 0;
     }
 
-    if (p->ctx.stmt_completed) {
+    if (frc == 1 || p->ctx.stmt_completed) {
       p->ctx.stmt_completed = 0;
       p->ctx.source = saved_source;
       return 1;
@@ -713,11 +711,15 @@ int synq_parser_try_macro_call(SyntaqliteParser* p,
 
   synq_end_macro(p);
 
-  // Feed the whole name!(args) span as a single TK_ID to Lemon.
-  int rc =
-      synq_parser_record_and_feed(p, SYNTAQLITE_TK_ID, id_offset, call_length);
+  // Feed the whole name!(args) span as a single TK_ID to Lemon.  A
+  // TK_ID shift mid-statement cannot complete a statement, so the
+  // shift's return value is always 0 and we don't need the main-loop's
+  // boundary filter here.
+  uint32_t layer_offset = id_offset - p->stmt_start_offset;
+  synq_parser_shift_token(p, SYNTAQLITE_TK_ID, p->source + id_offset,
+                          call_length, layer_offset);
   p->offset = end_offset;
-  return rc;
+  return 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -457,6 +457,28 @@ SYNTAQLITE_API const char* syntaqlite_parser_full_text(
     SyntaqliteParser* p,
     SyntaqliteLength* out_len);
 
+// Return the tokenization buffer for `layer_id`.
+//
+// Layer 0 is the authored-source slice for the current statement
+// (identical to `syntaqlite_parser_text`).  Layers > 0 are macro
+// expansion buffers — the text that the expansion-layer tokenizer
+// consumed for that layer.
+//
+// Token entries in `syntaqlite_result_tokens` carry `_layer_id` and a
+// layer-local `offset`: to recover a token's byte text, call
+// `syntaqlite_parser_layer_text(p, tok._layer_id, &buf_len)` and slice
+// `[tok.offset, tok.offset + tok.length)` from the returned pointer.
+//
+// The returned pointer is valid until the next parser_next, reset, or
+// destroy on the same parser.  Returns NULL with `*out_len == 0` when
+// `layer_id` is out of range for the current statement, when no
+// statement has been bound (layer 0), or when macros are compiled out
+// (layer > 0).
+SYNTAQLITE_API const char* syntaqlite_parser_layer_text(
+    SyntaqliteParser* p,
+    uint32_t layer_id,
+    SyntaqliteLength* out_len);
+
 // Post-expansion text for the current statement — materializes the
 // statement's source with every currently-active macro call replaced
 // by its expansion into a parser-owned scratch buffer.  The returned

--- a/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
@@ -109,7 +109,7 @@ typedef struct SynqParseCtx {
 
   // Byte offset of the token Lemon is currently processing (in
   // root-source coordinates).  Set at the start of
-  // `synq_parser_record_and_feed` *before* `feed_one_token` runs, so
+  // `synq_parser_shift_token` *before* `SYNQ_PARSER_FEED` runs, so
   // empty-rule reductions firing inside the feed observe the offset of
   // the token they're about to be shifted alongside.  BEFORE-style
   // markers use this to capture the start position of a non-terminal
@@ -119,7 +119,7 @@ typedef struct SynqParseCtx {
 
   // Byte offset just past the end of the most recently shifted terminal
   // (in root-source coordinates).  Updated in
-  // `synq_parser_record_and_feed` *after* `feed_one_token` returns, so
+  // `synq_parser_shift_token` *after* `SYNQ_PARSER_FEED` returns, so
   // that empty-rule reductions firing inside the feed see the end of
   // the *previous* shifted terminal, not the current one.  AFTER-style
   // markers use this to capture the end position of a non-terminal.

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -278,6 +278,31 @@ impl CParser {
         unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize)) }
     }
 
+    /// Tokenization buffer for `layer_id` — the authored-source slice
+    /// for the current statement (layer 0) or an expansion layer's
+    /// body (layer > 0).  Empty if `layer_id` is out of range or
+    /// macros are compiled out.
+    ///
+    /// # Safety
+    /// The returned slice must not outlive the borrow underlying `self`.
+    pub(crate) unsafe fn layer_text<'a>(&self, layer_id: u32) -> &'a str {
+        let mut out_len: u32 = 0;
+        // SAFETY: self is a valid, non-null CParser pointer owned by the caller.
+        let ptr = unsafe {
+            syntaqlite_parser_layer_text(
+                std::ptr::from_ref::<Self>(self).cast_mut(),
+                layer_id,
+                &raw mut out_len,
+            )
+        };
+        if ptr.is_null() || out_len == 0 {
+            return "";
+        }
+        // SAFETY: C guarantees `ptr` points to `out_len` bytes of valid
+        // UTF-8 within the parser's layer buffer.
+        unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, out_len as usize)) }
+    }
+
     /// Post-expansion source text — the bound source with every
     /// currently-active macro call replaced by its expansion.
     /// Materialized into the parser's scratch buffer; the returned
@@ -764,6 +789,8 @@ unsafe extern "C" {
         out_len: *mut u32,
     ) -> *const u8;
     fn syntaqlite_parser_full_text(p: *mut CParser, out_len: *mut u32) -> *const u8;
+    fn syntaqlite_parser_layer_text(p: *mut CParser, layer_id: u32, out_len: *mut u32)
+    -> *const u8;
     fn syntaqlite_parser_expanded_text(p: *mut CParser, out_len: *mut u32) -> *const u8;
     fn syntaqlite_parser_node_text(
         p: *mut CParser,

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -944,42 +944,25 @@ impl<'a> AnyParsedStatement<'a> {
         (text, DocRange { start, end })
     }
 
-    /// Statement-relative byte ranges for all collected tokens.
+    /// Token stream for the current statement.
     ///
-    /// Returns an empty iterator if `collect_tokens` was not enabled.
-    /// Always non-empty when the result comes from [`TypedParser::incremental_parse`],
-    /// which unconditionally enables token collection.
-    pub fn token_spans(&self) -> impl Iterator<Item = StmtRange> + use<'_> {
-        // SAFETY: self.raw is valid for 'a; the returned slice lives for 'a.
-        let raw: &[ffi::CParserToken] = unsafe { self.raw.as_ref().result_tokens() };
-        raw.iter().map(|t| {
-            StmtRange::from_offset_len(StmtOffset::from_raw(t.offset), StmtLen::from_raw(t.length))
-        })
-    }
-
-    /// Statement-local token stream with full per-token data
-    /// (text, type, flags, offset, length).
+    /// Yields every token the parser fed to Lemon while reducing the
+    /// statement — including tokens produced by macro expansion.
+    /// Each token's [`stmt_range`](AnyParserToken::stmt_range) gives
+    /// its authored-source range (layer-N tokens drill up to the
+    /// enclosing macro call site, just like `span_text` does for AST
+    /// spans), so most consumers can ignore layer identity entirely.
+    /// Layer-local info is still available via
+    /// [`layer_id`](AnyParserToken::layer_id) /
+    /// [`offset`](AnyParserToken::offset) /
+    /// [`length`](AnyParserToken::length) for advanced uses.
     ///
-    /// Like [`token_spans`](Self::token_spans) but returns full
-    /// [`AnyParserToken`] values including token type and flags. Used by
-    /// analysis passes that need to classify tokens (semantic highlighting,
-    /// completion, etc.). Requires `collect_tokens: true`.
+    /// Requires `collect_tokens: true` in [`ParserConfig`].
     pub fn tokens(&self) -> impl Iterator<Item = AnyParserToken<'a>> + use<'_, 'a> {
-        let source = self.text();
-        // SAFETY: self.raw is valid for 'a; the returned slice lives for 'a.
+        // SAFETY: self.raw is valid for 'a; the returned slices live for 'a.
         let raw: &'a [ffi::CParserToken] = unsafe { self.raw.as_ref().result_tokens() };
-        raw.iter().map(move |t| {
-            let offset = StmtOffset::from_raw(t.offset);
-            let length = StmtLen::from_raw(t.length);
-            let text = &source[StmtRange::from_offset_len(offset, length)];
-            AnyParserToken::new(
-                text,
-                AnyTokenType(t.type_),
-                ParserTokenFlags::from_raw(t.flags),
-                offset,
-                length,
-            )
-        })
+        raw.iter()
+            .map(move |t| build_parser_token(self.raw, t, AnyTokenType(t.type_)))
     }
 
     /// Comments attached to this statement with full per-comment data.
@@ -1331,25 +1314,17 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
         self.any.macro_rewrites()
     }
 
-    /// Statement-local token stream for this parse result.
+    /// Token stream for this parse result.  Yields every token fed
+    /// to Lemon across all expansion layers; see
+    /// [`AnyParsedStatement::tokens`] for the layer semantics.
     ///
     /// Requires `collect_tokens: true` and skips unknown token ordinals for `G`.
     pub fn tokens(&self) -> impl Iterator<Item = TypedParserToken<'a, G>> {
-        let source = self.any.text();
-        // SAFETY: self.any.raw is valid for 'a; the returned slice lives for 'a.
+        // SAFETY: self.any.raw is valid for 'a; the returned slices live for 'a.
         let raw: &'a [ffi::CParserToken] = unsafe { self.any.raw.as_ref().result_tokens() };
         raw.iter().filter_map(move |t| {
             let token_type = G::Token::from_token_type(AnyTokenType(t.type_))?;
-            let offset = StmtOffset::from_raw(t.offset);
-            let length = StmtLen::from_raw(t.length);
-            let text = &source[StmtRange::from_offset_len(offset, length)];
-            Some(TypedParserToken::new(
-                text,
-                token_type,
-                ParserTokenFlags::from_raw(t.flags),
-                offset,
-                length,
-            ))
+            Some(build_parser_token(self.any.raw, t, token_type))
         })
     }
 
@@ -1467,6 +1442,60 @@ fn ffi_comment<'a>(source: &'a StmtText, c: &ffi::CComment) -> Comment<'a> {
         length,
         TokenIdx::from_raw(c.token_idx),
         side,
+    )
+}
+
+/// Build a [`TypedParserToken`] from a raw FFI token entry, resolving
+/// its byte text against the owning layer's buffer and drilling up to
+/// the authored-source range via `span_text`.  Shared between the
+/// [`AnyParsedStatement`] and [`TypedParsedStatement`] token iterators.
+// `CParserToken._layer_id` and `TextSpan._layer_id` mirror the C ABI
+// (where the underscore signals "internal — use span APIs to resolve"),
+// so Rust reads of the field need the allow.
+#[expect(clippy::used_underscore_binding)]
+fn build_parser_token<'a, G: TypedDialect>(
+    raw: NonNull<CParser>,
+    t: &ffi::CParserToken,
+    token_type: G::Token,
+) -> TypedParserToken<'a, G> {
+    // SAFETY: raw is valid for 'a.  layer_text and span_text each
+    // borrow from parser-owned buffers that remain valid for 'a.
+    let buffer: &'a str = unsafe { raw.as_ref().layer_text(t._layer_id) };
+    let start = t.offset as usize;
+    let end = start.saturating_add(t.length as usize);
+    let text = buffer.get(start..end).unwrap_or("");
+    let layer_id = u8::try_from(t._layer_id).unwrap_or(u8::MAX);
+
+    let stmt_range = if t._layer_id == 0 {
+        StmtRange::from_offset_len(StmtOffset::from_raw(t.offset), StmtLen::from_raw(t.length))
+    } else {
+        // Drill up through the expansion-layer chain to the authored
+        // source range (same rule `span_text` uses for AST spans).
+        let span = crate::ast::TextSpan {
+            offset: t.offset,
+            length: t.length,
+            flags: 0,
+            _layer_id: t._layer_id,
+        };
+        let mut out_len: u32 = 0;
+        let mut out_offset: u32 = 0;
+        // SAFETY: raw is valid; span mirrors the token's layer
+        // position; the out pointers are live stack slots.
+        unsafe {
+            raw.as_ref()
+                .span_text(span, &raw mut out_len, &raw mut out_offset);
+        }
+        StmtRange::from_offset_len(StmtOffset::from_raw(out_offset), StmtLen::from_raw(out_len))
+    };
+
+    TypedParserToken::new(
+        text,
+        token_type,
+        ParserTokenFlags::from_raw(t.flags),
+        LayerOffset::from_raw(t.offset),
+        LayerLen::from_raw(t.length),
+        layer_id,
+        stmt_range,
     )
 }
 

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -246,12 +246,15 @@ impl<'a> ParserToken<'a> {
 
     /// Statement-relative byte offset of the token start.
     pub fn offset(&self) -> StmtOffset {
-        self.0.offset()
+        // SQLite has no macros; every token visible at this API level
+        // lives in the authored source (layer 0), so the token's
+        // layer-local offset IS its statement-relative offset.
+        StmtOffset::from_raw(self.0.offset().as_u32())
     }
 
     /// Byte length of the token text.
     pub fn length(&self) -> StmtLen {
-        self.0.length()
+        StmtLen::from_raw(self.0.length().as_u32())
     }
 }
 
@@ -320,7 +323,14 @@ impl<'a> ParsedStatement<'a> {
     ///
     /// Requires `collect_tokens: true` in [`ParserConfig`].
     pub fn tokens(&self) -> impl Iterator<Item = ParserToken<'a>> {
-        self.0.tokens().map(ParserToken)
+        // SQLite has no macros; this API only surfaces authored-source
+        // tokens.  Layer-N tokens can only arise if the caller plugs in
+        // a custom macro lookup via the dialect-agnostic API — they are
+        // elided here so statement-relative offsets stay meaningful.
+        self.0
+            .tokens()
+            .filter(|t| t.layer_id() == 0)
+            .map(ParserToken)
     }
 
     /// Comments that belong to this statement.
@@ -461,7 +471,14 @@ impl<'a> ParseError<'a> {
 
     /// Tokens collected during the (partial) parse, if `collect_tokens` was enabled.
     pub fn tokens(&self) -> impl Iterator<Item = ParserToken<'a>> {
-        self.0.tokens().map(ParserToken)
+        // SQLite has no macros; this API only surfaces authored-source
+        // tokens.  Layer-N tokens can only arise if the caller plugs in
+        // a custom macro lookup via the dialect-agnostic API — they are
+        // elided here so statement-relative offsets stay meaningful.
+        self.0
+            .tokens()
+            .filter(|t| t.layer_id() == 0)
+            .map(ParserToken)
     }
 
     /// Comments collected during the (partial) parse, if `collect_tokens` was enabled.
@@ -2325,5 +2342,57 @@ mod tests {
         assert_eq!(inner.call_text(), "mpass!(42)");
         let inner_arg_texts: Vec<&str> = inner.args().map(|a| a.text()).collect();
         assert_eq!(inner_arg_texts, vec!["42"]);
+    }
+
+    #[test]
+    fn tokens_include_expansion_layers_with_drilled_up_stmt_range() {
+        // The `tokens()` iterator yields every token fed to Lemon —
+        // including tokens produced by macro expansion.  For
+        // expansion-layer tokens, `stmt_range()` drills up to the
+        // authored call site, so consumers always get a meaningful
+        // statement-relative range.
+        let mut parser = Parser::with_config(
+            &ParserConfig::default()
+                .with_collect_tokens(true)
+                .with_macro_fallback(true),
+        );
+        let mut reg = TestMacroRegistry::new();
+        reg.register("id", &[], "42");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "SELECT id!() FROM t;";
+        let mut session = parser.parse(source);
+        let stmt = ok_stmt!(session);
+
+        // Collect raw token info via the dialect-agnostic iterator.
+        // Going through erase() ensures we see all layers.
+        let erased = stmt.erase();
+        let infos: Vec<(u8, &str, (u32, u32))> = erased
+            .tokens()
+            .map(|t| {
+                let range = t.stmt_range();
+                (
+                    t.layer_id(),
+                    t.text(),
+                    (range.start.as_u32(), range.len().as_u32()),
+                )
+            })
+            .collect();
+
+        // `SELECT` is layer 0; `42` is layer 1 (from the expansion);
+        // `FROM`, `t`, `;` are back at layer 0.
+        assert_eq!(
+            infos,
+            vec![
+                (0, "SELECT", (0, 6)),
+                // Expansion token: its `text()` is the expansion body,
+                // but its `stmt_range()` drills up to the call site
+                // `id!()` in the authored source.
+                (1, "42", (7, 5)),
+                (0, "FROM", (13, 4)),
+                (0, "t", (18, 1)),
+                (0, ";", (19, 1)),
+            ]
+        );
     }
 }

--- a/syntaqlite-syntax/src/parser/types.rs
+++ b/syntaqlite-syntax/src/parser/types.rs
@@ -3,7 +3,7 @@
 
 use crate::source::{
     ColumnNumber, LayerLen, LayerOffset, LayerText, LineNumber, RewriteIdx, StmtLen, StmtOffset,
-    TokenIdx,
+    StmtRange, TokenIdx,
 };
 
 use crate::dialect::TypedDialect;
@@ -211,13 +211,32 @@ pub use crate::dialect::ParserTokenFlags;
 ///
 /// Returned by [`super::TypedParsedStatement::tokens`]. Requires
 /// `collect_tokens: true` in [`super::ParserConfig`].
+///
+/// A token records both its *layer-local* position (where the parser
+/// actually consumed it — in the authored source for layer 0, or in a
+/// macro expansion buffer for layer > 0) and its *statement-relative*
+/// range (the authored-source range the user would point at when
+/// asking "where is this in my SQL?"):
+///
+/// - [`text`](Self::text) returns the exact byte slice for this token,
+///   from the authored source for layer-0 tokens or from the
+///   expansion-layer buffer for layer-N tokens.
+/// - [`layer_id`](Self::layer_id), [`offset`](Self::offset), and
+///   [`length`](Self::length) describe the token's position inside its
+///   owning layer — in [`LayerOffset`] / [`LayerLen`] coordinates.
+/// - [`stmt_range`](Self::stmt_range) collapses layer-N tokens up to
+///   their authored call-site range (the same drill-up rule used by
+///   the span-text APIs), so every token has a meaningful statement
+///   range regardless of layer.
 #[derive(Debug, Clone, Copy)]
 pub struct TypedParserToken<'a, G: TypedDialect> {
     text: &'a str,
     token_type: G::Token,
     flags: ParserTokenFlags,
-    offset: StmtOffset,
-    length: StmtLen,
+    offset: LayerOffset,
+    length: LayerLen,
+    layer_id: u8,
+    stmt_range: StmtRange,
 }
 
 impl<'a, G: TypedDialect> TypedParserToken<'a, G> {
@@ -225,8 +244,10 @@ impl<'a, G: TypedDialect> TypedParserToken<'a, G> {
         text: &'a str,
         token_type: G::Token,
         flags: ParserTokenFlags,
-        offset: StmtOffset,
-        length: StmtLen,
+        offset: LayerOffset,
+        length: LayerLen,
+        layer_id: u8,
+        stmt_range: StmtRange,
     ) -> Self {
         TypedParserToken {
             text,
@@ -234,10 +255,13 @@ impl<'a, G: TypedDialect> TypedParserToken<'a, G> {
             flags,
             offset,
             length,
+            layer_id,
+            stmt_range,
         }
     }
 
-    /// The source text slice covered by this token.
+    /// The byte text of this token — a slice of the authored source
+    /// (layer 0) or of the owning expansion layer's buffer (layer > 0).
     pub fn text(&self) -> &'a str {
         self.text
     }
@@ -252,14 +276,42 @@ impl<'a, G: TypedDialect> TypedParserToken<'a, G> {
         self.flags
     }
 
-    /// Statement-relative byte offset of the token start.
-    pub fn offset(&self) -> StmtOffset {
+    /// Byte offset of the token within its owning layer's buffer.
+    ///
+    /// For layer-0 tokens this equals the statement-relative offset.
+    /// For layer-N tokens it is a position in the expansion layer's
+    /// buffer; use [`stmt_range`](Self::stmt_range) for authored-source
+    /// coordinates.
+    pub fn offset(&self) -> LayerOffset {
         self.offset
     }
 
-    /// Byte length of the token text.
-    pub fn length(&self) -> StmtLen {
+    /// Byte length of the token text in its owning layer.
+    pub fn length(&self) -> LayerLen {
         self.length
+    }
+
+    /// The layer the token lives in.  `0` = authored source;
+    /// `>0` = an expansion layer.  Most consumers do not need this;
+    /// prefer [`stmt_range`](Self::stmt_range) for authored-source
+    /// positions.
+    pub fn layer_id(&self) -> u8 {
+        self.layer_id
+    }
+
+    /// Authored-source byte range for this token.
+    ///
+    /// For layer-0 tokens this is the token's own source position.
+    /// For tokens produced by macro expansion, this collapses up the
+    /// expansion chain to the enclosing macro call site (or, for
+    /// tokens substituted from a `$param`, to the caller's authored
+    /// argument text).  This mirrors the drill-up rule used by
+    /// `AnyParsedStatement::span_text`, so every token reports the
+    /// statement range the user would see in their source — multiple
+    /// expansion tokens from the same call may share the call site's
+    /// range.
+    pub fn stmt_range(&self) -> StmtRange {
+        self.stmt_range
     }
 }
 

--- a/syntaqlite/src/embedded/mod.rs
+++ b/syntaqlite/src/embedded/mod.rs
@@ -425,9 +425,10 @@ impl SemanticVisitor for TokenCapture {
     fn on_parsed_statement(&mut self, stmt: &syntaqlite_syntax::any::AnyParsedStatement<'_>) {
         let base = stmt.statement_base();
         for tok in stmt.tokens() {
+            let range = tok.stmt_range();
             self.tokens.push((
-                tok.offset().to_doc(base),
-                tok.length().into(),
+                range.start.to_doc(base),
+                range.len().into(),
                 tok.token_type(),
                 tok.flags(),
             ));
@@ -441,9 +442,10 @@ impl SemanticVisitor for TokenCapture {
     fn on_parse_error(&mut self, err: &syntaqlite_syntax::any::AnyParseError<'_>) {
         let base = err.statement_base();
         for tok in err.tokens() {
+            let range = tok.stmt_range();
             self.tokens.push((
-                tok.offset().to_doc(base),
-                tok.length().into(),
+                range.start.to_doc(base),
+                range.len().into(),
                 tok.token_type(),
                 tok.flags(),
             ));

--- a/syntaqlite/src/fmt/formatter.rs
+++ b/syntaqlite/src/fmt/formatter.rs
@@ -172,11 +172,17 @@ impl Formatter {
                 side: c.side(),
             }));
         self.token_entries.clear();
-        self.token_entries
-            .extend(erased.token_spans().map(|range| TokenEntry {
+        // `stmt_range` drills expansion-layer tokens up to their
+        // authored call-site range, so every token contributes an
+        // entry in statement coordinates — the same coordinate system
+        // the formatter emits in.
+        self.token_entries.extend(erased.tokens().map(|t| {
+            let range = t.stmt_range();
+            TokenEntry {
                 offset: range.start,
                 length: range.len(),
-            }));
+            }
+        }));
         // Only top-level fallback rewrites are meaningful here:
         // - `parent().is_none()` keeps offsets in the statement
         //   coordinate system the formatter compares against.

--- a/syntaqlite/src/lsp/analysis_data.rs
+++ b/syntaqlite/src/lsp/analysis_data.rs
@@ -413,9 +413,10 @@ impl SemanticVisitor for LspCapture<'_> {
     fn on_parsed_statement(&mut self, stmt: &AnyParsedStatement<'_>) {
         let base = stmt.statement_base();
         for tok in stmt.tokens() {
+            let range = tok.stmt_range();
             self.data.tokens.push(StoredToken {
-                offset: tok.offset().to_doc(base),
-                length: tok.length().into(),
+                offset: range.start.to_doc(base),
+                length: range.len().into(),
                 token_type: tok.token_type(),
                 flags: tok.flags(),
             });
@@ -431,9 +432,10 @@ impl SemanticVisitor for LspCapture<'_> {
     fn on_parse_error(&mut self, err: &AnyParseError<'_>) {
         let base = err.statement_base();
         for tok in err.tokens() {
+            let range = tok.stmt_range();
             self.data.tokens.push(StoredToken {
-                offset: tok.offset().to_doc(base),
-                length: tok.length().into(),
+                offset: range.start.to_doc(base),
+                length: range.len().into(),
                 token_type: tok.token_type(),
                 flags: tok.flags(),
             });

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -1129,7 +1129,6 @@ pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_text(&self, span: sy
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_text_abs(&self, span: syntaqlite_syntax::any::TextSpan) -> (&'a str, syntaqlite_syntax::source::DocRange)
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::statement_base(&self) -> syntaqlite_syntax::source::StatementBase
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::text(&self) -> &'a syntaqlite_syntax::source::StmtText
-pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::token_spans(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::source::StmtRange> + use<'_>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::tokens(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::AnyParserToken<'a>> + use<'_, 'a>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::traceback(&mut self, node_id: syntaqlite_syntax::any::AnyNodeId, field_idx: u8) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::TracebackFrame<'a>> + use<'_, 'a>
 pub fn syntaqlite_syntax::any::AnyTokenType::from(t: syntaqlite_syntax::TokenType) -> syntaqlite_syntax::any::AnyTokenType
@@ -1985,8 +1984,10 @@ pub fn syntaqlite_syntax::typed::TypedParser<G>::parse(&self, source: &str) -> s
 pub fn syntaqlite_syntax::typed::TypedParser<G>::set_macro_lookup(&mut self, handler: core::option::Option<alloc::boxed::Box<dyn syntaqlite_syntax::MacroLookup>>)
 pub fn syntaqlite_syntax::typed::TypedParser<G>::with_config(dialect: G, config: &syntaqlite_syntax::ParserConfig) -> Self
 pub fn syntaqlite_syntax::typed::TypedParserToken<'a, G>::flags(&self) -> syntaqlite_syntax::ParserTokenFlags
-pub fn syntaqlite_syntax::typed::TypedParserToken<'a, G>::length(&self) -> syntaqlite_syntax::source::StmtLen
-pub fn syntaqlite_syntax::typed::TypedParserToken<'a, G>::offset(&self) -> syntaqlite_syntax::source::StmtOffset
+pub fn syntaqlite_syntax::typed::TypedParserToken<'a, G>::layer_id(&self) -> u8
+pub fn syntaqlite_syntax::typed::TypedParserToken<'a, G>::length(&self) -> syntaqlite_syntax::source::LayerLen
+pub fn syntaqlite_syntax::typed::TypedParserToken<'a, G>::offset(&self) -> syntaqlite_syntax::source::LayerOffset
+pub fn syntaqlite_syntax::typed::TypedParserToken<'a, G>::stmt_range(&self) -> syntaqlite_syntax::source::StmtRange
 pub fn syntaqlite_syntax::typed::TypedParserToken<'a, G>::text(&self) -> &'a str
 pub fn syntaqlite_syntax::typed::TypedParserToken<'a, G>::token_type(&self) -> <G as syntaqlite_syntax::typed::TypedDialect>::Token
 pub fn syntaqlite_syntax::typed::TypedToken<'a, G>::text(&self) -> &'a str


### PR DESCRIPTION
## Summary

- Unify three token-feed paths (main loop, macro expansion, incremental API) onto one `synq_parser_shift_token`; expansion tokens now land in `p->tokens` with real `token_idx` and layer tags.
- Rust token API is layer-aware: `offset`/`length` are `LayerOffset`/`LayerLen`; `text()` resolves per-layer; `stmt_range()` drills expansion tokens up to the authored call site (same rule `span_text` uses for AST spans); `layer_id()` exposed.
- SQLite-level `ParserToken` stays layer-free — session elides any layer-N tokens at the facade boundary since SQLite itself has no macros.
- LSP, embedded, and formatter now call `stmt_range()` directly (no `Option` handling, no filter) — expansion tokens collapse to call-site ranges, which is what each tool wants.
- Removed `AnyParsedStatement::token_spans()` (redundant with `tokens().map(|t| t.stmt_range())`).

## Test plan

- [x] `tools/pre-push` — all green (fmt + c-deps + public-api + cli build + unit tests + ast/fmt/perfetto-fmt/perfetto-val integration + web playground).
- [x] Full `tools/run-integration-tests` — all 16 suites pass.
- [x] New Rust unit test `tokens_include_expansion_layers_with_drilled_up_stmt_range` exercises a registered macro (`id!()` → `42`) and verifies the iterator yields 5 tokens across layer 0 and layer 1 with correct per-layer text and drilled-up `stmt_range`.
- [x] C probe confirms expansion tokens appear in `p->tokens` with `layer_id > 0` and layer-local offsets.

## Why

This unblocks the paused `node_token_range` + `comment.layer_id` PR — it couldn't work correctly while `p->tokens` silently omitted expansion tokens. With the unified feed, node-level APIs can now report full token ranges that span expansion layers, and the drill-up in `stmt_range()` lets every consumer talk about token positions in authored-source coordinates without special-casing macros.