### PR TITLE
synq: fix symbol export in syntaqlite CLI for dynamically loaded dialects

### DIFF
--- a/syntaqlite-cli/build.rs
+++ b/syntaqlite-cli/build.rs
@@ -4,16 +4,33 @@
 //! Build script for `syntaqlite-cli`.
 
 fn main() {
-    // On Linux, link the `syntaqlite` binary with `-Wl,--export-dynamic` so
-    // its symbol table is placed in `.dynsym` and visible to `dlopen`'d
-    // dialect plugins. Without this, a dialect `.so` built with
-    // `-DSYNTAQLITE_OMIT_RUNTIME` (which strips the runtime-side
-    // `synq_extent_on_*` hooks, expecting the host binary to provide them)
-    // fails at load time with an undefined-symbol error.
+    // On Linux, dialect plugins built with `-DSYNTAQLITE_OMIT_RUNTIME` strip
+    // the runtime-side extent hooks (`synq_extent_on_shift` /
+    // `synq_extent_on_reduce`) and resolve them against the host binary at
+    // `dlopen` time. Those symbols must therefore live in the host's `.dynsym`.
     //
-    // macOS exports executable symbols by default; Windows uses a different
-    // model (export libraries / `__declspec(dllexport)`).
+    // We export ONLY those two hooks via `--dynamic-list`, deliberately NOT the
+    // whole symbol table via `--export-dynamic`. `--export-dynamic` places every
+    // global symbol — including the parser/tokenizer's own `Synq*Parse*`
+    // functions — into `.dynsym`, where ELF interposition rules let the host's
+    // copies override the identically-named symbols of a *self-contained* plugin
+    // (one that bundles its own runtime) at load time. That silently swaps the
+    // plugin's grammar for the host's SQLite parser. A scoped dynamic list
+    // exposes the hooks without enabling that interposition.
+    //
+    // macOS uses two-level namespaces (no flat interposition) and exports
+    // executable symbols on demand; Windows uses export libraries.
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux") {
-        println!("cargo:rustc-link-arg-bins=-Wl,--export-dynamic");
+        let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR set by cargo");
+        let list_path = std::path::Path::new(&out_dir).join("dynamic-symbols.txt");
+        std::fs::write(
+            &list_path,
+            "{\n  synq_extent_on_shift;\n  synq_extent_on_reduce;\n};\n",
+        )
+        .expect("write dynamic symbol list");
+        println!(
+            "cargo:rustc-link-arg-bins=-Wl,--dynamic-list={}",
+            list_path.display()
+        );
     }
 }

--- a/syntaqlite-cli/build.rs
+++ b/syntaqlite-cli/build.rs
@@ -1,0 +1,19 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+//! Build script for `syntaqlite-cli`.
+
+fn main() {
+    // On Linux, link the `syntaqlite` binary with `-Wl,--export-dynamic` so
+    // its symbol table is placed in `.dynsym` and visible to `dlopen`'d
+    // dialect plugins. Without this, a dialect `.so` built with
+    // `-DSYNTAQLITE_OMIT_RUNTIME` (which strips the runtime-side
+    // `synq_extent_on_*` hooks, expecting the host binary to provide them)
+    // fails at load time with an undefined-symbol error.
+    //
+    // macOS exports executable symbols by default; Windows uses a different
+    // model (export libraries / `__declspec(dllexport)`).
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux") {
+        println!("cargo:rustc-link-arg-bins=-Wl,--export-dynamic");
+    }
+}

--- a/syntaqlite-cli/tests/dynload_omit_runtime.rs
+++ b/syntaqlite-cli/tests/dynload_omit_runtime.rs
@@ -11,8 +11,8 @@
 //!   3. Load it through `syntaqlite --dialect <path> --dialect-name sqlite`
 //!      and parse a query.
 //!
-//! Without `build.rs` linking the host binary with `-Wl,--export-dynamic`,
-//! Linux loaders fail step 3 with:
+//! Without `build.rs` exporting the runtime hooks into the host binary's
+//! `.dynsym` (via `-Wl,--dynamic-list`), Linux loaders fail step 3 with:
 //!
 //!     symbol lookup error: ...: undefined symbol: synq_extent_on_shift
 //!
@@ -102,9 +102,9 @@ fn omit_runtime_dialect_plugin_resolves_against_host() {
     run(&mut cc, "cc -shared with -DSYNTAQLITE_OMIT_RUNTIME");
 
     // 3. Load the plugin through the CLI and parse a query. On Linux,
-    //    without `-Wl,--export-dynamic` on the host binary, this fails
-    //    inside `dlopen` (lazy-bind) or on first parse call with
-    //    `undefined symbol: synq_extent_on_shift`.
+    //    without the host binary exporting the runtime hooks into `.dynsym`
+    //    (`-Wl,--dynamic-list`), this fails inside `dlopen` (lazy-bind) or on
+    //    first parse call with `undefined symbol: synq_extent_on_shift`.
     let out = Command::new(bin())
         .arg("--dialect")
         .arg(&lib)
@@ -117,7 +117,7 @@ fn omit_runtime_dialect_plugin_resolves_against_host() {
     assert!(
         out.status.success(),
         "loading OMIT_RUNTIME dialect plugin failed — host likely lacks \
-         --export-dynamic (see syntaqlite-cli/build.rs)\n\
+         exported runtime hooks in .dynsym (see syntaqlite-cli/build.rs)\n\
          stdout:\n{stdout}\nstderr:\n{stderr}",
     );
     assert!(

--- a/syntaqlite-cli/tests/dynload_omit_runtime.rs
+++ b/syntaqlite-cli/tests/dynload_omit_runtime.rs
@@ -17,7 +17,7 @@
 //!     symbol lookup error: ...: undefined symbol: synq_extent_on_shift
 //!
 //! macOS executables export symbols by default, so the test passes there
-//! regardless of the build.rs flag — but it still exercises the OMIT_RUNTIME
+//! regardless of the build.rs flag — but it still exercises the `OMIT_RUNTIME`
 //! .dylib loading path.
 
 use std::path::{Path, PathBuf};

--- a/syntaqlite-cli/tests/dynload_omit_runtime.rs
+++ b/syntaqlite-cli/tests/dynload_omit_runtime.rs
@@ -1,0 +1,111 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+//! End-to-end regression test for the `cdylib` dialect-plugin flow:
+//!
+//!   1. Generate a full sqlite amalgamation.
+//!   2. Compile it as a shared library with `-DSYNTAQLITE_OMIT_RUNTIME`,
+//!      which strips the runtime-side hooks (`synq_extent_on_shift`,
+//!      `synq_extent_on_reduce`) — they must be resolved against the host
+//!      binary at `dlopen` time.
+//!   3. Load it through `syntaqlite --dialect <path> --dialect-name sqlite`
+//!      and parse a query.
+//!
+//! Without `build.rs` linking the host binary with `-Wl,--export-dynamic`,
+//! Linux loaders fail step 3 with:
+//!
+//!     symbol lookup error: ...: undefined symbol: synq_extent_on_shift
+//!
+//! macOS executables export symbols by default, so the test passes there
+//! regardless of the build.rs flag — but it still exercises the OMIT_RUNTIME
+//! .dylib loading path.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_syntaqlite")
+}
+
+fn run(cmd: &mut Command, ctx: &str) {
+    let out = cmd.output().unwrap_or_else(|e| panic!("{ctx}: spawn failed: {e}"));
+    assert!(
+        out.status.success(),
+        "{ctx} failed (exit={:?})\nstdout:\n{}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+fn shared_lib_path(dir: &Path, stem: &str) -> PathBuf {
+    let ext = if cfg!(target_os = "macos") {
+        "dylib"
+    } else {
+        "so"
+    };
+    dir.join(format!("lib{stem}.{ext}"))
+}
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore = "dlopen export model differs on Windows")]
+fn omit_runtime_dialect_plugin_resolves_against_host() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let amalg_dir = tmp.path();
+
+    // 1. Generate the full sqlite amalgamation (syntaqlite_sqlite.{h,c}).
+    run(
+        Command::new(bin())
+            .args(["dialect", "generate", "--name", "sqlite", "--output-type", "full"])
+            .arg("--output-dir")
+            .arg(amalg_dir),
+        "syntaqlite dialect generate",
+    );
+
+    let src = amalg_dir.join("syntaqlite_sqlite.c");
+    assert!(src.exists(), "amalgamation source not written: {}", src.display());
+
+    // 2. Compile as a shared library with OMIT_RUNTIME defined. This strips
+    //    `synq_extent_on_*` from the .so, requiring the host binary to
+    //    provide them at load time.
+    //
+    //    Linux: `ld` permits undefined symbols in shared objects by default.
+    //    macOS: `ld` rejects them unless `-undefined dynamic_lookup` defers
+    //           resolution to `dlopen` time.
+    let lib = shared_lib_path(amalg_dir, "sqlite_dialect_plugin");
+    let mut cc = Command::new("cc");
+    cc.args(["-shared", "-fPIC", "-DSYNTAQLITE_OMIT_RUNTIME"])
+        .arg("-I")
+        .arg(amalg_dir)
+        .arg("-o")
+        .arg(&lib)
+        .arg(&src);
+    if cfg!(target_os = "macos") {
+        cc.args(["-Wl,-undefined,dynamic_lookup"]);
+    }
+    run(&mut cc, "cc -shared with -DSYNTAQLITE_OMIT_RUNTIME");
+
+    // 3. Load the plugin through the CLI and parse a query. On Linux,
+    //    without `-Wl,--export-dynamic` on the host binary, this fails
+    //    inside `dlopen` (lazy-bind) or on first parse call with
+    //    `undefined symbol: synq_extent_on_shift`.
+    let out = Command::new(bin())
+        .arg("--dialect")
+        .arg(&lib)
+        .args(["--dialect-name", "sqlite", "fmt", "-e", "SELECT 1"])
+        .output()
+        .expect("spawn syntaqlite --dialect");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "loading OMIT_RUNTIME dialect plugin failed — host likely lacks \
+         --export-dynamic (see syntaqlite-cli/build.rs)\n\
+         stdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert!(
+        stdout.to_uppercase().contains("SELECT"),
+        "expected formatted SELECT in stdout; got:\n{stdout}",
+    );
+}

--- a/syntaqlite-cli/tests/dynload_omit_runtime.rs
+++ b/syntaqlite-cli/tests/dynload_omit_runtime.rs
@@ -28,7 +28,9 @@ fn bin() -> &'static str {
 }
 
 fn run(cmd: &mut Command, ctx: &str) {
-    let out = cmd.output().unwrap_or_else(|e| panic!("{ctx}: spawn failed: {e}"));
+    let out = cmd
+        .output()
+        .unwrap_or_else(|e| panic!("{ctx}: spawn failed: {e}"));
     assert!(
         out.status.success(),
         "{ctx} failed (exit={:?})\nstdout:\n{}\nstderr:\n{}",
@@ -48,7 +50,10 @@ fn shared_lib_path(dir: &Path, stem: &str) -> PathBuf {
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", ignore = "dlopen export model differs on Windows")]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "dlopen export model differs on Windows"
+)]
 fn omit_runtime_dialect_plugin_resolves_against_host() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let amalg_dir = tmp.path();
@@ -56,14 +61,25 @@ fn omit_runtime_dialect_plugin_resolves_against_host() {
     // 1. Generate the full sqlite amalgamation (syntaqlite_sqlite.{h,c}).
     run(
         Command::new(bin())
-            .args(["dialect", "generate", "--name", "sqlite", "--output-type", "full"])
+            .args([
+                "dialect",
+                "generate",
+                "--name",
+                "sqlite",
+                "--output-type",
+                "full",
+            ])
             .arg("--output-dir")
             .arg(amalg_dir),
         "syntaqlite dialect generate",
     );
 
     let src = amalg_dir.join("syntaqlite_sqlite.c");
-    assert!(src.exists(), "amalgamation source not written: {}", src.display());
+    assert!(
+        src.exists(),
+        "amalgamation source not written: {}",
+        src.display()
+    );
 
     // 2. Compile as a shared library with OMIT_RUNTIME defined. This strips
     //    `synq_extent_on_*` from the .so, requiring the host binary to


### PR DESCRIPTION
- Ensure the syntaqlite CLI binary re-exports the symbols dynamically-loaded dialect plugins need at runtime.
- Add an integration test (`dynload_omit_runtime.rs`) covering the dynamic-load path.
