### PR TITLE
synq: bump version to 0.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.5.11
+
+**Embedded SQL:**
+- syntaqlite can now extract and analyze SQL embedded inside host files. SQLite shell scripts (`.sql` dot-command files) are supported out of the box, with the embedded SQL masked out so the surrounding shell syntax is ignored ([#275](https://github.com/LalitMaganti/syntaqlite/pull/275)).
+- Embedded SQL handling is wired through all CLI commands (`ast`, `fmt`, `validate`) so formatting and validation operate on the SQL regions of shell files ([#276](https://github.com/LalitMaganti/syntaqlite/pull/276)).
+- The LSP analyzes embedded SQL via the same masking approach, surfacing diagnostics on the SQL regions of shell files in your editor ([#276](https://github.com/LalitMaganti/syntaqlite/pull/276)).
+
+**Parser:**
+- All-underscore identifiers (e.g. `_`, `__`) now resolve as SQL placeholders ([#274](https://github.com/LalitMaganti/syntaqlite/pull/274)).
+
+**Python bindings:**
+- Added an in-process FFI transport, removing the subprocess hop for faster Python bindings ([#271](https://github.com/LalitMaganti/syntaqlite/pull/271)).
+- Added support for building a Pyodide wheel so syntaqlite can run in the browser / Pyodide ([#272](https://github.com/LalitMaganti/syntaqlite/pull/272)).
+
+**Amalgamation:**
+- Dialect virtual functions are now automatically inlined in amalgamations ([#266](https://github.com/LalitMaganti/syntaqlite/pull/266)).
+
+**CLI:**
+- Fixed symbol export so dynamically loaded dialects work with the CLI ([#264](https://github.com/LalitMaganti/syntaqlite/pull/264)).
+
 ## 0.5.10
 
 **Zed extension:**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "benches"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "criterion",
  "syntaqlite",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "glob",
  "libloading",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-buildtools"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "cc",
  "clap",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-cli"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "clap",
  "glob",
@@ -1075,11 +1075,11 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-common"
-version = "0.5.10"
+version = "0.5.11"
 
 [[package]]
 name = "syntaqlite-syntax"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "cc",
  "libloading",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "syntaqlite-wasm"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ cargo install syntaqlite-cli
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.5.10", features = ["fmt"] }
+syntaqlite = { version = "0.5.11", features = ["fmt"] }
 ```
 
 **Python** ([API docs](https://docs.syntaqlite.com/latest/reference/python-api/))

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syntaqlite",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "SQLite SQL language server — diagnostics, formatting, completions, and semantic tokens",
   "author": {
     "name": "Lalit Maganti"

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "syntaqlite",
   "displayName": "syntaqlite",
   "description": "SQL language support powered by syntaqlite — diagnostics, formatting, completions, and semantic highlighting",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "publisher": "syntaqlite",
   "license": "Apache-2.0",
   "icon": "icon.png",

--- a/integrations/zed/Cargo.toml
+++ b/integrations/zed/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "syntaqlite-zed"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2024"
 
 [lib]

--- a/integrations/zed/extension.toml
+++ b/integrations/zed/extension.toml
@@ -3,7 +3,7 @@
 
 id = "syntaqlite-lsp"
 name = "Syntaqlite"
-version = "0.5.10"
+version = "0.5.11"
 schema_version = 1
 authors = ["Lalit Maganti <lalitmaganti@gmail.com>"]
 description = "SQL language support powered by syntaqlite — tokenizer, parser, formatter and validator built on SQLite's own grammar."

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntaqlite"
-version = "0.5.10"
+version = "0.5.11"
 description = "SQLite SQL tools — parser, formatter, validator, and MCP server"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}

--- a/python/syntaqlite/__init__.py
+++ b/python/syntaqlite/__init__.py
@@ -23,7 +23,7 @@ from typing import Any
 
 from .nodes import _wrap
 
-__version__ = "0.5.10"
+__version__ = "0.5.11"
 
 
 # ── Binary discovery ──────────────────────────────────────────────────────────

--- a/syntaqlite-buildtools/Cargo.toml
+++ b/syntaqlite-buildtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-buildtools"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2024"
 description = "Internal codegen and build tools for syntaqlite — not intended for direct use"
 license = "Apache-2.0"
@@ -20,8 +20,8 @@ dist = false
 doc = false
 
 [dependencies]
-syntaqlite-common = { version = "0.5.10", path = "../syntaqlite-common" }
-syntaqlite-syntax = { version = "0.5.10", path = "../syntaqlite-syntax", default-features = false, features = ["embedded-sources"] }
+syntaqlite-common = { version = "0.5.11", path = "../syntaqlite-common" }
+syntaqlite-syntax = { version = "0.5.11", path = "../syntaqlite-syntax", default-features = false, features = ["embedded-sources"] }
 clap = { version = "4.5", features = ["derive"] }
 tempfile = "3.8"
 serde = { version = "1", features = ["derive"] }

--- a/syntaqlite-cli/Cargo.toml
+++ b/syntaqlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-cli"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2024"
 repository.workspace = true
 description = "Fast, accurate SQLite SQL formatter, validator, and language server — built on SQLite's own grammar"
@@ -42,8 +42,8 @@ rmcp = { version = "0.1", features = ["server", "transport-io"], optional = true
 schemars = { version = "0.8", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-syntaqlite = { version = "0.5.10", path = "../syntaqlite", default-features = false, features = ["fmt", "lsp", "analysis", "experimental-embedded", "serde-json", "rpc"] }
-syntaqlite-syntax = { version = "0.5.10", path = "../syntaqlite-syntax" }
-syntaqlite-buildtools = { version = "0.5.10", path = "../syntaqlite-buildtools", optional = true }
+syntaqlite = { version = "0.5.11", path = "../syntaqlite", default-features = false, features = ["fmt", "lsp", "analysis", "experimental-embedded", "serde-json", "rpc"] }
+syntaqlite-syntax = { version = "0.5.11", path = "../syntaqlite-syntax" }
+syntaqlite-buildtools = { version = "0.5.11", path = "../syntaqlite-buildtools", optional = true }
 tempfile = "3.8"
 tokio = { version = "1", features = ["rt", "macros", "io-std"], optional = true }

--- a/syntaqlite-common/Cargo.toml
+++ b/syntaqlite-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-common"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2024"
 description = "Internal shared primitives for syntaqlite — not intended for direct use"
 license = "Apache-2.0"

--- a/syntaqlite-syntax/Cargo.toml
+++ b/syntaqlite-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-syntax"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2024"
 links = "syntaqlite_syntax"
 description = "Internal parser and tokenizer for syntaqlite — not intended for direct use"

--- a/syntaqlite-syntax/src/lib.rs
+++ b/syntaqlite-syntax/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! syntaqlite = { version = "0.5.10", default-features = false, features = ["sqlite"] }
+//! syntaqlite = { version = "0.5.11", default-features = false, features = ["sqlite"] }
 //! ```
 
 // ==== Public API ====

--- a/syntaqlite-wasm/Cargo.toml
+++ b/syntaqlite-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite-wasm"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2024"
 repository.workspace = true
 

--- a/syntaqlite/Cargo.toml
+++ b/syntaqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntaqlite"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2024"
 description = "Parser, formatter, validator, and language server for SQLite SQL — built on SQLite's own grammar"
 license = "Apache-2.0"
@@ -39,8 +39,8 @@ pin-cflags = ["sqlite", "syntaqlite-syntax/pin-cflags"]    # Pin compile-time fl
 workspace = true
 
 [dependencies]
-syntaqlite-common = { version = "0.5.10", path = "../syntaqlite-common" }
-syntaqlite-syntax = { version = "0.5.10", path = "../syntaqlite-syntax", default-features = false }
+syntaqlite-common = { version = "0.5.11", path = "../syntaqlite-common" }
+syntaqlite-syntax = { version = "0.5.11", path = "../syntaqlite-syntax", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 libloading = { version = "0.8", optional = true }

--- a/tests/benches/Cargo.toml
+++ b/tests/benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benches"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2024"
 publish = false
 

--- a/tests/comparison/parser/Cargo.toml
+++ b/tests/comparison/parser/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "parser-bench"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 
 [[bin]]

--- a/web/docs/content/guides/rust-api.md
+++ b/web/docs/content/guides/rust-api.md
@@ -10,7 +10,7 @@ weight = 1
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.5.10", features = ["fmt"] }
+syntaqlite = { version = "0.5.11", features = ["fmt"] }
 ```
 
 ## Format a query
@@ -127,7 +127,7 @@ Add the `analysis` and `sqlite` features:
 
 ```toml
 [dependencies]
-syntaqlite = { version = "0.5.10", features = ["analysis", "sqlite"] }
+syntaqlite = { version = "0.5.11", features = ["analysis", "sqlite"] }
 ```
 
 ```rust

--- a/web/syntaqlite-js/package.json
+++ b/web/syntaqlite-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syntaqlite",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "SQLite SQL parser, formatter, and validator for the browser — powered by WebAssembly",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Motivation

Cut the 0.5.11 release.

## Changes

- Bumps version to 0.5.11 across all Cargo.toml / pyproject.toml / integration manifests / README / docs.
- Adds 0.5.11 CHANGELOG entry.

Release notes:

**Embedded SQL:**
- syntaqlite can now extract and analyze SQL embedded inside host files. SQLite shell scripts are supported out of the box, with the embedded SQL masked out so the surrounding shell syntax is ignored (#275).
- Embedded SQL handling is wired through all CLI commands (`ast`, `fmt`, `validate`) so formatting and validation operate on the SQL regions of shell files (#276).
- The LSP analyzes embedded SQL via the same masking approach, surfacing diagnostics on the SQL regions of shell files in your editor (#276).

**Parser:**
- All-underscore identifiers (e.g. `_`, `__`) now resolve as SQL placeholders (#274).

**Python bindings:**
- Added an in-process FFI transport, removing the subprocess hop for faster Python bindings (#271).
- Added support for building a Pyodide wheel so syntaqlite can run in the browser / Pyodide (#272).

**Amalgamation:**
- Dialect virtual functions are now automatically inlined in amalgamations (#266).

**CLI:**
- Fixed symbol export so dynamically loaded dialects work with the CLI (#264).