### PR TITLE
synq: run each upstream test file in its own directory

### DIFF
--- a/python/dev/integration_tests/suites/upstream_sqlite.py
+++ b/python/dev/integration_tests/suites/upstream_sqlite.py
@@ -25,6 +25,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from collections import Counter
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
@@ -263,12 +264,14 @@ def _run_single_test(
     env["SYNTAQLITE_TEST_VALIDATE"] = "1" if validate else "0"
     env["tcl_interactive"] = "0"
 
+    # Concurrent tests would otherwise race over db files in a shared cwd.
     try:
-        proc = subprocess.run(
-            ["tclsh", "-"],
-            input=script, capture_output=True, text=True,
-            env=env, timeout=60,
-        )
+        with tempfile.TemporaryDirectory(prefix="synq-upstream-") as workdir:
+            proc = subprocess.run(
+                ["tclsh", "-"],
+                input=script, capture_output=True, text=True,
+                env=env, timeout=60, cwd=workdir,
+            )
     except subprocess.TimeoutExpired:
         log_file.unlink(missing_ok=True)
         return FileResult(file=name, error=f"tclsh timed out for {name}")


### PR DESCRIPTION
synq: run each upstream test file in its own directory

The upstream suite runs all 1174 test files concurrently from the repo root,
so they race over the database files they ATTACH and create. Which file ran
first decided the outcome, surfacing as an intermittent `no such table` gap
regression. Each file now gets its own temporary cwd, and the gap count is
stable across repeated runs.