### PR TITLE
synq: fix explain/explain query plan parsing in node extents

### DIFF
--- a/syntaqlite-buildtools/parser-actions/_common.y
+++ b/syntaqlite-buildtools/parser-actions/_common.y
@@ -234,6 +234,30 @@ cmdx(A) ::= cmd(B). {
         A = synq_parse_explain_stmt(
             pCtx, (SyntaqliteExplainMode)(pCtx->pending_explain_mode - 1), B);
         pCtx->pending_explain_mode = 0;
+        // Extend the wrapper node's extent leftwards to cover the EXPLAIN /
+        // EXPLAIN QUERY PLAN keyword, otherwise node_text() of an explained
+        // statement drops it (returning e.g. "SELECT 1" for "EXPLAIN SELECT 1").
+        //
+        // Why this isn't automatic: the keyword lives in the `explain`
+        // nonterminal, which is a sibling of `cmdx` in the parent rule
+        // `ecmd ::= explain cmdx SEMI`. SQLite marks that rule {NEVER-REDUCE}
+        // (and we mirror it: the statement is finished here, in cmdx), so the
+        // reduction that would normally merge `explain`'s span into the node
+        // never runs. The wrapper node is therefore built — and its extent
+        // recorded — spanning only `cmd`.
+        //
+        // Why n - 2: extent tracking shadows Lemon's symbol stack one entry per
+        // symbol. on_reduce runs before this action and has already collapsed
+        // `cmd` into the top entry (n - 1, == the new cmdx node). The `explain`
+        // nonterminal was reduced earlier and sits in the entry directly below
+        // it (n - 2). Its root_start is the byte offset of the keyword; folding
+        // it in (start only — the end is unchanged) makes the extent span the
+        // keyword through the wrapped statement.
+        if (pCtx->collect_node_extents) {
+            uint32_t n = syntaqlite_vec_len(&pCtx->extent_stack);
+            uint32_t kw = syntaqlite_vec_at(&pCtx->extent_stack, n - 2).root_start;
+            syntaqlite_vec_at(&pCtx->node_extents, A).root_start = kw;
+        }
     } else {
         A = B;
     }

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
@@ -7227,6 +7227,33 @@ static YYACTIONTYPE yy_reduce(
             pCtx, (SyntaqliteExplainMode)(pCtx->pending_explain_mode - 1),
             yymsp[0].minor.yy277);
         pCtx->pending_explain_mode = 0;
+        // Extend the wrapper node's extent leftwards to cover the EXPLAIN /
+        // EXPLAIN QUERY PLAN keyword, otherwise node_text() of an explained
+        // statement drops it (returning e.g. "SELECT 1" for "EXPLAIN SELECT
+        // 1").
+        //
+        // Why this isn't automatic: the keyword lives in the `explain`
+        // nonterminal, which is a sibling of `cmdx` in the parent rule
+        // `ecmd ::= explain cmdx SEMI`. SQLite marks that rule {NEVER-REDUCE}
+        // (and we mirror it: the statement is finished here, in cmdx), so the
+        // reduction that would normally merge `explain`'s span into the node
+        // never runs. The wrapper node is therefore built — and its extent
+        // recorded — spanning only `cmd`.
+        //
+        // Why n - 2: extent tracking shadows Lemon's symbol stack one entry per
+        // symbol. on_reduce runs before this action and has already collapsed
+        // `cmd` into the top entry (n - 1, == the new cmdx node). The `explain`
+        // nonterminal was reduced earlier and sits in the entry directly below
+        // it (n - 2). Its root_start is the byte offset of the keyword; folding
+        // it in (start only — the end is unchanged) makes the extent span the
+        // keyword through the wrapped statement.
+        if (pCtx->collect_node_extents) {
+          uint32_t n = syntaqlite_vec_len(&pCtx->extent_stack);
+          uint32_t kw =
+              syntaqlite_vec_at(&pCtx->extent_stack, n - 2).root_start;
+          syntaqlite_vec_at(&pCtx->node_extents, yylhsminor.yy277).root_start =
+              kw;
+        }
       } else {
         yylhsminor.yy277 = yymsp[0].minor.yy277;
       }

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -851,6 +851,40 @@ mod tests {
     }
 
     #[test]
+    fn parser_collect_node_extents_explain_spans_keyword() {
+        // EXPLAIN / EXPLAIN QUERY PLAN: the wrapper node is built in
+        // `cmdx ::= cmd`, while the keyword lives in the sibling `explain`
+        // nonterminal.  SQLite marks the parent `ecmd ::= explain cmdx SEMI`
+        // rule {NEVER-REDUCE}, so the wrapper's extent must be folded over the
+        // keyword at build time, else node_text drops it.  Regression test for
+        // EXPLAIN node_text losing the leading keyword.
+        let parser = Parser::with_config(&ParserConfig::default().with_collect_node_extents(true));
+
+        for (source, expected) in [
+            ("EXPLAIN SELECT 1;", "EXPLAIN SELECT 1"),
+            (
+                "EXPLAIN QUERY PLAN SELECT * FROM t;",
+                "EXPLAIN QUERY PLAN SELECT * FROM t",
+            ),
+            // Whitespace between keyword and statement is preserved verbatim.
+            ("EXPLAIN   SELECT 1;", "EXPLAIN   SELECT 1"),
+        ] {
+            let mut session = parser.parse(source);
+            let ParseOutcome::Ok(statement) = session.next() else {
+                panic!("expected Ok for {source:?}");
+            };
+            let root_id = statement.erase().root_id();
+            let (text, offset) = statement
+                .node_text(root_id)
+                .expect("root node should have recorded text");
+            assert_eq!(text, expected, "node_text for {source:?}");
+            // Extent starts at the keyword (byte 0 of the statement).
+            assert_eq!(offset, StmtOffset::default(), "offset for {source:?}");
+            drop(session);
+        }
+    }
+
+    #[test]
     fn parser_collect_node_extents_attributes_macro_tokens_to_call_site() {
         // The SELECT node crosses layers: `SELECT` comes from the root
         // source, `42` from `id`'s expansion buffer.  `node_text`


### PR DESCRIPTION
We were silently dropping the explain/explain query plan part.