### PR TITLE
synq: reject qualified names and index hints in trigger bodies

### DIFF
--- a/syntaqlite-buildtools/parser-actions/trigger.y
+++ b/syntaqlite-buildtools/parser-actions/trigger.y
@@ -117,21 +117,21 @@ trnm(A) ::= nm(A). {
 
 trnm(A) ::= nm DOT nm(X). {
     A = X;
-    // Qualified names not allowed in triggers, but grammar accepts them
+    pCtx->error = 1;
 }
 
-// ============ tridxby (index hints in triggers - ignored) ============
+// ============ tridxby (index hints; SQLite rejects these in triggers) ============
 
 tridxby ::= . {
     // empty
 }
 
 tridxby ::= INDEXED BY nm. {
-    // Not allowed in triggers, but grammar accepts
+    pCtx->error = 1;
 }
 
 tridxby ::= NOT INDEXED. {
-    // Not allowed in triggers, but grammar accepts
+    pCtx->error = 1;
 }
 
 // ============ Trigger commands ============

--- a/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
+++ b/syntaqlite-syntax/csrc/sqlite/sqlite_parse.c
@@ -9671,13 +9671,13 @@ static YYACTIONTYPE yy_reduce(
     case 317: /* trnm ::= nm DOT nm */
     {
       yymsp[-2].minor.yy0 = yymsp[0].minor.yy0;
-      // Qualified names not allowed in triggers, but grammar accepts them
+      pCtx->error = 1;
     } break;
     case 319: /* tridxby ::= INDEXED BY nm */
     case 320: /* tridxby ::= NOT INDEXED */
       yytestcase(yyruleno == 320);
       {
-        // Not allowed in triggers, but grammar accepts
+        pCtx->error = 1;
       }
       break;
     case 321: /* trigger_cmd ::= UPDATE orconf trnm tridxby SET setlist from

--- a/syntaqlite-syntax/src/parser/session.rs
+++ b/syntaqlite-syntax/src/parser/session.rs
@@ -591,6 +591,27 @@ mod tests {
     }
 
     #[test]
+    fn trigger_bodies_reject_qualified_names_and_index_hints() {
+        for sql in [
+            "CREATE TRIGGER tr AFTER INSERT ON t BEGIN DELETE FROM main.u WHERE x=1; END;",
+            "CREATE TRIGGER tr AFTER INSERT ON t BEGIN DELETE FROM u INDEXED BY i WHERE x=1; END;",
+            "CREATE TRIGGER tr AFTER INSERT ON t BEGIN UPDATE u NOT INDEXED SET x=1; END;",
+        ] {
+            let parser = Parser::new();
+            let mut session = parser.parse(sql);
+            assert!(
+                matches!(session.next(), ParseOutcome::Err(_)),
+                "should be rejected: {sql}"
+            );
+        }
+
+        let parser = Parser::new();
+        let mut session =
+            parser.parse("CREATE TRIGGER tr AFTER INSERT ON t BEGIN DELETE FROM u WHERE x=1; END;");
+        assert!(matches!(session.next(), ParseOutcome::Ok(_)));
+    }
+
+    #[test]
     fn parser_continues_after_statement_error() {
         let parser = Parser::new();
         let mut session = parser.parse("SELECT 1; SELECT ; SELECT 2;");


### PR DESCRIPTION
Inside a trigger body SQLite rejects a schema-qualified table name and any INDEXED BY / NOT INDEXED hint:

```
CREATE TRIGGER tr AFTER INSERT ON t BEGIN UPDATE main.u SET a=1; END;
-- sqlite3: qualified table names are not allowed on INSERT, UPDATE, and
--          DELETE statements within triggers
```

We accepted both and silently discarded the qualifier or the hint, which is the worst of the options: neither rejected nor preserved. Both now raise a parse error, matching SQLite.

`upstream-sqlite --validate` shows no regressions from baseline.