### PR TITLE
synq: Add Nix flake for the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ sqlite-amalgamations/.build-cache
 /tests/comparison/results/
 
 .zed
+
+# Nix
+result
+result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  description = "Fast, accurate SQLite SQL formatter, validator, and language server";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      inherit (nixpkgs) lib;
+
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems = lib.genAttrs systems;
+
+      cliManifest = lib.importTOML ./syntaqlite-cli/Cargo.toml;
+      workspaceManifest = lib.importTOML ./Cargo.toml;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = "syntaqlite";
+            version = cliManifest.package.version;
+
+            src = self;
+
+            cargoLock.lockFile = ./Cargo.lock;
+
+            cargoBuildFlags = [
+              "--package"
+              cliManifest.package.name
+            ];
+
+            cargoTestFlags = [
+              "--package"
+              cliManifest.package.name
+            ];
+
+            meta = {
+              description = cliManifest.package.description;
+              homepage = workspaceManifest.workspace.package.homepage;
+              license = lib.licenses.asl20;
+              mainProgram = "syntaqlite";
+              platforms = lib.platforms.unix;
+            };
+          };
+        }
+      );
+
+      checks = forAllSystems (system: {
+        default = self.packages.${system}.default;
+      });
+
+      overlays.default = final: _prev: {
+        syntaqlite = self.packages.${final.stdenv.hostPlatform.system}.default;
+      };
+    };
+}


### PR DESCRIPTION
Fixes #252 

Add a Nix flake that builds the syntaqlite CLI. 

I am not a Nix expert, and I don't know syntaqlite, and I used AI for this, so take it with a grain of salt.

Note that without a CI Action doing `nix flake check` or similar you could break this flake without knowing if you change the build.

I've done these tests:
  - `nix build .` - local build produces working `result/bin/syntaqlite`
  - `nix build github:areeh/syntaqlite/add-nix-flake` - remote build from a fresh checkout also produces working binary
  - `nix run .#` - runs the binary locally
  - `nix run github:areeh/syntaqlite/add-nix-flake -- …` - runs the binary as above
  - `nix flake check` - passes; runs the cli's 28 cargo tests during the check         
  - Consumed as `overlays.default` in my NixOS config — `nixos-rebuild` builds, binary works as Helix LSP
  - Verified `fmt` subcommand works on built binary
  
  And I looked at helix, jujutsu as inspiration.
 