### PR TITLE
synq: enable workflow_dispatch for nix CI

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,6 +19,7 @@ on:
       - "integrations/claude-code/**"
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: nix-${{ github.ref }}


### PR DESCRIPTION
Adds `workflow_dispatch` to the Nix workflow so failures can be rerun (or the workflow triggered ad-hoc) without pushing a new commit. Also serves as a smoke test that the action allowlist now permits `DeterminateSystems/nix-installer-action` and `nix-community/cache-nix-action`.