### PR TITLE
synq: handle embedded SQL across all CLI commands

### DIFF
--- a/python/dev/integration_tests/suites/analyze.py
+++ b/python/dev/integration_tests/suites/analyze.py
@@ -793,6 +793,205 @@ def _test_json_multiple_statements_multiple_records(ctx: SuiteContext) -> bool:
     return True
 
 
+# ── Shell language ────────────────────────────────────────────────────────
+#
+# sqlite3 CLI shell scripts mix dot-commands and `GO`/`/` terminators with SQL.
+# `analyze` auto-detects a shell script when it sees an unambiguous column-0
+# marker (a column-0 `.` dot-command or a column-0 `#` comment). The shell
+# fragments are skipped and only the SQL is analyzed, with diagnostics mapped
+# back to host-file coordinates. See https://sqlite.org/cli.html.
+
+
+def _write(tmp: str, name: str, content: str) -> Path:
+    """Write a file verbatim (bytes) so CRLF endings survive."""
+    p = Path(tmp) / name
+    p.write_bytes(content.encode("utf-8"))
+    return p
+
+
+def _run_file(ctx: SuiteContext, content: str, *extra: str) -> subprocess.CompletedProcess[str]:
+    """Write `content` to a temp .sql file and run `analyze` on it."""
+    with tempfile.TemporaryDirectory() as tmp:
+        f = _write(tmp, "script.sql", content)
+        return _run(ctx.binary, *extra, str(f))
+
+
+def _expect_clean(ctx: SuiteContext, name: str, content: str, *extra: str) -> bool:
+    """Assert the script analyzes cleanly: exit 0, no `error:` in stderr."""
+    result = _run_file(ctx, content, *extra)
+    if result.returncode != 0:
+        _fail(name, f"expected exit 0, got {result.returncode}: {result.stderr}")
+        return False
+    if "error:" in result.stderr:
+        _fail(name, f"unexpected 'error:' in stderr: {result.stderr}")
+        return False
+    _pass(name)
+    return True
+
+
+def _expect_syntax_error(
+    ctx: SuiteContext, name: str, content: str, near: str, loc: str
+) -> bool:
+    """Assert a syntax error near `near` mapped to `loc` (file:LINE:COL), exit 1."""
+    result = _run_file(ctx, content)
+    if result.returncode == 0:
+        _fail(name, f"expected non-zero exit, got 0: {result.stderr}")
+        return False
+    msg = f"syntax error near '{near}'"
+    if msg not in result.stderr:
+        _fail(name, f"expected {msg!r} in stderr, got: {result.stderr}")
+        return False
+    if loc not in result.stderr:
+        _fail(name, f"expected location {loc!r} in stderr, got: {result.stderr}")
+        return False
+    _pass(name)
+    return True
+
+
+def _test_shell_col0_dot_command_is_clean(ctx: SuiteContext) -> bool:
+    """A column-0 `.read` + SQL auto-detects as shell; the dot line is skipped."""
+    return _expect_clean(
+        ctx, "shell_col0_dot_command_is_clean", ".read a.sql\nSELECT 1;",
+    )
+
+
+def _test_shell_indented_dot_read_errors(ctx: SuiteContext) -> bool:
+    """Dot-commands require column 0; an indented `.read` is plain SQL and errors."""
+    return _expect_syntax_error(
+        ctx, "shell_indented_dot_read_errors",
+        "  .read foo.sql\nSELECT 1;", ".", "script.sql:1:3",
+    )
+
+
+def _test_shell_many_dot_commands_skipped(ctx: SuiteContext) -> bool:
+    """A broad set of column-0 dot-commands are all recognized and skipped."""
+    return _expect_clean(
+        ctx, "shell_many_dot_commands_skipped",
+        ".mode column\n.tables\n.schema\n\nSELECT 1;\n\n"
+        ".print hi\n.once out.txt\n.output\nSELECT 2;\n.dump\n.import data.csv t\n",
+    )
+
+
+def _test_shell_dot_mid_statement_is_sql(ctx: SuiteContext) -> bool:
+    """A leading-dot line while a statement is pending stays SQL, and errors."""
+    return _expect_syntax_error(
+        ctx, "shell_dot_mid_statement_is_sql",
+        ".read a.sql\nSELECT\n.foo", ".", "script.sql:3:1",
+    )
+
+
+def _test_shell_dot_command_trailing_semicolon(ctx: SuiteContext) -> bool:
+    """A trailing bare `;` on a dot-command (sqlite >= 3.52) is still skipped."""
+    return _expect_clean(
+        ctx, "shell_dot_command_trailing_semicolon",
+        ".read foo.sql;\nSELECT 1;",
+    )
+
+
+def _test_shell_go_terminator_splits_statements(ctx: SuiteContext) -> bool:
+    """In shell mode a lone `GO` terminates the pending statement."""
+    return _expect_clean(
+        ctx, "shell_go_terminator_splits_statements",
+        ".read a.sql\nSELECT 1\nGO\nSELECT 2;",
+    )
+
+
+def _test_shell_stray_go_in_pure_sql_errors(ctx: SuiteContext) -> bool:
+    """`GO` is a terminator only in shell mode; in plain SQL it is a parse error."""
+    return _expect_syntax_error(
+        ctx, "shell_stray_go_in_pure_sql_errors",
+        "SELECT 1;\nGO", "GO", "script.sql:2:1",
+    )
+
+
+def _test_shell_col0_hash_comment_skipped(ctx: SuiteContext) -> bool:
+    """A column-0 `#` whole-line comment is a shell marker and is skipped."""
+    return _expect_clean(
+        ctx, "shell_col0_hash_comment_skipped", "# a shell comment\nSELECT 1;",
+    )
+
+
+def _test_shell_indented_hash_errors(ctx: SuiteContext) -> bool:
+    """An indented `#` is not a comment; it reaches the SQL core and errors."""
+    return _expect_syntax_error(
+        ctx, "shell_indented_hash_errors",
+        ".read a.sql\n  # not a marker", "#", "script.sql:2:3",
+    )
+
+
+def _test_shell_issue88(ctx: SuiteContext) -> bool:
+    """Issue #88: multiple `.read` dot-commands followed by SQL must not error."""
+    return _expect_clean(
+        ctx, "shell_issue88",
+        ".read adapters/sqlite/scripts/includes/01-pragma.sql\n"
+        ".read adapters/sqlite/scripts/includes/02-drops.sql\nSELECT 1;",
+    )
+
+
+def _test_shell_sql_error_maps_to_correct_line(ctx: SuiteContext) -> bool:
+    """A genuine SQL error maps to the correct line; skipped dot lines don't shift coords."""
+    return _expect_syntax_error(
+        ctx, "shell_sql_error_maps_to_correct_line",
+        ".read a.sql\nSELECT 1;\nNOT VALID;", "NOT", "script.sql:3:1",
+    )
+
+
+def _test_shell_crlf_error_line_mapping(ctx: SuiteContext) -> bool:
+    """CRLF line endings must not desync line/offset mapping."""
+    return _expect_syntax_error(
+        ctx, "shell_crlf_error_line_mapping",
+        ".read a.sql\r\nNOT VALID;\r\nSELECT 1;", "NOT", "script.sql:2:1",
+    )
+
+
+def _test_shell_unknown_table_is_warning(ctx: SuiteContext) -> bool:
+    """Semantic diagnostics still flow in shell mode: an unknown table is a warning (exit 0)."""
+    result = _run_file(ctx, ".read a.sql\nSELECT * FROM nonexistent;")
+    if result.returncode != 0:
+        _fail("shell_unknown_table_is_warning",
+              f"expected exit 0 (warnings only), got {result.returncode}: {result.stderr}")
+        return False
+    if "warning:" not in result.stderr or "nonexistent" not in result.stderr:
+        _fail("shell_unknown_table_is_warning",
+              f"expected a 'warning:' about 'nonexistent', got: {result.stderr}")
+        return False
+    if "error:" in result.stderr:
+        _fail("shell_unknown_table_is_warning",
+              f"unexpected 'error:' in stderr: {result.stderr}")
+        return False
+    _pass("shell_unknown_table_is_warning")
+    return True
+
+
+def _test_shell_dot_commands_only_no_fragments(ctx: SuiteContext) -> bool:
+    """A file of only dot-commands yields zero SQL fragments and reports cleanly (exit 0)."""
+    result = _run_file(ctx, ".read a.sql\n.read b.sql\n")
+    if result.returncode != 0:
+        _fail("shell_dot_commands_only_no_fragments",
+              f"expected exit 0, got {result.returncode}: {result.stderr}")
+        return False
+    if "error:" in result.stderr:
+        _fail("shell_dot_commands_only_no_fragments",
+              f"unexpected 'error:' in stderr: {result.stderr}")
+        return False
+    if "no SQL fragments found" not in result.stderr:
+        _fail("shell_dot_commands_only_no_fragments",
+              f"expected 'no SQL fragments found' in stderr, got: {result.stderr}")
+        return False
+    _pass("shell_dot_commands_only_no_fragments")
+    return True
+
+
+def _test_shell_explicit_lang_forces_shell_mode(ctx: SuiteContext) -> bool:
+    """`--experimental-lang shell` forces shell mode without a column-0 marker."""
+    # No marker, so GO would collapse the two SELECTs as plain SQL; the flag
+    # makes GO a terminator and the script analyzes cleanly.
+    return _expect_clean(
+        ctx, "shell_explicit_lang_forces_shell_mode",
+        "SELECT 1\nGO\nSELECT 2;", "--experimental-lang", "shell",
+    )
+
+
 # ── Suite entry point ─────────────────────────────────────────────────────
 
 def run(ctx: SuiteContext) -> int:
@@ -840,6 +1039,22 @@ def run(ctx: SuiteContext) -> int:
         _test_json_unknown_table_includes_help,
         _test_json_allow_suppresses_records,
         _test_json_multiple_statements_multiple_records,
+        # Shell language
+        _test_shell_col0_dot_command_is_clean,
+        _test_shell_indented_dot_read_errors,
+        _test_shell_many_dot_commands_skipped,
+        _test_shell_dot_mid_statement_is_sql,
+        _test_shell_dot_command_trailing_semicolon,
+        _test_shell_go_terminator_splits_statements,
+        _test_shell_stray_go_in_pure_sql_errors,
+        _test_shell_col0_hash_comment_skipped,
+        _test_shell_indented_hash_errors,
+        _test_shell_issue88,
+        _test_shell_sql_error_maps_to_correct_line,
+        _test_shell_crlf_error_line_mapping,
+        _test_shell_unknown_table_is_warning,
+        _test_shell_dot_commands_only_no_fragments,
+        _test_shell_explicit_lang_forces_shell_mode,
     ]
     results = [t(ctx) for t in tests]
     passed = sum(results)

--- a/syntaqlite-cli/src/cli.rs
+++ b/syntaqlite-cli/src/cli.rs
@@ -69,6 +69,18 @@ pub(crate) enum KeywordCasing {
 pub(crate) enum HostLanguage {
     Python,
     Typescript,
+    /// sqlite3 CLI shell language (dot-commands, `GO`/`/` terminators).
+    Shell,
+}
+
+impl From<HostLanguage> for syntaqlite::embedded::HostLanguage {
+    fn from(lang: HostLanguage) -> Self {
+        match lang {
+            HostLanguage::Python => syntaqlite::embedded::HostLanguage::Python,
+            HostLanguage::Typescript => syntaqlite::embedded::HostLanguage::Typescript,
+            HostLanguage::Shell => syntaqlite::embedded::HostLanguage::Shell,
+        }
+    }
 }
 
 // ── Top-level CLI + Command enum ──────────────────────────────────────────
@@ -157,6 +169,10 @@ pub(crate) struct ParseArgs {
     /// Output format
     #[arg(short, long, value_enum, default_value_t = ParseOutput::Text)]
     pub(crate) output: ParseOutput,
+    /// [experimental] Host language for embedded SQL extraction (python, typescript, shell).
+    /// When omitted, sqlite3 shell scripts (`.read` dot-commands) are auto-detected.
+    #[arg(long = "experimental-lang")]
+    pub(crate) lang: Option<HostLanguage>,
 }
 
 #[derive(Args)]
@@ -187,6 +203,10 @@ pub(crate) struct FmtArgs {
     /// Output mode (formatted, bytecode, doc-tree)
     #[arg(short, long, value_enum, default_value_t = FmtOutput::Formatted)]
     pub(crate) output: FmtOutput,
+    /// [experimental] Host language for embedded SQL extraction (python, typescript, shell).
+    /// When omitted, sqlite3 shell scripts (`.read` dot-commands) are auto-detected.
+    #[arg(long = "experimental-lang")]
+    pub(crate) lang: Option<HostLanguage>,
 }
 
 #[derive(Args)]
@@ -208,7 +228,8 @@ pub(crate) struct AnalyzeArgs {
     /// Deny (error) a check category (repeatable)
     #[arg(short = 'D', long = "deny")]
     pub(crate) deny: Vec<String>,
-    /// [experimental] Host language for embedded SQL extraction (python, typescript)
+    /// [experimental] Host language for embedded SQL extraction (python, typescript, shell).
+    /// When omitted, sqlite3 shell scripts (`.read` dot-commands) are auto-detected.
     #[arg(long = "experimental-lang")]
     pub(crate) lang: Option<HostLanguage>,
     /// Output format
@@ -229,6 +250,10 @@ pub(crate) struct LineageArgs {
     /// Output format
     #[arg(short, long, value_enum, default_value_t = LineageOutput::Json)]
     pub(crate) output: LineageOutput,
+    /// [experimental] Host language for embedded SQL extraction (python, typescript, shell).
+    /// When omitted, sqlite3 shell scripts (`.read` dot-commands) are auto-detected.
+    #[arg(long = "experimental-lang")]
+    pub(crate) lang: Option<HostLanguage>,
     /// Restrict output to a subset (combined output is the default)
     #[command(subcommand)]
     pub(crate) scope: Option<LineageScope>,
@@ -244,6 +269,10 @@ pub(crate) struct TokenizeArgs {
     /// Output format
     #[arg(short, long, value_enum, default_value_t = IntrospectOutput::Text)]
     pub(crate) output: IntrospectOutput,
+    /// [experimental] Host language for embedded SQL extraction (python, typescript, shell).
+    /// When omitted, sqlite3 shell scripts (`.read` dot-commands) are auto-detected.
+    #[arg(long = "experimental-lang")]
+    pub(crate) lang: Option<HostLanguage>,
 }
 
 #[derive(Clone, Copy, Subcommand)]

--- a/syntaqlite-cli/src/commands/analyze.rs
+++ b/syntaqlite-cli/src/commands/analyze.rs
@@ -10,7 +10,7 @@ use syntaqlite::Diagnostic;
 use syntaqlite::analysis::{Help, Severity};
 use syntaqlite::any::AnyDialect;
 use syntaqlite::util::DiagnosticRenderer;
-use syntaqlite::{AnalysisConfig, Analyzer, Catalog};
+use syntaqlite::{AnalysisConfig, Catalog};
 
 use crate::cli::{AnalysisOutput, AnalyzeArgs, HostLanguage};
 use crate::config::{self, ConfigMode};
@@ -35,7 +35,6 @@ struct Validator<'a> {
     config: AnalysisConfig,
     lang: Option<HostLanguage>,
     schema_catalog: Catalog,
-    schema_files: Vec<String>,
     has_schema: bool,
 }
 
@@ -66,7 +65,6 @@ impl<'a> Validator<'a> {
             config: AnalysisConfig::default().with_checks(checks),
             lang: args.lang,
             schema_catalog,
-            schema_files,
             has_schema,
         })
     }
@@ -113,59 +111,34 @@ impl<'a> Validator<'a> {
                 renderer.on_no_fragments(src);
                 (false, false)
             }
-            Analysis::CatalogError => (true, true),
         }
     }
 
     // ── Computation ────────────────────────────────────────────────────────
 
     fn analyze(&self, src: &Source) -> Analysis {
-        match self.lang {
-            Some(lang) => self.analyze_embedded(src, lang),
-            None => Analysis::Diagnostics(self.analyze_standalone(src)),
-        }
-    }
-
-    fn analyze_standalone(&self, src: &Source) -> Vec<Diagnostic> {
-        let mut analyzer = Analyzer::with_dialect(self.dialect.clone());
-        let mut catalog = self.schema_catalog.clone();
-        let mut ctx = syntaqlite::AnalysisContext::new(&mut catalog).with_config(self.config);
-        let model = analyzer.analyze(&src.text, &mut ctx);
-        model.diagnostics().cloned().collect()
-    }
-
-    fn analyze_embedded(&self, src: &Source, lang: HostLanguage) -> Analysis {
-        let fragments = extract_fragments(&src.text, lang);
-        if fragments.is_empty() {
+        // Standalone SQL is one whole-document fragment, so both it and embedded
+        // host files run through the same analyzer; macro-fallback is derived
+        // per fragment (holes ⇒ on). An explicit/detected host language that
+        // yields no SQL is reported distinctly.
+        let lang = util::resolve_language(self.lang, src, self.dialect);
+        let fragments = syntaqlite::embedded::fragments(self.dialect.clone(), &src.text, lang);
+        if lang.is_some() && fragments.is_empty() {
             return Analysis::NoEmbeddedFragments;
         }
-        // The embedded analyzer consumes the catalog by value, so each
-        // embedded source has to build its own.
-        let catalog = match util::build_schema_catalog(self.dialect, &self.schema_files) {
-            Ok(c) => c,
-            Err(e) => {
-                eprintln!("error: {e}");
-                return Analysis::CatalogError;
-            }
-        };
         let mut analyzer = syntaqlite::embedded::EmbeddedAnalyzer::new(self.dialect.clone())
-            .with_catalog(catalog)
+            .with_catalog(self.schema_catalog.clone())
             .with_config(self.config);
-        let diags = analyzer.analyze(&fragments);
-        Analysis::Diagnostics(diags)
+        Analysis::Diagnostics(analyzer.analyze(&fragments))
     }
 }
 
-/// Output of a single source analysis — common shape across standalone and
-/// embedded analyzers. Rendering is the caller's problem.
+/// Output of a single source analysis. Rendering is the caller's problem.
 enum Analysis {
     /// The analyzer ran and produced zero or more diagnostics.
     Diagnostics(Vec<Diagnostic>),
-    /// Embedded-mode scan found no SQL fragments in the host source.
+    /// A host language was selected/detected but its source held no SQL.
     NoEmbeddedFragments,
-    /// Embedded-mode schema catalog failed to load. The error was already
-    /// printed to stderr; the caller should treat this as an errored source.
-    CatalogError,
 }
 
 // ── Renderer strategy ──────────────────────────────────────────────────────
@@ -229,16 +202,6 @@ impl Renderer for JsonRenderer {
             emit_diagnostic_json(&src.label, diag);
         }
         has_errors
-    }
-}
-
-fn extract_fragments(
-    source: &str,
-    lang: HostLanguage,
-) -> Vec<syntaqlite::embedded::EmbeddedFragment> {
-    match lang {
-        HostLanguage::Python => syntaqlite::embedded::extract_python(source),
-        HostLanguage::Typescript => syntaqlite::embedded::extract_typescript(source),
     }
 }
 

--- a/syntaqlite-cli/src/commands/fmt.rs
+++ b/syntaqlite-cli/src/commands/fmt.rs
@@ -33,6 +33,7 @@ struct FmtRun<'a> {
     output: FmtOutput,
     in_place: bool,
     check: bool,
+    lang: Option<crate::cli::HostLanguage>,
 }
 
 impl<'a> FmtRun<'a> {
@@ -51,6 +52,7 @@ impl<'a> FmtRun<'a> {
             output: args.output,
             in_place: args.in_place,
             check: args.check,
+            lang: args.lang,
         }
     }
 
@@ -73,7 +75,7 @@ impl<'a> FmtRun<'a> {
                 return Err(format!("--{flag} requires file arguments"));
             }
 
-            match self.format_text(&src.text) {
+            match self.format_text(src) {
                 Ok(out) => self.write_output(src, &out, multi, &mut unformatted)?,
                 Err(e) => {
                     render_format_error(&e, &src.text, &src.label);
@@ -149,8 +151,14 @@ impl<'a> FmtRun<'a> {
         Ok(())
     }
 
-    fn format_text(&self, source: &str) -> Result<String, FormatError> {
-        Formatter::with_dialect_config(self.dialect.clone(), &self.config).format(source)
+    fn format_text(&self, src: &Source) -> Result<String, FormatError> {
+        // Standalone SQL is one whole-document fragment, so the same splice path
+        // covers both it and embedded host files — the formatter is composed in
+        // via the closure.
+        let lang = util::resolve_language(self.lang, src, self.dialect);
+        let fragments = syntaqlite::embedded::fragments(self.dialect.clone(), &src.text, lang);
+        let mut formatter = Formatter::with_dialect_config(self.dialect.clone(), &self.config);
+        syntaqlite::embedded::splice(&src.text, &fragments, |sql| formatter.format(sql))
     }
 }
 

--- a/syntaqlite-cli/src/commands/lineage.rs
+++ b/syntaqlite-cli/src/commands/lineage.rs
@@ -11,7 +11,7 @@ use syntaqlite::analysis::{
 use syntaqlite::any::AnyDialect;
 use syntaqlite::{AnalysisConfig, Catalog};
 
-use crate::cli::{LineageArgs, LineageOutput, LineageScope};
+use crate::cli::{HostLanguage, LineageArgs, LineageOutput, LineageScope};
 use crate::config::{self, ConfigMode};
 use crate::util::{self, Source};
 
@@ -34,6 +34,7 @@ struct LineageRun<'a> {
     schema_catalog: Catalog,
     validation: AnalysisConfig,
     scope: Option<LineageScope>,
+    lang: Option<HostLanguage>,
 }
 
 impl<'a> LineageRun<'a> {
@@ -54,6 +55,7 @@ impl<'a> LineageRun<'a> {
             schema_catalog,
             validation: AnalysisConfig::default(),
             scope: args.scope,
+            lang: args.lang,
         })
     }
 
@@ -73,13 +75,36 @@ impl<'a> LineageRun<'a> {
     // ── Computation ────────────────────────────────────────────────────────
 
     fn analyze(&self, src: &Source) -> Vec<Record> {
+        match util::resolve_language(self.lang, src, self.dialect) {
+            Some(lang) => {
+                let mut records = Vec::new();
+                let mut base = 0;
+                for fragment in syntaqlite::embedded::extract(self.dialect.clone(), lang, &src.text)
+                {
+                    let (mut frag, count) =
+                        self.analyze_text(fragment.sql_text(), &src.label, base);
+                    records.append(&mut frag);
+                    base = base.saturating_add(count);
+                }
+                records
+            }
+            None => self.analyze_text(&src.text, &src.label, 0).0,
+        }
+    }
+
+    /// Analyze `text` as standalone SQL, returning its lineage records and the
+    /// number of statements (so callers can keep `statement_index` running
+    /// across the fragments of an embedded source). `base_index` offsets the
+    /// per-statement index reported in records.
+    fn analyze_text(&self, text: &str, label: &str, base_index: u32) -> (Vec<Record>, u32) {
         let mut analyzer = Analyzer::with_dialect(self.dialect.clone());
         let mut catalog = self.schema_catalog.clone();
         let mut ctx = syntaqlite::AnalysisContext::new(&mut catalog).with_config(self.validation);
-        let model = analyzer.analyze(&src.text, &mut ctx);
+        let model = analyzer.analyze(text, &mut ctx);
+        let statements = model.statements();
         let mut records = Vec::new();
-        for (idx, stmt) in model.statements().iter().enumerate() {
-            let idx = u32::try_from(idx).unwrap_or(u32::MAX);
+        for (idx, stmt) in statements.iter().enumerate() {
+            let idx = base_index.saturating_add(u32::try_from(idx).unwrap_or(u32::MAX));
             let errors: Vec<_> = stmt
                 .diagnostics()
                 .iter()
@@ -87,15 +112,15 @@ impl<'a> LineageRun<'a> {
                 .collect();
             if errors.is_empty() {
                 records.push(Record::Lineage(build_lineage_record(
-                    stmt, &src.label, idx, self.scope,
+                    stmt, label, idx, self.scope,
                 )));
             } else {
                 for d in &errors {
-                    records.push(Record::Error(build_error_record(d, &src.label, idx)));
+                    records.push(Record::Error(build_error_record(d, label, idx)));
                 }
             }
         }
-        records
+        (records, u32::try_from(statements.len()).unwrap_or(u32::MAX))
     }
 }
 

--- a/syntaqlite-cli/src/commands/parse.rs
+++ b/syntaqlite-cli/src/commands/parse.rs
@@ -9,7 +9,7 @@ use std::ops::Deref;
 use syntaqlite::Diagnostic;
 use syntaqlite::analysis::{DiagnosticMessage, Severity};
 use syntaqlite::any::{AnyDialect, AnyParser, ParseOutcome};
-use syntaqlite::source::StmtRange;
+use syntaqlite::source::{DocOffset, DocRange, StmtRange};
 use syntaqlite::util::DiagnosticRenderer;
 use syntaqlite_syntax::any::AnyDialect as SyntaxAnyDialect;
 use syntaqlite_syntax::typed::TypedParsedStatement;
@@ -25,7 +25,7 @@ pub(crate) fn run(dialect: &AnyDialect, args: &ParseArgs) -> Result<(), String> 
 
     for src in &sources {
         sink.on_source_start(src, multi);
-        let errors = parse_source(dialect, src, sink.as_mut());
+        let errors = parse_source(dialect, src, args.lang, sink.as_mut());
         total_errors += errors.len() as u64;
         sink.on_source_end(errors.len() as u64);
         if !errors.is_empty() {
@@ -43,32 +43,57 @@ pub(crate) fn run(dialect: &AnyDialect, args: &ParseArgs) -> Result<(), String> 
     }
 }
 
-/// Drive the parser to exhaustion, handing each successful statement to the
-/// sink and collecting error diagnostics to render after the loop. The
-/// parser borrows from its own session buffer, so sinks receive statements
-/// inside the loop rather than via a collected Vec.
-fn parse_source(dialect: &AnyDialect, src: &Source, sink: &mut dyn Sink) -> Vec<Diagnostic> {
-    let parser = AnyParser::new(dialect.deref().clone());
-    let mut session = parser.parse(&src.text);
+/// Drive the parser to exhaustion over a source, handing each successful
+/// statement to the sink and collecting error diagnostics to render after the
+/// loop. The source is split into embedded fragments (standalone SQL is one
+/// whole-document fragment), and each fragment's error ranges are shifted into
+/// host-file coordinates. The parser borrows from its own session buffer, so
+/// sinks receive statements inside the loop rather than via a collected Vec.
+fn parse_source(
+    dialect: &AnyDialect,
+    src: &Source,
+    lang: Option<crate::cli::HostLanguage>,
+    sink: &mut dyn Sink,
+) -> Vec<Diagnostic> {
+    let lang = util::resolve_language(lang, src, dialect);
     let mut errors = Vec::new();
-    loop {
-        match session.next() {
-            ParseOutcome::Ok(stmt) => sink.on_stmt(StmtView { inner: stmt }),
-            ParseOutcome::Err(err) => {
-                let start = err.offset().unwrap_or_default();
-                let length = err.length().unwrap_or_default();
-                let range = StmtRange::from_offset_len(start, length).to_doc(err.statement_base());
-                errors.push(Diagnostic::new(
-                    range,
-                    DiagnosticMessage::ParseError(err.message().to_string()),
-                    Severity::Error,
-                    None,
-                ));
+    for fragment in syntaqlite::embedded::fragments(dialect.clone(), &src.text, lang) {
+        let base = fragment.sql_range().start.as_usize();
+        let parser = AnyParser::new(dialect.deref().clone());
+        let mut session = parser.parse(fragment.sql_text());
+        loop {
+            match session.next() {
+                ParseOutcome::Ok(stmt) => sink.on_stmt(StmtView { inner: stmt }),
+                ParseOutcome::Err(err) => {
+                    let start = err.offset().unwrap_or_default();
+                    let length = err.length().unwrap_or_default();
+                    let range =
+                        StmtRange::from_offset_len(start, length).to_doc(err.statement_base());
+                    errors.push(Diagnostic::new(
+                        shift_range(range, base),
+                        DiagnosticMessage::ParseError(err.message().to_string()),
+                        Severity::Error,
+                        None,
+                    ));
+                }
+                ParseOutcome::Done => break,
             }
-            ParseOutcome::Done => break,
         }
     }
     errors
+}
+
+/// Shift a fragment-relative range into host-file coordinates.
+fn shift_range(range: DocRange, base: usize) -> DocRange {
+    if base == 0 {
+        return range;
+    }
+    let shift =
+        |o: DocOffset| DocOffset::from_raw(u32::try_from(o.as_usize() + base).unwrap_or(u32::MAX));
+    DocRange {
+        start: shift(range.start),
+        end: shift(range.end),
+    }
 }
 
 // ── StmtView ───────────────────────────────────────────────────────────────

--- a/syntaqlite-cli/src/commands/tokenize.rs
+++ b/syntaqlite-cli/src/commands/tokenize.rs
@@ -19,21 +19,43 @@ pub(crate) fn run(dialect: &AnyDialect, args: &TokenizeArgs) -> Result<(), Strin
 
     for src in &sources {
         sink.on_source_start(src, multi);
-        emit_source(dialect, &tokenizer, src, sink.as_mut());
+        // Standalone SQL is one whole-document fragment, so the same loop covers
+        // both it and embedded host files.
+        let lang = util::resolve_language(args.lang, src, dialect);
+        for fragment in syntaqlite::embedded::fragments(dialect.clone(), &src.text, lang) {
+            let base = fragment.sql_range().start.as_usize();
+            emit_text(
+                dialect,
+                &tokenizer,
+                src,
+                fragment.sql_text(),
+                base,
+                sink.as_mut(),
+            );
+        }
     }
     Ok(())
 }
 
-fn emit_source(dialect: &AnyDialect, tokenizer: &AnyTokenizer, src: &Source, sink: &mut dyn Sink) {
-    let base = src.text.as_ptr() as usize;
-    for tok in tokenizer.tokenize(&src.text) {
-        let text = tok.text();
-        let offset = (text.as_ptr() as usize).saturating_sub(base);
-        let length = text.len();
+/// Tokenize `text` and emit each token, shifting offsets by `base` (the text's
+/// byte offset in the host file; `0` for standalone SQL).
+fn emit_text(
+    dialect: &AnyDialect,
+    tokenizer: &AnyTokenizer,
+    src: &Source,
+    text: &str,
+    base: usize,
+    sink: &mut dyn Sink,
+) {
+    let ptr_base = text.as_ptr() as usize;
+    for tok in tokenizer.tokenize(text) {
+        let tok_text = tok.text();
+        let offset = (tok_text.as_ptr() as usize).saturating_sub(ptr_base) + base;
+        let length = tok_text.len();
         let tt = tok.token_type();
         sink.on_token(TokenView {
             src,
-            text,
+            text: tok_text,
             offset,
             length,
             token_type: tt.into(),

--- a/syntaqlite-cli/src/util.rs
+++ b/syntaqlite-cli/src/util.rs
@@ -12,7 +12,7 @@ use syntaqlite::any::AnyDialect;
 use syntaqlite::fmt::KeywordCase;
 use syntaqlite::{Catalog, CheckConfig, FormatConfig};
 
-use crate::cli::KeywordCasing;
+use crate::cli::{HostLanguage, KeywordCasing};
 use crate::config::{self, CheckOptions, FormatOptions, ProjectConfig};
 
 // ── Input sources ──────────────────────────────────────────────────────────
@@ -31,6 +31,25 @@ impl Source {
     pub(crate) fn is_file(&self) -> bool {
         self.path.is_some()
     }
+}
+
+/// Resolve the host language for a source. The explicit `--experimental-lang`
+/// flag wins; otherwise the content is auto-detected (today: sqlite3 shell
+/// scripts). `None` means standalone SQL — the command's plain path.
+pub(crate) fn resolve_language(
+    explicit: Option<HostLanguage>,
+    src: &Source,
+    dialect: &AnyDialect,
+) -> Option<syntaqlite::embedded::HostLanguage> {
+    if let Some(lang) = explicit {
+        return Some(lang.into());
+    }
+    let hint = src
+        .path
+        .as_deref()
+        .and_then(|p| p.extension())
+        .and_then(|e| e.to_str());
+    syntaqlite::embedded::detect(dialect.clone(), &src.text, hint)
 }
 
 /// Resolve the SQL input: `-e` expression, files, or stdin (in that priority order).


### PR DESCRIPTION
Route fmt, ast, tokenize, lineage, and analyze through the shared
embedded seam, so SQL embedded in host files is extracted and processed
with results mapped back to host-file offsets. Shell scripts are
auto-detected; Python/TypeScript are reachable via --experimental-lang,
now accepted by every command. fmt reformats each SQL fragment and
splices it back between the untouched host text.
