### PR TITLE
synq: bump version to 0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.5.6
+
+**Rust API:**
+- Added `AnyParsedStatement::node_token_range(node_id)` returning the inclusive token range for any AST node. Ranges include expansion-layer tokens, so macro-produced nodes report meaningful ranges instead of collapsing to empty ([#248](https://github.com/LalitMaganti/syntaqlite/pull/248)).
+- Added `AnyParsedStatement::node_leading_comments` / `node_trailing_comments` as composition sugar over `node_token_range` + `token_{leading,trailing}_comments` for the common boundary-comment case ([#248](https://github.com/LalitMaganti/syntaqlite/pull/248)).
+- Token API is now layer-aware: offsets/lengths are typed as `LayerOffset` / `LayerLen`, `text()` resolves per-layer, and `stmt_range()` drills expansion tokens up to the authored call site in source coordinates. `layer_id()` is exposed on tokens ([#247](https://github.com/LalitMaganti/syntaqlite/pull/247)).
+- `Comment::layer_id` distinguishes authored-source comments (layer 0) from comments inside macro expansion bodies (layer > 0); `Comment::text()` resolves against the owning layer's buffer ([#248](https://github.com/LalitMaganti/syntaqlite/pull/248)).
+- Removed `AnyParsedStatement::token_spans()` — use `tokens().map(|t| t.stmt_range())` instead ([#247](https://github.com/LalitMaganti/syntaqlite/pull/247)).
+
+**C API:**
+- Added `syntaqlite_node_token_range(p, node_id, &first, &last)` for O(1) inclusive token ranges per AST node, and `syntaqlite_node_{leading,trailing}_comments` for boundary comments at the node level ([#248](https://github.com/LalitMaganti/syntaqlite/pull/248)).
+- `SyntaqliteComment.layer_id` now distinguishes authored-source comments from comments inside macro expansion bodies ([#248](https://github.com/LalitMaganti/syntaqlite/pull/248)).
+
+**Formatter:**
+- New block-comment classification rule: a block comment is trailing on the preceding token only if it is same-line with that token AND nothing else follows on the rest of the line; otherwise it is leading on the next token. Previously, any block comment same-line with the preceding token was treated as trailing, conflating "annotates the prev token" with "sits between two tokens". Line comments are unchanged ([#248](https://github.com/LalitMaganti/syntaqlite/pull/248)).
+- Fixed `/* c */ KEYWORD` losing its separator between the comment and the following keyword after the leading-comment drain cleared `pending` ([#248](https://github.com/LalitMaganti/syntaqlite/pull/248)).
+
 ## 0.5.5
 
 **C API:**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "benches"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "criterion",
  "syntaqlite",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "glob",
  "libloading",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-buildtools"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "cc",
  "clap",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-cli"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "clap",
  "glob",
@@ -1075,11 +1075,11 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-common"
-version = "0.5.5"
+version = "0.5.6"
 
 [[package]]
 name = "syntaqlite-syntax"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "cc",
  "libloading",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-wasm"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ cargo install syntaqlite-cli
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.5.5", features = ["fmt"] }
+syntaqlite = { version = "0.5.6", features = ["fmt"] }
 ```
 
 **Python** ([API docs](https://docs.syntaqlite.com/latest/reference/python-api/))

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syntaqlite",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "SQLite SQL language server — diagnostics, formatting, completions, and semantic tokens",
   "author": {
     "name": "Lalit Maganti"

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "syntaqlite",
   "displayName": "syntaqlite",
   "description": "SQL language support powered by syntaqlite — diagnostics, formatting, completions, and semantic highlighting",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "publisher": "syntaqlite",
   "license": "Apache-2.0",
   "icon": "icon.png",

--- a/integrations/zed/Cargo.toml
+++ b/integrations/zed/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "syntaqlite-zed"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 
 [lib]

--- a/integrations/zed/extension.toml
+++ b/integrations/zed/extension.toml
@@ -3,7 +3,7 @@
 
 id = "syntaqlite"
 name = "Syntaqlite"
-version = "0.5.5"
+version = "0.5.6"
 schema_version = 1
 authors = ["Lalit Maganti <lalitmaganti@gmail.com>"]
 description = "SQL language support powered by syntaqlite — tokenizer, parser, formatter and validator built on SQLite's own grammar."

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntaqlite"
-version = "0.5.5"
+version = "0.5.6"
 description = "SQLite SQL tools — parser, formatter, validator, and MCP server"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}

--- a/python/syntaqlite/__init__.py
+++ b/python/syntaqlite/__init__.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from .nodes import _wrap
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 
 
 # ── Binary discovery ──────────────────────────────────────────────────────────

--- a/syntaqlite-buildtools/Cargo.toml
+++ b/syntaqlite-buildtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-buildtools"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 description = "Internal codegen and build tools for syntaqlite — not intended for direct use"
 license = "Apache-2.0"
@@ -20,8 +20,8 @@ dist = false
 doc = false
 
 [dependencies]
-syntaqlite-common = { version = "0.5.5", path = "../syntaqlite-common" }
-syntaqlite-syntax = { version = "0.5.5", path = "../syntaqlite-syntax", default-features = false, features = ["embedded-sources"] }
+syntaqlite-common = { version = "0.5.6", path = "../syntaqlite-common" }
+syntaqlite-syntax = { version = "0.5.6", path = "../syntaqlite-syntax", default-features = false, features = ["embedded-sources"] }
 clap = { version = "4.5", features = ["derive"] }
 tempfile = "3.8"
 serde = { version = "1", features = ["derive"] }

--- a/syntaqlite-cli/Cargo.toml
+++ b/syntaqlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-cli"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 repository.workspace = true
 description = "Fast, accurate SQLite SQL formatter, validator, and language server — built on SQLite's own grammar"
@@ -42,8 +42,8 @@ rmcp = { version = "0.1", features = ["server", "transport-io"], optional = true
 schemars = { version = "0.8", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-syntaqlite = { version = "0.5.5", path = "../syntaqlite", default-features = false, features = ["fmt", "lsp", "analysis", "experimental-embedded", "serde-json"] }
-syntaqlite-syntax = { version = "0.5.5", path = "../syntaqlite-syntax" }
-syntaqlite-buildtools = { version = "0.5.5", path = "../syntaqlite-buildtools", optional = true }
+syntaqlite = { version = "0.5.6", path = "../syntaqlite", default-features = false, features = ["fmt", "lsp", "analysis", "experimental-embedded", "serde-json"] }
+syntaqlite-syntax = { version = "0.5.6", path = "../syntaqlite-syntax" }
+syntaqlite-buildtools = { version = "0.5.6", path = "../syntaqlite-buildtools", optional = true }
 tempfile = "3.8"
 tokio = { version = "1", features = ["rt", "macros", "io-std"], optional = true }

--- a/syntaqlite-common/Cargo.toml
+++ b/syntaqlite-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-common"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 description = "Internal shared primitives for syntaqlite — not intended for direct use"
 license = "Apache-2.0"

--- a/syntaqlite-syntax/Cargo.toml
+++ b/syntaqlite-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-syntax"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 links = "syntaqlite_syntax"
 description = "Internal parser and tokenizer for syntaqlite — not intended for direct use"

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! syntaqlite = { version = "0.5.5", default-features = false, features = ["sqlite"] }
+//! syntaqlite = { version = "0.5.6", default-features = false, features = ["sqlite"] }
 //! ```
 
 // ==== Public API ====

--- a/syntaqlite-wasm/Cargo.toml
+++ b/syntaqlite-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-wasm"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 repository.workspace = true
 

--- a/syntaqlite/Cargo.toml
+++ b/syntaqlite/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "syntaqlite"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 description = "Parser, formatter, validator, and language server for SQLite SQL — built on SQLite's own grammar"
 license = "Apache-2.0"
@@ -40,8 +40,8 @@ pin-cflags = ["sqlite", "syntaqlite-syntax/pin-cflags"]    # Pin compile-time fl
 workspace = true
 
 [dependencies]
-syntaqlite-common = { version = "0.5.5", path = "../syntaqlite-common" }
-syntaqlite-syntax = { version = "0.5.5", path = "../syntaqlite-syntax", default-features = false }
+syntaqlite-common = { version = "0.5.6", path = "../syntaqlite-common" }
+syntaqlite-syntax = { version = "0.5.6", path = "../syntaqlite-syntax", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 libloading = { version = "0.8", optional = true }

--- a/tests/benches/Cargo.toml
+++ b/tests/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benches"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 publish = false
 

--- a/tests/comparison/parser/Cargo.toml
+++ b/tests/comparison/parser/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "parser-bench"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 
 [[bin]]

--- a/web/docs/content/guides/rust-api.md
+++ b/web/docs/content/guides/rust-api.md
@@ -10,7 +10,7 @@ weight = 1
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.5.5", features = ["fmt"] }
+syntaqlite = { version = "0.5.6", features = ["fmt"] }
 ```
 
 ## Format a query
@@ -127,7 +127,7 @@ Add the `analysis` and `sqlite` features:
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.5.5", features = ["analysis", "sqlite"] }
+syntaqlite = { version = "0.5.6", features = ["analysis", "sqlite"] }
 ```
 
 ```rust

--- a/web/syntaqlite-js/package.json
+++ b/web/syntaqlite-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syntaqlite",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "SQLite SQL parser, formatter, and validator for the browser — powered by WebAssembly",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Motivation

Cut the 0.5.6 release.

## Changes

- Bumps version to 0.5.6 across all Cargo.toml / pyproject.toml / integration manifests / README / docs.
- Adds 0.5.6 CHANGELOG entry.

Release notes:

**Rust API:**
- Added `AnyParsedStatement::node_token_range(node_id)` returning the inclusive token range for any AST node. Ranges include expansion-layer tokens, so macro-produced nodes report meaningful ranges instead of collapsing to empty (#248).
- Added `AnyParsedStatement::node_leading_comments` / `node_trailing_comments` as composition sugar over `node_token_range` + `token_{leading,trailing}_comments` for the common boundary-comment case (#248).
- Token API is now layer-aware: offsets/lengths are typed as `LayerOffset` / `LayerLen`, `text()` resolves per-layer, and `stmt_range()` drills expansion tokens up to the authored call site in source coordinates. `layer_id()` is exposed on tokens (#247).
- `Comment::layer_id` distinguishes authored-source comments (layer 0) from comments inside macro expansion bodies (layer > 0); `Comment::text()` resolves against the owning layer's buffer (#248).
- Removed `AnyParsedStatement::token_spans()` — use `tokens().map(|t| t.stmt_range())` instead (#247).

**C API:**
- Added `syntaqlite_node_token_range(p, node_id, &first, &last)` for O(1) inclusive token ranges per AST node, and `syntaqlite_node_{leading,trailing}_comments` for boundary comments at the node level (#248).
- `SyntaqliteComment.layer_id` now distinguishes authored-source comments from comments inside macro expansion bodies (#248).

**Formatter:**
- New block-comment classification rule: a block comment is trailing on the preceding token only if it is same-line with that token AND nothing else follows on the rest of the line; otherwise it is leading on the next token. Line comments are unchanged (#248).
- Fixed `/* c */ KEYWORD` losing its separator between the comment and the following keyword after the leading-comment drain cleared `pending` (#248).