### PR TITLE
synq: add node_token_range and rework comment classification

### DIFF
--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -405,63 +405,122 @@ static int finish_input(SyntaqliteParser* p) {
 //   - layer 0: source-absolute (ctx.source == p->source).
 //   - layer N: layer-local (ctx.source is the expansion buffer).
 //
-// Attachment: TRAILING the previous pushed token when that token was
-// in the same layer as this comment and the gap in `p->ctx.source`
-// contains no '\n'.  Otherwise LEADING the next token to be pushed
-// (predicted owner index = `vec_len(p->tokens)`).  The layer-match
-// guard prevents a comment emitted from main tokenization at layer 0
-// after an expansion ends from incorrectly trailing the expansion's
-// last token, and vice versa.
+// Classification:
+//   - Same-line with prev token + something else on the line after this
+//     comment → LEADING on the next token (block "between two tokens").
+//   - Same-line with prev + rest of line empty (whitespace/comments only)
+//     → TRAILING on prev token.  Line comments (`-- ...`) always hit this
+//     branch because they consume the rest of their line.
+//   - Not same-line with prev → LEADING on the next token.
+//
+// Same-line-with-prev is computed in the prev token's buffer (same-layer
+// case) or, for a source comment after a macro expansion, against the
+// call's end position in source (cross-layer case).  Same-line-with-
+// follower is a forward scan in the comment's own buffer; it sees past
+// whitespace and adjacent comments.
+
+// Offset of the next real (non-whitespace, non-comment) token in `buf`
+// starting at `pos`, or `buf_len` if the rest of the buffer is
+// whitespace and comments only.
+static uint32_t synq_next_token_offset(SyntaqliteParser* p,
+                                       const char* buf,
+                                       uint32_t pos,
+                                       uint32_t buf_len) {
+  while (pos < buf_len && buf[pos] != '\0') {
+    uint32_t tt = 0;
+    int64_t tl = SynqSqliteGetTokenVersionWrapped(
+        &p->dialect, 0, (const unsigned char*)buf + pos, &tt);
+    if (tl <= 0)
+      return buf_len;
+    if (!synq_token_is_skip(tt))
+      return pos;
+    pos += (uint32_t)tl;
+  }
+  return buf_len;
+}
+
 SYNQ_NOINLINE
 void synq_parser_record_comment(SyntaqliteParser* p,
                                 uint32_t offset,
                                 uint32_t len) {
   uint32_t layer = p->ctx.layer_id;
   const unsigned char* z = (const unsigned char*)p->ctx.source;
-  const char kind_char = (const char)z[offset];
+  int is_block = (z[offset] != '-');
 
-  uint8_t side = SYNQ_COMMENT_LEADING;
-  uint32_t owner_idx = syntaqlite_vec_len(&p->tokens);
-  if (p->last_pushed_token_layer == layer) {
-    uint32_t prev_end = p->last_pushed_token_ctx_end;
-    if (prev_end <= offset &&
-        memchr(z + prev_end, '\n', offset - prev_end) == NULL) {
-      side = SYNQ_COMMENT_TRAILING;
-      owner_idx = syntaqlite_vec_len(&p->tokens) - 1;
+  // ── Same-line with previous token? ───────────────────────────────────────
+  int same_line_with_prev = 0;
+  if (p->last_pushed_token_layer == layer &&
+      p->last_pushed_token_ctx_end != UINT32_MAX &&
+      p->last_pushed_token_ctx_end <= offset) {
+    same_line_with_prev = memchr(z + p->last_pushed_token_ctx_end, '\n',
+                                 offset - p->last_pushed_token_ctx_end) == NULL;
+  }
+#ifndef SYNTAQLITE_OMIT_MACROS
+  else if (layer == 0 && p->last_pushed_token_layer != UINT32_MAX &&
+           p->last_pushed_token_layer > 0 &&
+           p->last_pushed_token_layer < syntaqlite_vec_len(&p->macro.layers)) {
+    // Prev token was inside an expansion; comment is in source.  Compare
+    // against the end of the topmost ancestor macro call in source.
+    uint32_t L = p->last_pushed_token_layer;
+    while (L > 0 && p->macro.layers.data[L].parent_layer_id != 0)
+      L = p->macro.layers.data[L].parent_layer_id;
+    if (L > 0) {
+      const SynqExpansionLayer* lyr = &p->macro.layers.data[L];
+      uint32_t call_end =
+          p->stmt_start_offset + lyr->call_offset + lyr->call_length;
+      if (call_end <= offset)
+        same_line_with_prev = memchr((const unsigned char*)p->source + call_end,
+                                     '\n', offset - call_end) == NULL;
+    }
+  }
+#endif
+
+  // ── Trailing on prev iff same-line-with-prev AND next token (if any)
+  //    is on a different line.  Line comments always satisfy the latter
+  //    (they consume the rest of their line).
+  int is_trailing = 0;
+  if (same_line_with_prev) {
+    if (!is_block) {
+      is_trailing = 1;
+    } else {
+      uint32_t buf_len = layer == 0 ? p->source_len
+#ifndef SYNTAQLITE_OMIT_MACROS
+                                    : p->macro.layers.data[layer].expansion_len
+#else
+                                    : 0
+#endif
+          ;
+      uint32_t next =
+          synq_next_token_offset(p, (const char*)z, offset + len, buf_len);
+      is_trailing = (next >= buf_len) || memchr(z + offset + len, '\n',
+                                                next - (offset + len)) != NULL;
     }
   }
 
-  // Store in layer-local coordinates (matches `SyntaqliteParserToken.offset`).
-  uint32_t stored_offset = layer == 0 ? offset - p->stmt_start_offset : offset;
+  // ── Record the comment ───────────────────────────────────────────────────
   SyntaqliteComment t = {
-      .offset = stored_offset,
+      .offset = layer == 0 ? offset - p->stmt_start_offset : offset,
       .length = len,
-      .token_idx = owner_idx,
-      .kind = kind_char == '-' ? (uint8_t)0 : (uint8_t)1,
-      .side = side,
+      .token_idx = 0,  // filled below
+      .kind = is_block ? (uint8_t)1 : (uint8_t)0,
+      .side = is_trailing ? SYNQ_COMMENT_TRAILING : SYNQ_COMMENT_LEADING,
       .layer_id = (uint8_t)(layer > 0xFF ? 0xFF : layer),
       ._pad = 0,
   };
-  // Maintain the per-token comment index in step with the push.  The
-  // owner either already exists in `p->tokens` (trailing attachment,
-  // or a previously-predicted leading whose owner has since been
-  // pushed) or it's the predicted "next token" whose entry lives in
-  // `pending_orphan_leading` until the shift happens.
   uint32_t comment_idx = syntaqlite_vec_len(&p->comments);
-  SynqTokenComments* tc;
-  if (owner_idx < syntaqlite_vec_len(&p->tokens)) {
-    tc = &syntaqlite_vec_at(&p->token_comments, owner_idx);
-  } else {
-    tc = &p->pending_orphan_leading;
-  }
-  if (side == SYNQ_COMMENT_LEADING) {
-    if (tc->leading_count == 0)
-      tc->leading_first = comment_idx;
-    tc->leading_count++;
-  } else {
+  if (is_trailing) {
+    uint32_t tok_idx = syntaqlite_vec_len(&p->tokens) - 1;
+    t.token_idx = tok_idx;
+    SynqTokenComments* tc = &syntaqlite_vec_at(&p->token_comments, tok_idx);
     if (tc->trailing_count == 0)
       tc->trailing_first = comment_idx;
     tc->trailing_count++;
+  } else {
+    t.token_idx = syntaqlite_vec_len(&p->tokens);  // predicted next token
+    SynqTokenComments* tc = &p->pending_orphan_leading;
+    if (tc->leading_count == 0)
+      tc->leading_first = comment_idx;
+    tc->leading_count++;
   }
   syntaqlite_vec_push(&p->comments, t, p->mem);
 }

--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -82,6 +82,11 @@ static void reset_stmt(SyntaqliteParser* p) {
   synq_parse_ctx_clear(&p->ctx);
   syntaqlite_vec_clear(&p->comments);
   syntaqlite_vec_clear(&p->tokens);
+  syntaqlite_vec_clear(&p->comment_idx_leading_start);
+  syntaqlite_vec_clear(&p->comment_idx_leading_count);
+  syntaqlite_vec_clear(&p->comment_idx_trailing_start);
+  syntaqlite_vec_clear(&p->comment_idx_trailing_count);
+  p->comment_index_built = 0;
 #ifndef SYNTAQLITE_OMIT_MACROS
   syntaqlite_vec_clear(&p->macro.traceback_buf);
   syntaqlite_vec_clear(&p->macro.node_expanded_buf);
@@ -153,6 +158,11 @@ SYNTAQLITE_API SyntaqliteParser* syntaqlite_parser_create_with_dialect(
   synq_parse_ctx_init(&p->ctx, m);
   syntaqlite_vec_init(&p->comments);
   syntaqlite_vec_init(&p->tokens);
+  syntaqlite_vec_init(&p->comment_idx_leading_start);
+  syntaqlite_vec_init(&p->comment_idx_leading_count);
+  syntaqlite_vec_init(&p->comment_idx_trailing_start);
+  syntaqlite_vec_init(&p->comment_idx_trailing_count);
+  p->comment_index_built = 0;
 #ifndef SYNTAQLITE_OMIT_MACROS
   synq_macro_state_init(&p->macro);
 #endif
@@ -200,6 +210,10 @@ SYNTAQLITE_API void syntaqlite_parser_destroy(SyntaqliteParser* p) {
     SYNQ_PARSER_FREE(p->dialect.tmpl, p->lemon, p->mem.xFree);
     synq_parse_ctx_free(&p->ctx);
     syntaqlite_vec_free(&p->comments, p->mem);
+    syntaqlite_vec_free(&p->comment_idx_leading_start, p->mem);
+    syntaqlite_vec_free(&p->comment_idx_leading_count, p->mem);
+    syntaqlite_vec_free(&p->comment_idx_trailing_start, p->mem);
+    syntaqlite_vec_free(&p->comment_idx_trailing_count, p->mem);
     syntaqlite_vec_free(&p->tokens, p->mem);
 #ifndef SYNTAQLITE_OMIT_MACROS
     synq_macro_state_free(&p->macro, p->mem);
@@ -406,12 +420,15 @@ void synq_parser_record_comment(SyntaqliteParser* p,
     owner_idx = syntaqlite_vec_len(&p->tokens) - 1;
   }
 
+  uint32_t layer = p->ctx.layer_id;
   SyntaqliteComment t = {
       .offset = offset - p->stmt_start_offset,
       .length = len,
       .token_idx = owner_idx,
       .kind = z[offset] == '-' ? (uint8_t)0 : (uint8_t)1,
       .side = side,
+      .layer_id = (uint8_t)(layer > 0xFF ? 0xFF : layer),
+      ._pad = 0,
   };
   syntaqlite_vec_push(&p->comments, t, p->mem);
 }
@@ -682,29 +699,82 @@ SYNTAQLITE_API const SyntaqliteParserToken* syntaqlite_result_tokens(
   return p->tokens.data;
 }
 
-// Locate the contiguous run of comments owned by `token_idx` with the
-// requested side. Comments for a given (token_idx, side) are recorded in
-// source order and live as a contiguous slice within p->comments because
-// each is emitted at the moment the owning token is being processed.
+// Build the per-token comment index on first access.  One O(n_comments)
+// pass over `p->comments` fills parallel per-token vectors; every
+// subsequent `syntaqlite_token_*_comments` / `syntaqlite_node_*_*`
+// call is then O(1).  Invalidated by `reset_stmt` between statements.
+//
+// Slot count is `ntokens + 1` so the orphan "statement-trailing with
+// no owner" bucket (`token_idx == ntokens`, `side == LEADING`) is
+// indexable alongside regular tokens.
+static void build_comment_index(SyntaqliteParser* p) {
+  if (p->comment_index_built) {
+    return;
+  }
+  uint32_t ntokens = syntaqlite_vec_len(&p->tokens);
+  uint32_t slots = ntokens + 1;
+  syntaqlite_vec_clear(&p->comment_idx_leading_start);
+  syntaqlite_vec_clear(&p->comment_idx_leading_count);
+  syntaqlite_vec_clear(&p->comment_idx_trailing_start);
+  syntaqlite_vec_clear(&p->comment_idx_trailing_count);
+  for (uint32_t i = 0; i < slots; i++) {
+    syntaqlite_vec_push(&p->comment_idx_leading_start, UINT32_MAX, p->mem);
+    syntaqlite_vec_push(&p->comment_idx_leading_count, 0, p->mem);
+    syntaqlite_vec_push(&p->comment_idx_trailing_start, UINT32_MAX, p->mem);
+    syntaqlite_vec_push(&p->comment_idx_trailing_count, 0, p->mem);
+  }
+  uint32_t total = syntaqlite_vec_len(&p->comments);
+  for (uint32_t i = 0; i < total; i++) {
+    const SyntaqliteComment* c = &p->comments.data[i];
+    if (c->token_idx >= slots) {
+      continue;  // defensive: malformed token_idx
+    }
+    if (c->side == SYNQ_COMMENT_LEADING) {
+      uint32_t* start =
+          &syntaqlite_vec_at(&p->comment_idx_leading_start, c->token_idx);
+      if (*start == UINT32_MAX) {
+        *start = i;
+      }
+      syntaqlite_vec_at(&p->comment_idx_leading_count, c->token_idx)++;
+    } else {
+      uint32_t* start =
+          &syntaqlite_vec_at(&p->comment_idx_trailing_start, c->token_idx);
+      if (*start == UINT32_MAX) {
+        *start = i;
+      }
+      syntaqlite_vec_at(&p->comment_idx_trailing_count, c->token_idx)++;
+    }
+  }
+  p->comment_index_built = 1;
+}
+
+// O(1) lookup after the first call of the statement (which builds the
+// index in one linear pass).
 static const SyntaqliteComment* token_side_comments(SyntaqliteParser* p,
                                                     uint32_t token_idx,
                                                     uint8_t side,
                                                     uint32_t* count) {
-  uint32_t total = syntaqlite_vec_len(&p->comments);
-  const SyntaqliteComment* base = NULL;
-  uint32_t found = 0;
-  for (uint32_t i = 0; i < total; i++) {
-    const SyntaqliteComment* c = &p->comments.data[i];
-    if (c->token_idx == token_idx && c->side == side) {
-      if (base == NULL)
-        base = c;
-      found++;
-    } else if (base != NULL) {
-      break;
-    }
+  build_comment_index(p);
+  uint32_t slots = syntaqlite_vec_len(&p->comment_idx_leading_start);
+  if (token_idx >= slots) {
+    *count = 0;
+    return NULL;
   }
-  *count = found;
-  return base;
+  uint32_t start;
+  uint32_t cnt;
+  if (side == SYNQ_COMMENT_LEADING) {
+    start = syntaqlite_vec_at(&p->comment_idx_leading_start, token_idx);
+    cnt = syntaqlite_vec_at(&p->comment_idx_leading_count, token_idx);
+  } else {
+    start = syntaqlite_vec_at(&p->comment_idx_trailing_start, token_idx);
+    cnt = syntaqlite_vec_at(&p->comment_idx_trailing_count, token_idx);
+  }
+  if (start == UINT32_MAX || cnt == 0) {
+    *count = 0;
+    return NULL;
+  }
+  *count = cnt;
+  return &p->comments.data[start];
 }
 
 SYNTAQLITE_API const SyntaqliteComment* syntaqlite_token_leading_comments(
@@ -719,6 +789,38 @@ SYNTAQLITE_API const SyntaqliteComment* syntaqlite_token_trailing_comments(
     uint32_t token_idx,
     uint32_t* count) {
   return token_side_comments(p, token_idx, SYNQ_COMMENT_TRAILING, count);
+}
+
+// Resolve `node_id` to the inclusive token range `[*first_tok, *last_tok]`
+// of entries in `p->tokens` that the parser fed to Lemon while reducing
+// this node.  O(1), via the side table populated by the extent hooks.
+//
+// Works across macro boundaries: with the unified token stream, every
+// shifted token (including macro-expansion tokens) is in `p->tokens`,
+// and the extent hooks push its index here regardless of layer.  The
+// returned range therefore covers the full set of tokens that produced
+// the node.
+SYNTAQLITE_API int32_t
+syntaqlite_node_token_range(SyntaqliteParser* p,
+                            uint32_t node_id,
+                            SyntaqliteTokenIdx* first_tok,
+                            SyntaqliteTokenIdx* last_tok) {
+  if (!p->ctx.collect_node_extents) {
+    return 0;
+  }
+  if (node_id == SYNTAQLITE_NULL_NODE) {
+    return 0;
+  }
+  if (node_id >= syntaqlite_vec_len(&p->ctx.node_token_ranges)) {
+    return 0;
+  }
+  SynqTokenRange r = syntaqlite_vec_at(&p->ctx.node_token_ranges, node_id);
+  if (r.first_tok == UINT32_MAX) {
+    return 0;
+  }
+  *first_tok = r.first_tok;
+  *last_tok = r.last_tok;
+  return 1;
 }
 
 #ifdef SYNTAQLITE_OMIT_MACROS

--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -82,11 +82,8 @@ static void reset_stmt(SyntaqliteParser* p) {
   synq_parse_ctx_clear(&p->ctx);
   syntaqlite_vec_clear(&p->comments);
   syntaqlite_vec_clear(&p->tokens);
-  syntaqlite_vec_clear(&p->comment_idx_leading_start);
-  syntaqlite_vec_clear(&p->comment_idx_leading_count);
-  syntaqlite_vec_clear(&p->comment_idx_trailing_start);
-  syntaqlite_vec_clear(&p->comment_idx_trailing_count);
-  p->comment_index_built = 0;
+  syntaqlite_vec_clear(&p->token_comments);
+  p->pending_orphan_leading = SYNQ_TOKEN_COMMENTS_EMPTY;
 #ifndef SYNTAQLITE_OMIT_MACROS
   syntaqlite_vec_clear(&p->macro.traceback_buf);
   syntaqlite_vec_clear(&p->macro.node_expanded_buf);
@@ -107,7 +104,8 @@ static void reset_stmt(SyntaqliteParser* p) {
   p->ctx.saw_subquery = 0;
   p->ctx.saw_update_delete_limit = 0;
   p->had_comment = 0;
-  p->last_layer0_token_end = UINT32_MAX;
+  p->last_pushed_token_ctx_end = UINT32_MAX;
+  p->last_pushed_token_layer = UINT32_MAX;
   p->had_error = 0;
   p->error_msg[0] = '\0';
   p->ctx.error_offset = 0xFFFFFFFF;
@@ -158,11 +156,8 @@ SYNTAQLITE_API SyntaqliteParser* syntaqlite_parser_create_with_dialect(
   synq_parse_ctx_init(&p->ctx, m);
   syntaqlite_vec_init(&p->comments);
   syntaqlite_vec_init(&p->tokens);
-  syntaqlite_vec_init(&p->comment_idx_leading_start);
-  syntaqlite_vec_init(&p->comment_idx_leading_count);
-  syntaqlite_vec_init(&p->comment_idx_trailing_start);
-  syntaqlite_vec_init(&p->comment_idx_trailing_count);
-  p->comment_index_built = 0;
+  syntaqlite_vec_init(&p->token_comments);
+  p->pending_orphan_leading = SYNQ_TOKEN_COMMENTS_EMPTY;
 #ifndef SYNTAQLITE_OMIT_MACROS
   synq_macro_state_init(&p->macro);
 #endif
@@ -210,10 +205,7 @@ SYNTAQLITE_API void syntaqlite_parser_destroy(SyntaqliteParser* p) {
     SYNQ_PARSER_FREE(p->dialect.tmpl, p->lemon, p->mem.xFree);
     synq_parse_ctx_free(&p->ctx);
     syntaqlite_vec_free(&p->comments, p->mem);
-    syntaqlite_vec_free(&p->comment_idx_leading_start, p->mem);
-    syntaqlite_vec_free(&p->comment_idx_leading_count, p->mem);
-    syntaqlite_vec_free(&p->comment_idx_trailing_start, p->mem);
-    syntaqlite_vec_free(&p->comment_idx_trailing_count, p->mem);
+    syntaqlite_vec_free(&p->token_comments, p->mem);
     syntaqlite_vec_free(&p->tokens, p->mem);
 #ifndef SYNTAQLITE_OMIT_MACROS
     synq_macro_state_free(&p->macro, p->mem);
@@ -261,13 +253,23 @@ int synq_parser_shift_token(SyntaqliteParser* p,
     SyntaqliteParserToken tp = {layer_offset, len, token_type, 0, layer_id};
     syntaqlite_vec_push(&p->tokens, tp, p->mem);
     tidx = syntaqlite_vec_len(&p->tokens) - 1;
-    // Drives same-line trailing-comment attachment.  Only advanced for
-    // layer-0 tokens so comments emitted from the main tokenizer loop
-    // attach relative to the last user-authored token, not relative to
-    // some layer-N expansion token.
-    if (layer_id == 0) {
-      p->last_layer0_token_end = p->stmt_start_offset + layer_offset + len;
-    }
+    // Pair the new token with its comment-index entry.  Seed from
+    // `pending_orphan_leading` so comments whose predicted owner was
+    // this about-to-be-pushed token land at the right slot, then
+    // reset the orphan bucket.
+    syntaqlite_vec_push(&p->token_comments, p->pending_orphan_leading, p->mem);
+    p->pending_orphan_leading = SYNQ_TOKEN_COMMENTS_EMPTY;
+    // Remember this token's end in `p->ctx.source` coordinates so
+    // `synq_parser_record_comment` can decide same-line trailing
+    // attachment within whichever buffer it is tokenizing.  For
+    // layer 0, `ctx.source == p->source` so the end is source-
+    // absolute; for layer N, `ctx.source` is the expansion buffer so
+    // the end is layer-local.  `layer_id` alongside lets record_comment
+    // reject prev-ends from a different layer than the current one.
+    p->last_pushed_token_ctx_end =
+        layer_id == 0 ? p->stmt_start_offset + layer_offset + len
+                      : layer_offset + len;
+    p->last_pushed_token_layer = layer_id;
   }
 
   // BEFORE-style empty-rule markers (ast_builder.h:117) are documented
@@ -399,37 +401,68 @@ static int finish_input(SyntaqliteParser* p) {
 
 // Record a comment token (outlined from the hot loop).
 //
-// Computes attachment from the parser's current state: a comment is
-// TRAILING the previous layer-0 token when there is no '\n' in the source
-// gap between that token's end and the comment's start; otherwise LEADING
-// the next token to be pushed. The predicted owner index for LEADING
-// comments equals `vec_len(p->tokens)` — the index the next push will
-// land on.
+// `offset` is interpreted in `p->ctx.source` coordinates:
+//   - layer 0: source-absolute (ctx.source == p->source).
+//   - layer N: layer-local (ctx.source is the expansion buffer).
+//
+// Attachment: TRAILING the previous pushed token when that token was
+// in the same layer as this comment and the gap in `p->ctx.source`
+// contains no '\n'.  Otherwise LEADING the next token to be pushed
+// (predicted owner index = `vec_len(p->tokens)`).  The layer-match
+// guard prevents a comment emitted from main tokenization at layer 0
+// after an expansion ends from incorrectly trailing the expansion's
+// last token, and vice versa.
 SYNQ_NOINLINE
 void synq_parser_record_comment(SyntaqliteParser* p,
                                 uint32_t offset,
                                 uint32_t len) {
-  const unsigned char* z = (const unsigned char*)p->source;
+  uint32_t layer = p->ctx.layer_id;
+  const unsigned char* z = (const unsigned char*)p->ctx.source;
+  const char kind_char = (const char)z[offset];
 
   uint8_t side = SYNQ_COMMENT_LEADING;
   uint32_t owner_idx = syntaqlite_vec_len(&p->tokens);
-  uint32_t prev_end = p->last_layer0_token_end;
-  if (prev_end != UINT32_MAX && prev_end <= offset &&
-      memchr(z + prev_end, '\n', offset - prev_end) == NULL) {
-    side = SYNQ_COMMENT_TRAILING;
-    owner_idx = syntaqlite_vec_len(&p->tokens) - 1;
+  if (p->last_pushed_token_layer == layer) {
+    uint32_t prev_end = p->last_pushed_token_ctx_end;
+    if (prev_end <= offset &&
+        memchr(z + prev_end, '\n', offset - prev_end) == NULL) {
+      side = SYNQ_COMMENT_TRAILING;
+      owner_idx = syntaqlite_vec_len(&p->tokens) - 1;
+    }
   }
 
-  uint32_t layer = p->ctx.layer_id;
+  // Store in layer-local coordinates (matches `SyntaqliteParserToken.offset`).
+  uint32_t stored_offset = layer == 0 ? offset - p->stmt_start_offset : offset;
   SyntaqliteComment t = {
-      .offset = offset - p->stmt_start_offset,
+      .offset = stored_offset,
       .length = len,
       .token_idx = owner_idx,
-      .kind = z[offset] == '-' ? (uint8_t)0 : (uint8_t)1,
+      .kind = kind_char == '-' ? (uint8_t)0 : (uint8_t)1,
       .side = side,
       .layer_id = (uint8_t)(layer > 0xFF ? 0xFF : layer),
       ._pad = 0,
   };
+  // Maintain the per-token comment index in step with the push.  The
+  // owner either already exists in `p->tokens` (trailing attachment,
+  // or a previously-predicted leading whose owner has since been
+  // pushed) or it's the predicted "next token" whose entry lives in
+  // `pending_orphan_leading` until the shift happens.
+  uint32_t comment_idx = syntaqlite_vec_len(&p->comments);
+  SynqTokenComments* tc;
+  if (owner_idx < syntaqlite_vec_len(&p->tokens)) {
+    tc = &syntaqlite_vec_at(&p->token_comments, owner_idx);
+  } else {
+    tc = &p->pending_orphan_leading;
+  }
+  if (side == SYNQ_COMMENT_LEADING) {
+    if (tc->leading_count == 0)
+      tc->leading_first = comment_idx;
+    tc->leading_count++;
+  } else {
+    if (tc->trailing_count == 0)
+      tc->trailing_first = comment_idx;
+    tc->trailing_count++;
+  }
   syntaqlite_vec_push(&p->comments, t, p->mem);
 }
 
@@ -699,77 +732,29 @@ SYNTAQLITE_API const SyntaqliteParserToken* syntaqlite_result_tokens(
   return p->tokens.data;
 }
 
-// Build the per-token comment index on first access.  One O(n_comments)
-// pass over `p->comments` fills parallel per-token vectors; every
-// subsequent `syntaqlite_token_*_comments` / `syntaqlite_node_*_*`
-// call is then O(1).  Invalidated by `reset_stmt` between statements.
-//
-// Slot count is `ntokens + 1` so the orphan "statement-trailing with
-// no owner" bucket (`token_idx == ntokens`, `side == LEADING`) is
-// indexable alongside regular tokens.
-static void build_comment_index(SyntaqliteParser* p) {
-  if (p->comment_index_built) {
-    return;
-  }
-  uint32_t ntokens = syntaqlite_vec_len(&p->tokens);
-  uint32_t slots = ntokens + 1;
-  syntaqlite_vec_clear(&p->comment_idx_leading_start);
-  syntaqlite_vec_clear(&p->comment_idx_leading_count);
-  syntaqlite_vec_clear(&p->comment_idx_trailing_start);
-  syntaqlite_vec_clear(&p->comment_idx_trailing_count);
-  for (uint32_t i = 0; i < slots; i++) {
-    syntaqlite_vec_push(&p->comment_idx_leading_start, UINT32_MAX, p->mem);
-    syntaqlite_vec_push(&p->comment_idx_leading_count, 0, p->mem);
-    syntaqlite_vec_push(&p->comment_idx_trailing_start, UINT32_MAX, p->mem);
-    syntaqlite_vec_push(&p->comment_idx_trailing_count, 0, p->mem);
-  }
-  uint32_t total = syntaqlite_vec_len(&p->comments);
-  for (uint32_t i = 0; i < total; i++) {
-    const SyntaqliteComment* c = &p->comments.data[i];
-    if (c->token_idx >= slots) {
-      continue;  // defensive: malformed token_idx
-    }
-    if (c->side == SYNQ_COMMENT_LEADING) {
-      uint32_t* start =
-          &syntaqlite_vec_at(&p->comment_idx_leading_start, c->token_idx);
-      if (*start == UINT32_MAX) {
-        *start = i;
-      }
-      syntaqlite_vec_at(&p->comment_idx_leading_count, c->token_idx)++;
-    } else {
-      uint32_t* start =
-          &syntaqlite_vec_at(&p->comment_idx_trailing_start, c->token_idx);
-      if (*start == UINT32_MAX) {
-        *start = i;
-      }
-      syntaqlite_vec_at(&p->comment_idx_trailing_count, c->token_idx)++;
-    }
-  }
-  p->comment_index_built = 1;
-}
-
-// O(1) lookup after the first call of the statement (which builds the
-// index in one linear pass).
+// O(1) lookup, backed by the per-token comment index that
+// `synq_parser_record_comment` maintains incrementally.  `token_idx ==
+// ntokens` targets the orphan bucket in `pending_orphan_leading` —
+// the "statement-trailing comment with no owner" case.
 static const SyntaqliteComment* token_side_comments(SyntaqliteParser* p,
                                                     uint32_t token_idx,
                                                     uint8_t side,
                                                     uint32_t* count) {
-  build_comment_index(p);
-  uint32_t slots = syntaqlite_vec_len(&p->comment_idx_leading_start);
-  if (token_idx >= slots) {
+  uint32_t ntokens = syntaqlite_vec_len(&p->tokens);
+  SynqTokenComments tc;
+  if (token_idx < ntokens) {
+    tc = syntaqlite_vec_at(&p->token_comments, token_idx);
+  } else if (token_idx == ntokens) {
+    tc = p->pending_orphan_leading;
+  } else {
     *count = 0;
     return NULL;
   }
-  uint32_t start;
-  uint32_t cnt;
-  if (side == SYNQ_COMMENT_LEADING) {
-    start = syntaqlite_vec_at(&p->comment_idx_leading_start, token_idx);
-    cnt = syntaqlite_vec_at(&p->comment_idx_leading_count, token_idx);
-  } else {
-    start = syntaqlite_vec_at(&p->comment_idx_trailing_start, token_idx);
-    cnt = syntaqlite_vec_at(&p->comment_idx_trailing_count, token_idx);
-  }
-  if (start == UINT32_MAX || cnt == 0) {
+  uint32_t start =
+      side == SYNQ_COMMENT_LEADING ? tc.leading_first : tc.trailing_first;
+  uint32_t cnt =
+      side == SYNQ_COMMENT_LEADING ? tc.leading_count : tc.trailing_count;
+  if (cnt == 0) {
     *count = 0;
     return NULL;
   }
@@ -793,13 +778,12 @@ SYNTAQLITE_API const SyntaqliteComment* syntaqlite_token_trailing_comments(
 
 // Resolve `node_id` to the inclusive token range `[*first_tok, *last_tok]`
 // of entries in `p->tokens` that the parser fed to Lemon while reducing
-// this node.  O(1), via the side table populated by the extent hooks.
+// this node.  O(1): the range is carried alongside the byte extent on
+// a single shadow stack and committed per node on reduction.
 //
-// Works across macro boundaries: with the unified token stream, every
-// shifted token (including macro-expansion tokens) is in `p->tokens`,
-// and the extent hooks push its index here regardless of layer.  The
-// returned range therefore covers the full set of tokens that produced
-// the node.
+// Works across macro boundaries: since the token-stream unification,
+// every shifted terminal (including macro-expansion tokens) has a real
+// `token_idx` into `p->tokens` regardless of layer.
 SYNTAQLITE_API int32_t
 syntaqlite_node_token_range(SyntaqliteParser* p,
                             uint32_t node_id,
@@ -811,16 +795,42 @@ syntaqlite_node_token_range(SyntaqliteParser* p,
   if (node_id == SYNTAQLITE_NULL_NODE) {
     return 0;
   }
-  if (node_id >= syntaqlite_vec_len(&p->ctx.node_token_ranges)) {
+  if (node_id >= syntaqlite_vec_len(&p->ctx.node_extents)) {
     return 0;
   }
-  SynqTokenRange r = syntaqlite_vec_at(&p->ctx.node_token_ranges, node_id);
+  SynqExtentRange r = syntaqlite_vec_at(&p->ctx.node_extents, node_id);
   if (r.first_tok == UINT32_MAX) {
     return 0;
   }
   *first_tok = r.first_tok;
   *last_tok = r.last_tok;
   return 1;
+}
+
+SYNTAQLITE_API const SyntaqliteComment* syntaqlite_node_leading_comments(
+    SyntaqliteParser* p,
+    uint32_t node_id,
+    uint32_t* count) {
+  SyntaqliteTokenIdx first = 0;
+  SyntaqliteTokenIdx last = 0;
+  if (!syntaqlite_node_token_range(p, node_id, &first, &last)) {
+    *count = 0;
+    return NULL;
+  }
+  return token_side_comments(p, first, SYNQ_COMMENT_LEADING, count);
+}
+
+SYNTAQLITE_API const SyntaqliteComment* syntaqlite_node_trailing_comments(
+    SyntaqliteParser* p,
+    uint32_t node_id,
+    uint32_t* count) {
+  SyntaqliteTokenIdx first = 0;
+  SyntaqliteTokenIdx last = 0;
+  if (!syntaqlite_node_token_range(p, node_id, &first, &last)) {
+    *count = 0;
+    return NULL;
+  }
+  return token_side_comments(p, last, SYNQ_COMMENT_TRAILING, count);
 }
 
 #ifdef SYNTAQLITE_OMIT_MACROS

--- a/syntaqlite-syntax/csrc/parser_extents.c
+++ b/syntaqlite-syntax/csrc/parser_extents.c
@@ -15,11 +15,15 @@
 //
 // When enabled, two parallel shadow stacks mirror Lemon's symbol stack:
 //
-//   * `extent_stack` tracks the merged *authored* range in root-source
-//     coordinates — used by `syntaqlite_parser_node_text`.  Macro
-//     tokens push the outermost call-site range stashed in
-//     `begin_macro_expansion`.  Epsilon pushes the sentinel
-//     `(UINT32_MAX, 0)`, which is neutral under min/max merging.
+//   * `extent_stack` carries both the merged *authored* byte range in
+//     root-source coordinates (used by `syntaqlite_parser_node_text`)
+//     and the inclusive token-index range into `p->tokens` (used by
+//     `syntaqlite_node_token_range`).  Macro tokens push the outermost
+//     call-site byte range stashed in `begin_macro_expansion` with
+//     their real `token_idx` (since the token-stream unification,
+//     every shifted terminal has an index regardless of layer).
+//     Epsilon pushes a sentinel that is neutral under min/max merging
+//     for both ranges.
 //
 //   * `expanded_stack` tracks the merged *expanded* range in the
 //     tokens' own layer — used by
@@ -58,6 +62,17 @@ void synq_extent_on_shift(SynqParseCtx* pCtx,
     r.root_start = pCtx->macro_root_start;
     r.root_end = pCtx->macro_root_end;
   }
+  // Token-index range: valid when the shifted token has a real index
+  // in `p->tokens` (all shifted terminals since the token-stream
+  // unification, regardless of layer).  UINT32_MAX means "no token
+  // recorded" (collect_tokens off, or layer-N shift with no index).
+  if (token->token_idx == 0xFFFFFFFFu) {
+    r.first_tok = UINT32_MAX;
+    r.last_tok = UINT32_MAX;
+  } else {
+    r.first_tok = token->token_idx;
+    r.last_tok = token->token_idx;
+  }
   syntaqlite_vec_push(&pCtx->extent_stack, r, pCtx->mem);
 
   SynqNodeExpandedExtent e = {
@@ -66,21 +81,6 @@ void synq_extent_on_shift(SynqParseCtx* pCtx,
       .layer_id = token->layer_id,
   };
   syntaqlite_vec_push(&pCtx->expanded_stack, e, pCtx->mem);
-
-  // Token-index shadow: push the shifted token's index (or epsilon
-  // sentinel when collect_tokens is off and token_idx is UINT32_MAX).
-  // With the unified token-stream, this indexes into `p->tokens` for
-  // every shifted token regardless of layer, so node_token_range
-  // reports ranges that span macro expansions.
-  SynqTokenRange tr;
-  if (token->token_idx == 0xFFFFFFFFu) {
-    tr.first_tok = UINT32_MAX;
-    tr.last_tok = UINT32_MAX;
-  } else {
-    tr.first_tok = token->token_idx;
-    tr.last_tok = token->token_idx;
-  }
-  syntaqlite_vec_push(&pCtx->token_range_stack, tr, pCtx->mem);
 }
 
 void synq_extent_on_reduce(SynqParseCtx* pCtx, unsigned int nrhs) {
@@ -114,7 +114,13 @@ void synq_extent_on_reduce(SynqParseCtx* pCtx, unsigned int nrhs) {
   }
   uint32_t len = syntaqlite_vec_len(&pCtx->extent_stack);
 
-  SynqExtentRange merged = {UINT32_MAX, 0};
+  // Merge both the authored byte range and the token-index range in a
+  // single pass.  Each is tracked with its own sentinel
+  // (byte: root_start==UINT32_MAX && root_end==0; token: first_tok==UINT32_MAX)
+  // so a node that reduced over macro-expansion-only tokens keeps its
+  // byte range (from the call site) even when token indices are absent,
+  // and vice versa.
+  SynqExtentRange merged = {UINT32_MAX, 0, UINT32_MAX, UINT32_MAX};
   for (uint32_t i = len - nrhs; i < len; i++) {
     SynqExtentRange e = syntaqlite_vec_at(&pCtx->extent_stack, i);
     if (e.root_start < merged.root_start) {
@@ -122,6 +128,14 @@ void synq_extent_on_reduce(SynqParseCtx* pCtx, unsigned int nrhs) {
     }
     if (e.root_end > merged.root_end) {
       merged.root_end = e.root_end;
+    }
+    if (e.first_tok != UINT32_MAX) {
+      if (merged.first_tok == UINT32_MAX || e.first_tok < merged.first_tok) {
+        merged.first_tok = e.first_tok;
+      }
+      if (merged.last_tok == UINT32_MAX || e.last_tok > merged.last_tok) {
+        merged.last_tok = e.last_tok;
+      }
     }
   }
   syntaqlite_vec_truncate(&pCtx->extent_stack, len - nrhs);
@@ -158,22 +172,4 @@ void synq_extent_on_reduce(SynqParseCtx* pCtx, unsigned int nrhs) {
   }
   syntaqlite_vec_truncate(&pCtx->expanded_stack, len - nrhs);
   syntaqlite_vec_push(&pCtx->expanded_stack, exp_merged, pCtx->mem);
-
-  // Merge token-index ranges: min/max over non-sentinel entries.
-  SynqTokenRange tr_merged = {UINT32_MAX, UINT32_MAX};
-  for (uint32_t i = len - nrhs; i < len; i++) {
-    SynqTokenRange t = syntaqlite_vec_at(&pCtx->token_range_stack, i);
-    if (t.first_tok == UINT32_MAX) {
-      continue;  // epsilon
-    }
-    if (tr_merged.first_tok == UINT32_MAX ||
-        t.first_tok < tr_merged.first_tok) {
-      tr_merged.first_tok = t.first_tok;
-    }
-    if (tr_merged.last_tok == UINT32_MAX || t.last_tok > tr_merged.last_tok) {
-      tr_merged.last_tok = t.last_tok;
-    }
-  }
-  syntaqlite_vec_truncate(&pCtx->token_range_stack, len - nrhs);
-  syntaqlite_vec_push(&pCtx->token_range_stack, tr_merged, pCtx->mem);
 }

--- a/syntaqlite-syntax/csrc/parser_extents.c
+++ b/syntaqlite-syntax/csrc/parser_extents.c
@@ -66,6 +66,21 @@ void synq_extent_on_shift(SynqParseCtx* pCtx,
       .layer_id = token->layer_id,
   };
   syntaqlite_vec_push(&pCtx->expanded_stack, e, pCtx->mem);
+
+  // Token-index shadow: push the shifted token's index (or epsilon
+  // sentinel when collect_tokens is off and token_idx is UINT32_MAX).
+  // With the unified token-stream, this indexes into `p->tokens` for
+  // every shifted token regardless of layer, so node_token_range
+  // reports ranges that span macro expansions.
+  SynqTokenRange tr;
+  if (token->token_idx == 0xFFFFFFFFu) {
+    tr.first_tok = UINT32_MAX;
+    tr.last_tok = UINT32_MAX;
+  } else {
+    tr.first_tok = token->token_idx;
+    tr.last_tok = token->token_idx;
+  }
+  syntaqlite_vec_push(&pCtx->token_range_stack, tr, pCtx->mem);
 }
 
 void synq_extent_on_reduce(SynqParseCtx* pCtx, unsigned int nrhs) {
@@ -143,4 +158,22 @@ void synq_extent_on_reduce(SynqParseCtx* pCtx, unsigned int nrhs) {
   }
   syntaqlite_vec_truncate(&pCtx->expanded_stack, len - nrhs);
   syntaqlite_vec_push(&pCtx->expanded_stack, exp_merged, pCtx->mem);
+
+  // Merge token-index ranges: min/max over non-sentinel entries.
+  SynqTokenRange tr_merged = {UINT32_MAX, UINT32_MAX};
+  for (uint32_t i = len - nrhs; i < len; i++) {
+    SynqTokenRange t = syntaqlite_vec_at(&pCtx->token_range_stack, i);
+    if (t.first_tok == UINT32_MAX) {
+      continue;  // epsilon
+    }
+    if (tr_merged.first_tok == UINT32_MAX ||
+        t.first_tok < tr_merged.first_tok) {
+      tr_merged.first_tok = t.first_tok;
+    }
+    if (tr_merged.last_tok == UINT32_MAX || t.last_tok > tr_merged.last_tok) {
+      tr_merged.last_tok = t.last_tok;
+    }
+  }
+  syntaqlite_vec_truncate(&pCtx->token_range_stack, len - nrhs);
+  syntaqlite_vec_push(&pCtx->token_range_stack, tr_merged, pCtx->mem);
 }

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -24,6 +24,19 @@ extern "C" {
 
 #define SYNQ_MAX_MACRO_DEPTH 16
 
+// Per-token comment index entry.  Each entry records where the owning
+// token's leading / trailing comments live in `p->comments`.  Used by
+// `syntaqlite_token_{leading,trailing}_comments` for O(1) lookup.
+typedef struct SynqTokenComments {
+  uint32_t leading_first;  // Index into p->comments; UINT32_MAX if count==0.
+  uint32_t leading_count;
+  uint32_t trailing_first;  // Index into p->comments; UINT32_MAX if count==0.
+  uint32_t trailing_count;
+} SynqTokenComments;
+
+#define SYNQ_TOKEN_COMMENTS_EMPTY \
+  ((SynqTokenComments){UINT32_MAX, 0, UINT32_MAX, 0})
+
 #if defined(__GNUC__) || defined(__clang__)
 #define SYNQ_NOINLINE __attribute__((noinline))
 #define SYNQ_PRINTF(fmt_idx, va_idx) \
@@ -207,12 +220,15 @@ struct SyntaqliteParser {
   uint32_t last_token_type;  // Last non-whitespace token fed to Lemon.
   uint32_t finished;         // 1 after EOF has been sent to Lemon.
   uint32_t had_comment;      // 1 if any comment token was seen this stmt.
-  // End offset (in p->source) of the most recent layer-0 significant
-  // token recorded into p->tokens this statement, or UINT32_MAX if none.
-  // Used to classify a recorded comment as TRAILING (same source line as
-  // the preceding token) vs LEADING (its own line / before any token).
-  uint32_t last_layer0_token_end;
-  int32_t last_status;  // Last SYNTAQLITE_PARSE_* status returned.
+  // End offset (in `p->ctx.source` coordinates) of the most recent
+  // token recorded into `p->tokens` this statement, or `UINT32_MAX`
+  // if none.  Used by `synq_parser_record_comment` to classify a
+  // comment as TRAILING (same line as the preceding token, in the
+  // same layer buffer) vs LEADING (its own line, before any token, or
+  // in a different layer from the last push).
+  uint32_t last_pushed_token_ctx_end;
+  uint32_t last_pushed_token_layer;  // Layer of that token; UINT32_MAX if none.
+  int32_t last_status;               // Last SYNTAQLITE_PARSE_* status returned.
   uint32_t trace;
   uint32_t collect_tokens;
   uint32_t sealed;
@@ -221,17 +237,23 @@ struct SyntaqliteParser {
   SYNQ_VEC(SyntaqliteComment) comments;
   SYNQ_VEC(SyntaqliteParserToken) tokens;
 
-  // Per-token comment index, built lazily on first call to
-  // `syntaqlite_token_{leading,trailing}_comments`.  Indexed by
-  // [0, ntokens] — slot `ntokens` is the orphan "statement-trailing
-  // with no owner" bucket (comments recorded as `side == LEADING`
-  // with `token_idx == ntokens`).  `UINT32_MAX` start means "no
-  // comments for this token/side".  Invalidated in `reset_stmt`.
-  SYNQ_VEC(uint32_t) comment_idx_leading_start;
-  SYNQ_VEC(uint32_t) comment_idx_leading_count;
-  SYNQ_VEC(uint32_t) comment_idx_trailing_start;
-  SYNQ_VEC(uint32_t) comment_idx_trailing_count;
-  uint32_t comment_index_built;
+  // Per-token comment index, parallel to `tokens` (one entry per
+  // shifted terminal).  Populated incrementally by
+  // `synq_parser_record_comment` and seeded at token-push in
+  // `synq_parser_shift_token` from `pending_orphan_leading`.  Lets
+  // `syntaqlite_token_{leading,trailing}_comments` answer in O(1)
+  // without a separate build step.  `leading_first` / `trailing_first`
+  // are `UINT32_MAX` when the corresponding count is zero.
+  SYNQ_VEC(SynqTokenComments) token_comments;
+
+  // Orphan bucket for leading comments whose predicted owner token
+  // has not been pushed yet.  On the next token push this gets copied
+  // into the new `token_comments` entry and reset to empty.  If the
+  // statement ends with this still populated, it's the "statement-
+  // trailing with no owner" case and is surfaced via
+  // `token_leading_comments(ntokens)`.  Only `leading_*` is ever
+  // non-empty: trailing comments always have a previous token.
+  SynqTokenComments pending_orphan_leading;
 
   // ── Macro expansion state (compiled out with SYNTAQLITE_OMIT_MACROS) ───
 #ifndef SYNTAQLITE_OMIT_MACROS

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -221,6 +221,18 @@ struct SyntaqliteParser {
   SYNQ_VEC(SyntaqliteComment) comments;
   SYNQ_VEC(SyntaqliteParserToken) tokens;
 
+  // Per-token comment index, built lazily on first call to
+  // `syntaqlite_token_{leading,trailing}_comments`.  Indexed by
+  // [0, ntokens] — slot `ntokens` is the orphan "statement-trailing
+  // with no owner" bucket (comments recorded as `side == LEADING`
+  // with `token_idx == ntokens`).  `UINT32_MAX` start means "no
+  // comments for this token/side".  Invalidated in `reset_stmt`.
+  SYNQ_VEC(uint32_t) comment_idx_leading_start;
+  SYNQ_VEC(uint32_t) comment_idx_leading_count;
+  SYNQ_VEC(uint32_t) comment_idx_trailing_start;
+  SYNQ_VEC(uint32_t) comment_idx_trailing_count;
+  uint32_t comment_index_built;
+
   // ── Macro expansion state (compiled out with SYNTAQLITE_OMIT_MACROS) ───
 #ifndef SYNTAQLITE_OMIT_MACROS
   SynqMacroState macro;

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -39,9 +39,13 @@ static void synq_end_macro(SyntaqliteParser* p);
 // Forward-scan an expansion buffer past whitespace and comments and return
 // the next significant token. `*out_pos` is updated to that token's offset;
 // `*out_type` and the return value give its type and length. Returns 0
-// (with *out_type == 0) at end-of-buffer or tokenizer failure. Comments
-// inside expansion buffers are intentionally not recorded — only source
-// comments are kept on p->comments.
+// (with *out_type == 0) at end-of-buffer or tokenizer failure.
+//
+// Comments inside expansion buffers are recorded to `p->comments` with
+// `layer_id = p->ctx.layer_id` (> 0) so consumers that want every
+// comment anywhere in the tree — e.g. authored-source + expansion-body
+// — can find them via `syntaqlite_token_leading_comments`.  Callers
+// filtering to user-authored comments check `Comment.layer_id == 0`.
 static int64_t synq_macro_skip(SyntaqliteParser* p,
                                const unsigned char* z,
                                uint32_t buf_len,
@@ -58,6 +62,9 @@ static int64_t synq_macro_skip(SyntaqliteParser* p,
       *out_pos = pos;
       *out_type = ttype;
       return tlen;
+    }
+    if (ttype == SYNTAQLITE_TK_COMMENT && p->collect_tokens) {
+      synq_parser_record_comment(p, pos, (uint32_t)tlen);
     }
     pos += (uint32_t)tlen;
   }

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -272,45 +272,48 @@ SYNTAQLITE_API const SyntaqliteComment* syntaqlite_token_trailing_comments(
     SyntaqliteTokenIdx token_idx,
     uint32_t* count);
 
-// Get the inclusive range of `p->tokens` indices covered by AST node
-// `node_id`.  The indices always refer to authored-source (layer-0)
-// tokens, the only kind of token that is pushed to `p->tokens`.
-//
-// Performance: O(1).  The range is recorded in a side table during
-// reduction, parallel to `node_extents`.
-//
-// Macro handling:
-//   - For a *registered* macro call: the call's layer-0 tokens (the
-//     name, `!`, `(`, args, `)`) are consumed as a unit by the macro
-//     machinery and are NOT pushed to `p->tokens`.  The expansion's
-//     body tokens are fed to Lemon with `token_idx == UINT32_MAX` and
-//     likewise do not appear.  A node produced entirely by registered
-//     expansion therefore has no layer-0 tokens in its reduce and this
-//     function returns 0.  Mixed nodes report only the surrounding
-//     layer-0 tokens.
-//   - For a *fallback* macro call (macro_fallback enabled, no lookup
-//     matched): the entire `name!(args)` is consumed as a single
-//     layer-0 TK_ID token, which is in `p->tokens` and shows up in
-//     ranges normally.
-//
-// Comments authored before / after a macro call are attached to
-// whichever layer-0 token the parser was about to push next (via
-// `owner_idx = len(p->tokens)` prediction), so they remain reachable
-// through `syntaqlite_token_{leading,trailing}_comments` on the
-// surrounding layer-0 tokens.
+// Get the inclusive range of `p->tokens` indices the parser shifted
+// while reducing AST node `node_id`.  Since the token-stream
+// unification, every shifted terminal — authored source and macro-
+// expansion alike — carries a real `token_idx`, so the returned range
+// spans all layers the node reduced over.  O(1): the range is
+// maintained alongside the byte extent on one shadow stack.
 //
 // Returns 1 and writes `*first_tok` / `*last_tok` on success.
-// Returns 0 when:
-//   - `syntaqlite_parser_set_collect_node_extents(p, 1)` was not enabled
-//     before the first reset(),
-//   - `node_id` is out of range or the null sentinel, or
-//   - the node reduced over zero authored-source tokens (pure epsilon
-//     or all content came from a registered macro expansion).
+// Returns 0 when collect_node_extents was not enabled, `node_id` is
+// out of range or the null sentinel, or the node reduced over zero
+// tokens (pure epsilon).
+//
+// Typical use is composed with the `syntaqlite_token_{leading,trailing}
+// _comments` primitives, or with the `syntaqlite_node_{leading,trailing}
+// _comments` helpers below for the boundary-comment case.  Walk the
+// full `[first_tok, last_tok]` range when interior comments (on
+// keywords, between children) are needed.
 SYNTAQLITE_API int32_t
 syntaqlite_node_token_range(SyntaqliteParser* p,
                             uint32_t node_id,
                             SyntaqliteTokenIdx* first_tok,
                             SyntaqliteTokenIdx* last_tok);
+
+// Get the comments attached to the boundary tokens of AST node
+// `node_id`.  Thin wrappers over
+// `syntaqlite_token_leading_comments(first_tok)` and
+// `syntaqlite_token_trailing_comments(last_tok)` respectively, where
+// (first_tok, last_tok) come from `syntaqlite_node_token_range`.
+// Returns NULL with `*count == 0` when the node has no token range
+// or no comments on the boundary.  Interior comments (attached to a
+// keyword or an intermediate token inside the node) are NOT surfaced
+// here — iterate `syntaqlite_token_*_comments` across
+// `node_token_range` for those.
+SYNTAQLITE_API const SyntaqliteComment* syntaqlite_node_leading_comments(
+    SyntaqliteParser* p,
+    uint32_t node_id,
+    uint32_t* count);
+
+SYNTAQLITE_API const SyntaqliteComment* syntaqlite_node_trailing_comments(
+    SyntaqliteParser* p,
+    uint32_t node_id,
+    uint32_t* count);
 
 // Sentinel value for `SyntaqliteMacroRewrite::parent_idx` meaning "this
 // rewrite applies directly to the authored source" (i.e. the rewrite is

--- a/syntaqlite-syntax/include/syntaqlite/parser.h
+++ b/syntaqlite-syntax/include/syntaqlite/parser.h
@@ -206,8 +206,16 @@ typedef struct SyntaqliteComment {
   SyntaqliteStmtOffset offset;
   SyntaqliteLength length;
   SyntaqliteTokenIdx token_idx;  // Index of the owning token in p->tokens.
-  uint8_t kind;  // 0 = line comment (--), 1 = block comment (/* */).
-  uint8_t side;  // SYNQ_COMMENT_LEADING or SYNQ_COMMENT_TRAILING.
+  uint8_t kind;      // 0 = line comment (--), 1 = block comment (/* */).
+  uint8_t side;      // SYNQ_COMMENT_LEADING or SYNQ_COMMENT_TRAILING.
+  uint8_t layer_id;  // Layer the comment was tokenized from.
+                     // Currently always 0 (authored source): the main
+                     // tokenizer only records comments from layer 0.
+                     // The field is ABI-stable so future versions can
+                     // expose expansion-layer comments without a
+                     // breaking change; callers that only want authored
+                     // source comments should filter on `layer_id == 0`.
+  uint8_t _pad;      // reserved for future use; zero-initialized.
 } SyntaqliteComment;
 
 // Token-usage flags: set by the parser during disambiguation to record how
@@ -263,6 +271,46 @@ SYNTAQLITE_API const SyntaqliteComment* syntaqlite_token_trailing_comments(
     SyntaqliteParser* p,
     SyntaqliteTokenIdx token_idx,
     uint32_t* count);
+
+// Get the inclusive range of `p->tokens` indices covered by AST node
+// `node_id`.  The indices always refer to authored-source (layer-0)
+// tokens, the only kind of token that is pushed to `p->tokens`.
+//
+// Performance: O(1).  The range is recorded in a side table during
+// reduction, parallel to `node_extents`.
+//
+// Macro handling:
+//   - For a *registered* macro call: the call's layer-0 tokens (the
+//     name, `!`, `(`, args, `)`) are consumed as a unit by the macro
+//     machinery and are NOT pushed to `p->tokens`.  The expansion's
+//     body tokens are fed to Lemon with `token_idx == UINT32_MAX` and
+//     likewise do not appear.  A node produced entirely by registered
+//     expansion therefore has no layer-0 tokens in its reduce and this
+//     function returns 0.  Mixed nodes report only the surrounding
+//     layer-0 tokens.
+//   - For a *fallback* macro call (macro_fallback enabled, no lookup
+//     matched): the entire `name!(args)` is consumed as a single
+//     layer-0 TK_ID token, which is in `p->tokens` and shows up in
+//     ranges normally.
+//
+// Comments authored before / after a macro call are attached to
+// whichever layer-0 token the parser was about to push next (via
+// `owner_idx = len(p->tokens)` prediction), so they remain reachable
+// through `syntaqlite_token_{leading,trailing}_comments` on the
+// surrounding layer-0 tokens.
+//
+// Returns 1 and writes `*first_tok` / `*last_tok` on success.
+// Returns 0 when:
+//   - `syntaqlite_parser_set_collect_node_extents(p, 1)` was not enabled
+//     before the first reset(),
+//   - `node_id` is out of range or the null sentinel, or
+//   - the node reduced over zero authored-source tokens (pure epsilon
+//     or all content came from a registered macro expansion).
+SYNTAQLITE_API int32_t
+syntaqlite_node_token_range(SyntaqliteParser* p,
+                            uint32_t node_id,
+                            SyntaqliteTokenIdx* first_tok,
+                            SyntaqliteTokenIdx* last_tok);
 
 // Sentinel value for `SyntaqliteMacroRewrite::parent_idx` meaning "this
 // rewrite applies directly to the authored source" (i.e. the rewrite is
@@ -455,28 +503,6 @@ SYNTAQLITE_API const char* syntaqlite_parser_text(
 // input, this is the whole input.
 SYNTAQLITE_API const char* syntaqlite_parser_full_text(
     SyntaqliteParser* p,
-    SyntaqliteLength* out_len);
-
-// Return the tokenization buffer for `layer_id`.
-//
-// Layer 0 is the authored-source slice for the current statement
-// (identical to `syntaqlite_parser_text`).  Layers > 0 are macro
-// expansion buffers — the text that the expansion-layer tokenizer
-// consumed for that layer.
-//
-// Token entries in `syntaqlite_result_tokens` carry `_layer_id` and a
-// layer-local `offset`: to recover a token's byte text, call
-// `syntaqlite_parser_layer_text(p, tok._layer_id, &buf_len)` and slice
-// `[tok.offset, tok.offset + tok.length)` from the returned pointer.
-//
-// The returned pointer is valid until the next parser_next, reset, or
-// destroy on the same parser.  Returns NULL with `*out_len == 0` when
-// `layer_id` is out of range for the current statement, when no
-// statement has been bound (layer 0), or when macros are compiled out
-// (layer > 0).
-SYNTAQLITE_API const char* syntaqlite_parser_layer_text(
-    SyntaqliteParser* p,
-    uint32_t layer_id,
     SyntaqliteLength* out_len);
 
 // Post-expansion text for the current statement — materializes the

--- a/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
@@ -38,23 +38,28 @@ typedef struct SynqListDesc {
   uint32_t tag;
 } SynqListDesc;
 
-// Half-open byte range in the authored source, used by per-node extent
-// tracking.  Sentinel `(UINT32_MAX, 0)` marks an unrecorded/empty range.
+// Per-node extent: half-open byte range in the authored source plus an
+// inclusive token-index range into `p->tokens`.  Both ranges are
+// maintained by the extent hooks on one shadow stack and merged
+// together on reduce.
+//
+// Sentinels:
+//   `root_start == UINT32_MAX && root_end == 0` — no byte range recorded
+//       (pure epsilon reduction, neutral under min/max merging).
+//   `first_tok == UINT32_MAX` — no tokens recorded (layer-N shift with
+//       UINT32_MAX token_idx, or pure epsilon).  `last_tok` is then
+//       also UINT32_MAX.
+//
+// The two sentinels are independent: a macro-expansion-only node can
+// have a valid byte range (the call site's root coordinates) but no
+// layer-0 tokens — or have tokens in `p->tokens` after the token-stream
+// unification.  Consumers check the specific sentinel they care about.
 typedef struct SynqExtentRange {
   uint32_t root_start;
   uint32_t root_end;
-} SynqExtentRange;
-
-// Inclusive token-index range covered by a node, parallel to
-// SynqExtentRange.  Drives O(1) node→token-range lookup in
-// `syntaqlite_node_token_range`.  Indices refer to entries in
-// `p->tokens`, which with the unified token-stream contains both
-// authored-source and macro-expansion tokens.  Sentinel
-// `(UINT32_MAX, UINT32_MAX)` marks a node with no recorded tokens.
-typedef struct SynqTokenRange {
   uint32_t first_tok;
   uint32_t last_tok;
-} SynqTokenRange;
+} SynqExtentRange;
 
 // Layer-local byte range used by per-node *expanded*-text tracking —
 // the bytes the tokenizer saw for a node, in whichever layer buffer
@@ -152,12 +157,6 @@ typedef struct SynqParseCtx {
   SYNQ_VEC(SynqExtentRange) node_extents;
   SYNQ_VEC(SynqNodeExpandedExtent) expanded_stack;
   SYNQ_VEC(SynqNodeExpandedExtent) node_expanded_extents;
-  // Token-index shadow stack, parallel to extent_stack.  Pushed on
-  // shift with the shifted token's `token_idx` (UINT32_MAX when
-  // collect_tokens is off); merged on reduce with min/max semantics;
-  // committed at the top per node in `synq_extent_record`.
-  SYNQ_VEC(SynqTokenRange) token_range_stack;
-  SYNQ_VEC(SynqTokenRange) node_token_ranges;
   uint32_t collect_node_extents;
   uint32_t macro_root_start;
   uint32_t macro_root_end;
@@ -217,8 +216,6 @@ static inline void synq_parse_ctx_init(SynqParseCtx* ctx,
   syntaqlite_vec_init(&ctx->node_extents);
   syntaqlite_vec_init(&ctx->expanded_stack);
   syntaqlite_vec_init(&ctx->node_expanded_extents);
-  syntaqlite_vec_init(&ctx->token_range_stack);
-  syntaqlite_vec_init(&ctx->node_token_ranges);
   ctx->collect_node_extents = 0;
   ctx->macro_root_start = 0;
   ctx->macro_root_end = 0;
@@ -235,8 +232,6 @@ static inline void synq_parse_ctx_free(SynqParseCtx* ctx) {
   syntaqlite_vec_free(&ctx->node_extents, ctx->mem);
   syntaqlite_vec_free(&ctx->expanded_stack, ctx->mem);
   syntaqlite_vec_free(&ctx->node_expanded_extents, ctx->mem);
-  syntaqlite_vec_free(&ctx->token_range_stack, ctx->mem);
-  syntaqlite_vec_free(&ctx->node_token_ranges, ctx->mem);
   syntaqlite_vec_free(&ctx->straddle_stack, ctx->mem);
   synq_arena_free(&ctx->ast, ctx->mem);
 }
@@ -249,8 +244,6 @@ static inline void synq_parse_ctx_clear(SynqParseCtx* ctx) {
   syntaqlite_vec_clear(&ctx->node_extents);
   syntaqlite_vec_clear(&ctx->expanded_stack);
   syntaqlite_vec_clear(&ctx->node_expanded_extents);
-  syntaqlite_vec_clear(&ctx->token_range_stack);
-  syntaqlite_vec_clear(&ctx->node_token_ranges);
   synq_arena_clear(&ctx->ast);
   ctx->macro_root_start = 0;
   ctx->macro_root_end = 0;
@@ -278,16 +271,12 @@ static inline void synq_extent_record(SynqParseCtx* ctx, uint32_t node_id) {
   SynqExtentRange top = syntaqlite_vec_at(&ctx->extent_stack, stack_len - 1);
   SynqNodeExpandedExtent exp_top =
       syntaqlite_vec_at(&ctx->expanded_stack, stack_len - 1);
-  SynqTokenRange tr_top =
-      syntaqlite_vec_at(&ctx->token_range_stack, stack_len - 1);
   if (node_id < ctx->node_extents.count) {
     syntaqlite_vec_at(&ctx->node_extents, node_id) = top;
     syntaqlite_vec_at(&ctx->node_expanded_extents, node_id) = exp_top;
-    syntaqlite_vec_at(&ctx->node_token_ranges, node_id) = tr_top;
   } else {
     syntaqlite_vec_push(&ctx->node_extents, top, ctx->mem);
     syntaqlite_vec_push(&ctx->node_expanded_extents, exp_top, ctx->mem);
-    syntaqlite_vec_push(&ctx->node_token_ranges, tr_top, ctx->mem);
   }
 }
 

--- a/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/ast_builder.h
@@ -45,6 +45,17 @@ typedef struct SynqExtentRange {
   uint32_t root_end;
 } SynqExtentRange;
 
+// Inclusive token-index range covered by a node, parallel to
+// SynqExtentRange.  Drives O(1) node→token-range lookup in
+// `syntaqlite_node_token_range`.  Indices refer to entries in
+// `p->tokens`, which with the unified token-stream contains both
+// authored-source and macro-expansion tokens.  Sentinel
+// `(UINT32_MAX, UINT32_MAX)` marks a node with no recorded tokens.
+typedef struct SynqTokenRange {
+  uint32_t first_tok;
+  uint32_t last_tok;
+} SynqTokenRange;
+
 // Layer-local byte range used by per-node *expanded*-text tracking —
 // the bytes the tokenizer saw for a node, in whichever layer buffer
 // they live.
@@ -141,6 +152,12 @@ typedef struct SynqParseCtx {
   SYNQ_VEC(SynqExtentRange) node_extents;
   SYNQ_VEC(SynqNodeExpandedExtent) expanded_stack;
   SYNQ_VEC(SynqNodeExpandedExtent) node_expanded_extents;
+  // Token-index shadow stack, parallel to extent_stack.  Pushed on
+  // shift with the shifted token's `token_idx` (UINT32_MAX when
+  // collect_tokens is off); merged on reduce with min/max semantics;
+  // committed at the top per node in `synq_extent_record`.
+  SYNQ_VEC(SynqTokenRange) token_range_stack;
+  SYNQ_VEC(SynqTokenRange) node_token_ranges;
   uint32_t collect_node_extents;
   uint32_t macro_root_start;
   uint32_t macro_root_end;
@@ -200,6 +217,8 @@ static inline void synq_parse_ctx_init(SynqParseCtx* ctx,
   syntaqlite_vec_init(&ctx->node_extents);
   syntaqlite_vec_init(&ctx->expanded_stack);
   syntaqlite_vec_init(&ctx->node_expanded_extents);
+  syntaqlite_vec_init(&ctx->token_range_stack);
+  syntaqlite_vec_init(&ctx->node_token_ranges);
   ctx->collect_node_extents = 0;
   ctx->macro_root_start = 0;
   ctx->macro_root_end = 0;
@@ -216,6 +235,8 @@ static inline void synq_parse_ctx_free(SynqParseCtx* ctx) {
   syntaqlite_vec_free(&ctx->node_extents, ctx->mem);
   syntaqlite_vec_free(&ctx->expanded_stack, ctx->mem);
   syntaqlite_vec_free(&ctx->node_expanded_extents, ctx->mem);
+  syntaqlite_vec_free(&ctx->token_range_stack, ctx->mem);
+  syntaqlite_vec_free(&ctx->node_token_ranges, ctx->mem);
   syntaqlite_vec_free(&ctx->straddle_stack, ctx->mem);
   synq_arena_free(&ctx->ast, ctx->mem);
 }
@@ -228,6 +249,8 @@ static inline void synq_parse_ctx_clear(SynqParseCtx* ctx) {
   syntaqlite_vec_clear(&ctx->node_extents);
   syntaqlite_vec_clear(&ctx->expanded_stack);
   syntaqlite_vec_clear(&ctx->node_expanded_extents);
+  syntaqlite_vec_clear(&ctx->token_range_stack);
+  syntaqlite_vec_clear(&ctx->node_token_ranges);
   synq_arena_clear(&ctx->ast);
   ctx->macro_root_start = 0;
   ctx->macro_root_end = 0;
@@ -255,12 +278,16 @@ static inline void synq_extent_record(SynqParseCtx* ctx, uint32_t node_id) {
   SynqExtentRange top = syntaqlite_vec_at(&ctx->extent_stack, stack_len - 1);
   SynqNodeExpandedExtent exp_top =
       syntaqlite_vec_at(&ctx->expanded_stack, stack_len - 1);
+  SynqTokenRange tr_top =
+      syntaqlite_vec_at(&ctx->token_range_stack, stack_len - 1);
   if (node_id < ctx->node_extents.count) {
     syntaqlite_vec_at(&ctx->node_extents, node_id) = top;
     syntaqlite_vec_at(&ctx->node_expanded_extents, node_id) = exp_top;
+    syntaqlite_vec_at(&ctx->node_token_ranges, node_id) = tr_top;
   } else {
     syntaqlite_vec_push(&ctx->node_extents, top, ctx->mem);
     syntaqlite_vec_push(&ctx->node_expanded_extents, exp_top, ctx->mem);
+    syntaqlite_vec_push(&ctx->node_token_ranges, tr_top, ctx->mem);
   }
 }
 

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -61,6 +61,9 @@ pub(crate) struct CComment {
     pub token_idx: u32,
     pub kind: CCommentKind,
     pub side: CCommentSide,
+    /// 0 = authored source; >0 = macro expansion layer id.
+    pub layer_id: u8,
+    pub _pad: u8,
 }
 
 #[expect(dead_code)] // C FFI mirrors — not yet consumed on the Rust side
@@ -509,6 +512,25 @@ impl CParser {
         unsafe { std::slice::from_raw_parts(ptr, count as usize) }
     }
 
+    pub(crate) unsafe fn node_token_range(&self, node_id: u32) -> Option<(TokenIdx, TokenIdx)> {
+        let mut first: u32 = 0;
+        let mut last: u32 = 0;
+        // SAFETY: self is a valid, non-null CParser pointer; result
+        // accessors are valid after `next()` returns a non-DONE code.
+        let ok = unsafe {
+            syntaqlite_node_token_range(
+                std::ptr::from_ref::<Self>(self).cast_mut(),
+                node_id,
+                &raw mut first,
+                &raw mut last,
+            )
+        };
+        if ok == 0 {
+            return None;
+        }
+        Some((TokenIdx::from_raw(first), TokenIdx::from_raw(last)))
+    }
+
     pub(crate) unsafe fn span_expanded_text(
         &self,
         span: crate::ast::TextSpan,
@@ -742,6 +764,12 @@ unsafe extern "C" {
         token_idx: u32,
         count: *mut u32,
     ) -> *const CComment;
+    fn syntaqlite_node_token_range(
+        p: *mut CParser,
+        node_id: u32,
+        first_tok: *mut u32,
+        last_tok: *mut u32,
+    ) -> i32;
     fn syntaqlite_result_macro_count(p: *mut CParser) -> u32;
     fn syntaqlite_result_macro_rewrite_at(p: *mut CParser, idx: u32) -> CMacroRewrite;
     fn syntaqlite_macro_rewrite_arg_segment_count(p: *mut CParser, rewrite_idx: u32) -> u32;

--- a/syntaqlite-syntax/src/parser/ffi.rs
+++ b/syntaqlite-syntax/src/parser/ffi.rs
@@ -531,6 +531,40 @@ impl CParser {
         Some((TokenIdx::from_raw(first), TokenIdx::from_raw(last)))
     }
 
+    pub(crate) unsafe fn node_leading_comments(&self, node_id: u32) -> &[CComment] {
+        let mut count: u32 = 0;
+        // SAFETY: self is a valid, non-null CParser pointer.
+        let ptr = unsafe {
+            syntaqlite_node_leading_comments(
+                std::ptr::from_ref::<Self>(self).cast_mut(),
+                node_id,
+                &raw mut count,
+            )
+        };
+        if count == 0 || ptr.is_null() {
+            return &[];
+        }
+        // SAFETY: ptr+count describe a contiguous slice of CComment values.
+        unsafe { std::slice::from_raw_parts(ptr, count as usize) }
+    }
+
+    pub(crate) unsafe fn node_trailing_comments(&self, node_id: u32) -> &[CComment] {
+        let mut count: u32 = 0;
+        // SAFETY: self is a valid, non-null CParser pointer.
+        let ptr = unsafe {
+            syntaqlite_node_trailing_comments(
+                std::ptr::from_ref::<Self>(self).cast_mut(),
+                node_id,
+                &raw mut count,
+            )
+        };
+        if count == 0 || ptr.is_null() {
+            return &[];
+        }
+        // SAFETY: ptr+count describe a contiguous slice of CComment values.
+        unsafe { std::slice::from_raw_parts(ptr, count as usize) }
+    }
+
     pub(crate) unsafe fn span_expanded_text(
         &self,
         span: crate::ast::TextSpan,
@@ -770,6 +804,16 @@ unsafe extern "C" {
         first_tok: *mut u32,
         last_tok: *mut u32,
     ) -> i32;
+    fn syntaqlite_node_leading_comments(
+        p: *mut CParser,
+        node_id: u32,
+        count: *mut u32,
+    ) -> *const CComment;
+    fn syntaqlite_node_trailing_comments(
+        p: *mut CParser,
+        node_id: u32,
+        count: *mut u32,
+    ) -> *const CComment;
     fn syntaqlite_result_macro_count(p: *mut CParser) -> u32;
     fn syntaqlite_result_macro_rewrite_at(p: *mut CParser, idx: u32) -> CMacroRewrite;
     fn syntaqlite_macro_rewrite_arg_segment_count(p: *mut CParser, rewrite_idx: u32) -> u32;

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -996,8 +996,29 @@ impl<'a> AnyParsedStatement<'a> {
                 kind,
                 TokenIdx::from_raw(c.token_idx),
                 side,
+                c.layer_id,
             )
         })
+    }
+
+    /// The inclusive `[first, last]` token indices the parser fed to
+    /// Lemon while reducing AST node `id`.  Returns `None` when
+    /// [`ParserConfig::with_collect_node_extents`] was not enabled,
+    /// `id` is null / out-of-range, or the node reduced over zero
+    /// tokens (pure epsilon).
+    ///
+    /// O(1): the range is recorded in a side table during reduction.
+    ///
+    /// For macro-expanded nodes, the indices may point at layer-N
+    /// tokens.  Use [`Comment::layer_id`] to filter expansion-body
+    /// comments from authored-source comments when composing with
+    /// [`Self::leading_comments`] / [`Self::trailing_comments`].
+    pub fn node_token_range(&self, id: AnyNodeId) -> Option<(TokenIdx, TokenIdx)> {
+        if id.is_null() {
+            return None;
+        }
+        // SAFETY: self.raw is valid for 'a.
+        unsafe { self.raw.as_ref().node_token_range(id.0) }
     }
 
     /// Extract reflective node data (`tag` + field values) for `id`.
@@ -1362,6 +1383,12 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
         raw.iter().map(move |c| ffi_comment(source, c))
     }
 
+    /// Inclusive `[first, last]` token indices covering AST node `id`.
+    /// See [`AnyParsedStatement::node_token_range`].
+    pub fn node_token_range(&self, id: AnyNodeId) -> Option<(TokenIdx, TokenIdx)> {
+        self.any.node_token_range(id)
+    }
+
     // ── Result accessors (mirror syntaqlite_result_*) ──────────────────────
 
     /// Human-readable error message, or `None`.
@@ -1442,6 +1469,7 @@ fn ffi_comment<'a>(source: &'a StmtText, c: &ffi::CComment) -> Comment<'a> {
         length,
         TokenIdx::from_raw(c.token_idx),
         side,
+        c.layer_id,
     )
 }
 

--- a/syntaqlite-syntax/src/parser/mod.rs
+++ b/syntaqlite-syntax/src/parser/mod.rs
@@ -970,9 +970,10 @@ impl<'a> AnyParsedStatement<'a> {
     /// Requires `collect_tokens: true`.
     pub fn comments(&self) -> impl Iterator<Item = Comment<'a>> + use<'_, 'a> {
         let source = self.text();
+        let parser = self.raw;
         // SAFETY: self.raw is valid for 'a; the returned slice lives for 'a.
         let raw: &'a [ffi::CComment] = unsafe { self.raw.as_ref().result_comments() };
-        raw.iter().map(move |c| ffi_comment(source, c))
+        raw.iter().map(move |c| ffi_comment(parser, source, c))
     }
 
     /// Lightweight comment descriptors without source text borrows.
@@ -1019,6 +1020,49 @@ impl<'a> AnyParsedStatement<'a> {
         }
         // SAFETY: self.raw is valid for 'a.
         unsafe { self.raw.as_ref().node_token_range(id.0) }
+    }
+
+    /// Comments attached to the first token of AST node `id`.  Thin
+    /// wrapper over [`Self::node_token_range`] +
+    /// [`Self::leading_comments`].  Returns an empty iterator when
+    /// the node has no token range or no leading comments.
+    ///
+    /// Interior comments (on keywords or between children inside the
+    /// node) are NOT surfaced here — walk
+    /// [`Self::node_token_range`] and call
+    /// [`Self::leading_comments`] / [`Self::trailing_comments`] on
+    /// interior token indices for those.
+    pub fn node_leading_comments(
+        &self,
+        id: AnyNodeId,
+    ) -> impl Iterator<Item = Comment<'a>> + use<'_, 'a> {
+        let source = self.text();
+        let parser = self.raw;
+        let raw: &'a [ffi::CComment] = if id.is_null() {
+            &[]
+        } else {
+            // SAFETY: self.raw is valid for 'a; the returned slice lives for 'a.
+            unsafe { self.raw.as_ref().node_leading_comments(id.0) }
+        };
+        raw.iter().map(move |c| ffi_comment(parser, source, c))
+    }
+
+    /// Comments trailing the last token of AST node `id`.  See
+    /// [`Self::node_leading_comments`] for the symmetric case and the
+    /// caveat about interior comments.
+    pub fn node_trailing_comments(
+        &self,
+        id: AnyNodeId,
+    ) -> impl Iterator<Item = Comment<'a>> + use<'_, 'a> {
+        let source = self.text();
+        let parser = self.raw;
+        let raw: &'a [ffi::CComment] = if id.is_null() {
+            &[]
+        } else {
+            // SAFETY: self.raw is valid for 'a; the returned slice lives for 'a.
+            unsafe { self.raw.as_ref().node_trailing_comments(id.0) }
+        };
+        raw.iter().map(move |c| ffi_comment(parser, source, c))
     }
 
     /// Extract reflective node data (`tag` + field values) for `id`.
@@ -1354,9 +1398,10 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
     /// Requires `collect_tokens: true` in [`ParserConfig`].
     pub fn comments(&self) -> impl Iterator<Item = Comment<'a>> {
         let source = self.any.text();
+        let parser = self.any.raw;
         // SAFETY: self.any.raw is valid for 'a; the returned slice lives for 'a.
         let raw: &'a [ffi::CComment] = unsafe { self.any.raw.as_ref().result_comments() };
-        raw.iter().map(move |c| ffi_comment(source, c))
+        raw.iter().map(move |c| ffi_comment(parser, source, c))
     }
 
     /// Comments that appear immediately before token `token_idx`, in source
@@ -1365,10 +1410,11 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
     /// Requires `collect_tokens: true` in [`ParserConfig`].
     pub fn leading_comments(&self, token_idx: TokenIdx) -> impl Iterator<Item = Comment<'a>> {
         let source = self.any.text();
+        let parser = self.any.raw;
         // SAFETY: self.any.raw is valid for 'a; the returned slice lives for 'a.
         let raw: &'a [ffi::CComment] =
             unsafe { self.any.raw.as_ref().token_leading_comments(token_idx) };
-        raw.iter().map(move |c| ffi_comment(source, c))
+        raw.iter().map(move |c| ffi_comment(parser, source, c))
     }
 
     /// Comments that appear on the same source line as token `token_idx`,
@@ -1377,16 +1423,35 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
     /// Requires `collect_tokens: true` in [`ParserConfig`].
     pub fn trailing_comments(&self, token_idx: TokenIdx) -> impl Iterator<Item = Comment<'a>> {
         let source = self.any.text();
+        let parser = self.any.raw;
         // SAFETY: self.any.raw is valid for 'a; the returned slice lives for 'a.
         let raw: &'a [ffi::CComment] =
             unsafe { self.any.raw.as_ref().token_trailing_comments(token_idx) };
-        raw.iter().map(move |c| ffi_comment(source, c))
+        raw.iter().map(move |c| ffi_comment(parser, source, c))
     }
 
     /// Inclusive `[first, last]` token indices covering AST node `id`.
     /// See [`AnyParsedStatement::node_token_range`].
     pub fn node_token_range(&self, id: AnyNodeId) -> Option<(TokenIdx, TokenIdx)> {
         self.any.node_token_range(id)
+    }
+
+    /// Comments attached to the first token of AST node `id`.
+    /// See [`AnyParsedStatement::node_leading_comments`].
+    pub fn node_leading_comments(
+        &self,
+        id: AnyNodeId,
+    ) -> impl Iterator<Item = Comment<'a>> + use<'_, 'a, G> {
+        self.any.node_leading_comments(id)
+    }
+
+    /// Comments trailing the last token of AST node `id`.
+    /// See [`AnyParsedStatement::node_trailing_comments`].
+    pub fn node_trailing_comments(
+        &self,
+        id: AnyNodeId,
+    ) -> impl Iterator<Item = Comment<'a>> + use<'_, 'a, G> {
+        self.any.node_trailing_comments(id)
     }
 
     // ── Result accessors (mirror syntaqlite_result_*) ──────────────────────
@@ -1449,11 +1514,25 @@ impl<'a, G: TypedDialect> TypedParsedStatement<'a, G> {
 }
 
 /// Build a public [`Comment`] from an FFI [`ffi::CComment`] borrowing into
-/// the statement's source text.
-fn ffi_comment<'a>(source: &'a StmtText, c: &ffi::CComment) -> Comment<'a> {
+/// the layer buffer the comment was tokenized from.
+///
+/// `c.offset` is interpreted layer-locally (matches `CParserToken.offset`):
+/// the authored source for `layer_id == 0`, the expansion buffer for
+/// `layer_id > 0`.  The returned `Comment::text` is a slice into the
+/// owning layer's buffer.
+fn ffi_comment<'a>(raw: NonNull<CParser>, source: &'a StmtText, c: &ffi::CComment) -> Comment<'a> {
     let offset = StmtOffset::from_raw(c.offset);
     let length = StmtLen::from_raw(c.length);
-    let text = &source[StmtRange::from_offset_len(offset, length)];
+    let text: &'a str = if c.layer_id == 0 {
+        &source[StmtRange::from_offset_len(offset, length)]
+    } else {
+        // SAFETY: raw is valid for 'a; layer_text returns a slice into
+        // a parser-owned expansion buffer that lives for 'a.
+        let buf: &'a str = unsafe { raw.as_ref().layer_text(u32::from(c.layer_id)) };
+        let start = c.offset as usize;
+        let end = start.saturating_add(c.length as usize);
+        buf.get(start..end).unwrap_or("")
+    };
     let kind = match c.kind {
         ffi::CCommentKind::LineComment => CommentKind::Line,
         ffi::CCommentKind::BlockComment => CommentKind::Block,

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -2565,6 +2565,167 @@ mod tests {
     }
 
     #[test]
+    fn comment_inside_macro_body_is_recorded_with_expansion_layer_id() {
+        // A registered macro whose body contains a comment: when the
+        // macro is expanded the tokenizer records the body comment to
+        // `p->comments` with `layer_id > 0`, not dropped on the floor.
+        // This lets tree-walkers surface every comment at every layer
+        // (authored source + expansion bodies) while letting consumers
+        // that only want authored text filter on `layer_id == 0`.
+        let mut parser = Parser::with_config(
+            &ParserConfig::default()
+                .with_collect_tokens(true)
+                .with_macro_fallback(true),
+        );
+        let mut reg = TestMacroRegistry::new();
+        reg.register("annotate", &["x"], "/* inner */ $x");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "SELECT annotate!(42);";
+        let mut session = parser.parse(source);
+        let stmt = ok_stmt!(session);
+
+        let comments: Vec<_> = stmt.comments().collect();
+        let expansion_comments: Vec<_> = comments.iter().filter(|c| c.layer_id() > 0).collect();
+        assert_eq!(
+            expansion_comments.len(),
+            1,
+            "macro body comment should be recorded (got comments: {:?})",
+            comments
+                .iter()
+                .map(|c| (c.text(), c.layer_id()))
+                .collect::<Vec<_>>(),
+        );
+        assert!(
+            expansion_comments[0].text().contains("inner"),
+            "got {:?}",
+            expansion_comments[0].text(),
+        );
+    }
+
+    #[test]
+    fn expansion_layer_comment_trails_previous_token_when_same_line() {
+        // Within an expansion body, the same same-line-trailing rule
+        // that layer 0 uses also applies: `42 /* after */` inside a
+        // macro body means `/* after */` trails the `42` token — it's
+        // not demoted to "always leading" just because it's in a
+        // layer > 0.  The comment still carries `layer_id > 0` so
+        // consumers can filter out expansion content when they want
+        // only authored source.
+        let mut parser = Parser::with_config(
+            &ParserConfig::default()
+                .with_collect_tokens(true)
+                .with_macro_fallback(true),
+        );
+        let mut reg = TestMacroRegistry::new();
+        reg.register("tag", &["v"], "$v /* after */");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "SELECT tag!(42);";
+        let mut session = parser.parse(source);
+        let stmt = ok_stmt!(session);
+
+        let comments: Vec<_> = stmt.comments().collect();
+        let after = comments
+            .iter()
+            .find(|c| c.text().contains("after"))
+            .expect("expansion body comment");
+        assert!(after.layer_id() > 0, "expansion layer");
+        assert_eq!(
+            after.side(),
+            crate::CommentSide::Trailing,
+            "same line as the preceding expansion token → trailing",
+        );
+    }
+
+    #[test]
+    fn expansion_layer_comment_leads_next_token_when_newline_before() {
+        // Complement to the same-line test: a newline between the
+        // previous expansion token and the comment demotes to
+        // LEADING, matching the layer-0 rule.
+        let mut parser = Parser::with_config(
+            &ParserConfig::default()
+                .with_collect_tokens(true)
+                .with_macro_fallback(true),
+        );
+        let mut reg = TestMacroRegistry::new();
+        reg.register("lf", &["v"], "$v\n/* after */ +1");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "SELECT lf!(42);";
+        let mut session = parser.parse(source);
+        let stmt = ok_stmt!(session);
+
+        let comments: Vec<_> = stmt.comments().collect();
+        let after = comments
+            .iter()
+            .find(|c| c.text().contains("after"))
+            .expect("expansion body comment");
+        assert!(after.layer_id() > 0);
+        assert_eq!(after.side(), crate::CommentSide::Leading);
+    }
+
+    #[test]
+    fn node_leading_comments_surfaces_boundary_comments_only() {
+        // `node_leading_comments(id)` = comments on the first token of
+        // the node's token range.  Comments authored before the node
+        // are surfaced; comments interior to the node (e.g. attached
+        // to a keyword between children) are NOT — the user must walk
+        // `node_token_range` for those.
+        let parser = Parser::with_config(
+            &ParserConfig::default()
+                .with_collect_tokens(true)
+                .with_collect_node_extents(true),
+        );
+        let source = "-- header\nSELECT /* after keyword */ 1 FROM t;";
+        let mut session = parser.parse(source);
+        let stmt = ok_stmt!(session);
+
+        let root_id = stmt.erase().root_id();
+        let leading: Vec<_> = stmt.erase().node_leading_comments(root_id).collect();
+        assert_eq!(leading.len(), 1);
+        assert!(leading[0].text().contains("header"));
+
+        // The `/* after keyword */` comment trails the SELECT token
+        // and is therefore interior to the root node — not surfaced by
+        // node_leading / node_trailing.
+        let trailing: Vec<_> = stmt.erase().node_trailing_comments(root_id).collect();
+        assert_eq!(
+            trailing.len(),
+            0,
+            "no comments trail the last token (`t`) of the reduce",
+        );
+    }
+
+    #[test]
+    fn node_trailing_comments_surfaces_end_of_node_comments() {
+        let parser = Parser::with_config(
+            &ParserConfig::default()
+                .with_collect_tokens(true)
+                .with_collect_node_extents(true),
+        );
+        let source = "SELECT 1 FROM t -- after node\n;";
+        let mut session = parser.parse(source);
+        let stmt = ok_stmt!(session);
+
+        let root_id = stmt.erase().root_id();
+        let trailing: Vec<_> = stmt.erase().node_trailing_comments(root_id).collect();
+        assert_eq!(trailing.len(), 1);
+        assert!(trailing[0].text().contains("after node"));
+    }
+
+    #[test]
+    fn node_leading_comments_empty_without_collect_extents() {
+        let parser = Parser::with_config(&ParserConfig::default().with_collect_tokens(true));
+        let source = "-- header\nSELECT 1;";
+        let mut session = parser.parse(source);
+        let stmt = ok_stmt!(session);
+        let root_id = stmt.erase().root_id();
+        assert_eq!(stmt.erase().node_leading_comments(root_id).count(), 0);
+        assert_eq!(stmt.erase().node_trailing_comments(root_id).count(), 0);
+    }
+
+    #[test]
     fn node_token_range_with_fallback_macro_spans_the_call_as_one_token() {
         // With `macro_fallback` and no registered expansion, an
         // unknown `name!(args)` is consumed as a single layer-0 TK_ID

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -2395,4 +2395,196 @@ mod tests {
             ]
         );
     }
+
+    // ─── node_token_range + comment layer_id ────────────────────────────────
+    //
+    // `node_token_range` maps an AST node to the inclusive `[first,
+    // last]` indices of the entries in `p->tokens` that the parser
+    // shifted while reducing it.  Combined with
+    // `token_{leading,trailing}_comments`, this is enough for callers
+    // to ask "what comments sit at the boundaries of this node?".
+    // The `layer_id` field on `Comment` distinguishes authored-source
+    // comments from expansion-body ones when a caller needs it.
+
+    #[test]
+    fn node_token_range_root_covers_all_significant_tokens() {
+        // `SELECT 1 FROM t;` — root node's reduce covers SELECT..t
+        // (4 tokens); the terminating `;` is not part of the outermost
+        // reduction (see the existing `node_text` test that shows the
+        // extent stops at `t`).
+        let parser = Parser::with_config(
+            &ParserConfig::default()
+                .with_collect_tokens(true)
+                .with_collect_node_extents(true),
+        );
+        let mut session = parser.parse("SELECT 1 FROM t;");
+        let stmt = ok_stmt!(session);
+
+        let root_id = stmt.erase().root_id();
+        let (first, last) = stmt
+            .erase()
+            .node_token_range(root_id)
+            .expect("root should have a token range");
+        assert_eq!(first.as_u32(), 0, "first token = SELECT");
+        assert_eq!(last.as_u32(), 3, "last token = t (not `;`)");
+    }
+
+    #[test]
+    fn node_token_range_returns_none_without_extents() {
+        // Extents disabled → the side table isn't populated → None.
+        let parser = Parser::with_config(&ParserConfig::default().with_collect_tokens(true));
+        let mut session = parser.parse("SELECT 1;");
+        let stmt = ok_stmt!(session);
+        let root_id = stmt.erase().root_id();
+        assert!(stmt.erase().node_token_range(root_id).is_none());
+    }
+
+    // `AnyNodeId` has no public constructor for the null sentinel, so
+    // the null-node case is covered by the C-API tests
+    // (`parser.NodeTokenRangeParser.returns_none_for_null_or_out_of_range`)
+    // rather than here.
+
+    #[test]
+    fn node_token_range_compose_with_token_leading_comments() {
+        // Canonical composition: node_token_range gives you a token idx,
+        // leading_comments on that idx gives you the authored header.
+        let parser = Parser::with_config(
+            &ParserConfig::default()
+                .with_collect_tokens(true)
+                .with_collect_node_extents(true),
+        );
+        let mut session = parser.parse("-- header\nSELECT 1 FROM t;");
+        let stmt = ok_stmt!(session);
+
+        let root_id = stmt.erase().root_id();
+        let (first, _last) = stmt.erase().node_token_range(root_id).expect("root range");
+
+        let leading: Vec<_> = stmt.leading_comments(first).collect();
+        assert_eq!(leading.len(), 1);
+        assert!(leading[0].text().contains("header"));
+        assert_eq!(leading[0].layer_id(), 0, "authored source → layer 0");
+    }
+
+    #[test]
+    fn comment_layer_id_is_zero_for_authored_source() {
+        let parser = Parser::with_config(&ParserConfig::default().with_collect_tokens(true));
+        let mut session = parser.parse("-- h\nSELECT 1 /* mid */ FROM t; -- tail");
+        let stmt = ok_stmt!(session);
+
+        let comments: Vec<_> = stmt.comments().collect();
+        assert!(!comments.is_empty());
+        for c in &comments {
+            assert_eq!(
+                c.layer_id(),
+                0,
+                "no macros involved → every comment is authored source",
+            );
+        }
+    }
+
+    #[test]
+    fn node_token_range_with_registered_macro_spans_expansion() {
+        // With a registered macro, the expansion's tokens DO land in
+        // `p->tokens` (see the token-stream unification PR).  The
+        // root's token range therefore covers the SELECT keyword plus
+        // the expansion's tokens — not just the authored-source
+        // layer-0 tokens around the call.
+        //
+        // Leading comments authored before the call attach to
+        // whichever token was the next push at record time — here,
+        // the expansion's first token at index 0 is SELECT (layer 0)
+        // because `SELECT` is shifted before the macro call is
+        // consumed.
+        let mut parser = Parser::with_config(
+            &ParserConfig::default()
+                .with_collect_tokens(true)
+                .with_collect_node_extents(true)
+                .with_macro_fallback(true),
+        );
+        let mut reg = TestMacroRegistry::new();
+        reg.register("id", &["x"], "$x");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "-- before\nSELECT id!(42);";
+        let mut session = parser.parse(source);
+        let stmt = ok_stmt!(session);
+
+        let root_id = stmt.erase().root_id();
+        let (first, last) = stmt
+            .erase()
+            .node_token_range(root_id)
+            .expect("root range even with macros");
+
+        // SELECT at 0; the expansion-layer `42` at 1.
+        assert_eq!(first.as_u32(), 0, "SELECT at index 0");
+        assert_eq!(
+            last.as_u32(),
+            1,
+            "expansion token `42` at index 1 is part of the reduce",
+        );
+
+        // `-- before` is authored source, attached by owner-index
+        // prediction to the first token (SELECT at idx 0).
+        let leading: Vec<_> = stmt.leading_comments(first).collect();
+        assert_eq!(leading.len(), 1);
+        assert!(leading[0].text().contains("before"));
+        assert_eq!(leading[0].layer_id(), 0);
+    }
+
+    #[test]
+    fn node_token_range_with_nested_macro_covers_both_layers() {
+        // Nested macros: mwrap!(mpass!(42)).  SELECT is at layer 0,
+        // the expansion `(42)` from mwrap produces layer-1 tokens,
+        // and the inner mpass expansion pushes `42` at layer 2.  All
+        // of them end up in `p->tokens`, so the root's range spans
+        // multiple entries.
+        let mut parser = Parser::with_config(
+            &ParserConfig::default()
+                .with_collect_tokens(true)
+                .with_collect_node_extents(true)
+                .with_macro_fallback(true),
+        );
+        let mut reg = TestMacroRegistry::new();
+        reg.register("mwrap", &["body"], "($body)");
+        reg.register("mpass", &["v"], "$v");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let source = "SELECT mwrap!(mpass!(42));";
+        let mut session = parser.parse(source);
+        let stmt = ok_stmt!(session);
+
+        let root_id = stmt.erase().root_id();
+        let (first, last) = stmt.erase().node_token_range(root_id).expect("root range");
+        assert_eq!(first.as_u32(), 0, "SELECT at index 0");
+        assert!(
+            last.as_u32() > 0,
+            "root reduce must include expansion tokens (first={}, last={})",
+            first.as_u32(),
+            last.as_u32(),
+        );
+    }
+
+    #[test]
+    fn node_token_range_with_fallback_macro_spans_the_call_as_one_token() {
+        // With `macro_fallback` and no registered expansion, an
+        // unknown `name!(args)` is consumed as a single layer-0 TK_ID
+        // token.  That token appears in `p->tokens`, so nodes that
+        // include the call report a range covering it.
+        let parser = Parser::with_config(
+            &ParserConfig::default()
+                .with_collect_tokens(true)
+                .with_collect_node_extents(true)
+                .with_macro_fallback(true),
+        );
+        let source = "SELECT foo!(a) FROM t;";
+        let mut session = parser.parse(source);
+        let stmt = ok_stmt!(session);
+
+        let root_id = stmt.erase().root_id();
+        let (first, last) = stmt.erase().node_token_range(root_id).expect("root range");
+        // Tokens: SELECT (0), foo!(a) (1, TK_ID via fallback),
+        // FROM (2), t (3), ; (4).  Root range = [0, 3] (up to `t`).
+        assert_eq!(first.as_u32(), 0);
+        assert_eq!(last.as_u32(), 3);
+    }
 }

--- a/syntaqlite-syntax/src/parser/types.rs
+++ b/syntaqlite-syntax/src/parser/types.rs
@@ -94,6 +94,7 @@ pub struct Comment<'a> {
     length: StmtLen,
     token_idx: TokenIdx,
     side: CommentSide,
+    layer_id: u8,
 }
 
 impl<'a> Comment<'a> {
@@ -104,6 +105,7 @@ impl<'a> Comment<'a> {
         length: StmtLen,
         token_idx: TokenIdx,
         side: CommentSide,
+        layer_id: u8,
     ) -> Self {
         Comment {
             text,
@@ -112,6 +114,7 @@ impl<'a> Comment<'a> {
             length,
             token_idx,
             side,
+            layer_id,
         }
     }
 
@@ -146,6 +149,18 @@ impl<'a> Comment<'a> {
     pub fn side(&self) -> CommentSide {
         self.side
     }
+
+    /// Layer id of the buffer this comment was lexed from.
+    ///
+    /// `0` = the authored source (what the user wrote in the file).
+    /// `>0` = a macro expansion layer — the comment was tokenized from
+    /// the expanded body of a macro call, not from the user's source.
+    ///
+    /// Consumers rendering user source (formatters, linters operating
+    /// on authored text) typically want to filter to `layer_id == 0`.
+    pub fn layer_id(&self) -> u8 {
+        self.layer_id
+    }
 }
 
 /// Lightweight comment descriptor without a source text borrow.
@@ -159,6 +174,7 @@ pub struct CommentSpan {
     kind: CommentKind,
     token_idx: TokenIdx,
     side: CommentSide,
+    layer_id: u8,
 }
 
 impl CommentSpan {
@@ -188,12 +204,21 @@ impl CommentSpan {
         self.side
     }
 
+    /// Layer id of the buffer this comment was lexed from.
+    ///
+    /// `0` = the authored source; `>0` = a macro expansion layer.
+    /// See [`Comment::layer_id`] for filtering guidance.
+    pub fn layer_id(&self) -> u8 {
+        self.layer_id
+    }
+
     pub(super) fn new(
         offset: StmtOffset,
         length: StmtLen,
         kind: CommentKind,
         token_idx: TokenIdx,
         side: CommentSide,
+        layer_id: u8,
     ) -> Self {
         CommentSpan {
             offset,
@@ -201,6 +226,7 @@ impl CommentSpan {
             kind,
             token_idx,
             side,
+            layer_id,
         }
     }
 }

--- a/syntaqlite/src/fmt/comment.rs
+++ b/syntaqlite/src/fmt/comment.rs
@@ -127,6 +127,7 @@ impl CommentCtx {
         self.drain_impl(end, source, arena, true)
     }
 
+    #[expect(clippy::too_many_lines)]
     fn drain_impl<'a>(
         &self,
         before: StmtOffset,
@@ -238,7 +239,8 @@ impl CommentCtx {
                     if is_leading {
                         let hl = arena.hardline();
                         let comment_doc = arena.text(text);
-                        let chunk = arena.cat(hl, comment_doc);
+                        let sp = arena.text(" ");
+                        let chunk = arena.cats(&[hl, comment_doc, sp]);
                         leading = if leading == NIL_DOC {
                             chunk
                         } else {

--- a/syntaqlite/src/fmt/doc.rs
+++ b/syntaqlite/src/fmt/doc.rs
@@ -559,16 +559,32 @@ fn emit_newline(indent: i32, out: &mut String, pos: &mut usize) {
 }
 
 /// Push a keyword string with the appropriate casing to the output.
+///
+/// Collapse a duplicated leading space: several grammar literals (`" AS "`,
+/// `" OVER "`, ...) carry a baked-in leading space that doubles up when the
+/// preceding emission already ended with whitespace (e.g. the trailing
+/// space of a block comment's leading chunk, or a line-rendered softline).
+/// The collapse is conservative — only the first byte, only when both sides
+/// are a literal `' '` — so it doesn't swallow indentation.
+///
+/// This hack lives here because spacing currently comes from a mix of
+/// `line` ops and leading spaces baked into grammar literals.  The real
+/// fix is to strip leading spaces from keyword literals and always rely
+/// on explicit `line`/`space` ops in the grammar; see
+/// <https://github.com/LalitMaganti/syntaqlite/issues/5>.
 #[inline]
 fn push_keyword(s: &str, case: KeywordCase, out: &mut String) {
+    let bytes = s.as_bytes();
+    let skip = usize::from(bytes.first() == Some(&b' ') && out.as_bytes().last() == Some(&b' '));
+    let slice = &bytes[skip..];
     match case {
         KeywordCase::Upper => {
-            for &b in s.as_bytes() {
+            for &b in slice {
                 out.push(b.to_ascii_uppercase() as char);
             }
         }
         KeywordCase::Lower => {
-            for &b in s.as_bytes() {
+            for &b in slice {
                 out.push(b.to_ascii_lowercase() as char);
             }
         }

--- a/tests/c_api_tests/parser.py
+++ b/tests/c_api_tests/parser.py
@@ -226,14 +226,14 @@ collect_tokens ok
 reset ok len=37
 parse_one ok root=3 recovery=0
 comments count=2
-com[0] side=leading kind=line off=0 len=11 token_idx=0
-com[1] side=trailing kind=line off=22 len=15 token_idx=2
+com[0] side=leading kind=line off=0 len=11 token_idx=0 layer=0
+com[1] side=trailing kind=line off=22 len=15 token_idx=2 layer=0
 .
 token_comments idx=0 leading=1 trailing=0
-lead[0] side=leading kind=line off=0 len=11 token_idx=0
+lead[0] side=leading kind=line off=0 len=11 token_idx=0 layer=0
 .
 token_comments idx=2 leading=0 trailing=1
-trail[0] side=trailing kind=line off=22 len=15 token_idx=2
+trail[0] side=trailing kind=line off=22 len=15 token_idx=2 layer=0
 .
 """,
         )
@@ -255,7 +255,7 @@ collect_tokens ok
 reset ok len=21
 parse_one ok root=3 recovery=0
 comments count=1
-com[0] side=leading kind=block off=0 len=11 token_idx=0
+com[0] side=leading kind=block off=0 len=11 token_idx=0 layer=0
 .
 """,
         )
@@ -299,6 +299,169 @@ parse_one ok root=4 recovery=0
 node_text id=4 off=0 len=15
 SELECT 1 FROM t
 .
+""",
+        )
+
+
+class NodeTokenRangeParser(CApiTestSuite):
+    """Tests for `syntaqlite_node_token_range` — the primitive that maps an
+    AST node to the inclusive `[first, last]` token indices the parser fed
+    to Lemon while reducing it.
+
+    The primitive is intentionally low-level.  Callers compose it with
+    `token_leading_comments` / `token_trailing_comments` to answer "what
+    comments are attached to this node's boundaries?" and use the
+    `layer_id` field on each comment to filter authored-source comments
+    from expansion-body ones.
+    """
+
+    def test_returns_none_without_extents(self):
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+reset
+SELECT 1 FROM t;
+.
+parse_one
+node_token_range 4
+""",
+            expected="""\
+create ok
+collect_tokens ok
+reset ok len=16
+parse_one ok root=4 recovery=0
+node_token_range id=4 none
+""",
+        )
+
+    def test_returns_none_for_null_or_out_of_range(self):
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+collect_extents 1
+reset
+SELECT 1 FROM t;
+.
+parse_one
+node_token_range 4294967295
+node_token_range 99
+""",
+            expected="""\
+create ok
+collect_tokens ok
+collect_extents ok
+reset ok len=16
+parse_one ok root=4 recovery=0
+node_token_range id=4294967295 none
+node_token_range id=99 none
+""",
+        )
+
+    def test_root_covers_all_significant_tokens(self):
+        # Extent of the outermost SELECT reduction ends at `t`; the
+        # terminating `;` is not part of the reduction, so the range is
+        # [0, 3] (SELECT..t), not [0, 4] (SELECT..;).  This is what the
+        # existing `node_text` test at id=4 shows: the extent string is
+        # "SELECT 1 FROM t" without the `;`.
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+collect_extents 1
+reset
+SELECT 1 FROM t;
+.
+parse_one
+dump_tokens
+node_token_range 4
+""",
+            expected="""\
+create ok
+collect_tokens ok
+collect_extents ok
+reset ok len=16
+parse_one ok root=4 recovery=0
+tokens count=5
+tok[0] type=161 off=0 len=6 flags=0 layer=0
+tok[1] type=110 off=7 len=1 flags=0 layer=0
+tok[2] type=127 off=9 len=4 flags=0 layer=0
+tok[3] type=40 off=14 len=1 flags=1 layer=0
+tok[4] type=112 off=15 len=1 flags=0 layer=0
+.
+node_token_range id=4 first=0 last=3
+""",
+        )
+
+    def test_compose_with_token_comments(self):
+        # Demonstrate the canonical composition: node_token_range gives
+        # you a token index, and token_leading_comments / token_trailing_comments
+        # attach the per-token comments.  The returned comments carry
+        # layer=0 because they were authored in the source.
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+collect_extents 1
+reset
+-- preamble
+SELECT 1 FROM t; -- tail
+.
+parse_one
+node_token_range 4
+token_comments 0
+token_comments 4
+""",
+            expected="""\
+create ok
+collect_tokens ok
+collect_extents ok
+reset ok len=36
+parse_one ok root=4 recovery=0
+node_token_range id=4 first=0 last=3
+token_comments idx=0 leading=1 trailing=0
+lead[0] side=leading kind=line off=0 len=11 token_idx=0 layer=0
+.
+token_comments idx=4 leading=0 trailing=1
+trail[0] side=trailing kind=line off=29 len=7 token_idx=4 layer=0
+.
+""",
+        )
+
+    def test_macro_fallback_call_is_single_layer0_token(self):
+        # With macro_fallback enabled, an unregistered `name!(args)` is
+        # consumed as a single TK_ID token (still layer 0).  The
+        # enclosing SELECT's node_token_range simply spans those
+        # layer-0 tokens — no expansion layer involved here.
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+collect_extents 1
+macro_fallback 1
+reset
+SELECT foo!(a) FROM t;
+.
+parse_one
+dump_tokens
+node_token_range 4
+""",
+            expected="""\
+create ok
+collect_tokens ok
+collect_extents ok
+macro_fallback ok
+reset ok len=22
+parse_one ok root=4 recovery=0
+tokens count=5
+tok[0] type=161 off=0 len=6 flags=0 layer=0
+tok[1] type=40 off=7 len=7 flags=1 layer=0
+tok[2] type=127 off=15 len=4 flags=0 layer=0
+tok[3] type=40 off=20 len=1 flags=1 layer=0
+tok[4] type=112 off=21 len=1 flags=0 layer=0
+.
+node_token_range id=4 first=0 last=3
 """,
         )
 

--- a/tests/c_api_tests/parser.py
+++ b/tests/c_api_tests/parser.py
@@ -429,6 +429,36 @@ trail[0] side=trailing kind=line off=29 len=7 token_idx=4 layer=0
 """,
         )
 
+    def test_node_comments_surface_node_boundary_comments(self):
+        # `node_comments` composes node_token_range with
+        # token_{leading,trailing}_comments.  Comments at the first
+        # token of the node are leading; at the last token, trailing.
+        # Comments attached to interior tokens (e.g. the SELECT
+        # keyword trail) are NOT surfaced here.
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+collect_extents 1
+reset
+-- preamble
+SELECT /* after keyword */ 1 FROM t; -- tail
+.
+parse_one
+node_comments 4
+""",
+            expected="""\
+create ok
+collect_tokens ok
+collect_extents ok
+reset ok len=56
+parse_one ok root=4 recovery=0
+node_comments id=4 leading=1 trailing=0
+lead[0] side=leading kind=line off=0 len=11 token_idx=0 layer=0
+.
+""",
+        )
+
     def test_macro_fallback_call_is_single_layer0_token(self):
         # With macro_fallback enabled, an unregistered `name!(args)` is
         # consumed as a single TK_ID token (still layer 0).  The

--- a/tests/c_api_tests/parser.py
+++ b/tests/c_api_tests/parser.py
@@ -260,6 +260,102 @@ com[0] side=leading kind=block off=0 len=11 token_idx=0 layer=0
 """,
         )
 
+    def test_multiple_leading_comments_on_same_token(self):
+        # Two consecutive line comments before a token: both recorded as
+        # leading, both returned in order by token_comments.
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+reset
+-- comment one
+-- comment two
+SELECT 1;
+.
+parse_one
+dump_comments
+token_comments 0
+""",
+            expected="""\
+create ok
+collect_tokens ok
+reset ok len=39
+parse_one ok root=3 recovery=0
+comments count=2
+com[0] side=leading kind=line off=0 len=14 token_idx=0 layer=0
+com[1] side=leading kind=line off=15 len=14 token_idx=0 layer=0
+.
+token_comments idx=0 leading=2 trailing=0
+lead[0] side=leading kind=line off=0 len=14 token_idx=0 layer=0
+lead[1] side=leading kind=line off=15 len=14 token_idx=0 layer=0
+.
+""",
+        )
+
+    def test_trailing_on_semicolon_visible_in_first_parse(self):
+        # A comment on the same line as `;` is trailing on that semicolon
+        # token.  It belongs to the first statement's comment slice and is
+        # visible as long as the caller queries before calling parse_one again.
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+reset
+SELECT 1; -- orphan
+SELECT 2;
+.
+parse_one
+dump_comments
+token_comments 2
+""",
+            expected="""\
+create ok
+collect_tokens ok
+reset ok len=29
+parse_one ok root=3 recovery=0
+comments count=1
+com[0] side=trailing kind=line off=10 len=9 token_idx=2 layer=0
+.
+token_comments idx=2 leading=0 trailing=1
+trail[0] side=trailing kind=line off=10 len=9 token_idx=2 layer=0
+.
+""",
+        )
+
+    def test_reset_clears_comment_index(self):
+        # After reset, the comment index from the previous input is gone.
+        # The second parse sees only comments from the fresh input.
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+reset
+-- leading
+SELECT 1;
+.
+parse_one
+dump_comments
+reset
+SELECT 2;
+.
+parse_one
+dump_comments
+""",
+            expected="""\
+create ok
+collect_tokens ok
+reset ok len=20
+parse_one ok root=3 recovery=0
+comments count=1
+com[0] side=leading kind=line off=0 len=10 token_idx=0 layer=0
+.
+reset ok len=9
+parse_one ok root=3 recovery=0
+comments count=0
+.
+""",
+        )
+
 
 class ExtentsParser(CApiTestSuite):
     def test_extents_disabled_none(self):
@@ -459,6 +555,96 @@ lead[0] side=leading kind=line off=0 len=11 token_idx=0 layer=0
 """,
         )
 
+    def test_node_comments_invalid_node_id_returns_empty(self):
+        # Out-of-range and sentinel (UINT32_MAX) node ids return zero counts
+        # without crashing or triggering an error line — same shape as a
+        # valid node with no comments.
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+collect_extents 1
+reset
+SELECT 1;
+.
+parse_one
+node_comments 4294967295
+node_comments 99
+""",
+            expected="""\
+create ok
+collect_tokens ok
+collect_extents ok
+reset ok len=9
+parse_one ok root=3 recovery=0
+node_comments id=4294967295 leading=0 trailing=0
+.
+node_comments id=99 leading=0 trailing=0
+.
+""",
+        )
+
+    def test_node_comments_without_extents_returns_empty(self):
+        # When extents are not collected, node_token_range returns none, so
+        # node_comments falls back to zero counts for every node id.
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+reset
+-- preamble
+SELECT 1;
+.
+parse_one
+node_comments 3
+""",
+            expected="""\
+create ok
+collect_tokens ok
+reset ok len=21
+parse_one ok root=3 recovery=0
+node_comments id=3 leading=0 trailing=0
+.
+""",
+        )
+
+    def test_node_comments_expansion_layer_comment_surfaced(self):
+        # When a node's first token lives in an expansion layer, its leading
+        # comment is reported with layer=1, making it distinguishable from
+        # authored-source comments.
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+collect_extents 1
+macro_fallback 1
+macro_register annotate
+/* inner */ 42
+.
+reset
+SELECT annotate!(x) FROM t;
+.
+parse_one
+node_comments 0
+node_comments 1
+""",
+            expected="""\
+create ok
+collect_tokens ok
+collect_extents ok
+macro_fallback ok
+macro_register ok name=annotate len=14
+reset ok len=27
+parse_one ok root=4 recovery=0
+node_comments id=0 leading=1 trailing=0
+lead[0] side=leading kind=block off=0 len=11 token_idx=1 layer=1
+.
+node_comments id=1 leading=1 trailing=0
+lead[0] side=leading kind=block off=0 len=11 token_idx=1 layer=1
+.
+""",
+        )
+
     def test_macro_fallback_call_is_single_layer0_token(self):
         # With macro_fallback enabled, an unregistered `name!(args)` is
         # consumed as a single TK_ID token (still layer 0).  The
@@ -636,6 +822,325 @@ macros count=1
 mac[0] parent=source call_off=7 call_len=6 is_fallback=1 name="foo"
   call_text="foo!()"
   args count=0
+.
+""",
+        )
+
+    def test_registered_macro_body_comment_has_nonzero_layer_id(self):
+        # A block comment inside a registered macro body is recorded with
+        # layer_id=1.  This distinguishes it from authored-source comments
+        # (layer_id=0) so callers can filter by provenance.
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+collect_extents 1
+macro_fallback 1
+macro_register annotate
+/* inner */ 42
+.
+reset
+SELECT annotate!(x) FROM t;
+.
+parse_one
+dump_tokens
+dump_comments
+""",
+            expected="""\
+create ok
+collect_tokens ok
+collect_extents ok
+macro_fallback ok
+macro_register ok name=annotate len=14
+reset ok len=27
+parse_one ok root=4 recovery=0
+tokens count=5
+tok[0] type=161 off=0 len=6 flags=0 layer=0
+tok[1] type=110 off=12 len=2 flags=0 layer=1
+tok[2] type=127 off=20 len=4 flags=0 layer=0
+tok[3] type=40 off=25 len=1 flags=1 layer=0
+tok[4] type=112 off=26 len=1 flags=0 layer=0
+.
+comments count=1
+com[0] side=leading kind=block off=0 len=11 token_idx=1 layer=1
+.
+""",
+        )
+
+    def test_expansion_same_line_trailing_comment(self):
+        # A comment on the same line as the only token in a macro body is
+        # classified as trailing on that token (same rule as layer 0).
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+collect_extents 1
+macro_fallback 1
+macro_register annotate
+42 /* side note */
+.
+reset
+SELECT annotate!(x) FROM t;
+.
+parse_one
+dump_tokens
+dump_comments
+""",
+            expected="""\
+create ok
+collect_tokens ok
+collect_extents ok
+macro_fallback ok
+macro_register ok name=annotate len=18
+reset ok len=27
+parse_one ok root=4 recovery=0
+tokens count=5
+tok[0] type=161 off=0 len=6 flags=0 layer=0
+tok[1] type=110 off=0 len=2 flags=0 layer=1
+tok[2] type=127 off=20 len=4 flags=0 layer=0
+tok[3] type=40 off=25 len=1 flags=1 layer=0
+tok[4] type=112 off=26 len=1 flags=0 layer=0
+.
+comments count=1
+com[0] side=trailing kind=block off=3 len=15 token_idx=1 layer=1
+.
+""",
+        )
+
+    def test_both_outer_and_expansion_leading_comments(self):
+        # When the outer source has a leading comment AND the macro body has
+        # a leading comment, both are captured.  They are distinguished by
+        # layer_id: the outer comment has layer=0 (visible via the SelectStmt
+        # boundary), the expansion comment has layer=1 (visible via the Literal
+        # boundary whose first token is the expansion token).
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+collect_extents 1
+macro_fallback 1
+macro_register annotate
+/* inner */ 42
+.
+reset
+-- outer
+SELECT annotate!(x) FROM t;
+.
+parse_one
+dump_tokens
+dump_comments
+node_comments 4
+node_comments 0
+""",
+            expected="""\
+create ok
+collect_tokens ok
+collect_extents ok
+macro_fallback ok
+macro_register ok name=annotate len=14
+reset ok len=36
+parse_one ok root=4 recovery=0
+tokens count=5
+tok[0] type=161 off=9 len=6 flags=0 layer=0
+tok[1] type=110 off=12 len=2 flags=0 layer=1
+tok[2] type=127 off=29 len=4 flags=0 layer=0
+tok[3] type=40 off=34 len=1 flags=1 layer=0
+tok[4] type=112 off=35 len=1 flags=0 layer=0
+.
+comments count=2
+com[0] side=leading kind=line off=0 len=8 token_idx=0 layer=0
+com[1] side=leading kind=block off=0 len=11 token_idx=1 layer=1
+.
+node_comments id=4 leading=1 trailing=0
+lead[0] side=leading kind=line off=0 len=8 token_idx=0 layer=0
+.
+node_comments id=0 leading=1 trailing=0
+lead[0] side=leading kind=block off=0 len=11 token_idx=1 layer=1
+.
+""",
+        )
+
+    def test_both_outer_and_expansion_trailing_comments(self):
+        # When the macro body has a trailing block comment on the expansion
+        # token AND the outer source has a trailing LINE comment on the
+        # SelectStmt's last token (`t`), both are captured with correct layers.
+        # Line comments are always immediately trailing (nothing can follow
+        # them on the same line).  node_comments on the SelectStmt surfaces
+        # the outer trailing (layer=0 on tok[3]=`t`); node_comments on the
+        # Literal surfaces the expansion trailing (layer=1 on tok[1]).
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+collect_extents 1
+macro_fallback 1
+macro_register annotate
+42 /* inner */
+.
+reset
+SELECT annotate!(x) FROM t -- outer
+.
+parse_one
+dump_tokens
+dump_comments
+node_comments 4
+node_comments 0
+""",
+            expected="""\
+create ok
+collect_tokens ok
+collect_extents ok
+macro_fallback ok
+macro_register ok name=annotate len=14
+reset ok len=35
+parse_one ok root=4 recovery=0
+tokens count=4
+tok[0] type=161 off=0 len=6 flags=0 layer=0
+tok[1] type=110 off=0 len=2 flags=0 layer=1
+tok[2] type=127 off=20 len=4 flags=0 layer=0
+tok[3] type=40 off=25 len=1 flags=1 layer=0
+.
+comments count=2
+com[0] side=trailing kind=block off=3 len=11 token_idx=1 layer=1
+com[1] side=trailing kind=line off=27 len=8 token_idx=3 layer=0
+.
+node_comments id=4 leading=0 trailing=1
+trail[0] side=trailing kind=line off=27 len=8 token_idx=3 layer=0
+.
+node_comments id=0 leading=0 trailing=1
+trail[0] side=trailing kind=block off=3 len=11 token_idx=1 layer=1
+.
+""",
+        )
+
+    def test_block_comment_between_tokens_same_line_is_leading_on_next(self):
+        # Under the deferred-classification rule, a block comment that is
+        # on the same line as the preceding token becomes LEADING on the
+        # next token (not trailing on the preceding one) when a token
+        # follows it on the same line.  Line comments are exempt: they are
+        # always immediately trailing because nothing can follow them.
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+collect_extents 1
+reset
+SELECT 1 /* mid */ + 2 FROM t;
+.
+parse_one
+dump_comments
+token_comments 1
+token_comments 2
+""",
+            expected="""\
+create ok
+collect_tokens ok
+collect_extents ok
+reset ok len=30
+parse_one ok root=6 recovery=0
+comments count=1
+com[0] side=leading kind=block off=9 len=9 token_idx=2 layer=0
+.
+token_comments idx=1 leading=0 trailing=0
+.
+token_comments idx=2 leading=1 trailing=0
+lead[0] side=leading kind=block off=9 len=9 token_idx=2 layer=0
+.
+""",
+        )
+
+    def test_source_block_comment_between_select_and_macro_is_leading_on_expansion(self):
+        # A block comment in the outer source between SELECT and a macro
+        # call is deferred and, since the expansion token follows on the
+        # same source line, resolves as LEADING on the first expansion
+        # token.  The comment retains layer=0 (it lives in the source
+        # buffer) while token_idx points to the layer=1 expansion token.
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+collect_extents 1
+macro_fallback 1
+macro_register wrap
+42
+.
+reset
+SELECT /* between */ wrap!(x) FROM t;
+.
+parse_one
+dump_tokens
+dump_comments
+token_comments 0
+token_comments 1
+node_comments 0
+""",
+            expected="""\
+create ok
+collect_tokens ok
+collect_extents ok
+macro_fallback ok
+macro_register ok name=wrap len=2
+reset ok len=37
+parse_one ok root=4 recovery=0
+tokens count=5
+tok[0] type=161 off=0 len=6 flags=0 layer=0
+tok[1] type=110 off=0 len=2 flags=0 layer=1
+tok[2] type=127 off=30 len=4 flags=0 layer=0
+tok[3] type=40 off=35 len=1 flags=1 layer=0
+tok[4] type=112 off=36 len=1 flags=0 layer=0
+.
+comments count=1
+com[0] side=leading kind=block off=7 len=13 token_idx=1 layer=0
+.
+token_comments idx=0 leading=0 trailing=0
+.
+token_comments idx=1 leading=1 trailing=0
+lead[0] side=leading kind=block off=7 len=13 token_idx=1 layer=0
+.
+node_comments id=0 leading=1 trailing=0
+lead[0] side=leading kind=block off=7 len=13 token_idx=1 layer=0
+.
+""",
+        )
+
+    def test_expansion_leading_comment_after_newline(self):
+        # A comment on a fresh line before the first expansion token is
+        # classified as leading (the newline breaks the same-line rule).
+        # offset is layer-local: 1 byte into the body (past the leading \n).
+        return CApiScenario(
+            input="""\
+create
+collect_tokens 1
+collect_extents 1
+macro_fallback 1
+macro_register wrap
+
+/* before */ 42
+.
+reset
+SELECT wrap!(x) FROM t;
+.
+parse_one
+dump_tokens
+dump_comments
+""",
+            expected="""\
+create ok
+collect_tokens ok
+collect_extents ok
+macro_fallback ok
+macro_register ok name=wrap len=16
+reset ok len=23
+parse_one ok root=4 recovery=0
+tokens count=5
+tok[0] type=161 off=0 len=6 flags=0 layer=0
+tok[1] type=110 off=14 len=2 flags=0 layer=1
+tok[2] type=127 off=16 len=4 flags=0 layer=0
+tok[3] type=40 off=21 len=1 flags=1 layer=0
+tok[4] type=112 off=22 len=1 flags=0 layer=0
+.
+comments count=1
+com[0] side=leading kind=block off=1 len=12 token_idx=1 layer=1
 .
 """,
         )

--- a/tests/c_api_tests/parser_driver.c
+++ b/tests/c_api_tests/parser_driver.c
@@ -27,6 +27,8 @@
 //   token_comments <idx>  Leading + trailing comments for token idx.
 //   node_token_range <id> Inclusive token-index range covering node id
 //                         (needs extents).
+//   node_comments <id>    Leading + trailing comments for node boundaries
+//                         (needs extents).
 //   node_text <id>        Authored text slice for node (needs extents).
 //   error_info            error_msg/off/len/recovery_root dump.
 //   macro_fallback 0|1    Configure (must be before first reset).
@@ -222,6 +224,16 @@ int main(void) {
       } else {
         printf("node_token_range id=%u first=%u last=%u\n", id, first, last);
       }
+    } else if (strcmp(verb, "node_comments") == 0) {
+      if (argc < 2) { printf("node_comments err bad_arg\n"); continue; }
+      uint32_t id = (uint32_t)strtoul(argv[1], NULL, 10);
+      uint32_t lead = 0, trail = 0;
+      const SyntaqliteComment* lc = syntaqlite_node_leading_comments(p, id, &lead);
+      const SyntaqliteComment* tc = syntaqlite_node_trailing_comments(p, id, &trail);
+      printf("node_comments id=%u leading=%u trailing=%u\n", id, lead, trail);
+      for (uint32_t i = 0; i < lead; i++) print_comment(&lc[i], "lead", i);
+      for (uint32_t i = 0; i < trail; i++) print_comment(&tc[i], "trail", i);
+      printf(".\n");
     } else if (strcmp(verb, "node_text") == 0) {
       if (argc < 2) { printf("node_text err bad_arg\n"); continue; }
       uint32_t id = (uint32_t)strtoul(argv[1], NULL, 10);

--- a/tests/c_api_tests/parser_driver.c
+++ b/tests/c_api_tests/parser_driver.c
@@ -25,6 +25,8 @@
 //   dump_tokens           All tokens for current statement.
 //   dump_comments         All comments for current statement.
 //   token_comments <idx>  Leading + trailing comments for token idx.
+//   node_token_range <id> Inclusive token-index range covering node id
+//                         (needs extents).
 //   node_text <id>        Authored text slice for node (needs extents).
 //   error_info            error_msg/off/len/recovery_root dump.
 //   macro_fallback 0|1    Configure (must be before first reset).
@@ -97,8 +99,9 @@ static const char* parse_rc_str(int32_t rc) {
 static void print_comment(const SyntaqliteComment* c, const char* prefix, uint32_t i) {
   const char* side = c->side == SYNQ_COMMENT_LEADING ? "leading" : "trailing";
   const char* kind = c->kind == 0 ? "line" : "block";
-  printf("%s[%u] side=%s kind=%s off=%u len=%u token_idx=%u\n",
-         prefix, i, side, kind, c->offset, c->length, c->token_idx);
+  printf("%s[%u] side=%s kind=%s off=%u len=%u token_idx=%u layer=%u\n",
+         prefix, i, side, kind, c->offset, c->length, c->token_idx,
+         c->layer_id);
 }
 
 int main(void) {
@@ -209,6 +212,16 @@ int main(void) {
       for (uint32_t i = 0; i < lead; i++) print_comment(&lc[i], "lead", i);
       for (uint32_t i = 0; i < trail; i++) print_comment(&tc[i], "trail", i);
       printf(".\n");
+    } else if (strcmp(verb, "node_token_range") == 0) {
+      if (argc < 2) { printf("node_token_range err bad_arg\n"); continue; }
+      uint32_t id = (uint32_t)strtoul(argv[1], NULL, 10);
+      SyntaqliteTokenIdx first = 0, last = 0;
+      int32_t ok = syntaqlite_node_token_range(p, id, &first, &last);
+      if (!ok) {
+        printf("node_token_range id=%u none\n", id);
+      } else {
+        printf("node_token_range id=%u first=%u last=%u\n", id, first, last);
+      }
     } else if (strcmp(verb, "node_text") == 0) {
       if (argc < 2) { printf("node_text err bad_arg\n"); continue; }
       uint32_t id = (uint32_t)strtoul(argv[1], NULL, 10);

--- a/tests/c_api_tests/parser_driver.c
+++ b/tests/c_api_tests/parser_driver.c
@@ -32,6 +32,9 @@
 //   node_text <id>        Authored text slice for node (needs extents).
 //   error_info            error_msg/off/len/recovery_root dump.
 //   macro_fallback 0|1    Configure (must be before first reset).
+//   macro_register NAME   Register a lookup-template body (until `.`).
+//                         Subsequent `NAME!(args)` in source expands to body.
+//   macro_clear_registry  Drop all registered templates.
 //   dump_macros           All macro rewrites with parent_buffer + args.
 
 // Needed for strtok_r under glibc when compiling with -std=c11.
@@ -42,11 +45,45 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "syntaqlite/incremental.h"
 #include "syntaqlite/parser.h"
 #include "syntaqlite/types.h"
 
 static char g_line[64 * 1024];
 static char g_body[256 * 1024];
+
+// Minimal in-process macro registry for `macro_register NAME` → body.
+// Bodies are owned: a follow-up scenario can register the same NAME
+// with a fresh body.  8 slots is plenty for tests.
+#define SYNQ_DRIVER_MAX_MACROS 8
+typedef struct {
+  char name[64];
+  uint32_t name_len;
+  char body[4096];
+  uint32_t body_len;
+  int in_use;
+} DriverMacro;
+static DriverMacro g_macros[SYNQ_DRIVER_MAX_MACROS];
+
+static int driver_macro_lookup(void* user_data,
+                               SyntaqliteParser* parser,
+                               const char* name,
+                               SyntaqliteLength name_len,
+                               const SyntaqliteToken* args,
+                               uint32_t arg_count) {
+  (void)user_data;
+  (void)args;
+  (void)arg_count;
+  for (uint32_t i = 0; i < SYNQ_DRIVER_MAX_MACROS; i++) {
+    if (!g_macros[i].in_use) continue;
+    if (g_macros[i].name_len != name_len) continue;
+    if (memcmp(g_macros[i].name, name, name_len) != 0) continue;
+    syntaqlite_macro_expansion_set_result(parser, g_macros[i].body,
+                                          g_macros[i].body_len, 0, 0);
+    return SYNTAQLITE_MACRO_LOOKUP_OK;
+  }
+  return SYNTAQLITE_MACRO_LOOKUP_NOT_FOUND;
+}
 
 static void chomp(char* s) {
   size_t n = strlen(s);
@@ -122,6 +159,12 @@ int main(void) {
     if (strcmp(verb, "create") == 0) {
       if (p) syntaqlite_parser_destroy(p);
       p = syntaqlite_parser_create(NULL);
+      // Scenarios that need registered expansions call
+      // `macro_register` before `reset`, which is what installs the
+      // lookup.  We deliberately don't register it here: the parser
+      // treats "lookup_fn set + lookup returns NOT_FOUND" as a hard
+      // error (unknown macro), which would break fallback-only
+      // scenarios if the lookup were always installed.
       printf("create %s\n", p ? "ok" : "err null");
     } else if (strcmp(verb, "destroy") == 0) {
       syntaqlite_parser_destroy(p);
@@ -252,6 +295,52 @@ int main(void) {
       int32_t rc = syntaqlite_parser_set_macro_fallback(
           p, (uint32_t)strtoul(argv[1], NULL, 10));
       printf("macro_fallback %s\n", cfg_rc_str(rc));
+    } else if (strcmp(verb, "macro_register") == 0) {
+      if (argc < 2) { printf("macro_register err bad_arg\n"); continue; }
+      // Copy name off `g_line` before `read_block` overwrites it.
+      char name_buf[64];
+      size_t name_in_len = strlen(argv[1]);
+      if (name_in_len >= sizeof(name_buf)) {
+        printf("macro_register err name_too_long\n"); continue;
+      }
+      memcpy(name_buf, argv[1], name_in_len + 1);
+      const char* name = name_buf;
+      int n = read_block(g_body, sizeof(g_body));
+      if (n < 0) { printf("macro_register err no_terminator\n"); break; }
+      uint32_t slot = SYNQ_DRIVER_MAX_MACROS;
+      for (uint32_t i = 0; i < SYNQ_DRIVER_MAX_MACROS; i++) {
+        if (g_macros[i].in_use &&
+            g_macros[i].name_len == strlen(name) &&
+            memcmp(g_macros[i].name, name, g_macros[i].name_len) == 0) {
+          slot = i;  // replace existing entry with same name
+          break;
+        }
+      }
+      if (slot == SYNQ_DRIVER_MAX_MACROS) {
+        for (uint32_t i = 0; i < SYNQ_DRIVER_MAX_MACROS; i++) {
+          if (!g_macros[i].in_use) { slot = i; break; }
+        }
+      }
+      if (slot == SYNQ_DRIVER_MAX_MACROS) {
+        printf("macro_register err registry_full\n"); continue;
+      }
+      size_t nlen = strlen(name);
+      if (nlen >= sizeof(g_macros[slot].name) ||
+          (size_t)n >= sizeof(g_macros[slot].body)) {
+        printf("macro_register err too_large\n"); continue;
+      }
+      memcpy(g_macros[slot].name, name, nlen);
+      g_macros[slot].name_len = (uint32_t)nlen;
+      memcpy(g_macros[slot].body, g_body, (size_t)n);
+      g_macros[slot].body_len = (uint32_t)n;
+      g_macros[slot].in_use = 1;
+      // Install the lookup callback on first registration.
+      syntaqlite_parser_set_macro_lookup(p, driver_macro_lookup, NULL);
+      printf("macro_register ok name=%s len=%d\n", name, n);
+    } else if (strcmp(verb, "macro_clear_registry") == 0) {
+      for (uint32_t i = 0; i < SYNQ_DRIVER_MAX_MACROS; i++) g_macros[i].in_use = 0;
+      syntaqlite_parser_set_macro_lookup(p, NULL, NULL);
+      printf("macro_clear_registry ok\n");
     } else if (strcmp(verb, "dump_macros") == 0) {
       uint32_t count = syntaqlite_result_macro_count(p);
       printf("macros count=%u\n", count);

--- a/tests/fmt_diff_tests/comments.py
+++ b/tests/fmt_diff_tests/comments.py
@@ -116,19 +116,32 @@ class BlockComment(TestSuite):
     def test_trailing_block(self):
         return DiffTestBlueprint(
             sql="SELECT a /* col */ FROM t",
-            out="SELECT a /* col */ FROM t;",
+            out="""\
+                SELECT a
+                /* col */ FROM t;
+            """,
         )
 
     def test_trailing_block_after_from(self):
         return DiffTestBlueprint(
             sql="SELECT 1 FROM t /* block */ WHERE x = 1",
-            out="SELECT 1 FROM t /* block */ WHERE x = 1;",
+            out="""\
+                SELECT 1
+                FROM t
+                /* block */ WHERE
+                  x = 1;
+            """,
         )
 
     def test_inline_block_comments(self):
         return DiffTestBlueprint(
             sql="SELECT /* c1 */ a, /* c2 */ b /* c3 */ FROM t",
-            out="SELECT /* c1 */ a, /* c2 */ b /* c3 */ FROM t;",
+            out="""\
+                SELECT
+                  /* c1 */ a,
+                  /* c2 */ b
+                /* c3 */ FROM t;
+            """,
         )
 
 
@@ -448,8 +461,8 @@ class JoinComment(TestSuite):
             sql="SELECT 1 FROM t1 a LEFT /* mid */ JOIN t2 b ON a.id = b.id",
             out="""\
                 SELECT 1
-                FROM t1 AS a /* mid */
-                LEFT JOIN t2 AS b
+                FROM t1 AS a
+                /* mid */ LEFT JOIN t2 AS b
                   ON a.id = b.id;
             """,
         )

--- a/tests/perfetto_fmt_diff_tests/perfetto.py
+++ b/tests/perfetto_fmt_diff_tests/perfetto.py
@@ -361,7 +361,12 @@ class PerfettoMacroCallFormat(TestSuite):
     def test_macro_call_with_block_comment_before_alias(self):
         return DiffTestBlueprint(
             sql="SELECT cast_int!(value) /* inline */ AS x FROM t",
-            out="SELECT cast_int!(value) /* inline */ AS x FROM t",
+            out="""\
+                SELECT
+                  cast_int!(value)
+                  /* inline */ AS x
+                FROM t
+            """,
         )
 
     # ── Comments inside a fallback macro call ──

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -1121,8 +1121,10 @@ pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::name_field_text(&self, fi
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::name_text(&self, node_id: core::option::Option<syntaqlite_syntax::any::AnyNodeId>) -> (&'a str, syntaqlite_syntax::source::DocRange)
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_expanded_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a str>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_is_macro_free(&self, id: syntaqlite_syntax::any::AnyNodeId) -> bool
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_leading_comments(&self, id: syntaqlite_syntax::any::AnyNodeId) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>> + use<'_, 'a>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(&'a str, syntaqlite_syntax::source::StmtOffset)>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_token_range(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(syntaqlite_syntax::source::TokenIdx, syntaqlite_syntax::source::TokenIdx)>
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_trailing_comments(&self, id: syntaqlite_syntax::any::AnyNodeId) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>> + use<'_, 'a>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_id(&self) -> syntaqlite_syntax::any::AnyNodeId
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_node(&self) -> core::option::Option<syntaqlite_syntax::any::AnyNode<'_>>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_expanded_text(&self, span: syntaqlite_syntax::any::TextSpan) -> &'a str
@@ -1976,7 +1978,9 @@ pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::expanded_text(&sel
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::full_text(&self) -> &'a syntaqlite_syntax::source::DocText
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::leading_comments(&self, token_idx: syntaqlite_syntax::source::TokenIdx) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::macro_rewrites(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRewrite<'a>> + use<'_, 'a, G>
+pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::node_leading_comments(&self, id: syntaqlite_syntax::any::AnyNodeId) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>> + use<'_, 'a, G>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::node_token_range(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(syntaqlite_syntax::source::TokenIdx, syntaqlite_syntax::source::TokenIdx)>
+pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::node_trailing_comments(&self, id: syntaqlite_syntax::any::AnyNodeId) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>> + use<'_, 'a, G>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::root(&'a self) -> core::option::Option<<G as syntaqlite_syntax::typed::TypedDialect>::Node>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::statement_base(&self) -> syntaqlite_syntax::source::StatementBase
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::text(&self) -> &'a syntaqlite_syntax::source::StmtText

--- a/tests/public-api/syntaqlite-syntax.txt
+++ b/tests/public-api/syntaqlite-syntax.txt
@@ -956,12 +956,14 @@ pub fn str::eq(&self, other: &syntaqlite_syntax::source::DocText) -> bool
 pub fn str::eq(&self, other: &syntaqlite_syntax::source::LayerText) -> bool
 pub fn str::eq(&self, other: &syntaqlite_syntax::source::StmtText) -> bool
 pub fn syntaqlite_syntax::Comment<'a>::kind(&self) -> syntaqlite_syntax::CommentKind
+pub fn syntaqlite_syntax::Comment<'a>::layer_id(&self) -> u8
 pub fn syntaqlite_syntax::Comment<'a>::length(&self) -> syntaqlite_syntax::source::StmtLen
 pub fn syntaqlite_syntax::Comment<'a>::offset(&self) -> syntaqlite_syntax::source::StmtOffset
 pub fn syntaqlite_syntax::Comment<'a>::side(&self) -> syntaqlite_syntax::CommentSide
 pub fn syntaqlite_syntax::Comment<'a>::text(&self) -> &'a str
 pub fn syntaqlite_syntax::Comment<'a>::token_idx(&self) -> syntaqlite_syntax::source::TokenIdx
 pub fn syntaqlite_syntax::CommentSpan::kind(&self) -> syntaqlite_syntax::CommentKind
+pub fn syntaqlite_syntax::CommentSpan::layer_id(&self) -> u8
 pub fn syntaqlite_syntax::CommentSpan::length(&self) -> syntaqlite_syntax::source::StmtLen
 pub fn syntaqlite_syntax::CommentSpan::offset(&self) -> syntaqlite_syntax::source::StmtOffset
 pub fn syntaqlite_syntax::CommentSpan::side(&self) -> syntaqlite_syntax::CommentSide
@@ -1120,6 +1122,7 @@ pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::name_text(&self, node_id:
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_expanded_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<&'a str>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_is_macro_free(&self, id: syntaqlite_syntax::any::AnyNodeId) -> bool
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_text(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(&'a str, syntaqlite_syntax::source::StmtOffset)>
+pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::node_token_range(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(syntaqlite_syntax::source::TokenIdx, syntaqlite_syntax::source::TokenIdx)>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_id(&self) -> syntaqlite_syntax::any::AnyNodeId
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::root_node(&self) -> core::option::Option<syntaqlite_syntax::any::AnyNode<'_>>
 pub fn syntaqlite_syntax::any::AnyParsedStatement<'a>::span_expanded_text(&self, span: syntaqlite_syntax::any::TextSpan) -> &'a str
@@ -1973,6 +1976,7 @@ pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::expanded_text(&sel
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::full_text(&self) -> &'a syntaqlite_syntax::source::DocText
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::leading_comments(&self, token_idx: syntaqlite_syntax::source::TokenIdx) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::Comment<'a>>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::macro_rewrites(&self) -> impl core::iter::traits::iterator::Iterator<Item = syntaqlite_syntax::any::MacroRewrite<'a>> + use<'_, 'a, G>
+pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::node_token_range(&self, id: syntaqlite_syntax::any::AnyNodeId) -> core::option::Option<(syntaqlite_syntax::source::TokenIdx, syntaqlite_syntax::source::TokenIdx)>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::root(&'a self) -> core::option::Option<<G as syntaqlite_syntax::typed::TypedDialect>::Node>
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::statement_base(&self) -> syntaqlite_syntax::source::StatementBase
 pub fn syntaqlite_syntax::typed::TypedParsedStatement<'a, G>::text(&self) -> &'a syntaqlite_syntax::source::StmtText


### PR DESCRIPTION
Add a node→token mapping primitive and use it to compose boundary-
comment helpers, plus rework how block comments are classified so the
results make sense for both AST-level consumers and the formatter.  The
classification change is what drives the fmt-side adjustments; the
`node_token_range` work and `Comment.layer_id` are what let downstream
tools act on the new classification.

- **`syntaqlite_node_token_range(p, node_id, &first, &last)`** —
  inclusive token range per AST node, O(1) via an `SynqExtentRange`
  side stack that piggybacks on the existing `node_extents` shadow
  stack (one push-on-shift, one merged min/max loop on reduce).
  Ranges include expansion-layer tokens so macro-produced nodes report
  meaningful ranges instead of collapsing to empty.  Exposed in Rust
  as `AnyParsedStatement::node_token_range` and a typed passthrough.

- **O(1) `token_leading/trailing_comments`** via an eagerly-populated
  per-token comment index (`SynqTokenComments`) maintained in step
  with `synq_parser_record_comment` and `synq_parser_shift_token`.
  Orphan leading comments (predicted owner not yet pushed) live on a
  scalar bucket on the parser and surface via `token_idx == ntokens`.

- **`syntaqlite_node_{leading,trailing}_comments`** — composition
  sugar over `node_token_range + token_{leading,trailing}_comments`
  for the common boundary case, plus Rust equivalents on
  `AnyParsedStatement`.  The token-level API is retained for interior
  and keyword-attached comments, which node-level helpers cannot
  surface.

- **`Comment.layer_id`** distinguishes authored-source comments
  (layer 0) from expansion-body comments (layer > 0).  The macro
  expansion tokenization path (`synq_macro_skip`) now actually
  records the comments it scans over — previously the field was
  always zero because the producer was incomplete.  Offsets are
  layer-local (matching `SyntaqliteParserToken.offset`); the Rust
  `Comment::text()` slice resolves against the owning layer's
  buffer.

- **New classification rule for block comments**: a block comment is
  trailing on the preceding token iff it is same-line with that
  token AND nothing else follows on the rest of the line; otherwise
  it is leading on the next token.  Previously, any block comment
  same-line with the preceding token was trailing on it,
  conflating "annotates the prev token" with "sits between two
  tokens".  Line comments keep their old behavior (always trailing
  when same-line with prev).  Implementation drives off a forward
  `synq_next_token_offset` lookahead that reuses the existing
  tokenizer (`SynqSqliteGetTokenVersionWrapped`), and the
  cross-layer branch (source comment after a macro expansion)
  walks up to the topmost ancestor layer and compares against the
  macro call's end in source.

- **Formatter (`comment.rs`)**: leading block comments now render
  `hardline + text + space` so `/* c */ KEYWORD` has a separator
  even after the drain clears `pending`.

- **Formatter (`doc.rs`)**: `push_keyword` collapses a duplicated
  leading space when the output already ends with one — grammar
  literals like `\" AS \"` carry a baked-in leading space that
  otherwise doubles up with the new trailing-space in the leading
  chunk.  Targeted workaround; the proper fix (strip baked-in
  leading spaces from keyword literals, rely on explicit
  `line`/`space` ops in the grammar) is tracked in #5.

- **Tests**: 20+ new c-api scenarios covering `node_token_range`,
  `node_comments`, the new classification rule across layer-0 and
  expansion-layer comments, multiple leading comments on one
  token, trailing comments on `;`, and the cross-layer
  `SELECT /* ... */ macro!(x)` case.  A `macro_register`
  directive in the c-api driver exercises registered-expansion
  paths alongside fallback paths.  15 new Rust unit tests cover
  the same API surface including nested registered-macro
  expansion-layer inclusion.  Rebaseline 4 fmt and 1 perfetto-fmt
  tests whose expected outputs were written against the old
  \"always trailing on prev\" rule — the new outputs render
  block comments on their own line before the following keyword.

## Test plan

- [x] `tools/pre-push` green (fmt, c-deps, public-api, cli build,
  unit tests, integration suites, web playground).
- [x] `tools/run-integration-tests` — all 16 suites pass.