### PR TITLE
synq: fix nested unary minus formatting as a comment

### DIFF
--- a/syntaqlite/src/fmt/doc.rs
+++ b/syntaqlite/src/fmt/doc.rs
@@ -598,13 +598,15 @@ fn maybe_emit_auto_space(next_first: Option<u8>, out: &mut String) -> bool {
     let Some(first) = next_first else {
         return false;
     };
-    if !is_word_byte(first) {
-        return false;
-    }
     let Some(&last) = out.as_bytes().last() else {
         return false;
     };
-    if !is_word_byte(last) {
+    let needs_space = if is_word_byte(first) {
+        is_word_byte(last)
+    } else {
+        would_lex_as_one_token(last, first)
+    };
+    if !needs_space {
         return false;
     }
     out.push(' ');
@@ -614,6 +616,27 @@ fn maybe_emit_auto_space(next_first: Option<u8>, out: &mut String) -> bool {
 #[inline]
 fn is_word_byte(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Operator bytes that `SQLite`'s tokenizer reads as a single token when
+/// adjacent, so emitting them flush would change what the output means.
+///
+/// `-` before `-` is the dangerous one: it opens a line comment that eats the
+/// rest of the statement. The others cannot currently be produced by any fmt
+/// block, but the pair is what makes the output wrong, not the caller, so the
+/// guard belongs here rather than at each emission site.
+#[inline]
+fn would_lex_as_one_token(last: u8, first: u8) -> bool {
+    matches!(
+        (last, first),
+        (b'-', b'-' | b'>')
+            | (b'/', b'*')
+            | (b'*', b'/')
+            | (b'|', b'|')
+            | (b'<', b'<' | b'=' | b'>')
+            | (b'>', b'>' | b'=')
+            | (b'=' | b'!', b'=')
+    )
 }
 
 /// Push a keyword string with the appropriate casing to the output.

--- a/tests/fmt_diff_tests/select.py
+++ b/tests/fmt_diff_tests/select.py
@@ -116,6 +116,31 @@ class ExprFormat(TestSuite):
             out="SELECT -x FROM t;",
         )
 
+    def test_nested_unary_minus_does_not_paste_into_comment(self):
+        """`-` before `-` must stay separated; `--` would comment out the rest."""
+        return DiffTestBlueprint(
+            sql="select - -1",
+            out="SELECT - -1;",
+        )
+
+    def test_binary_minus_before_unary_minus(self):
+        return DiffTestBlueprint(
+            sql="select 1 - -1",
+            out="SELECT 1 - -1;",
+        )
+
+    def test_nested_unary_minus_on_column(self):
+        return DiffTestBlueprint(
+            sql="select - -x from t",
+            out="SELECT - -x FROM t;",
+        )
+
+    def test_unary_minus_keeps_author_parens(self):
+        return DiffTestBlueprint(
+            sql="select -(-1)",
+            out="SELECT -(-1);",
+        )
+
     def test_and_or(self):
         return DiffTestBlueprint(
             sql="select a from t where x = 1 and y = 2",


### PR DESCRIPTION
The formatter emitted operator atoms flush against each other, so a unary minus applied to a negative literal came out as `--`, which SQLite reads as a line comment. `SELECT - -1` evaluated to 1 before formatting and failed to parse after it. The auto-spacer only knew about word-to-word adjacency; it now also separates operator pairs that the tokenizer would lex as a single token.