### PR TITLE
synq: apply a constraint name to every constraint it covers

### DIFF
--- a/syntaqlite-buildtools/parser-actions/create_table.y
+++ b/syntaqlite-buildtools/parser-actions/create_table.y
@@ -124,7 +124,8 @@ columnlist(A) ::= columnname(CN) carglist(CG). {
 
 carglist(A) ::= carglist(L) ccons(C). {
     if (C.node != SYNTAQLITE_NULL_NODE) {
-        // Apply pending constraint name from the list to this node
+        // The name stays pending: SQLite reads it without clearing, so it
+        // names every constraint until a new column or a tconscomma.
         SyntaqliteNode *node = AST_NODE(&pCtx->ast, C.node);
         node->column_constraint.constraint_name = L.pending_name;
         if (L.list == SYNTAQLITE_NULL_NODE) {
@@ -132,7 +133,7 @@ carglist(A) ::= carglist(L) ccons(C). {
         } else {
             A.list = synq_parse_column_constraint_list(pCtx, L.list, C.node);
         }
-        A.pending_name = SYNQ_NO_SPAN;
+        A.pending_name = L.pending_name;
         A.last_node = C.node;
     } else if (C.pending_name.length > 0) {
         // CONSTRAINT nm — store pending name for next constraint
@@ -502,7 +503,7 @@ conslist(A) ::= conslist(L) tconscomma(SEP) tcons(TC). {
         } else {
             A.list = synq_parse_table_constraint_list(pCtx, L.list, TC.node);
         }
-        A.pending_name = SYNQ_NO_SPAN;
+        A.pending_name = pending;
         A.last_node = TC.node;
     } else if (TC.pending_name.length > 0) {
         A.list = L.list;

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
@@ -7936,7 +7936,8 @@ static YYACTIONTYPE yy_reduce(
     case 68: /* carglist ::= carglist ccons */
     {
       if (yymsp[0].minor.yy150.node != SYNTAQLITE_NULL_NODE) {
-        // Apply pending constraint name from the list to this node
+        // The name stays pending: SQLite reads it without clearing, so it
+        // names every constraint until a new column or a tconscomma.
         SyntaqliteNode* node = AST_NODE(&pCtx->ast, yymsp[0].minor.yy150.node);
         node->column_constraint.constraint_name =
             yymsp[-1].minor.yy430.pending_name;
@@ -7947,7 +7948,7 @@ static YYACTIONTYPE yy_reduce(
           yylhsminor.yy430.list = synq_parse_column_constraint_list(
               pCtx, yymsp[-1].minor.yy430.list, yymsp[0].minor.yy150.node);
         }
-        yylhsminor.yy430.pending_name = SYNQ_NO_SPAN;
+        yylhsminor.yy430.pending_name = yymsp[-1].minor.yy430.pending_name;
         yylhsminor.yy430.last_node = yymsp[0].minor.yy150.node;
       } else if (yymsp[0].minor.yy150.pending_name.length > 0) {
         // CONSTRAINT nm — store pending name for next constraint
@@ -8306,7 +8307,7 @@ static YYACTIONTYPE yy_reduce(
           yylhsminor.yy430.list = synq_parse_table_constraint_list(
               pCtx, yymsp[-2].minor.yy430.list, yymsp[0].minor.yy150.node);
         }
-        yylhsminor.yy430.pending_name = SYNQ_NO_SPAN;
+        yylhsminor.yy430.pending_name = pending;
         yylhsminor.yy430.last_node = yymsp[0].minor.yy150.node;
       } else if (yymsp[0].minor.yy150.pending_name.length > 0) {
         yylhsminor.yy430.list = yymsp[-2].minor.yy430.list;

--- a/tests/fmt_diff_tests/create_table.py
+++ b/tests/fmt_diff_tests/create_table.py
@@ -526,3 +526,37 @@ class TableConstraintFormat(TestSuite):
             sql="create table t (id integer, [set] text)",
             out='CREATE TABLE t(id integer, "set" text);',
         )
+
+class ConstraintNamePropagation(TestSuite):
+    """A pending CONSTRAINT name applies to every constraint until cleared.
+
+    SQLite reads `constraintName` without clearing it (build.c:1915); it is
+    cleared only by a `tconscomma` or by starting a new column.
+    """
+
+    def test_name_applies_to_every_column_constraint(self):
+        return DiffTestBlueprint(
+            sql="create table t(a constraint c check(a>0) check(a<9))",
+            out="CREATE TABLE t(a CONSTRAINT c CHECK(a > 0) CONSTRAINT c CHECK(a < 9));",
+        )
+
+    def test_name_applies_to_every_table_constraint(self):
+        return DiffTestBlueprint(
+            sql="create table t(a, b, constraint two check(b<10) check(a>0))",
+            out=(
+                "CREATE TABLE t(a, b, CONSTRAINT two CHECK(b < 10), "
+                "CONSTRAINT two CHECK(a > 0));"
+            ),
+        )
+
+    def test_comma_clears_the_pending_name(self):
+        return DiffTestBlueprint(
+            sql="create table t(a, b, constraint two check(b<10), check(a>0))",
+            out="CREATE TABLE t(a, b, CONSTRAINT two CHECK(b < 10), CHECK(a > 0));",
+        )
+
+    def test_name_does_not_cross_a_column_boundary(self):
+        return DiffTestBlueprint(
+            sql="create table t(a constraint c check(a>0), b check(b>0))",
+            out="CREATE TABLE t(a CONSTRAINT c CHECK(a > 0), b CHECK(b > 0));",
+        )


### PR DESCRIPTION
A pending CONSTRAINT name was consumed by the first constraint and then cleared, but SQLite reads the name without clearing it (`build.c:1915`): everything up to the next column or comma carries that name.

```
CREATE TABLE t(a,b, CONSTRAINT two CHECK(b<10) CHECK(a>0));
INSERT INTO t VALUES(0,1);
-- sqlite3:  CHECK constraint failed: two
-- was:      CHECK constraint failed: a>0
```

Verified differentially: the formatted output now produces the same constraint name as the input in sqlite3 for every named case.