### PR TITLE
synq: add advisory nix flake CI

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,46 @@
+# Build the Nix flake on PRs and pushes to main.
+#
+# Advisory by design: continue-on-error makes the workflow-run status succeed
+# even when `nix flake check` fails, so failures surface in the PR check list
+# without gating merges. To promote this to a required check, drop
+# continue-on-error, add "nix flake check" to branch protection, and mirror the
+# job name in ci-docs-noop.yml.
+name: Nix
+
+on:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "web/docs/**"
+      - "*.md"
+      - "LICENSE"
+      - ".github/workflows/**"
+      - "!.github/workflows/nix.yml"
+      - "integrations/claude-code/**"
+  push:
+    branches: [main]
+
+concurrency:
+  group: nix-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  flake-check:
+    name: nix flake check
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Cache /nix/store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'Cargo.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 5G
+
+      - name: nix flake check
+        run: nix flake check --print-build-logs


### PR DESCRIPTION
Runs `nix flake check` on PRs and pushes to main as a non-blocking
job, so flake breakage is visible without gating merges.

- Caches `/nix/store` via `nix-community/cache-nix-action`, which uses
  GitHub Actions' built-in cache.
- Linux-only. `nix flake check` without `--all-systems` only verifies
  the runner's arch.

Depends on #253.

