### PR TITLE
synq: recursion check via layer parent chain, not a separate stack

### DIFF
--- a/syntaqlite-syntax/csrc/parser.c
+++ b/syntaqlite-syntax/csrc/parser.c
@@ -92,7 +92,6 @@ static void reset_stmt(SyntaqliteParser* p) {
   if (p->source)
     synq_layers_push_sentinel(&p->macro.layers, p->source, p->source_len,
                               p->mem);
-  p->macro.expansion_depth = 0;
 #endif
   p->ctx.layer_id = 0;
   p->ctx.cur_shift_start = 0;

--- a/syntaqlite-syntax/csrc/parser_internal.h
+++ b/syntaqlite-syntax/csrc/parser_internal.h
@@ -23,7 +23,6 @@ extern "C" {
 // ── Tunables ────────────────────────────────────────────────────────────────
 
 #define SYNQ_MAX_MACRO_DEPTH 16
-#define SYNQ_MAX_MACRO_ARGS 64
 
 // Per-token comment index entry.  Each entry records where the owning
 // token's leading / trailing comments live in `p->comments`.  Used by
@@ -145,7 +144,6 @@ typedef struct SynqExpansionLayer {
 } SynqExpansionLayer;
 
 typedef SYNQ_VEC(SynqExpansionLayer) SynqExpansionLayerVec;
-typedef SYNQ_VEC(uint8_t) SynqByteVec;
 
 // All macro-related parser state, including layer tree and scratch buffers.
 // Factored into a single sub-struct so the parser struct has one guarded
@@ -168,26 +166,6 @@ typedef struct SynqMacroState {
   // ── Scratch buffers (reused across invocations, freed in destroy) ──────
   SYNQ_VEC(uint8_t) expand_buf;  // Template expansion output.
   SYNQ_VEC(uint8_t) body_buf;    // NUL-terminated body staging.
-  // Flat scratch arena for eager arg pre-expansion.  Usage is
-  // stack-disciplined: each `synq_parser_expand_and_feed_macro` records
-  // `count` on entry and truncates back to that mark before feeding its
-  // own expansion, so an inner call's pre-expansion temporaries don't
-  // fragment the outer caller's accumulating bytes (when the outer is
-  // itself in pre-expansion).  Pointers into this vec are taken only
-  // after `pre_expand_args` is done pushing, since pushes can realloc.
-  SynqByteVec arg_scratch;
-
-  // 1 while expand_and_feed is running in scratch (pre-expansion)
-  // mode.  When set, helper tokenizers skip side effects that would
-  // store mis-attributed metadata (comments) — the bytes are preserved
-  // verbatim into arg_scratch and get re-tokenized at the correct
-  // layer when the substituted body runs through Lemon-mode feed.
-  int in_pre_expand;
-
-  // ── Blue-paint recursion detection ─────────────────────────────────────
-  const char* expansion_names[SYNQ_MAX_MACRO_DEPTH];
-  uint32_t expansion_name_lens[SYNQ_MAX_MACRO_DEPTH];
-  uint32_t expansion_depth;
 
   // ── Nesting depth (0 = not in macro) ───────────────────────────────────
   uint32_t depth;
@@ -333,12 +311,9 @@ uint32_t synq_parser_scan_macro_args(SyntaqliteParser* p,
                                      uint32_t max_args,
                                      uint32_t* out_end_offset);
 
-// Expand a macro call via the lookup callback, push the expansion
-// layer, feed its tokens, and clean up.  The sink (Lemon vs.
-// arg_scratch) is determined by `p->macro.in_pre_expand` — set by
-// `pre_expand_args` when an outer call is pre-expanding its own
-// args, cleared otherwise.  Returns 0 on success, -1 if not a macro
-// or on error.  Updates *out_end_offset to the position past ')'.
+// Expand a macro call via the lookup callback, push the expansion layer,
+// feed its tokens, and clean up.  Returns 0 on success, -1 if not a
+// macro or on error.  Updates *out_end_offset to the position past ')'.
 int synq_parser_expand_and_feed_macro(SyntaqliteParser* p,
                                       const char* buf,
                                       uint32_t buf_len,

--- a/syntaqlite-syntax/csrc/parser_macros.c
+++ b/syntaqlite-syntax/csrc/parser_macros.c
@@ -63,15 +63,7 @@ static int64_t synq_macro_skip(SyntaqliteParser* p,
       *out_type = ttype;
       return tlen;
     }
-    // In pre-expansion (scratch) mode, ctx.layer_id and `pos` don't
-    // describe a buffer record_comment can correctly attribute to: the
-    // macro layer hasn't been pushed yet and `pos` is local to the
-    // arg-text being scanned, not to ctx.source.  Skip recording here
-    // — the comment bytes are preserved into arg_scratch and will be
-    // re-tokenized at the right layer when the substituted body is
-    // fed through Lemon mode.
-    if (ttype == SYNTAQLITE_TK_COMMENT && p->collect_tokens &&
-        !p->macro.in_pre_expand) {
+    if (ttype == SYNTAQLITE_TK_COMMENT && p->collect_tokens) {
       synq_parser_record_comment(p, pos, (uint32_t)tlen);
     }
     pos += (uint32_t)tlen;
@@ -136,9 +128,7 @@ uint32_t synq_parser_scan_macro_args(SyntaqliteParser* p,
     // for them. Record them here instead so consumers that ask
     // "are there any comments in byte range [call_off, call_end)?"
     // (notably the formatter's structured-args bail) see the truth.
-    // Same suppression as synq_macro_skip in pre-expansion mode.
-    if (ttype == SYNTAQLITE_TK_COMMENT && p->collect_tokens &&
-        !p->macro.in_pre_expand) {
+    if (ttype == SYNTAQLITE_TK_COMMENT && p->collect_tokens) {
       synq_parser_record_comment(p, pos, (uint32_t)tlen);
     }
 
@@ -189,7 +179,6 @@ uint32_t synq_parser_scan_macro_args(SyntaqliteParser* p,
 void synq_macro_state_init(SynqMacroState* m) {
   syntaqlite_vec_init(&m->expand_buf);
   syntaqlite_vec_init(&m->body_buf);
-  syntaqlite_vec_init(&m->arg_scratch);
   syntaqlite_vec_init(&m->layers);
   syntaqlite_vec_init(&m->traceback_buf);
   syntaqlite_vec_init(&m->node_expanded_buf);
@@ -198,7 +187,6 @@ void synq_macro_state_init(SynqMacroState* m) {
 void synq_macro_state_free(SynqMacroState* m, SyntaqliteMemMethods mem) {
   syntaqlite_vec_free(&m->expand_buf, mem);
   syntaqlite_vec_free(&m->body_buf, mem);
-  syntaqlite_vec_free(&m->arg_scratch, mem);
   synq_layers_free_owned(&m->layers, mem);
   syntaqlite_vec_free(&m->layers, mem);
   syntaqlite_vec_free(&m->traceback_buf, mem);
@@ -320,20 +308,9 @@ SYNTAQLITE_API void syntaqlite_macro_expansion_set_result_with_arg_map(
 // Forward declaration — mutual recursion with expand_and_feed.
 // (canonical declaration in parser_internal.h)
 
-// Tokenize `buf` and dispatch each token according to
-// `p->macro.in_pre_expand`:
-//   * 0 → feed the token to Lemon (normal expansion).
-//   * 1 → append `buf` bytes — including inter-token whitespace and
-//     comments, with nested calls' expansion content spliced in — to
-//     `p->macro.arg_scratch` (eager arg pre-expansion sink).
-//
+// Tokenize `buf` and feed each token to Lemon.
 // `depth` is the current expansion nesting (for recursion limit).
-// Returns: 0 = ok, 1 = statement boundary (Lemon mode only), -1 = error.
-//
-// Trailing whitespace / comments after the last significant token in
-// `buf` are NOT appended in scratch mode — only bytes up to the end of
-// each token are flushed.  That's fine for arg pre-expansion: trailing
-// whitespace doesn't affect re-tokenization.
+// Returns: 0 = ok, 1 = statement boundary, -1 = error.
 static int expand_and_feed(SyntaqliteParser* p,
                            const char* buf,
                            uint32_t buf_len,
@@ -345,18 +322,13 @@ static int expand_and_feed(SyntaqliteParser* p,
     return -1;
   }
 
-  // Swap ctx.source so any read against `p->ctx.source` during
-  // tokenization (Lemon action offsets, fallback paths) lines up with
-  // the buf we're processing.
+  // Temporarily swap ctx.source so Lemon action offset computations are
+  // relative to the expansion buffer.
   const char* saved_source = p->ctx.source;
   p->ctx.source = buf;
 
-  const int to_scratch = p->macro.in_pre_expand;
   const unsigned char* z = (const unsigned char*)buf;
   uint32_t pos = 0;
-  // Scratch-mode cursor: bytes in [last_emit_end, current emission
-  // start) are inter-token whitespace/comments we still owe the sink.
-  uint32_t last_emit_end = 0;
 
   while (pos < buf_len) {
     uint32_t ttype = 0;
@@ -375,20 +347,11 @@ static int expand_and_feed(SyntaqliteParser* p,
     if (ttype == SYNTAQLITE_TK_ID && la_type == SYNTAQLITE_TK_BANG &&
         p->ctx.in_macro_def_body == 0) {
       uint32_t nested_end = 0;
-      // In scratch mode, flush pending inter-token bytes before
-      // recursing — the recursive call writes inner's expansion
-      // *content* into the scratch, not the inner's call source.
-      if (to_scratch && pos > last_emit_end) {
-        syntaqlite_vec_push_n(&p->macro.arg_scratch,
-                              (const uint8_t*)(buf + last_emit_end),
-                              pos - last_emit_end, p->mem);
-      }
       int erc = synq_parser_expand_and_feed_macro(p, buf, buf_len, pos,
                                                   (uint32_t)tlen, bang_pos,
                                                   depth + 1, &nested_end);
       if (erc == 0) {
         pos = nested_end;
-        last_emit_end = nested_end;
         continue;
       }
       // erc == -1: not a macro or error — feed ID normally below.
@@ -396,16 +359,6 @@ static int expand_and_feed(SyntaqliteParser* p,
         p->ctx.source = saved_source;
         return -1;
       }
-    }
-
-    if (to_scratch) {
-      uint32_t token_end = pos + (uint32_t)tlen;
-      syntaqlite_vec_push_n(&p->macro.arg_scratch,
-                            (const uint8_t*)(buf + last_emit_end),
-                            token_end - last_emit_end, p->mem);
-      last_emit_end = token_end;
-      pos = token_end;
-      continue;
     }
 
     // Feed the token through the unified shift path: it pushes to
@@ -441,78 +394,7 @@ static int expand_and_feed(SyntaqliteParser* p,
   return 0;
 }
 
-// Pre-expand each arg that contains a nested macro call into the
-// shared `arg_scratch` arena; args without '!' are passed through.
-// Runs before the callee's blue-paint frame is pushed so nested calls
-// in args are checked against the *caller's* stack (diamond pattern).
-//
-// Pointers into `arg_scratch.data` are deferred until all pushes are
-// done because intermediate pushes can realloc and invalidate any
-// pointer captured mid-loop.  The arena is truncated back to its
-// caller's mark in `synq_parser_expand_and_feed_macro` before the
-// caller feeds its own expansion.
-// Inner worker: assumes `p->macro.in_pre_expand` is already 1.  Kept
-// separate from `pre_expand_args` so that wrapper owns the flag's
-// save/restore around a single call site.
-static int pre_expand_args_inner(SyntaqliteParser* p,
-                                 const char* buf,
-                                 uint32_t arg_count,
-                                 const SynqMacroArg* args,
-                                 SyntaqliteToken* token_args,
-                                 uint32_t depth) {
-  uint32_t arg_starts[SYNQ_MAX_MACRO_ARGS];
-  uint32_t arg_lens[SYNQ_MAX_MACRO_ARGS];
-  uint8_t expanded[SYNQ_MAX_MACRO_ARGS] = {0};
-
-  for (uint32_t i = 0; i < arg_count; i++) {
-    const char* arg_text = buf + args[i].offset;
-    uint32_t arg_len = args[i].length;
-    if (!memchr(arg_text, '!', arg_len))
-      continue;
-
-    arg_starts[i] = p->macro.arg_scratch.count;
-    if (expand_and_feed(p, arg_text, arg_len, depth) < 0)
-      return -1;
-    arg_lens[i] = p->macro.arg_scratch.count - arg_starts[i];
-    expanded[i] = 1;
-  }
-
-  // Resolve pointers now that all pushes (including any from recursive
-  // calls) are done; arg_scratch.data is stable from this point until
-  // the caller's truncate/feed.
-  for (uint32_t i = 0; i < arg_count; i++) {
-    if (!expanded[i])
-      continue;
-    token_args[i].text = (const char*)p->macro.arg_scratch.data + arg_starts[i];
-    token_args[i].length = arg_lens[i];
-  }
-  return 0;
-}
-
-static int pre_expand_args(SyntaqliteParser* p,
-                           const char* buf,
-                           uint32_t arg_count,
-                           const SynqMacroArg* args,
-                           SyntaqliteToken* token_args,
-                           uint32_t depth) {
-  // `in_pre_expand` is the dynamic-scope flag that tells everyone
-  // downstream — expand_and_feed (which writes to scratch instead of
-  // Lemon), synq_macro_skip / scan_macro_args (which suppress comment
-  // recording) — that we're inside arg pre-expansion.  Save and
-  // restore so nesting through recursive macro calls is well-behaved:
-  // an inner pre_expand_args inherits the 1 and restores to 1.
-  int saved = p->macro.in_pre_expand;
-  p->macro.in_pre_expand = 1;
-  int rc = pre_expand_args_inner(p, buf, arg_count, args, token_args, depth);
-  p->macro.in_pre_expand = saved;
-  return rc;
-}
-
 // Expand a macro call and feed the expanded tokens into the parser.
-// The sink (Lemon vs. arg_scratch) is read from
-// `p->macro.in_pre_expand`, which is owned by `pre_expand_args` and
-// set whenever we're inside an outer call's arg pre-expansion.  No
-// per-call propagation needed.
 //
 // Combines lookup-callback invocation, layer creation, and token feeding
 // into a single operation.  The layer is pushed *before* the callback so
@@ -531,46 +413,65 @@ int synq_parser_expand_and_feed_macro(SyntaqliteParser* p,
   if (!p->macro.lookup_fn)
     return -1;
 
-  // Check blue-paint: recursion detection.
-  for (uint32_t i = 0; i < p->macro.expansion_depth; i++) {
-    if (synq_name_eq_ci(p->macro.expansion_names[i],
-                        p->macro.expansion_name_lens[i], buf + id_offset,
-                        id_len)) {
-      snprintf(p->error_msg, sizeof(p->error_msg),
-               "recursive macro expansion: '%.*s'", (int)id_len,
-               buf + id_offset);
-      p->had_error = 1;
-      return -1;
+  // Recursion check.  Walks the chain of lexical wrappers (the macros
+  // whose authored bodies contain the call site we're about to expand)
+  // looking for a match against the callee's name.
+  //
+  // The chain isn't quite the parent-layer chain: a call that came in
+  // through a `$param` substitution was authored by the substituting
+  // layer's caller, not by the substituting layer itself, so the
+  // substituting layer doesn't belong on the chain.  Two filters
+  // capture that:
+  //
+  //  1. If `id_offset` falls inside one of the current layer's
+  //     `arg_segments`, the call we're about to expand was authored
+  //     by the current layer's caller — start the walk one layer up.
+  //
+  //  2. When walking, stop at any layer whose `body_call_offset` is
+  //     ARG_INTERNAL: its own call came through a `$param` substitution
+  //     too, and anything further up doesn't lexically author the call
+  //     site either.
+  {
+    uint32_t walk = p->ctx.layer_id;
+    if (walk > 0) {
+      const SynqExpansionLayer* cur = &p->macro.layers.data[walk];
+      for (uint32_t i = 0; i < cur->arg_segment_count; i++) {
+        const SynqArgSegment* seg = &cur->arg_segments[i];
+        if (id_offset >= seg->sub_offset &&
+            id_offset < seg->sub_offset + seg->sub_length) {
+          walk = cur->parent_layer_id;
+          break;
+        }
+      }
+    }
+    while (walk > 0) {
+      const SynqExpansionLayer* lyr = &p->macro.layers.data[walk];
+      if (synq_name_eq_ci(lyr->name, lyr->name_len, buf + id_offset, id_len)) {
+        snprintf(p->error_msg, sizeof(p->error_msg),
+                 "recursive macro expansion: '%.*s'", (int)id_len,
+                 buf + id_offset);
+        p->had_error = 1;
+        return -1;
+      }
+      if (lyr->body_call_offset == SYNTAQLITE_MACRO_BODY_CALL_ARG_INTERNAL)
+        break;
+      walk = lyr->parent_layer_id;
     }
   }
 
   // Scan args.
-  SynqMacroArg args[SYNQ_MAX_MACRO_ARGS];
+  SynqMacroArg args[64];
   uint32_t end_offset = 0;
-  uint32_t arg_count = synq_parser_scan_macro_args(
-      p, buf, buf_len, bang_offset, args, SYNQ_MAX_MACRO_ARGS, &end_offset);
+  uint32_t arg_count = synq_parser_scan_macro_args(p, buf, buf_len, bang_offset,
+                                                   args, 64, &end_offset);
 
-  SyntaqliteToken token_args[SYNQ_MAX_MACRO_ARGS];
-  uint32_t token_arg_count =
-      arg_count < SYNQ_MAX_MACRO_ARGS ? arg_count : SYNQ_MAX_MACRO_ARGS;
+  SyntaqliteToken token_args[64];
+  uint32_t token_arg_count = arg_count < 64 ? arg_count : 64;
   for (uint32_t i = 0; i < token_arg_count; i++) {
     token_args[i].text = buf + args[i].offset;
     token_args[i].length = args[i].length;
     token_args[i].type = 0;
   }
-
-  // Capture arg_scratch high-water mark.  pre_expand_args pushes
-  // temporaries above it; we restore to this mark before feeding our
-  // own expansion so that (a) when our caller is itself in scratch
-  // mode, our expansion bytes append at the caller's position keeping
-  // its slot contiguous, and (b) we don't leak temporaries on errors.
-  uint32_t scratch_mark = p->macro.arg_scratch.count;
-
-  if (pre_expand_args(p, buf, token_arg_count, args, token_args, depth) < 0) {
-    p->macro.arg_scratch.count = scratch_mark;
-    return -1;
-  }
-
   // Push the expansion layer *before* the callback so set_result /
   // expand_and_set_result can write directly into it.
   uint32_t call_length = end_offset - id_offset;
@@ -599,7 +500,6 @@ int synq_parser_expand_and_feed_macro(SyntaqliteParser* p,
     p->macro.depth--;
     if (rc == -2)
       p->had_error = 1;
-    p->macro.arg_scratch.count = scratch_mark;
     return -1;
   }
 
@@ -627,21 +527,9 @@ int synq_parser_expand_and_feed_macro(SyntaqliteParser* p,
 
   p->ctx.layer_id = new_layer_idx;
 
-  // Push blue-paint for recursion detection.
-  p->macro.expansion_names[p->macro.expansion_depth] = buf + id_offset;
-  p->macro.expansion_name_lens[p->macro.expansion_depth] = id_len;
-  p->macro.expansion_depth++;
-
-  // Truncate scratch back to the caller's mark before feeding our
-  // expansion.  In scratch mode, this exposes the caller's
-  // accumulating position so our expansion bytes append contiguously
-  // onto it.  In Lemon mode, it just frees our pre-expansion temps.
-  p->macro.arg_scratch.count = scratch_mark;
-
   // Feed expanded tokens (may trigger nested macro expansions).
   int frc = expand_and_feed(p, data, data_len, depth);
 
-  p->macro.expansion_depth--;
   synq_end_macro(p);
 
   if (frc < 0)

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -1252,19 +1252,17 @@ mod tests {
     }
 
     #[test]
-    fn macro_rewrite_nested_args_are_expanded_eagerly_at_top_level() {
-        // Eager arg expansion (the fix for the diamond-recursion false
-        // positive): a nested call inside an arg is expanded *before*
-        // the outer macro's blue-paint is pushed. As a consequence the
-        // inner call's parent in the rewrite tree is the call-site
-        // layer (source for top-level), not the outer macro — and it
-        // shows up *before* the outer macro in rewrite order.
+    fn macro_rewrite_nested_body_call_offsets_via_substituted_arg() {
+        // Repro of the traceback example from issue #145:
+        //   CREATE PERFETTO MACRO n(x Expr) RETURNS Expr AS ($x);
+        //   CREATE PERFETTO MACRO m(x Expr) RETURNS Expr AS ($x);
+        //   SELECT m!(n!(nonexistent_col));
         //
-        // Previously (lazy expansion) the inner call was tokenized from
-        // the outer macro's substituted body and got the
-        // MACRO_BODY_CALL_ARG_INTERNAL sentinel for body_call_offset.
-        // With eager expansion the inner call has clean offsets in the
-        // authored source.
+        // The inner n!(...) call is tokenized from the substituted text
+        // of m's $x, not from m's authored body — downstream Rewriter
+        // consumers need the arg-internal sentinel (u32::MAX on both
+        // body_call_offset and body_call_length) to signal "descend via
+        // arg segments" instead of "rewrite in the parent's body".
         let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
         let mut reg = TestMacroRegistry::new();
         reg.register("n", &["x"], "($x)");
@@ -1280,19 +1278,28 @@ mod tests {
         };
 
         let rewrites: Vec<_> = stmt.macro_rewrites().collect();
-        assert_eq!(rewrites.len(), 2, "n (expanded first, eagerly) + m");
+        assert_eq!(rewrites.len(), 2, "m + n");
 
-        // Eager order: n is expanded during m's arg pre-expansion, so it
-        // lands in the rewrites list first.
-        let inner = &rewrites[0];
-        assert_eq!(inner.name(), "n");
-        assert_eq!(inner.parent(), None, "inner call is lexically at source");
-
-        let outer = &rewrites[1];
+        let outer = &rewrites[0];
         assert_eq!(outer.name(), "m");
         assert_eq!(outer.parent(), None);
+        // For top-level calls the parent is the authored source, so
+        // body_call_offset/length fall through to call_offset/length.
         assert_eq!(outer.body_call_offset(), outer.call_offset());
         assert_eq!(outer.body_call_length(), outer.call_length());
+
+        let inner = &rewrites[1];
+        assert_eq!(inner.name(), "n");
+        assert_eq!(inner.parent(), Some(RewriteIdx::from_raw(0)));
+        // The nested n!(42) call lives entirely inside m's substituted
+        // $x arg — call_offset/length are in the post-substitution
+        // expansion buffer, but there's no clean position in m's
+        // authored body "($x)".  The arg-internal sentinel signals this.
+        assert_eq!(
+            inner.body_call_offset(),
+            crate::MACRO_BODY_CALL_ARG_INTERNAL
+        );
+        assert_eq!(inner.body_call_length(), LayerLen::from_raw(u32::MAX));
     }
 
     #[test]
@@ -1362,17 +1369,20 @@ mod tests {
     }
 
     #[test]
-    fn macro_rewrite_arg_segment_resolves_to_source_after_eager_expansion() {
-        // Eager arg expansion: for `m!(n!(nonexistent_col))`, n is
-        // expanded first (during m's arg pre-expansion) and lands at
-        // rewrites[0]. Its single arg "nonexistent_col" is verbatim
-        // source text — n's arg_segments drill straight to source.
+    fn macro_rewrite_arg_segment_chain_resolves_to_source() {
+        // Reproduces the chain from issue #145: for `m!(n!(nonexistent_col))`,
+        // downstream consumers walk each rewrite's arg_segments to anchor
+        // the innermost token back to its authored position in the source.
         //
-        // The previous behaviour was a two-link chain: m's arg segment
-        // pointed at the literal "n!(nonexistent_col)" in source, and
-        // n's arg segment pointed into m's expansion buffer. Eager
-        // expansion collapses that chain because the nested call is
-        // resolved before m's substitution runs at all.
+        // The chain for `nonexistent_col`:
+        //   * n's $x segment: origin = rewrite(0) i.e. m's expansion buffer
+        //     at the position of "nonexistent_col" within "(n!(nonexistent_col))"
+        //     (n's arg text was tokenized from m's expansion, not the source).
+        //   * m's $x segment at that position: origin = source, pointing at
+        //     "n!(nonexistent_col)" in the authored SQL.
+        //
+        // Recursing one more step via n's arg text inside m's arg text gets
+        // back to the "nonexistent_col" position in the source.
         use crate::parser::ArgOrigin;
         let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
         let mut reg = TestMacroRegistry::new();
@@ -1391,18 +1401,53 @@ mod tests {
         let rewrites: Vec<_> = stmt.macro_rewrites().collect();
         assert_eq!(rewrites.len(), 2);
 
-        // rewrites[0] is `n` — expanded eagerly while preparing m's args.
-        // n's $x segment resolves directly to "nonexistent_col" in source.
+        // m's arg segment points into the authored source; origin_offset
+        // is statement-relative when origin is Source.
         let stmt_text = stmt.text();
-        let n_segs: Vec<_> = rewrites[0].arg_segments().collect();
-        assert_eq!(n_segs.len(), 1);
-        assert_eq!(n_segs[0].origin(), ArgOrigin::Source);
-        let n_arg_range = crate::source::StmtRange::from_offset_len(
-            StmtOffset::from_raw(n_segs[0].origin_offset().as_u32()),
-            StmtLen::from_raw(n_segs[0].origin_length().as_u32()),
+        let m_segs: Vec<_> = rewrites[0].arg_segments().collect();
+        assert_eq!(m_segs.len(), 1);
+        assert_eq!(m_segs[0].origin(), ArgOrigin::Source);
+        // Arg-segment origin_offset is a LayerOffset; at Source origin
+        // the "layer" is the statement, so reinterpret as StmtRange.
+        let m_arg_range = crate::source::StmtRange::from_offset_len(
+            StmtOffset::from_raw(m_segs[0].origin_offset().as_u32()),
+            StmtLen::from_raw(m_segs[0].origin_length().as_u32()),
         );
-        let n_arg_text = &stmt_text[n_arg_range];
-        assert_eq!(n_arg_text, "nonexistent_col");
+        let m_arg_text = &stmt_text[m_arg_range];
+        assert_eq!(m_arg_text, "n!(nonexistent_col)");
+
+        // n's arg segment origin is m's expansion buffer — one link in
+        // the chain.  The consumer resolves by finding the m segment
+        // whose expansion range contains n's arg, then recursing.
+        let n_segs: Vec<_> = rewrites[1].arg_segments().collect();
+        assert_eq!(n_segs.len(), 1);
+        assert_eq!(
+            n_segs[0].origin(),
+            ArgOrigin::Rewrite(RewriteIdx::from_raw(0))
+        );
+        let m_expansion = rewrites[0].expansion();
+        let n_arg_range =
+            LayerRange::from_offset_len(n_segs[0].origin_offset(), n_segs[0].origin_length());
+        let n_arg_in_m_expansion = &m_expansion[n_arg_range];
+        assert_eq!(n_arg_in_m_expansion, "nonexistent_col");
+
+        // Walk the chain: n's arg inside m's expansion, intersected with
+        // m's segment, lands on the position of "nonexistent_col" in
+        // the source.
+        let n_arg_off_in_m = n_segs[0].origin_offset();
+        let m_seg = &m_segs[0];
+        assert!(
+            n_arg_off_in_m >= m_seg.expansion_offset()
+                && n_arg_off_in_m + n_segs[0].origin_length()
+                    <= m_seg.expansion_offset() + m_seg.expansion_length()
+        );
+        let delta = n_arg_off_in_m - m_seg.expansion_offset();
+        let source_off = m_seg.origin_offset() + delta;
+        let source_len = n_segs[0].origin_length();
+        let off = source_off.as_usize();
+        let len = source_len.as_usize();
+        let authored = &source[off..off + len];
+        assert_eq!(authored, "nonexistent_col");
     }
 
     #[test]
@@ -2704,27 +2749,27 @@ mod tests {
         assert_eq!(last.as_u32(), 3);
     }
 
-    // ── Eager arg expansion: diamond, recursion, depth limit ──────────────
+    // ── Recursion-check scoping across `$param`-substituted call sites ────
     //
-    // The blue-paint recursion check used to be name-only and would
-    // false-fire on a "diamond" — `outer!(inner!())` where `inner`'s body
-    // legitimately re-invokes `outer`'s callee, but only because the arg
-    // had been pasted into `outer`'s body before nested expansion ran.
-    // Args are now eagerly expanded with the caller's blue-paint stack
-    // (the current macro is not yet pushed), so the diamond resolves
-    // without the outer macro appearing on the stack during arg eval.
+    // When a nested macro call's position in the current layer's expansion
+    // falls inside one of the layer's `arg_segments`, the call was authored
+    // by the layer's caller, not inside the layer's own body.  The
+    // recursion check excludes such layers from the chain of lexical
+    // wrappers it walks — see the comment block in `parser_macros.c` over
+    // `synq_parser_expand_and_feed_macro` for the precise rules.
 
     #[test]
-    fn eager_diamond_two_macros_passes() {
-        // Minimal diamond. Two macros, one statement.
-        //   pass(x)  AS ($x)         -- emits its argument
-        //   caller() AS (pass!(0))   -- body calls pass
-        //   SELECT pass!(caller!()); -- arg to pass is a call to caller,
-        //                              whose body calls pass.
-        // Name-only blue-paint would error on the second `pass`; eager
-        // expansion places `caller!()` outside `pass`'s blue-paint scope,
-        // and the inner `pass!(0)` then runs at stack=[caller] with no
-        // false match.
+    fn recursion_check_allows_diamond_through_arg() {
+        // pass(x)  AS $x       — emits its argument
+        // caller() AS pass!(0) — body calls pass
+        // SELECT pass!(caller!());
+        //
+        // Although `pass` appears on the expansion chain twice, the
+        // inner `pass!(0)` sits inside `caller`'s body, and `caller`
+        // itself was tokenized from `pass`'s `$x` substitution.  Walking
+        // the lexical-wrapper chain from the inner `pass!(0)` stops at
+        // `caller` (its `body_call_offset` is ARG_INTERNAL), so the
+        // outer `pass` is never reached.
         let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
         let mut reg = TestMacroRegistry::new();
         reg.register("pass", &["x"], "$x");
@@ -2742,11 +2787,52 @@ mod tests {
     }
 
     #[test]
-    fn eager_diamond_three_macros_perfetto_shape() {
-        // The Perfetto stdlib pattern that surfaced the bug. `_iub` (the
-        // common pass-through) appears on the call chain twice through
-        // the diamond, but separated by `nbisu`'s body and with a smaller
-        // argument the second time.
+    fn recursion_check_detects_direct_self_call_in_body() {
+        // A macro whose authored body literally calls itself is a real
+        // cycle: the recursive call is at a body-internal position (not
+        // inside any arg segment), so the lexical-wrapper walk finds
+        // the macro itself on the chain.
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let mut reg = TestMacroRegistry::new();
+        reg.register("loops", &[], "loops!()");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let mut session = parser.parse("SELECT loops!();");
+        match session.next() {
+            ParseOutcome::Err(_) => {}
+            ParseOutcome::Ok(_) => panic!("expected recursion error, got Ok"),
+            ParseOutcome::Done => panic!("expected recursion error, got Done"),
+        }
+    }
+
+    #[test]
+    fn recursion_check_detects_mutual_cycle_through_bodies() {
+        // a's body literally contains a call to b; b's body literally
+        // contains a call to a.  All links are body-internal, so the
+        // walk traverses the full chain and finds a match.
+        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
+        let mut reg = TestMacroRegistry::new();
+        reg.register("a", &[], "b!()");
+        reg.register("b", &[], "a!()");
+        parser.set_macro_lookup(Some(Box::new(reg)));
+
+        let mut session = parser.parse("SELECT a!();");
+        match session.next() {
+            ParseOutcome::Err(_) => {}
+            ParseOutcome::Ok(_) => panic!("expected recursion error, got Ok"),
+            ParseOutcome::Done => panic!("expected recursion error, got Done"),
+        }
+    }
+
+    #[test]
+    fn recursion_check_allows_diamond_perfetto_shape() {
+        // `_iub` is invoked on two separate paths through the call
+        // graph — once directly from `conv`'s body, and once from
+        // `nbisu`'s body (where `nbisu` was itself tokenized from
+        // `conv`'s `$b` substitution).  The two `_iub` calls are
+        // independent: the chain of lexical wrappers from the inner
+        // `_iub` call site stops at `nbisu` (ARG_INTERNAL), so the
+        // outer `_iub` is not on it.
         let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
         let mut reg = TestMacroRegistry::new();
         reg.register("_iub", &["b"], "(SELECT start_ts FROM $b) IS NULL");
@@ -2774,300 +2860,56 @@ mod tests {
     }
 
     #[test]
-    fn eager_arg_with_no_nested_calls_still_works() {
-        // Sanity: arg without nested macros still works (no regression
-        // on the common case).
+    fn nested_macro_inside_arg_records_arg_internal_sentinel() {
+        // A macro call that appears only as a nested call inside an
+        // outer macro's arg (no occurrence in the outer body) records
+        // its layer as a child of the outer macro with
+        // body_call_offset = body_call_length = ARG_INTERNAL.  The
+        // outer macro's expansion buffer holds the authored arg text
+        // verbatim, with the nested call site preserved literally so
+        // downstream consumers can locate it via the outer macro's
+        // `arg_segments`.
         let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
         let mut reg = TestMacroRegistry::new();
-        reg.register("pass", &["x"], "$x");
+        reg.register("foo", &["a"], "$a");
+        reg.register("bar", &["a"], "(SELECT $a)");
         parser.set_macro_lookup(Some(Box::new(reg)));
 
-        let mut session = parser.parse("SELECT pass!(42);");
-        match session.next() {
-            ParseOutcome::Ok(_) => {}
-            ParseOutcome::Done => panic!("expected a statement"),
-            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
-        }
-    }
-
-    #[test]
-    fn eager_direct_recursion_still_errors() {
-        // True direct recursion: M(x) AS (M!($x)); M!(0).
-        // The recursion check must still fire when the call chain
-        // genuinely re-enters the same macro.
-        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
-        let mut reg = TestMacroRegistry::new();
-        reg.register("recur", &["x"], "recur!($x)");
-        parser.set_macro_lookup(Some(Box::new(reg)));
-
-        let mut session = parser.parse("SELECT recur!(0);");
-        match session.next() {
-            ParseOutcome::Err(e) => {
-                let msg = e.message();
-                assert!(
-                    msg.contains("recursive macro expansion") || msg.contains("depth limit"),
-                    "expected recursion or depth error, got: {msg}"
-                );
-            }
-            other => panic!("expected error for direct recursion, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn eager_mutual_recursion_still_errors() {
-        // Mutual recursion: A() AS (B!()), B() AS (A!()).
-        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
-        let mut reg = TestMacroRegistry::new();
-        reg.register("a_m", &[], "b_m!()");
-        reg.register("b_m", &[], "a_m!()");
-        parser.set_macro_lookup(Some(Box::new(reg)));
-
-        let mut session = parser.parse("SELECT a_m!();");
-        match session.next() {
-            ParseOutcome::Err(e) => {
-                let msg = e.message();
-                assert!(
-                    msg.contains("recursive macro expansion") || msg.contains("depth limit"),
-                    "expected recursion or depth error, got: {msg}"
-                );
-            }
-            other => panic!("expected error for mutual recursion, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn eager_recursion_through_arg_still_errors() {
-        // M(x) AS (M!($x)); M!(M!(0))
-        // The outer M's arg is M!(0). Eager expansion of the arg:
-        //   - enter M (for M!(0)) at stack=[]
-        //   - body becomes M!(0)
-        //   - encounter M!(0) -> stack=[M] -> recursion error.
-        // The error fires during arg expansion, before the outer M
-        // is even started. Same diagnostic, just earlier.
-        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
-        let mut reg = TestMacroRegistry::new();
-        reg.register("recur", &["x"], "recur!($x)");
-        parser.set_macro_lookup(Some(Box::new(reg)));
-
-        let mut session = parser.parse("SELECT recur!(recur!(0));");
-        match session.next() {
-            ParseOutcome::Err(e) => {
-                let msg = e.message();
-                assert!(
-                    msg.contains("recursive macro expansion") || msg.contains("depth limit"),
-                    "expected recursion or depth error, got: {msg}"
-                );
-            }
-            other => panic!("expected error, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn eager_sibling_calls_at_top_level_work() {
-        // Calling the same macro twice in sequence at top level is not
-        // recursion; each call starts at stack=[].
-        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
-        let mut reg = TestMacroRegistry::new();
-        reg.register("pass", &["x"], "$x");
-        parser.set_macro_lookup(Some(Box::new(reg)));
-
-        let mut session = parser.parse("SELECT pass!(1) + pass!(2);");
-        match session.next() {
-            ParseOutcome::Ok(_) => {}
-            ParseOutcome::Done => panic!("expected a statement"),
-            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
-        }
-    }
-
-    #[test]
-    fn eager_arg_expansion_no_extents_still_parses_ok() {
-        // Sanity: with eager expansion `pass!(inner_v!())` should parse
-        // cleanly when extent tracking is disabled. (The
-        // collect_node_extents path stresses straddle/extent bookkeeping
-        // for pre-expanded arg layers; that's covered by the suite below.)
-        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
-        let mut reg = TestMacroRegistry::new();
-        reg.register("pass", &["x"], "($x)");
-        reg.register("inner_v", &[], "99");
-        parser.set_macro_lookup(Some(Box::new(reg)));
-
-        let mut session = parser.parse("SELECT pass!(inner_v!());");
-        match session.next() {
-            ParseOutcome::Ok(_) => {}
-            ParseOutcome::Done => panic!("expected a statement"),
-            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
-        }
-    }
-
-    #[test]
-    fn eager_arg_expansion_with_extents_tracking() {
-        // collect_node_extents path: nested-call args go through
-        // pre_expand_args (expand_and_feed in buffer mode), which calls
-        // begin_macro_expansion at ctx.layer_id=0 before the outer
-        // macro is started.  Verifies the straddle / macro_root
-        // bookkeeping doesn't blow up on the pre-expanded inner layer.
-        let mut parser = Parser::with_config(
-            &ParserConfig::default()
-                .with_collect_tokens(true)
-                .with_collect_node_extents(true)
-                .with_macro_fallback(true),
-        );
-        let mut reg = TestMacroRegistry::new();
-        reg.register("pass", &["x"], "($x)");
-        reg.register("inner_v", &[], "99");
-        parser.set_macro_lookup(Some(Box::new(reg)));
-
-        let mut session = parser.parse("SELECT pass!(inner_v!());");
-        match session.next() {
-            ParseOutcome::Ok(_) => {}
-            ParseOutcome::Done => panic!("expected a statement"),
-            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
-        }
-    }
-
-    #[test]
-    fn eager_arg_with_two_calls_both_expand() {
-        // Arg that contains two sibling nested calls.
-        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
-        let mut reg = TestMacroRegistry::new();
-        reg.register("pair", &["a", "b"], "($a + $b)");
-        reg.register("two", &[], "2");
-        reg.register("three", &[], "3");
-        parser.set_macro_lookup(Some(Box::new(reg)));
-
-        let mut session = parser.parse("SELECT pair!(two!(), three!());");
-        match session.next() {
-            ParseOutcome::Ok(_) => {}
-            ParseOutcome::Done => panic!("expected a statement"),
-            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
-        }
-    }
-
-    #[test]
-    fn eager_three_level_nesting_in_arg() {
-        // outer!(mid!(inner!())) — three levels of nesting in the arg.
-        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
-        let mut reg = TestMacroRegistry::new();
-        reg.register("outer_m", &["x"], "$x");
-        reg.register("mid_m", &["x"], "$x");
-        reg.register("inner_m", &[], "7");
-        parser.set_macro_lookup(Some(Box::new(reg)));
-
-        let mut session = parser.parse("SELECT outer_m!(mid_m!(inner_m!()));");
-        match session.next() {
-            ParseOutcome::Ok(_) => {}
-            ParseOutcome::Done => panic!("expected a statement"),
-            ParseOutcome::Err(e) => panic!("unexpected error: {}", e.message()),
-        }
-    }
-
-    #[test]
-    fn eager_arg_pre_expansion_preserves_inter_token_bytes() {
-        // Regression: expand_and_feed's buffer mode used to drop inter-token
-        // whitespace, so a multi-token nested expansion collapsed into
-        // adjacent text (e.g. "1 + 2" → "1+2", which still parses but
-        // means something different).
-        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
-        let mut reg = TestMacroRegistry::new();
-        reg.register("pass", &["x"], "$x");
-        reg.register("structured", &[], "1 + 2, NULL, (3 * 4)");
-        parser.set_macro_lookup(Some(Box::new(reg)));
-
-        let mut session = parser.parse("SELECT pass!(structured!());");
-        let ParseOutcome::Ok(stmt) = session.next() else {
-            panic!("expected statement")
-        };
-        let pass = stmt
-            .macro_rewrites()
-            .find(|r| r.name() == "pass")
-            .expect("pass rewrite");
-        assert_eq!(pass.expansion(), "1 + 2, NULL, (3 * 4)");
-    }
-
-    #[test]
-    fn eager_arg_with_body_internal_call_after_substitution() {
-        // `wrap`'s authored body has BOTH a $param substitution AND a
-        // body-internal `leaf!(7)`.  After eager pre-expansion the
-        // $param text sits beside the call; leaf's body_call_offset
-        // must still point at leaf!(7)'s position in the authored body
-        // (independent of the arg's actual post-expansion length).
-        let mut parser = Parser::with_config(&ParserConfig::default().with_macro_fallback(true));
-        let mut reg = TestMacroRegistry::new();
-        reg.register("leaf", &["v"], "$v");
-        reg.register("inner_v", &[], "9 + 8");
-        reg.register("wrap", &["a"], "$a + leaf!(7)");
-        parser.set_macro_lookup(Some(Box::new(reg)));
-
-        let mut session = parser.parse("SELECT wrap!(inner_v!());");
-        let ParseOutcome::Ok(stmt) = session.next() else {
-            panic!("expected statement")
-        };
-        let rewrites: Vec<_> = stmt.macro_rewrites().collect();
-        let wrap = rewrites.iter().find(|r| r.name() == "wrap").unwrap();
-        assert_eq!(wrap.expansion(), "9 + 8 + leaf!(7)");
-        let leaf = rewrites.iter().find(|r| r.name() == "leaf").unwrap();
-        assert_eq!(leaf.parent(), Some(RewriteIdx::from_raw(1)));
-        // Authored "$a + leaf!(7)": leaf!(7) at offset 5, length 8.
-        assert_eq!(leaf.body_call_offset(), LayerOffset::from_raw(5));
-        assert_eq!(leaf.body_call_length(), LayerLen::from_raw(8));
-    }
-
-    #[test]
-    fn eager_arg_with_comment_does_not_corrupt_recorded_comments() {
-        // Comments inside a pre-expanded arg used to be recorded by
-        // synq_macro_skip with arg-local offsets interpreted as
-        // source-relative, producing OOB reads or garbage text on
-        // Comment::text() lookups.  After the fix, recording is
-        // suppressed in pre-expansion mode; the comment bytes still
-        // flow through into the substituted body where Lemon-mode
-        // tokenization records them at the expansion layer.
-        //
-        // The comment legitimately appears twice in the recorded
-        // stream: once at layer 0 (scan_macro_args sees it while
-        // splitting top-level args, before pre-expansion begins), and
-        // once at the expansion layer (body re-tokenization).  Both
-        // must dereference to the right text — that's the regression
-        // signal we care about.
-        let mut parser = Parser::with_config(
-            &ParserConfig::default()
-                .with_collect_tokens(true)
-                .with_macro_fallback(true),
-        );
-        let mut reg = TestMacroRegistry::new();
-        reg.register("pass", &["x"], "($x)");
-        reg.register("inner_v", &[], "99");
-        parser.set_macro_lookup(Some(Box::new(reg)));
-
-        let source = "SELECT pass!(/* note */ inner_v!());";
+        let source = "SELECT bar!(foo!(123));";
         let mut session = parser.parse(source);
-        let ParseOutcome::Ok(stmt) = session.next() else {
-            panic!("expected statement")
+        let stmt = match session.next() {
+            ParseOutcome::Ok(stmt) => stmt,
+            ParseOutcome::Done => panic!("expected statement"),
+            ParseOutcome::Err(err) => panic!("unexpected error: {}", err.message()),
         };
 
-        let notes: Vec<_> = stmt
-            .comments()
-            .filter(|c| c.text().contains("note"))
-            .collect();
-        assert!(
-            !notes.is_empty(),
-            "expected /* note */ to be recorded at least once",
-        );
-        for c in &notes {
-            assert_eq!(
-                c.text(),
-                "/* note */",
-                "recorded comment text doesn't match — likely bogus offset",
-            );
-        }
+        let rewrites: Vec<_> = stmt.macro_rewrites().collect();
+        assert_eq!(rewrites.len(), 2, "bar + foo");
 
-        // Sanity: every recorded comment in the statement (not just
-        // the /* note */ ones) must dereference to a real comment.
-        for c in stmt.comments() {
-            let t = c.text();
-            assert!(
-                t.starts_with("--") || t.starts_with("/*"),
-                "recorded comment text not a comment: {t:?}",
-            );
-        }
+        // Rewrites are recorded in push order, root-down.
+        let bar = &rewrites[0];
+        assert_eq!(bar.name(), "bar");
+        assert_eq!(bar.parent(), None);
+        // bar's expansion contains the authored arg text verbatim.
+        assert_eq!(bar.expansion(), "(SELECT foo!(123))");
+
+        let foo = &rewrites[1];
+        assert_eq!(foo.name(), "foo");
+        assert_eq!(foo.parent(), Some(RewriteIdx::from_raw(0)));
+        // ARG_INTERNAL marks a call that came in through a $param
+        // substitution: it has no position in the parent's authored
+        // body, so consumers must descend through the parent's
+        // matching arg segment to locate it.
+        assert_eq!(foo.body_call_offset(), LayerOffset::from_raw(u32::MAX));
+        assert_eq!(foo.body_call_length(), LayerLen::from_raw(u32::MAX));
+        assert_eq!(foo.expansion(), "123");
+
+        // foo's $a substitution segment locates the `$a` token in
+        // foo's authored body ("$a" — at body[0, 2)).
+        let foo_segs: Vec<_> = foo.arg_segments().collect();
+        assert_eq!(foo_segs.len(), 1);
+        let seg = &foo_segs[0];
+        assert_eq!(seg.body_offset(), LayerOffset::from_raw(0));
+        assert_eq!(seg.body_length(), LayerLen::from_raw(2));
     }
 }


### PR DESCRIPTION
Reverts #260 (eager arg pre-expansion, which broke the rewrite tree
for downstream consumers like perfetto's MacroRewriteBuilder) and
replaces the diamond-recursion fix it carried with a structurally
smaller mechanism.

The diamond false-positive (`pass!(caller!())` where pass and caller
each reference the other through args) needed eager pre-expansion in
names with no notion of lexical vs. arg-substituted scope.  Once the
check looks at the data structure that already encodes scope — the
expansion layer tree, with `body_call_offset == ARG_INTERNAL`
marking calls that came in through `$param` substitution — the
diamond resolves naturally without pre-expansion.

The new check walks up `parent_layer_id` from `ctx.layer_id`:

  1. If the call we're about to expand sits inside one of the
     current layer's `arg_segments`, skip the current layer — its
     body doesn't lexically wrap this call (the call was authored
     by the layer's caller).

  2. Walk up.  A name match is a real cycle.  But the chain stops
     at the first arg-internal layer: anything above an arg-internal
     link didn't lexically author the call site we're at.

This subsumes both the name-based blue-paint and the diamond
suspension into a single short walk.  Removes the global
`expansion_names`/`expansion_name_lens`/`expansion_depth` arrays
and their push/pop bookkeeping.  Net: -56 lines of state +
mechanism, +43 lines of walk.