### PR TITLE
synq: stop the generated parser depending on libc strncasecmp

### DIFF
--- a/syntaqlite-syntax/include/syntaqlite_dialect/sqlite_compat.h
+++ b/syntaqlite-syntax/include/syntaqlite_dialect/sqlite_compat.h
@@ -24,14 +24,35 @@ typedef uint32_t u32;
 #define SQLITE_DIGIT_SEPARATOR '_'
 #endif
 
-// Case-insensitive string comparison (POSIX strncasecmp / MSVC _strnicmp)
-#ifdef _MSC_VER
-#include <string.h>
-#define SYNQ_STRNCASECMP _strnicmp
-#else
-#include <strings.h>
-#define SYNQ_STRNCASECMP strncasecmp
-#endif
+// Case-insensitive comparison over ASCII, which is all SQL keywords need.
+// Deliberately not libc's strncasecmp: the generated parser is compiled into
+// embeddings that do not necessarily provide it, such as an Emscripten side
+// module, where the unresolved import aborts the engine mid-parse.
+#include <stddef.h>
+
+static inline int synq_strncasecmp_ascii(const char* a,
+                                         const char* b,
+                                         size_t n) {
+  for (size_t i = 0; i < n; i++) {
+    unsigned char ca = (unsigned char)a[i];
+    unsigned char cb = (unsigned char)b[i];
+    if (ca >= 'A' && ca <= 'Z') {
+      ca = (unsigned char)(ca - 'A' + 'a');
+    }
+    if (cb >= 'A' && cb <= 'Z') {
+      cb = (unsigned char)(cb - 'A' + 'a');
+    }
+    if (ca != cb) {
+      return (int)ca - (int)cb;
+    }
+    if (ca == 0) {
+      return 0;
+    }
+  }
+  return 0;
+}
+
+#define SYNQ_STRNCASECMP synq_strncasecmp_ascii
 
 // C++17 fallthrough, C no-op
 #ifdef __cplusplus

--- a/web/playground/e2e/playground.spec.ts
+++ b/web/playground/e2e/playground.spec.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 import {test, expect} from "@playwright/test";
+import LZString from "lz-string";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -141,4 +142,18 @@ test("switching output tab updates the URL hash to ot=ast", async ({page}) => {
     const hash = await getHash(page);
     expect(new URLSearchParams(hash).get("ot")).toBe("ast");
   }
+});
+
+test("table options parse without trapping the wasm engine", async ({page}) => {
+  // Table options are matched with a case-insensitive compare in the dialect's
+  // generated parser. libc's strncasecmp is not resolvable from the emscripten
+  // side module, so relying on it aborts the engine mid-parse.
+  const sql = "CREATE TABLE t(a PRIMARY KEY) WITHOUT ROWID;";
+  await page.goto("/#s=" + LZString.compressToEncodedURIComponent(sql));
+
+  // Syntax highlighting splits keywords into spans, so match them singly.
+  const viewer = page.locator(".sq-viewer-pane");
+  await expect(viewer).toContainText(/WITHOUT/i, {timeout: 15000});
+  await expect(viewer).toContainText(/ROWID/i);
+  await expect(viewer).not.toContainText(/unreachable/i);
 });


### PR DESCRIPTION
Table options and join keywords are matched with a case-insensitive compare in the generated parser. That resolved to libc `strncasecmp`, which an Emscripten side module does not provide: the import traps, aborting the engine mid-parse. In the web playground any statement reaching one of those comparisons died with "unreachable" instead of parsing.

SQL keywords are ASCII, so the compare is now a small local one with no libc dependency, which also keeps the amalgamation self-contained for embedders.