### PR TITLE
synq: flag column refs whose table qualifier is not in scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ This allows projects like libSQL, rqlite, or custom embedded databases to use sy
 - `DialectEnv<'d>` parameterized on lifetime — no `'static` requirement, enables stack-allocated test dialects
 - Unsafe minimized: `DialectEnv` safe accessors wrap all raw pointer access; `Interpreter` has zero unsafe
 - AST dump is in C (`syntaqlite_dump_node`), not Rust — single source of truth for metadata
+- **Named diagnostic suppression**: the analyzer never silently ignores a resolution failure (no bare `=> {}` arms). Every intentional accept names an `AcceptedRef` variant (`syntaqlite/src/analysis/engine/statement_visitor.rs`) — either modeled SQLite behavior (permanent) or an unmodeled construct (tracked debt: cite the construct, delete the variant once the walker models it in scope)
 
 ## Git Workflow
 

--- a/syntaqlite/src/analysis/catalog.rs
+++ b/syntaqlite/src/analysis/catalog.rs
@@ -122,7 +122,7 @@ pub(crate) enum ColumnResolution {
     },
     /// Table is in scope but this column is not in its known list.
     TableFoundColumnMissing,
-    /// The qualifier table is not in scope — table check already reported this.
+    /// The qualifier names no source anywhere in the statement so far.
     TableNotFound,
     /// Unqualified column not found in any table in scope.
     NotFound,

--- a/syntaqlite/src/analysis/engine/mod.rs
+++ b/syntaqlite/src/analysis/engine/mod.rs
@@ -553,6 +553,100 @@ mod tests {
     }
 
     #[test]
+    fn unknown_qualifier_flagged_with_scope_suggestion() {
+        let mut analyzer = sqlite_analyzer();
+        let mut catalog = sqlite_catalog();
+        catalog.layer_mut(CatalogLayer::Database).insert_table(
+            "foo",
+            Some(vec!["id".into(), "name".into()]),
+            false,
+        );
+        let mut ctx = AnalysisContext::new(&mut catalog);
+        // Issue #281: `b` is never defined; the only alias in scope is `a`.
+        let model = analyzer.analyze("SELECT b.id FROM foo AS a", &mut ctx);
+        assert_eq!(diag_messages(&model), vec!["unknown table: b".to_string()]);
+        let help = model
+            .diagnostics()
+            .next()
+            .and_then(|d| d.help())
+            .map(ToString::to_string);
+        assert_eq!(help.as_deref(), Some("did you mean 'a'?"));
+    }
+
+    #[test]
+    fn aliased_table_hides_base_name() {
+        let mut analyzer = sqlite_analyzer();
+        let mut catalog = sqlite_catalog();
+        catalog.layer_mut(CatalogLayer::Database).insert_table(
+            "foo",
+            Some(vec!["id".into()]),
+            false,
+        );
+        let mut ctx = AnalysisContext::new(&mut catalog);
+        // SQLite: once aliased, the base name is not addressable.
+        let model = analyzer.analyze("SELECT foo.id FROM foo AS a", &mut ctx);
+        assert_eq!(
+            diag_messages(&model),
+            vec!["unknown table: foo".to_string()],
+        );
+    }
+
+    #[test]
+    fn excluded_resolves_in_upsert_do_update() {
+        let mut analyzer = sqlite_analyzer();
+        let mut catalog = sqlite_catalog();
+        catalog.layer_mut(CatalogLayer::Database).insert_table(
+            "foo",
+            Some(vec!["id".into(), "name".into()]),
+            false,
+        );
+        let mut ctx = AnalysisContext::new(&mut catalog);
+        let model = analyzer.analyze(
+            "INSERT INTO foo(id) VALUES (1) ON CONFLICT(id) \
+             DO UPDATE SET name = excluded.name WHERE excluded.id > foo.id",
+            &mut ctx,
+        );
+        assert_eq!(diag_messages(&model), Vec::<String>::new());
+    }
+
+    #[test]
+    fn excluded_carries_target_columns() {
+        let mut analyzer = sqlite_analyzer();
+        let mut catalog = sqlite_catalog();
+        catalog.layer_mut(CatalogLayer::Database).insert_table(
+            "foo",
+            Some(vec!["id".into(), "name".into()]),
+            false,
+        );
+        let mut ctx = AnalysisContext::new(&mut catalog);
+        let model = analyzer.analyze(
+            "INSERT INTO foo(id) VALUES (1) ON CONFLICT(id) DO UPDATE SET name = excluded.nosuch",
+            &mut ctx,
+        );
+        assert_eq!(
+            diag_messages(&model),
+            vec!["unknown column: excluded.nosuch".to_string()],
+        );
+    }
+
+    #[test]
+    fn excluded_not_visible_outside_do_update() {
+        let mut analyzer = sqlite_analyzer();
+        let mut catalog = sqlite_catalog();
+        catalog.layer_mut(CatalogLayer::Database).insert_table(
+            "foo",
+            Some(vec!["id".into()]),
+            false,
+        );
+        let mut ctx = AnalysisContext::new(&mut catalog);
+        let model = analyzer.analyze("SELECT excluded.id FROM foo", &mut ctx);
+        assert_eq!(
+            diag_messages(&model),
+            vec!["unknown table: excluded".to_string()],
+        );
+    }
+
+    #[test]
     fn sources_bind_before_expressions_resolve() {
         let mut analyzer = sqlite_analyzer();
         let mut catalog = sqlite_catalog();
@@ -624,6 +718,37 @@ mod tests {
             .insert_table("t1", Some(vec!["a".into()]), false);
         let mut ctx = AnalysisContext::new(&mut catalog);
         let model = analyzer.analyze("SELECT b.a FROM t1 AS 'b'", &mut ctx);
+        assert_eq!(diag_messages(&model), Vec::<String>::new());
+    }
+
+    #[test]
+    fn view_body_name_resolution_is_deferred() {
+        let mut analyzer = sqlite_analyzer();
+        let mut catalog = sqlite_catalog();
+        catalog.layer_mut(CatalogLayer::Database).insert_table(
+            "t1",
+            Some(vec!["aa".into()]),
+            false,
+        );
+        let mut ctx = AnalysisContext::new(&mut catalog);
+        // SQLite stores view bodies unresolved; errors surface at first use.
+        let model = analyzer.analyze(
+            "CREATE VIEW v AS SELECT 1 FROM t1 AS bb WHERE bb.aa <= sts.aa",
+            &mut ctx,
+        );
+        assert_eq!(diag_messages(&model), Vec::<String>::new());
+    }
+
+    #[test]
+    fn hole_placeholder_qualifier_accepted() {
+        let mut analyzer = sqlite_analyzer();
+        let mut catalog = sqlite_catalog();
+        catalog
+            .layer_mut(CatalogLayer::Database)
+            .insert_table("t1", Some(vec!["a".into()]), false);
+        let mut ctx = AnalysisContext::new(&mut catalog);
+        // Embedded-SQL hole placeholders stand in for host expressions.
+        let model = analyzer.analyze("SELECT ___.a FROM t1", &mut ctx);
         assert_eq!(diag_messages(&model), Vec::<String>::new());
     }
 

--- a/syntaqlite/src/analysis/engine/query_scope.rs
+++ b/syntaqlite/src/analysis/engine/query_scope.rs
@@ -182,6 +182,20 @@ impl QueryScope {
         frame.named.values().next()?.columns.clone()
     }
 
+    /// Collect all source names in the active frames, for fuzzy
+    /// suggestions on an unresolved qualifier.
+    pub(crate) fn all_source_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .frames
+            .iter()
+            .flat_map(|f| f.named.keys())
+            .cloned()
+            .collect();
+        names.sort_unstable();
+        names.dedup();
+        names
+    }
+
     /// Collect all known column names (for fuzzy suggestions).
     pub(crate) fn all_column_names(&self, table: Option<&str>) -> Vec<String> {
         let mut names: Vec<String> = Vec::new();

--- a/syntaqlite/src/analysis/engine/statement_visitor.rs
+++ b/syntaqlite/src/analysis/engine/statement_visitor.rs
@@ -34,6 +34,67 @@ fn is_hole_placeholder(name: &str) -> bool {
     !name.is_empty() && name.bytes().all(|b| b == b'_')
 }
 
+/// Why an unresolved column reference is intentionally accepted without a
+/// diagnostic.
+///
+/// Naming a variant here is the only sanctioned way to skip a diagnostic on
+/// a resolution failure — never a bare `=> {}` arm (issue #281: exactly
+/// that silently hid every unknown qualifier to protect one unmodeled
+/// construct). Variants either model real `SQLite` behavior (permanent) or
+/// name an unmodeled construct (tracked debt: cite the construct, delete
+/// the variant once the walker registers it in scope).
+enum AcceptedRef {
+    /// `SQLite` DQS bug-compat: an unresolved `"foo"` written with double
+    /// quotes in the original source re-reads as a string literal.
+    DqsStringLiteral,
+    /// `SQLite` resolves bare TRUE/FALSE identifiers to integer literals.
+    BooleanLiteral,
+    /// Embedded-SQL hole placeholder — stands in for a host expression.
+    HolePlaceholder,
+    /// `SQLite` defers view-body name resolution until the view is first
+    /// used; a CREATE VIEW referencing unknown qualifiers still prepares.
+    ViewBodyDeferredResolution,
+}
+
+/// Decide whether an unresolved column ref is intentionally accepted.
+/// `None` means the failure deserves a diagnostic.
+fn accepted_ref(ev: &ColumnRefEvent<'_>) -> Option<AcceptedRef> {
+    match ev.resolution {
+        ColumnResolution::Found { .. } => None,
+        ColumnResolution::TableNotFound => {
+            // Only the qualifier's own text matters here — the column being
+            // a hole doesn't make an unknown qualifier valid.
+            if ev.table.is_some_and(is_hole_placeholder) {
+                Some(AcceptedRef::HolePlaceholder)
+            } else if ev.in_view_body {
+                Some(AcceptedRef::ViewBodyDeferredResolution)
+            } else {
+                None
+            }
+        }
+        ColumnResolution::TableFoundColumnMissing => {
+            if ev.dqs_candidate {
+                Some(AcceptedRef::DqsStringLiteral)
+            } else if is_hole_placeholder(ev.column) {
+                Some(AcceptedRef::HolePlaceholder)
+            } else {
+                None
+            }
+        }
+        ColumnResolution::NotFound => {
+            if ev.column.eq_ignore_ascii_case("true") || ev.column.eq_ignore_ascii_case("false") {
+                Some(AcceptedRef::BooleanLiteral)
+            } else if ev.dqs_candidate {
+                Some(AcceptedRef::DqsStringLiteral)
+            } else if is_hole_placeholder(ev.column) {
+                Some(AcceptedRef::HolePlaceholder)
+            } else {
+                None
+            }
+        }
+    }
+}
+
 impl CheckConfig {
     /// Get the check level for a diagnostic message's category.
     pub(crate) fn level_for(self, message: &DiagnosticMessage) -> CheckLevel {
@@ -126,6 +187,72 @@ impl<'a, V: SemanticVisitor> StatementVisitor<'a, V> {
             });
         }
     }
+
+    /// Diagnose a column ref whose resolution failed and was not accepted
+    /// by [`accepted_ref`].
+    fn emit_unresolved_column_ref(
+        &mut self,
+        stmt: &mut AnyParsedStatement<'_>,
+        cx: &mut WalkCtx<'_>,
+        ev: &ColumnRefEvent<'_>,
+    ) {
+        match ev.resolution {
+            // Gated out by the caller / accepted_ref.
+            // Gated out by the caller / accepted_ref.
+            ColumnResolution::Found { .. } => {}
+            ColumnResolution::TableNotFound => {
+                let tbl = ev.table.expect("qualifier present when TableNotFound");
+                let candidates = cx.scope.all_source_names();
+                let suggestion =
+                    best_suggestion(tbl, &candidates, self.config.suggestion_threshold());
+                self.emit(
+                    stmt,
+                    ev.node_id,
+                    ev.table_idx,
+                    ev.table_range.unwrap_or(ev.range),
+                    DiagnosticMessage::UnknownTable {
+                        name: tbl.to_string(),
+                    },
+                    suggestion.map(Help::Suggestion),
+                );
+            }
+            ColumnResolution::TableFoundColumnMissing => {
+                let tbl = ev
+                    .table
+                    .expect("qualifier present when TableFoundColumnMissing");
+                let candidates = cx.scope.all_column_names(Some(tbl));
+                let suggestion =
+                    best_suggestion(ev.column, &candidates, self.config.suggestion_threshold());
+                self.emit(
+                    stmt,
+                    ev.node_id,
+                    ev.column_idx,
+                    ev.range,
+                    DiagnosticMessage::UnknownColumn {
+                        column: ev.column.to_string(),
+                        table: Some(tbl.to_string()),
+                    },
+                    suggestion.map(Help::Suggestion),
+                );
+            }
+            ColumnResolution::NotFound => {
+                let candidates = cx.scope.all_column_names(None);
+                let suggestion =
+                    best_suggestion(ev.column, &candidates, self.config.suggestion_threshold());
+                self.emit(
+                    stmt,
+                    ev.node_id,
+                    ev.column_idx,
+                    ev.range,
+                    DiagnosticMessage::UnknownColumn {
+                        column: ev.column.to_string(),
+                        table: None,
+                    },
+                    suggestion.map(Help::Suggestion),
+                );
+            }
+        }
+    }
 }
 
 impl<V: SemanticVisitor> SemanticVisitor for StatementVisitor<'_, V> {
@@ -174,53 +301,8 @@ impl<V: SemanticVisitor> SemanticVisitor for StatementVisitor<'_, V> {
         cx: &mut WalkCtx<'_>,
         ev: ColumnRefEvent<'_>,
     ) {
-        match ev.resolution {
-            ColumnResolution::Found { .. } | ColumnResolution::TableNotFound => {}
-            ColumnResolution::TableFoundColumnMissing => {
-                // DQS bug-compat: unresolved `"foo"` is re-interpreted as a
-                // string literal by SQLite. Don't FP here.
-                if !ev.dqs_candidate && !is_hole_placeholder(ev.column) {
-                    let tbl = ev
-                        .table
-                        .expect("qualifier present when TableFoundColumnMissing");
-                    let candidates = cx.scope.all_column_names(Some(tbl));
-                    let suggestion =
-                        best_suggestion(ev.column, &candidates, self.config.suggestion_threshold());
-                    self.emit(
-                        stmt,
-                        ev.node_id,
-                        ev.column_idx,
-                        ev.range,
-                        DiagnosticMessage::UnknownColumn {
-                            column: ev.column.to_string(),
-                            table: Some(tbl.to_string()),
-                        },
-                        suggestion.map(Help::Suggestion),
-                    );
-                }
-            }
-            ColumnResolution::NotFound => {
-                // SQLite resolves bare TRUE/FALSE identifiers to integer
-                // literals.
-                let is_bool_literal = ev.column.eq_ignore_ascii_case("true")
-                    || ev.column.eq_ignore_ascii_case("false");
-                if !is_bool_literal && !ev.dqs_candidate && !is_hole_placeholder(ev.column) {
-                    let candidates = cx.scope.all_column_names(None);
-                    let suggestion =
-                        best_suggestion(ev.column, &candidates, self.config.suggestion_threshold());
-                    self.emit(
-                        stmt,
-                        ev.node_id,
-                        ev.column_idx,
-                        ev.range,
-                        DiagnosticMessage::UnknownColumn {
-                            column: ev.column.to_string(),
-                            table: None,
-                        },
-                        suggestion.map(Help::Suggestion),
-                    );
-                }
-            }
+        if !matches!(ev.resolution, ColumnResolution::Found { .. }) && accepted_ref(&ev).is_none() {
+            self.emit_unresolved_column_ref(stmt, cx, &ev);
         }
         self.extra.on_column_ref(stmt, cx, ev);
     }

--- a/syntaqlite/src/analysis/engine/walker.rs
+++ b/syntaqlite/src/analysis/engine/walker.rs
@@ -76,6 +76,12 @@ pub(crate) struct ColumnRefEvent<'a> {
     pub(crate) range: DocRange,
     pub(crate) column: &'a str,
     pub(crate) table: Option<&'a str>,
+    pub(crate) table_idx: u8,
+    /// Document-absolute range of the qualifier, when present.
+    pub(crate) table_range: Option<DocRange>,
+    /// The ref is inside a CREATE VIEW body, where `SQLite` defers name
+    /// resolution until the view is first used.
+    pub(crate) in_view_body: bool,
     pub(crate) resolution: &'a ColumnResolution,
     /// `SQLite`'s double-quoted-string bug-compat: a `"foo"` identifier in
     /// expression position that doesn't resolve to a column is re-interpreted
@@ -234,6 +240,8 @@ pub(crate) struct SemanticWalker<'a, 'b> {
     catalog: &'a mut Catalog,
     scope: QueryScope,
     roles: &'static [SemanticRole],
+    /// Depth of nested CREATE VIEW bodies currently being walked.
+    view_body_depth: u32,
 }
 
 impl<'a, 'b> SemanticWalker<'a, 'b> {
@@ -247,6 +255,7 @@ impl<'a, 'b> SemanticWalker<'a, 'b> {
             catalog,
             scope: QueryScope::default(),
             roles,
+            view_body_depth: 0,
         }
     }
 
@@ -279,11 +288,20 @@ impl<'a, 'b> SemanticWalker<'a, 'b> {
         let role = StmtReader::new(self.stmt, self.roles).role_for_tag(tag);
 
         match role {
-            SemanticRole::DefineTable { select, .. } | SemanticRole::DefineView { select, .. } => {
+            SemanticRole::DefineTable { select, .. } => {
                 if V::WANTS_RELATION_DEFINITION || V::WANTS_COLUMN_DEFINITION {
                     self.emit_ddl_definitions(visitor, node_id);
                 }
                 self.walk_opt(visitor, fields.node_id_at(select));
+            }
+            SemanticRole::DefineView { select, .. } => {
+                if V::WANTS_RELATION_DEFINITION || V::WANTS_COLUMN_DEFINITION {
+                    self.emit_ddl_definitions(visitor, node_id);
+                }
+                // SQLite defers view-body name resolution to first use.
+                self.view_body_depth += 1;
+                self.walk_opt(visitor, fields.node_id_at(select));
+                self.view_body_depth -= 1;
             }
             SemanticRole::DefineFunction { select, .. } => {
                 self.walk_opt(visitor, fields.node_id_at(select));
@@ -575,9 +593,12 @@ impl<'a, 'b> SemanticWalker<'a, 'b> {
             return;
         }
         let column = self.stmt.span_expanded_text(col_sp);
-        let table = match fields[table_idx as usize] {
-            FieldValue::Span(sp) if !sp.is_empty() => Some(self.stmt.span_expanded_text(sp)),
-            _ => None,
+        let (table, table_range) = match fields[table_idx as usize] {
+            FieldValue::Span(sp) if !sp.is_empty() => {
+                let (_, r) = self.stmt.span_text_abs(sp);
+                (Some(self.stmt.span_expanded_text(sp)), Some(r))
+            }
+            _ => (None, None),
         };
         let (_, range) = self.stmt.span_text_abs(col_sp);
         // SQLite's DQS bug-compat applies only to identifiers that were
@@ -594,8 +615,11 @@ impl<'a, 'b> SemanticWalker<'a, 'b> {
                 range,
                 column,
                 table,
+                table_idx,
+                table_range,
                 resolution: &resolution,
                 dqs_candidate,
+                in_view_body: self.view_body_depth > 0,
             };
             let mut cx = WalkCtx {
                 catalog: self.catalog,

--- a/syntaqlite/src/analysis/engine/walker.rs
+++ b/syntaqlite/src/analysis/engine/walker.rs
@@ -286,7 +286,17 @@ impl<'a, 'b> SemanticWalker<'a, 'b> {
             return;
         };
         let role = StmtReader::new(self.stmt, self.roles).role_for_tag(tag);
+        self.dispatch_role(visitor, node_id, role, &fields);
+    }
 
+    /// Route a node to its role-specific walker.
+    fn dispatch_role<V: SemanticVisitor>(
+        &mut self,
+        visitor: &mut V,
+        node_id: AnyNodeId,
+        role: SemanticRole,
+        fields: &NodeFields,
+    ) {
         match role {
             SemanticRole::DefineTable { select, .. } => {
                 if V::WANTS_RELATION_DEFINITION || V::WANTS_COLUMN_DEFINITION {
@@ -314,16 +324,16 @@ impl<'a, 'b> SemanticWalker<'a, 'b> {
             | SemanticRole::CteBinding { .. } => self.walk_children(visitor, node_id),
 
             SemanticRole::Call { name, args } => {
-                self.walk_call(visitor, node_id, &fields, name, args);
+                self.walk_call(visitor, node_id, fields, name, args);
             }
             SemanticRole::ColumnRef { column, table } => {
-                self.walk_column_ref(visitor, node_id, &fields, column, table);
+                self.walk_column_ref(visitor, node_id, fields, column, table);
             }
             SemanticRole::SourceRef { name, alias, .. } => {
-                self.walk_source_ref(visitor, node_id, &fields, name, alias);
+                self.walk_source_ref(visitor, node_id, fields, name, alias);
             }
             SemanticRole::ScopedSource { body, alias } => {
-                self.walk_scoped_source(visitor, &fields, body, alias);
+                self.walk_scoped_source(visitor, fields, body, alias);
             }
             SemanticRole::Query {
                 from,
@@ -336,7 +346,7 @@ impl<'a, 'b> SemanticWalker<'a, 'b> {
             } => self.walk_query(
                 visitor,
                 node_id,
-                &fields,
+                fields,
                 from,
                 columns,
                 where_clause,
@@ -349,16 +359,16 @@ impl<'a, 'b> SemanticWalker<'a, 'b> {
                 recursive,
                 bindings,
                 body,
-            } => self.walk_cte_scope(visitor, &fields, recursive, bindings, body),
+            } => self.walk_cte_scope(visitor, fields, recursive, bindings, body),
             SemanticRole::TriggerScope {
                 target: _,
                 when,
                 body,
-            } => self.walk_trigger_scope(visitor, &fields, when, body),
+            } => self.walk_trigger_scope(visitor, fields, when, body),
             SemanticRole::DmlScope {
                 with_recursive,
                 with_ctes,
-            } => self.walk_dml_scope(visitor, &fields, with_recursive, with_ctes),
+            } => self.walk_dml_scope(visitor, fields, with_recursive, with_ctes),
             SemanticRole::UpsertScope {
                 columns,
                 target_where,
@@ -367,7 +377,7 @@ impl<'a, 'b> SemanticWalker<'a, 'b> {
             } => {
                 self.walk_upsert_scope(
                     visitor,
-                    &fields,
+                    fields,
                     columns,
                     target_where,
                     setlist,
@@ -380,7 +390,7 @@ impl<'a, 'b> SemanticWalker<'a, 'b> {
                 orderby,
                 limit_clause,
             } => {
-                self.walk_compound_scope(visitor, &fields, left, right, orderby, limit_clause);
+                self.walk_compound_scope(visitor, fields, left, right, orderby, limit_clause);
             }
         }
     }

--- a/tests/semantic_diff_tests/unknown_table.py
+++ b/tests/semantic_diff_tests/unknown_table.py
@@ -75,3 +75,49 @@ class UnknownTable(TestSuite):
               |                                        ^~~~~~
 """,
         )
+
+
+class UnknownQualifier(TestSuite):
+    """A qualified column ref whose qualifier names no source in scope.
+
+    Regression tests for https://github.com/LalitMaganti/syntaqlite/issues/281:
+    `SELECT b.id FROM foo AS a` used to be silently accepted.
+    """
+
+    def test_undefined_alias_is_flagged(self):
+        return DiffTestBlueprint(
+            sql="CREATE TABLE foo (id INT, name TEXT); SELECT b.id FROM foo AS a",
+            strict_schema=True,
+            out="""\
+            error: unknown table 'b'
+             --> <stdin>:1:46
+              |
+            1 | CREATE TABLE foo (id INT, name TEXT); SELECT b.id FROM foo AS a
+              |                                              ^
+              = help: did you mean 'a'?
+""",
+        )
+
+    def test_alias_hides_base_table_name(self):
+        return DiffTestBlueprint(
+            sql="CREATE TABLE foo (id INT); SELECT foo.id FROM foo AS a",
+            strict_schema=True,
+            out="""\
+            error: unknown table 'foo'
+             --> <stdin>:1:35
+              |
+            1 | CREATE TABLE foo (id INT); SELECT foo.id FROM foo AS a
+              |                                   ^~~
+""",
+        )
+
+    def test_excluded_in_upsert_not_flagged(self):
+        return DiffTestBlueprint(
+            sql=(
+                "CREATE TABLE foo (id INT PRIMARY KEY, name TEXT); "
+                "INSERT INTO foo(id) VALUES (1) "
+                "ON CONFLICT(id) DO UPDATE SET name = excluded.name"
+            ),
+            strict_schema=True,
+            out="",
+        )

--- a/tests/upstream_baselines/parse_acceptance.linux.json
+++ b/tests/upstream_baselines/parse_acceptance.linux.json
@@ -2,10 +2,10 @@
   "total": 395694,
   "parse_ok": 290637,
   "parse_error": 105057,
-  "both_accept": 288666,
-  "both_reject": 105908,
-  "false_positive": 535,
-  "gap": 585,
+  "both_accept": 288664,
+  "both_reject": 105917,
+  "false_positive": 537,
+  "gap": 576,
   "false_positive_categories": {
     "unknown column": 77,
     "unknown function: fts3_tokenizer": 12,
@@ -19,7 +19,7 @@
     "unknown table (system): sqlite_stat1": 52,
     "unknown table (system): sqlite_stat4": 1,
     "unknown table (system): sqlite_temp_master": 9,
-    "unknown table (user-defined)": 148
+    "unknown table (user-defined)": 150
   },
   "gap_categories": {
     "AUTOINCREMENT not allowed on WITHOUT ROWID tables": 2,
@@ -84,7 +84,7 @@
     "multiple references to recursive table: ?": 1,
     "no query solution": 1,
     "no such collation sequence: ?": 11,
-    "no such column": 35,
+    "no such column": 26,
     "no such function": 36,
     "no such index: ?": 8,
     "no such table": 87,


### PR DESCRIPTION
Previously unknown qualifiers were silently accepted to avoid false
positives on unmodeled constructs (e.g. UPSERT).

Now that scoping is modeled properly, emit "unknown table" with a fuzzy
suggestion instead. Every intentional accept is a named AcceptedRef
variant.

Fixes #281.
