### PR TITLE
synq: serve playground completions over LSP

### DIFF
--- a/web/playground/e2e/playground.spec.ts
+++ b/web/playground/e2e/playground.spec.ts
@@ -89,6 +89,30 @@ test("default load writes a preset param to the hash (not custom SQL)", async ({
   expect(params.has("s")).toBe(false);
 });
 
+// ---------------------------------------------------------------------------
+// Completions (served over the in-process LSP)
+// ---------------------------------------------------------------------------
+
+test("typing in the editor surfaces SQL completions", async ({page}) => {
+  await page.goto("/");
+  // The viewer pane rendering formatted SQL proves the wasm engine and
+  // dialect finished loading — only then can completions answer.
+  await expect(page.locator(".sq-viewer-pane")).toContainText(/SELECT/i, {timeout: 15000});
+
+  const editor = page.locator(".sq-workspace .monaco-editor").first();
+  await expect(editor).toBeVisible();
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.type("SELECT 1 FROM t WHERE ");
+  // Explicitly trigger suggest for determinism.
+  await page.keyboard.press("Control+Space");
+
+  const suggestions = page.locator(".suggest-widget .monaco-list-row");
+  await expect(suggestions.first()).toBeVisible({timeout: 10000});
+  // Keyword completions must be present (e.g. NOT/EXISTS/CASE after WHERE).
+  expect(await suggestions.count()).toBeGreaterThan(0);
+});
+
 test("switching output tab updates the URL hash to ot=ast", async ({page}) => {
   await page.goto("/");
   // Wait for page to settle.

--- a/web/playground/src/lsp_session.ts
+++ b/web/playground/src/lsp_session.ts
@@ -1,0 +1,128 @@
+// Copyright 2025 The syntaqlite Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import type {Engine} from "syntaqlite";
+
+/** JSON-RPC error code for "server not initialized". */
+const SERVER_NOT_INITIALIZED = -32002;
+
+interface LspMessage {
+  id?: number;
+  method?: string;
+  result?: unknown;
+  error?: {code: number; message: string};
+  params?: unknown;
+}
+
+export interface LspCompletionItem {
+  label: string;
+  kind?: number;
+  sortText?: string;
+  detail?: string;
+}
+
+/** Minimal LSP client over `Engine.lspMessage` for editor features.
+ *
+ *  Documents are synced lazily: each request first brings the server's copy
+ *  of the document up to the caller's version (didOpen/didChange with full
+ *  text). Server pushes (publishDiagnostics) are discarded — the playground
+ *  has its own diagnostics pipeline.
+ *
+ *  Dialect switches rebuild the WASM session's language server, which
+ *  resets its lifecycle. The client self-heals: on a "server not
+ *  initialized" error it re-runs the handshake, re-opens the document, and
+ *  retries once. */
+export class LspSession {
+  private nextId = 1;
+  private initialized = false;
+  /** Last version synced to the server, per document URI. */
+  private syncedVersions = new Map<string, number>();
+
+  constructor(private engine: Engine) {}
+
+  private send(msg: object): LspMessage[] {
+    return this.engine.lspMessage(msg) as LspMessage[];
+  }
+
+  private reset(): void {
+    this.initialized = false;
+    this.syncedVersions.clear();
+  }
+
+  private ensureInitialized(): void {
+    if (this.initialized) return;
+    this.send({
+      jsonrpc: "2.0", id: this.nextId++, method: "initialize",
+      params: {capabilities: {}},
+    });
+    this.send({jsonrpc: "2.0", method: "initialized", params: {}});
+    this.initialized = true;
+  }
+
+  private syncDocument(uri: string, text: string, version: number): void {
+    const synced = this.syncedVersions.get(uri);
+    if (synced === version) return;
+    if (synced === undefined) {
+      this.send({
+        jsonrpc: "2.0", method: "textDocument/didOpen",
+        params: {textDocument: {uri, languageId: "sql", version, text}},
+      });
+    } else {
+      this.send({
+        jsonrpc: "2.0", method: "textDocument/didChange",
+        params: {textDocument: {uri, version}, contentChanges: [{text}]},
+      });
+    }
+    this.syncedVersions.set(uri, version);
+  }
+
+  /** Request completions at a zero-based UTF-16 `line`/`character` position,
+   *  syncing the document first. Returns an empty list on any failure. */
+  completions(
+    uri: string,
+    text: string,
+    version: number,
+    line: number,
+    character: number,
+  ): LspCompletionItem[] {
+    try {
+      return this.completionsOnce(uri, text, version, line, character, true);
+    } catch (e) {
+      console.warn("LSP completion failed:", e);
+      return [];
+    }
+  }
+
+  private completionsOnce(
+    uri: string,
+    text: string,
+    version: number,
+    line: number,
+    character: number,
+    retry: boolean,
+  ): LspCompletionItem[] {
+    this.ensureInitialized();
+    this.syncDocument(uri, text, version);
+    const id = this.nextId++;
+    const out = this.send({
+      jsonrpc: "2.0", id, method: "textDocument/completion",
+      params: {textDocument: {uri}, position: {line, character}},
+    });
+    const response = out.find((m) => m.id === id);
+    if (response?.error) {
+      // The WASM language server is rebuilt on dialect switches, losing the
+      // handshake and document state; redo both and retry once.
+      if (retry && response.error.code === SERVER_NOT_INITIALIZED) {
+        this.reset();
+        return this.completionsOnce(uri, text, version, line, character, false);
+      }
+      console.warn("LSP completion error:", response.error.message);
+      return [];
+    }
+    const result = response?.result;
+    if (Array.isArray(result)) return result as LspCompletionItem[];
+    // CompletionList shape ({isIncomplete, items}) or null.
+    const items = (result as {items?: unknown} | null | undefined)?.items;
+    return Array.isArray(items) ? (items as LspCompletionItem[]) : [];
+  }
+}

--- a/web/playground/src/main.ts
+++ b/web/playground/src/main.ts
@@ -9,6 +9,7 @@ import "monaco-editor/esm/vs/basic-languages/python/python.contribution";
 import "monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution";
 import {FORMATTED_MODEL_URI, INPUT_MODEL_URI} from "./app/editor_models";
 import type {Engine} from "syntaqlite";
+import {LspSession} from "./lsp_session";
 import {AppComponent} from "./components/app";
 import "./styles/main.css";
 
@@ -93,26 +94,36 @@ function registerSemanticTokensProvider(engine: Engine): void {
   monaco.languages.registerDocumentRangeSemanticTokensProvider("typescript", provider);
 }
 
-function registerCompletionProvider(app: App, engine: Engine): void {
+/** LSP `CompletionItemKind` values → Monaco kinds. */
+const LSP_COMPLETION_KINDS = new Map<number, monaco.languages.CompletionItemKind>([
+  [3, monaco.languages.CompletionItemKind.Function],
+  [5, monaco.languages.CompletionItemKind.Field], // column
+  [14, monaco.languages.CompletionItemKind.Keyword],
+  [22, monaco.languages.CompletionItemKind.Struct], // table
+]);
+
+function registerCompletionProvider(app: App, engine: Engine, lsp: LspSession): void {
   monaco.languages.registerCompletionItemProvider("sql", {
     triggerCharacters: [" ", "\t", ";", "(", ","],
     provideCompletionItems(
       model: monaco.editor.ITextModel,
       position: monaco.Position,
     ): monaco.languages.ProviderResult<monaco.languages.CompletionList> {
-      if (!engine.ready) return {suggestions: []};
+      if (!engine.ready || !engine.lspSupported) return {suggestions: []};
       if (app.languageMode !== "sql") return {suggestions: []};
       if (model.uri.toString() !== INPUT_MODEL_URI) {
         return {suggestions: []};
       }
 
-      const source = model.getValue();
-      const offset = model.getOffsetAt(position);
-      const version = model.getVersionId();
-      const result = engine.runCompletions(source, offset, version);
-      if (!result.ok || result.items.length === 0) {
-        return {suggestions: []};
-      }
+      // Monaco positions are 1-based UTF-16; LSP positions are 0-based UTF-16.
+      const items = lsp.completions(
+        INPUT_MODEL_URI,
+        model.getValue(),
+        model.getVersionId(),
+        position.lineNumber - 1,
+        position.column - 1,
+      );
+      if (items.length === 0) return {suggestions: []};
 
       const word = model.getWordUntilPosition(position);
       const range = new monaco.Range(
@@ -122,15 +133,13 @@ function registerCompletionProvider(app: App, engine: Engine): void {
         word.endColumn,
       );
 
-      const suggestions: monaco.languages.CompletionItem[] = result.items.map((item) => ({
+      const suggestions: monaco.languages.CompletionItem[] = items.map((item) => ({
         label: item.label,
         insertText: item.label,
+        sortText: item.sortText,
+        detail: item.detail,
         kind:
-          item.kind === "function"
-            ? monaco.languages.CompletionItemKind.Function
-            : item.kind === "class"
-              ? monaco.languages.CompletionItemKind.Class
-              : monaco.languages.CompletionItemKind.Keyword,
+          LSP_COMPLETION_KINDS.get(item.kind ?? 0) ?? monaco.languages.CompletionItemKind.Text,
         range,
       }));
 
@@ -205,7 +214,7 @@ async function main() {
     app.schemaContext.apply(app.runtime, schema, schemaFormat);
 
     registerSemanticTokensProvider(app.runtime);
-    registerCompletionProvider(app, app.runtime);
+    registerCompletionProvider(app, app.runtime, new LspSession(app.runtime));
     registerCodeActionProvider(app);
     app.runtime.updateStatus("Ready.");
   } catch (err) {


### PR DESCRIPTION
The playground completion provider called `wasm_completions` directly with byte offsets — a bespoke path duplicating what the LSP entry point from #301 now provides. This switches it to a small LSP client over `Engine.lspMessage`: sync the document (`didOpen`/`didChange`), request `textDocument/completion`, and map LSP kinds to Monaco kinds — picking up server-side sort priorities and kind details the direct path lacked.

Dialect switches rebuild the wasm language server and reset its lifecycle, so the client self-heals: on a server-not-initialized error it redoes the handshake, re-opens the document, and retries once.

Adds the first e2e coverage for the suggest widget (all 10 e2e tests pass locally).

Stacked on #301; the diagnostics and semantic-tokens paths could migrate the same way in a future change.